### PR TITLE
Fix(zoning): Correctly fetch and parse UK planning data

### DIFF
--- a/api/proxy-planning.js
+++ b/api/proxy-planning.js
@@ -1,7 +1,7 @@
 // api/proxy-planning.js (Vercel or Netlify function)
 export default async function handler(req, res) {
-  const { lat, lng } = req.query;
-  const url = `https://planning.data.gov.uk/api/v1/constraints?lat=${lat}&lon=${lng}`;
+  const { lat, lon } = req.query;
+  const url = `https://planning.data.gov.uk/api/v1/constraints?lat=${lat}&lon=${lon}`;
   const response = await fetch(url);
   const text = await response.text();
   res.setHeader('Access-Control-Allow-Origin', '*');

--- a/src/services/enhancedLocationIntelligence.js
+++ b/src/services/enhancedLocationIntelligence.js
@@ -10,7 +10,7 @@ export const enhancedLocationIntelligence = {
    * @returns {Promise<{zoning: any, designGuidelines: any, dataQuality: string, citations: string[]}>}
    */
   async getAuthorativeZoningData(address, coords) {
-    const { lat, lng } = coords || {};
+    const { lat, lng: lon } = coords || {}; // Use lon to match the API parameter
     let zoningInfo = null;
     let designGuidelines = null;
     let citations = [];
@@ -18,45 +18,65 @@ export const enhancedLocationIntelligence = {
 
     try {
       // Use the proxy to fetch UK planning constraints
-      const url = `/api/proxy-planning?lat=${lat}&lon=${lng}`;
+      const url = `/api/proxy-planning?lat=${lat}&lon=${lon}`;
       const resp = await fetch(url);
       if (!resp.ok) {
         throw new Error(`API request failed with status ${resp.status}`);
       }
       const data = await resp.json();
 
-      // Simplify constraints into the fields your UI expects
-      let zoneType = 'Unknown';
-      let note = '';
-      let characteristics = [];
-      let materials = [];
+      // Enhanced parsing of UK planning constraints
+      const zoneTypes = new Set();
+      const notes = new Set();
+      const characteristics = new Set();
+      const materials = new Set();
 
-      if (Array.isArray(data)) {
-        for (const item of data) {
-          const label = (item.label || item.name || '').toLowerCase();
-          if (label.includes('conservation')) {
-            zoneType = 'Conservation Area';
-            note = 'Within a designated conservation area';
-            characteristics.push('Historic character');
-          } else if (label.includes('listed')) {
-            zoneType = 'Listed Building';
-            note = 'Property is a listed building';
-            characteristics.push('Protected heritage building');
-            materials.push('Traditional stone/brick');
-          } else if (label.includes('tree preservation') || label.includes('tpo')) {
-            characteristics.push('Tree preservation order');
+      const constraintMappings = {
+        'conservation area': { type: 'Conservation Area', note: 'Subject to special planning controls.', chars: ['Historic character preservation'], mats: ['Traditional materials'] },
+        'listed building': { type: 'Listed Building', note: 'Alterations are heavily restricted.', chars: ['Protected heritage asset'], mats: ['Original materials must be preserved'] },
+        'tree preservation order': { type: 'TPO', note: 'Contains protected trees.', chars: ['Development must accommodate trees'], mats: [] },
+        'green belt': { type: 'Green Belt', note: 'Strong restrictions on new development.', chars: ['Preservation of openness'], mats: [] },
+        'area of outstanding natural beauty': { type: 'AONB', note: 'Development must conserve natural beauty.', chars: ['High scenic quality'], mats: ['Natural and local materials'] },
+        'national park': { type: 'National Park', note: 'Strict development policies apply.', chars: ['Conservation of wildlife and heritage'], mats: ['Locally sourced materials'] },
+        'site of special scientific interest': { type: 'SSSI', note: 'Development restricted to protect biological/geological features.', chars: ['Protected wildlife habitats'], mats: [] },
+        'flood zone 2': { type: 'Flood Zone 2', note: 'Medium probability of flooding.', chars: ['Flood risk assessment required'], mats: ['Water-resistant materials'] },
+        'flood zone 3': { type: 'Flood Zone 3', note: 'High probability of flooding.', chars: ['Resilient construction required'], mats: ['Water-resistant materials'] },
+      };
+
+      if (data && Array.isArray(data.features)) {
+        for (const feature of data.features) {
+          const constraintName = (feature.properties?.name || '').toLowerCase();
+          let matched = false;
+          for (const [key, value] of Object.entries(constraintMappings)) {
+            if (constraintName.includes(key)) {
+              zoneTypes.add(value.type);
+              notes.add(value.note);
+              value.chars.forEach(c => characteristics.add(c));
+              value.mats.forEach(m => materials.add(m));
+              matched = true;
+            }
+          }
+          if (!matched && feature.properties?.name) {
+             characteristics.add(feature.properties.name); // Add unknown constraints to characteristics
           }
         }
       }
 
+      let finalZoneType = 'Standard Regulations';
+      if (zoneTypes.size > 0) {
+        finalZoneType = [...zoneTypes].join(', ');
+      } else if (data?.features?.length > 0) {
+        finalZoneType = 'Area with Planning Constraints';
+      }
+
       zoningInfo = {
-        type: zoneType,
-        note: note || null,
+        type: finalZoneType,
+        note: [...notes].join(' ') || null,
         maxHeight: null,      // UK constraints API doesn’t supply this directly
         density: null,
         setbacks: null,
-        characteristics: characteristics.length ? characteristics.join(', ') : null,
-        materials: materials.length ? materials.join(', ') : null,
+        characteristics: [...characteristics].join('. ') || null,
+        materials: [...materials].join(', ') || null,
         raw: data, // Keep raw data for debugging if needed
       };
       designGuidelines = [

--- a/src/services/enhancedLocationIntelligence.test.js
+++ b/src/services/enhancedLocationIntelligence.test.js
@@ -22,9 +22,9 @@ describe('enhancedLocationIntelligence', () => {
       // Mock the fetch call to the proxy
       window.fetch.mockResolvedValue({
         ok: true,
-        json: jest.fn().mockResolvedValue([
-          { label: 'Conservation Area' }
-        ]),
+        json: jest.fn().mockResolvedValue({
+          features: [{ properties: { name: 'Conservation Area' } }],
+        }),
       });
 
       const result = await enhancedLocationIntelligence.getAuthorativeZoningData(address, coords);


### PR DESCRIPTION
This commit addresses an issue where UK postcodes were not providing zoning information. The main problems were a bug in the CORS proxy, and insufficient parsing of the planning data.

The changes in this commit include:
- Fixed a bug in the `api/proxy-planning.js` serverless function where it was using the wrong query parameter (`lng` instead of `lon`).
- Implemented a more robust parsing mechanism in `src/services/enhancedLocationIntelligence.js` for the data from `planning.data.gov.uk`. The new logic can identify various types of planning constraints (e.g., Conservation Area, Listed Building, Green Belt) and transform them into a structured format for the UI.
- Updated the tests in `src/services/enhancedLocationIntelligence.test.js` to align with the new data parsing logic and response format.
- Addressed a minor variable name inconsistency (`lng` vs `lon`) in `src/services/enhancedLocationIntelligence.js` for clarity and robustness.