### PR TITLE
Fix crash in location analysis due to undefined properties

### DIFF
--- a/src/ArchitectAIEnhanced.js
+++ b/src/ArchitectAIEnhanced.js
@@ -411,7 +411,7 @@ const ArchitectAIEnhanced = () => {
           });
       }
 
-      if (geocodeResponse.data.status !== 'OK' || geocodeResponse.data.results.length === 0) {
+      if (geocodeResponse.data.status !== 'OK' || !geocodeResponse.data.results || geocodeResponse.data.results.length === 0) {
         throw new Error(`Geocoding failed: ${geocodeResponse.data.status}`);
       }
 
@@ -439,7 +439,7 @@ const ArchitectAIEnhanced = () => {
       );
 
       // Recommend architectural style
-      const architecturalStyle = locationIntelligence.recommendArchitecturalStyle(addressComponents);
+      const architecturalStyle = locationIntelligence.recommendArchitecturalStyle(locationResult, seasonalClimateData.climate);
 
       // Step 4: Populate location data
       const newLocationData = {


### PR DESCRIPTION
This commit addresses a bug that caused the application to crash with a "Cannot read properties of undefined (reading 'find')" error during location analysis.

The root causes were twofold:
1. The `recommendArchitecturalStyle` function was being called with incorrect parameters (the `addressComponents` array instead of the full `locationResult` object).
2. The error handling for the geocoding API response was not robust enough to handle cases where the `results` array might be missing.

This commit implements the following fixes in `src/ArchitectAIEnhanced.js`:
- The geocoding response validation is enhanced to safely check for the existence of the `results` array before accessing it.
- The call to `recommendArchitecturalStyle` is corrected to pass the entire `locationResult` object and the `climate` data, aligning it with the function's expected signature.

These changes prevent the crash and make the location analysis feature more robust.