### PR TITLE
security: replace wildcard CORS with origin-validated allowlist

### DIFF
--- a/api/_shared/cors.js
+++ b/api/_shared/cors.js
@@ -1,0 +1,96 @@
+/**
+ * Shared CORS utility for Vercel serverless functions.
+ *
+ * Validates the request Origin against an allowlist and sets
+ * appropriate CORS headers. Replaces the previous pattern of
+ * hardcoding Access-Control-Allow-Origin: * in every endpoint.
+ */
+
+const ALLOWED_ORIGINS = [
+  "https://www.archiaisolution.pro",
+  "https://archiaisolution.pro",
+  "http://localhost:3000",
+  "http://localhost:3001",
+];
+
+// Match Vercel preview deployments: architect-ai-platform-*.vercel.app
+const VERCEL_PREVIEW_RE =
+  /^https:\/\/architect-ai-platform[a-z0-9-]*\.vercel\.app$/;
+
+/**
+ * Resolve the allowed origin for the given request.
+ * Returns the matched origin string, or the production origin as default.
+ */
+function resolveOrigin(reqOrigin) {
+  if (!reqOrigin) return ALLOWED_ORIGINS[0]; // default to production
+
+  if (ALLOWED_ORIGINS.includes(reqOrigin)) return reqOrigin;
+  if (VERCEL_PREVIEW_RE.test(reqOrigin)) return reqOrigin;
+
+  // Check ALLOWED_ORIGINS env var for additional origins (comma-separated)
+  const extra = process.env.ALLOWED_ORIGINS;
+  if (extra) {
+    const list = extra
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (list.includes(reqOrigin)) return reqOrigin;
+  }
+
+  return ALLOWED_ORIGINS[0]; // reject unknown origins by returning production
+}
+
+/**
+ * Set CORS headers on a Node.js res object (standard Vercel serverless functions).
+ *
+ * @param {import('http').IncomingMessage} req
+ * @param {import('http').ServerResponse} res
+ * @param {object} [opts]
+ * @param {string} [opts.methods] - Allowed HTTP methods (default: "GET, POST, OPTIONS")
+ */
+export function setCorsHeaders(req, res, opts = {}) {
+  const origin = req.headers?.origin || "";
+  const methods = opts.methods || "GET, POST, OPTIONS";
+
+  res.setHeader("Access-Control-Allow-Origin", resolveOrigin(origin));
+  res.setHeader("Access-Control-Allow-Methods", methods);
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization, X-Requested-With",
+  );
+  res.setHeader("Vary", "Origin");
+}
+
+/**
+ * Return CORS headers object for Edge runtime functions (Response API).
+ *
+ * @param {Request} req - Web API Request
+ * @param {object} [opts]
+ * @param {string} [opts.methods] - Allowed HTTP methods
+ * @returns {Record<string, string>}
+ */
+export function getCorsHeaders(req, opts = {}) {
+  const origin = req.headers?.get?.("origin") || "";
+  const methods = opts.methods || "GET, OPTIONS";
+
+  return {
+    "Access-Control-Allow-Origin": resolveOrigin(origin),
+    "Access-Control-Allow-Methods": methods,
+    "Access-Control-Allow-Headers":
+      "Content-Type, Authorization, X-Requested-With",
+    Vary: "Origin",
+  };
+}
+
+/**
+ * Handle an OPTIONS preflight request for Node runtime.
+ * Returns true if the request was an OPTIONS preflight (caller should return early).
+ */
+export function handlePreflight(req, res, opts = {}) {
+  if (req.method === "OPTIONS") {
+    setCorsHeaders(req, res, opts);
+    res.status(200).end();
+    return true;
+  }
+  return false;
+}

--- a/api/ai-gateway/chat.js
+++ b/api/ai-gateway/chat.js
@@ -12,6 +12,8 @@
  * - Defaults to high-capability model for architectural reasoning
  */
 
+import { setCorsHeaders, handlePreflight } from "../_shared/cors.js";
+
 const AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
 
 // Model mapping from Together.ai to AI Gateway equivalents
@@ -26,15 +28,8 @@ const MODEL_MAPPING = {
 
 export default async function handler(req, res) {
   // Handle OPTIONS for CORS preflight
-  if (req.method === "OPTIONS") {
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader(
-      "Access-Control-Allow-Headers",
-      "Content-Type, Authorization",
-    );
-    return res.status(200).end();
-  }
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   // Only allow POST requests
   if (req.method !== "POST") {
@@ -152,14 +147,6 @@ export default async function handler(req, res) {
       },
       raw: data,
     };
-
-    // Set CORS headers
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader(
-      "Access-Control-Allow-Headers",
-      "Content-Type, Authorization",
-    );
 
     res.status(200).json(normalizedResponse);
   } catch (error) {

--- a/api/ai-gateway/image.js
+++ b/api/ai-gateway/image.js
@@ -12,6 +12,8 @@
  * - FLUX.1-schnell → bfl/flux-kontext-pro (for faster generation)
  */
 
+import { setCorsHeaders, handlePreflight } from "../_shared/cors.js";
+
 const AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
 
 // Model mapping from Together.ai FLUX to AI Gateway BFL models
@@ -24,15 +26,8 @@ const MODEL_MAPPING = {
 
 export default async function handler(req, res) {
   // Handle OPTIONS for CORS preflight
-  if (req.method === "OPTIONS") {
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader(
-      "Access-Control-Allow-Headers",
-      "Content-Type, Authorization",
-    );
-    return res.status(200).end();
-  }
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   // Only allow POST requests
   if (req.method !== "POST") {
@@ -169,14 +164,6 @@ export default async function handler(req, res) {
       traceId,
       raw: data,
     };
-
-    // Set CORS headers
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader(
-      "Access-Control-Allow-Headers",
-      "Content-Type, Authorization",
-    );
 
     res.status(200).json(normalizedResponse);
   } catch (error) {

--- a/api/anthropic-messages.js
+++ b/api/anthropic-messages.js
@@ -6,14 +6,12 @@
  * via Claude Sonnet with tool_choice.
  */
 
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
+
 export default async function handler(req, res) {
-  // Handle OPTIONS for CORS preflight
-  if (req.method === "OPTIONS") {
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-    return res.status(200).end();
-  }
+  // CORS
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   // Only allow POST requests
   if (req.method !== "POST") {
@@ -78,11 +76,6 @@ export default async function handler(req, res) {
 
     const latencyMs = Date.now() - startTime;
     console.log(`✅ [Anthropic] Messages request successful (${latencyMs}ms)`);
-
-    // Set CORS headers for browser requests
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
     res.status(200).json(data);
   } catch (error) {

--- a/api/controlnet-render.js
+++ b/api/controlnet-render.js
@@ -11,13 +11,11 @@
  * Requires: REPLICATE_API_TOKEN environment variable
  */
 
-module.exports = async (req, res) => {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
-  if (req.method === "OPTIONS") return res.status(200).end();
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });
   }
@@ -141,4 +139,4 @@ module.exports = async (req, res) => {
     console.error("[ControlNet] Error:", error.message);
     res.status(500).json({ error: error.message });
   }
-};
+}

--- a/api/drift-detect.js
+++ b/api/drift-detect.js
@@ -9,6 +9,7 @@
 
 import sharp from "sharp";
 import pixelmatch from "pixelmatch";
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
 /**
  * Compute SSIM-like similarity using pixelmatch
@@ -172,14 +173,9 @@ function extractRegion(imageData, fullWidth, x, y, width, height) {
 }
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  // CORS
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });

--- a/api/genarch-job.js
+++ b/api/genarch-job.js
@@ -13,33 +13,31 @@
  * - Or use a queue-based architecture (SQS, Cloud Tasks)
  */
 
-export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
-  if (req.method === 'OPTIONS') {
-    return res.status(200).end();
-  }
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "GET, POST, DELETE, OPTIONS" }))
+    return;
+  setCorsHeaders(req, res, { methods: "GET, POST, DELETE, OPTIONS" });
 
   // Check if we're in development mode
-  const isDev = process.env.NODE_ENV !== 'production' && process.env.VERCEL !== '1';
+  const isDev =
+    process.env.NODE_ENV !== "production" && process.env.VERCEL !== "1";
 
   if (!isDev) {
     // Production (Vercel) - Cannot run genarch pipeline
     return res.status(501).json({
       success: false,
-      error: 'NOT_IMPLEMENTED_IN_SERVERLESS',
+      error: "NOT_IMPLEMENTED_IN_SERVERLESS",
       message:
-        'The genarch pipeline requires Python and cannot run in Vercel serverless functions.',
-      hint: 'For development, use npm run server to start the Express server. For production, deploy genarch as a separate Python service.',
-      documentation: 'See docs/GENARCH_SETUP.md for deployment options.',
+        "The genarch pipeline requires Python and cannot run in Vercel serverless functions.",
+      hint: "For development, use npm run server to start the Express server. For production, deploy genarch as a separate Python service.",
+      documentation: "See docs/GENARCH_SETUP.md for deployment options.",
     });
   }
 
   // Development mode - Proxy to Express server
-  const EXPRESS_URL = process.env.EXPRESS_SERVER_URL || 'http://localhost:3001';
+  const EXPRESS_URL = process.env.EXPRESS_SERVER_URL || "http://localhost:3001";
 
   try {
     // Build the proxy URL
@@ -54,11 +52,11 @@ export default async function handler(req, res) {
     const fetchOptions = {
       method: req.method,
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
     };
 
-    if (req.method === 'POST' && req.body) {
+    if (req.method === "POST" && req.body) {
       fetchOptions.body = JSON.stringify(req.body);
     }
 
@@ -67,12 +65,13 @@ export default async function handler(req, res) {
 
     return res.status(response.status).json(data);
   } catch (error) {
-    console.error('[Genarch Proxy] Error:', error.message);
+    console.error("[Genarch Proxy] Error:", error.message);
 
     return res.status(503).json({
       success: false,
-      error: 'EXPRESS_SERVER_UNAVAILABLE',
-      message: 'Could not connect to Express server. Run npm run server to start it.',
+      error: "EXPRESS_SERVER_UNAVAILABLE",
+      message:
+        "Could not connect to Express server. Run npm run server to start it.",
       details: error.message,
     });
   }

--- a/api/genarch/jobs/[jobId].js
+++ b/api/genarch/jobs/[jobId].js
@@ -8,6 +8,8 @@
  * This proxies requests to the RunPod backend, adding the API key server-side.
  */
 
+import { setCorsHeaders, handlePreflight } from "../../_shared/cors.js";
+
 // Environment variables
 const RUNPOD_GENARCH_URL = process.env.RUNPOD_GENARCH_URL;
 const GENARCH_API_KEY = process.env.GENARCH_API_KEY;
@@ -75,14 +77,8 @@ async function proxyToRunPod(method, path, res) {
 }
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, DELETE, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (handlePreflight(req, res, { methods: "GET, DELETE, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, DELETE, OPTIONS" });
 
   const { jobId } = req.query;
 

--- a/api/genarch/jobs/index.js
+++ b/api/genarch/jobs/index.js
@@ -9,6 +9,8 @@
  * The GENARCH_API_KEY is never exposed to the browser.
  */
 
+import { setCorsHeaders, handlePreflight } from "../../_shared/cors.js";
+
 // Environment variables
 const RUNPOD_GENARCH_URL = process.env.RUNPOD_GENARCH_URL; // e.g., https://genarch.yourdomain.com
 const GENARCH_API_KEY = process.env.GENARCH_API_KEY;
@@ -88,14 +90,8 @@ async function proxyToRunPod(method, path, body = null, res) {
 }
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (handlePreflight(req, res, { methods: "GET, POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, POST, OPTIONS" });
 
   // Route: POST /api/genarch/jobs - Create job
   if (req.method === "POST") {

--- a/api/genarch/runs/[...params].js
+++ b/api/genarch/runs/[...params].js
@@ -8,6 +8,8 @@
  * Binary files (PDF, DXF, GLB) are streamed through.
  */
 
+import { setCorsHeaders, handlePreflight } from "../../_shared/cors.js";
+
 // Environment variables
 const RUNPOD_GENARCH_URL = process.env.RUNPOD_GENARCH_URL;
 const GENARCH_API_KEY = process.env.GENARCH_API_KEY;
@@ -26,14 +28,8 @@ function buildHeaders() {
 }
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (handlePreflight(req, res, { methods: "GET, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, OPTIONS" });
 
   if (req.method !== "GET") {
     return res.status(405).json({

--- a/api/health.js
+++ b/api/health.js
@@ -4,21 +4,17 @@
  * Returns the health status of the API and configured services.
  */
 
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 import {
   GENARCH_CONTRACT_VERSION,
   GENARCH_VERSION_HEADER,
 } from "../src/services/genarch/genarchContract.js";
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  // CORS
+  if (handlePreflight(req, res, { methods: "GET, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, OPTIONS" });
   res.setHeader(GENARCH_VERSION_HEADER, GENARCH_CONTRACT_VERSION);
-
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
 
   if (req.method !== "GET") {
     return res.status(405).json({ error: "Method not allowed" });

--- a/api/openai-chat.js
+++ b/api/openai-chat.js
@@ -3,46 +3,46 @@
  * Handles OpenAI API requests securely from the frontend
  */
 
-export default async function handler(req, res) {
-  // Enable CORS
-  res.setHeader('Access-Control-Allow-Credentials', true);
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version'
-  );
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
-  // Handle OPTIONS request
-  if (req.method === 'OPTIONS') {
-    res.status(200).end();
+export default async function handler(req, res) {
+  // CORS
+  if (
+    handlePreflight(req, res, {
+      methods: "GET, OPTIONS, PATCH, DELETE, POST, PUT",
+    })
+  )
     return;
-  }
+  setCorsHeaders(req, res, {
+    methods: "GET, OPTIONS, PATCH, DELETE, POST, PUT",
+  });
+  res.setHeader("Access-Control-Allow-Credentials", "true");
 
   // Only allow POST requests
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
   }
 
   try {
     // In Vercel, use OPENAI_API_KEY (without REACT_APP_ prefix)
-    const apiKey = process.env.OPENAI_API_KEY || process.env.REACT_APP_OPENAI_API_KEY;
+    const apiKey =
+      process.env.OPENAI_API_KEY || process.env.REACT_APP_OPENAI_API_KEY;
 
     if (!apiKey) {
-      console.error('OpenAI API key not found in environment variables');
+      console.error("OpenAI API key not found in environment variables");
       return res.status(500).json({
-        error: 'OpenAI API key not configured',
-        details: 'Please set OPENAI_API_KEY in Vercel environment variables'
+        error: "OpenAI API key not configured",
+        details: "Please set OPENAI_API_KEY in Vercel environment variables",
       });
     }
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify(req.body)
+      body: JSON.stringify(req.body),
     });
 
     const data = await response.json();
@@ -53,7 +53,7 @@ export default async function handler(req, res) {
 
     res.status(200).json(data);
   } catch (error) {
-    console.error('OpenAI proxy error:', error);
+    console.error("OpenAI proxy error:", error);
     res.status(500).json({ error: error.message });
   }
 }

--- a/api/openai-images.js
+++ b/api/openai-images.js
@@ -4,14 +4,12 @@
  * (matches server.cjs behavior for dev/prod consistency)
  */
 
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
+
 export default async function handler(req, res) {
-  // Handle OPTIONS for CORS preflight
-  if (req.method === "OPTIONS") {
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-    return res.status(200).end();
-  }
+  // CORS
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   // Only allow POST requests
   if (req.method !== "POST") {
@@ -88,11 +86,6 @@ export default async function handler(req, res) {
 
     if (imageUrl) {
       console.log("✅ [FLUX.1] Image generated successfully (via redirect)");
-
-      // Set CORS headers for browser requests
-      res.setHeader("Access-Control-Allow-Origin", "*");
-      res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-      res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
       // Transform to match DALL-E 3 response format for compatibility
       res.status(200).json({

--- a/api/overlay-site-map.js
+++ b/api/overlay-site-map.js
@@ -1,4 +1,5 @@
-import sharp from 'sharp';
+import sharp from "sharp";
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
 const DEFAULT_INSET = {
   x: 0.025,
@@ -6,19 +7,19 @@ const DEFAULT_INSET = {
   width: 0.34,
   height: 0.16,
   paddingRatio: 0.02,
-  labelHeightRatio: 0.05
+  labelHeightRatio: 0.05,
 };
 
 const svgBuffer = (svg) => Buffer.from(svg);
 
 async function sourceToBuffer(source) {
   if (!source) {
-    throw new Error('Source is required');
+    throw new Error("Source is required");
   }
 
-  if (source.startsWith('data:')) {
-    const base64 = source.split(',')[1];
-    return Buffer.from(base64, 'base64');
+  if (source.startsWith("data:")) {
+    const base64 = source.split(",")[1];
+    return Buffer.from(base64, "base64");
   }
 
   const response = await fetch(source);
@@ -37,21 +38,17 @@ function normalizeInset(inset = {}) {
     width: inset.width ?? DEFAULT_INSET.width,
     height: inset.height ?? DEFAULT_INSET.height,
     paddingRatio: inset.paddingRatio ?? DEFAULT_INSET.paddingRatio,
-    labelHeightRatio: inset.labelHeightRatio ?? DEFAULT_INSET.labelHeightRatio
+    labelHeightRatio: inset.labelHeightRatio ?? DEFAULT_INSET.labelHeightRatio,
   };
 }
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  // Enable CORS
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
-  if (req.method === 'OPTIONS') {
-    return res.status(200).end();
-  }
-
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed. Use POST.' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed. Use POST." });
   }
 
   try {
@@ -59,11 +56,13 @@ export default async function handler(req, res) {
       baseImageUrl,
       siteMapDataUrl,
       inset: insetInput,
-      label = 'SITE PLAN — REAL CONTEXT OVERLAY (Scale 1:1250)'
+      label = "SITE PLAN — REAL CONTEXT OVERLAY (Scale 1:1250)",
     } = req.body || {};
 
     if (!baseImageUrl || !siteMapDataUrl) {
-      return res.status(400).json({ error: 'baseImageUrl and siteMapDataUrl are required' });
+      return res
+        .status(400)
+        .json({ error: "baseImageUrl and siteMapDataUrl are required" });
     }
 
     const baseBuffer = await sourceToBuffer(baseImageUrl);
@@ -74,7 +73,7 @@ export default async function handler(req, res) {
     const inset = normalizeInset(insetInput);
 
     if (!baseMetadata.width || !baseMetadata.height) {
-      throw new Error('Unable to determine base image dimensions');
+      throw new Error("Unable to determine base image dimensions");
     }
 
     const panelWidth = Math.round(baseMetadata.width * inset.width);
@@ -82,23 +81,29 @@ export default async function handler(req, res) {
     const panelX = Math.round(baseMetadata.width * inset.x);
     const panelY = Math.round(baseMetadata.height * inset.y);
     const padding = Math.max(4, Math.round(panelWidth * inset.paddingRatio));
-    const labelHeight = Math.max(20, Math.round(panelHeight * inset.labelHeightRatio));
+    const labelHeight = Math.max(
+      20,
+      Math.round(panelHeight * inset.labelHeightRatio),
+    );
     const mapWidth = Math.max(8, panelWidth - padding * 2);
-    const mapHeight = Math.max(8, panelHeight - padding - labelHeight - padding);
+    const mapHeight = Math.max(
+      8,
+      panelHeight - padding - labelHeight - padding,
+    );
 
     const background = await sharp({
       create: {
         width: panelWidth,
         height: panelHeight,
         channels: 4,
-        background: '#ffffff'
-      }
+        background: "#ffffff",
+      },
     })
       .png()
       .toBuffer();
 
     const resizedSiteMap = await sharp(siteMapBuffer)
-      .resize(mapWidth, mapHeight, { fit: 'cover' })
+      .resize(mapWidth, mapHeight, { fit: "cover" })
       .png()
       .toBuffer();
 
@@ -107,8 +112,8 @@ export default async function handler(req, res) {
         {
           input: resizedSiteMap,
           top: labelHeight,
-          left: padding
-        }
+          left: padding,
+        },
       ])
       .png()
       .toBuffer();
@@ -118,22 +123,20 @@ export default async function handler(req, res) {
         <rect x="0" y="0" width="${panelWidth}" height="${labelHeight}" fill="#f6f6f6"/>
         <text x="${padding}" y="${labelHeight / 2 + 4}" font-family="Arial" font-size="${Math.max(
           18,
-          Math.round(panelWidth * 0.02)
+          Math.round(panelWidth * 0.02),
         )}" font-weight="bold" fill="#333">${label}</text>
-      </svg>`
+      </svg>`,
     );
 
     panelImage = await sharp(panelImage)
-      .composite([
-        { input: labelSvg, top: 0, left: 0 }
-      ])
+      .composite([{ input: labelSvg, top: 0, left: 0 }])
       .png()
       .toBuffer();
 
     const borderSvg = svgBuffer(
       `<svg width="${panelWidth}" height="${panelHeight}" xmlns="http://www.w3.org/2000/svg">
         <rect x="0" y="0" width="${panelWidth - 1}" height="${panelHeight - 1}" fill="none" stroke="#333333" stroke-width="3"/>
-      </svg>`
+      </svg>`,
     );
 
     panelImage = await sharp(panelImage)
@@ -146,31 +149,30 @@ export default async function handler(req, res) {
         {
           input: panelImage,
           top: panelY,
-          left: panelX
-        }
+          left: panelX,
+        },
       ])
       .png()
       .toBuffer();
 
-    const dataUrl = `data:image/png;base64,${finalBuffer.toString('base64')}`;
+    const dataUrl = `data:image/png;base64,${finalBuffer.toString("base64")}`;
 
     return res.status(200).json({
       url: dataUrl,
       metadata: {
         width: baseMetadata.width,
         height: baseMetadata.height,
-        format: 'png',
+        format: "png",
         inset: {
           x: panelX,
           y: panelY,
           width: panelWidth,
-          height: panelHeight
-        }
-      }
+          height: panelHeight,
+        },
+      },
     });
   } catch (error) {
-    console.error('❌ Overlay site map error:', error);
+    console.error("❌ Overlay site map error:", error);
     return res.status(500).json({ error: error.message });
   }
 }
-

--- a/api/overlay.js
+++ b/api/overlay.js
@@ -1,11 +1,12 @@
 /**
  * Overlay Composition API Endpoint
- * 
+ *
  * Server-side overlay composition for site maps and other overlays.
  * Ensures deterministic, pixel-perfect overlay placement.
  */
 
-import { createCanvas, loadImage } from 'canvas';
+import { createCanvas, loadImage } from "canvas";
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
 /**
  * Composite overlay onto base image
@@ -16,82 +17,92 @@ import { createCanvas, loadImage } from 'canvas';
  * @param {number} baseHeight - Base image height
  * @returns {Canvas} Composited canvas
  */
-function compositeOverlay(baseImage, overlayImage, position, baseWidth, baseHeight) {
+function compositeOverlay(
+  baseImage,
+  overlayImage,
+  position,
+  baseWidth,
+  baseHeight,
+) {
   const canvas = createCanvas(baseWidth, baseHeight);
-  const ctx = canvas.getContext('2d');
-  
+  const ctx = canvas.getContext("2d");
+
   // Draw base image
   ctx.drawImage(baseImage, 0, 0, baseWidth, baseHeight);
-  
+
   // Calculate overlay position in pixels
   const overlayX = Math.round(position.x * baseWidth);
   const overlayY = Math.round(position.y * baseHeight);
   const overlayWidth = Math.round(position.width * baseWidth);
   const overlayHeight = Math.round(position.height * baseHeight);
-  
+
   // Draw overlay
   ctx.drawImage(overlayImage, overlayX, overlayY, overlayWidth, overlayHeight);
-  
+
   return canvas;
 }
 
 export default async function handler(req, res) {
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+  // Enable CORS
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
   }
-  
+
   try {
-    const { baseImageUrl, overlays = [], format = 'png' } = req.body;
-    
+    const { baseImageUrl, overlays = [], format = "png" } = req.body;
+
     if (!baseImageUrl) {
-      return res.status(400).json({ error: 'baseImageUrl required' });
+      return res.status(400).json({ error: "baseImageUrl required" });
     }
-    
+
     // Load base image
     const baseImage = await loadImage(baseImageUrl);
     const baseWidth = baseImage.width;
     const baseHeight = baseImage.height;
-    
+
     // Start with base image
     let currentCanvas = createCanvas(baseWidth, baseHeight);
-    let currentCtx = currentCanvas.getContext('2d');
+    let currentCtx = currentCanvas.getContext("2d");
     currentCtx.drawImage(baseImage, 0, 0);
-    
+
     // Apply overlays in order
     for (const overlay of overlays) {
       if (!overlay.dataUrl) {
-        console.warn('Overlay missing dataUrl, skipping:', overlay.id);
+        console.warn("Overlay missing dataUrl, skipping:", overlay.id);
         continue;
       }
-      
+
       const overlayImage = await loadImage(overlay.dataUrl);
-      
+
       currentCanvas = compositeOverlay(
         currentCanvas,
         overlayImage,
         overlay.position || { x: 0, y: 0, width: 1, height: 1 },
         baseWidth,
-        baseHeight
+        baseHeight,
       );
     }
-    
+
     // Convert to buffer
-    const buffer = currentCanvas.toBuffer(format === 'png' ? 'image/png' : 'image/jpeg');
-    
+    const buffer = currentCanvas.toBuffer(
+      format === "png" ? "image/png" : "image/jpeg",
+    );
+
     // Return as data URL
-    const dataUrl = `data:image/${format};base64,${buffer.toString('base64')}`;
-    
+    const dataUrl = `data:image/${format};base64,${buffer.toString("base64")}`;
+
     return res.status(200).json({
       url: dataUrl,
       width: baseWidth,
       height: baseHeight,
       overlaysApplied: overlays.length,
-      format
+      format,
     });
-    
   } catch (error) {
-    console.error('Overlay composition error:', error);
+    console.error("Overlay composition error:", error);
     return res.status(500).json({ error: error.message });
   }
 }
-

--- a/api/plan.js
+++ b/api/plan.js
@@ -8,6 +8,8 @@
  * Does NOT generate images (use /api/render for that)
  */
 
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
+
 export const config = {
   runtime: "nodejs",
   maxDuration: 60,
@@ -15,13 +17,8 @@ export const config = {
 
 export default async function handler(req, res) {
   // Enable CORS
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed" });

--- a/api/proxy-image.js
+++ b/api/proxy-image.js
@@ -9,21 +9,30 @@
  * @route GET /api/proxy-image
  */
 
+import { getCorsHeaders } from "./_shared/cors.js";
+
 export const config = {
-  runtime: 'edge',
-  regions: ['iad1'], // Use a single region for consistency
+  runtime: "edge",
+  regions: ["iad1"], // Use a single region for consistency
 };
 
 export default async function handler(req) {
+  const corsHeaders = getCorsHeaders(req, { methods: "GET, OPTIONS" });
+
+  // Handle OPTIONS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
   const url = new URL(req.url);
-  const imageUrl = url.searchParams.get('url');
+  const imageUrl = url.searchParams.get("url");
 
   if (!imageUrl) {
-    return new Response(JSON.stringify({ error: 'Missing url parameter' }), {
+    return new Response(JSON.stringify({ error: "Missing url parameter" }), {
       status: 400,
       headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
+        ...corsHeaders,
+        "Content-Type": "application/json",
       },
     });
   }
@@ -37,61 +46,69 @@ export default async function handler(req) {
     try {
       parsedUrl = new URL(decodedUrl);
     } catch {
-      return new Response(JSON.stringify({ error: 'Invalid URL' }), {
+      return new Response(JSON.stringify({ error: "Invalid URL" }), {
         status: 400,
         headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
+          ...corsHeaders,
+          "Content-Type": "application/json",
         },
       });
     }
 
     // Only allow HTTPS
-    if (parsedUrl.protocol !== 'https:') {
-      return new Response(JSON.stringify({ error: 'Only HTTPS URLs are allowed' }), {
-        status: 400,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
+    if (parsedUrl.protocol !== "https:") {
+      return new Response(
+        JSON.stringify({ error: "Only HTTPS URLs are allowed" }),
+        {
+          status: 400,
+          headers: {
+            ...corsHeaders,
+            "Content-Type": "application/json",
+          },
         },
-      });
+      );
     }
 
     // Allowlist of trusted domains
     const trustedDomains = [
-      'api.together.ai', // Together.ai main API domain
-      'api.together.xyz', // Together.ai alternative domain
-      'together.xyz',
-      'together.ai', // Together.ai short URLs
-      'replicate.delivery',
-      'replicate.com',
-      'pbxt.replicate.delivery',
-      'oaidalleapiprodscus.blob.core.windows.net',
-      'imgur.com',
-      'i.imgur.com',
-      'cloudflare-ipfs.com',
-      'ipfs.io',
-      'arweave.net',
+      "api.together.ai", // Together.ai main API domain
+      "api.together.xyz", // Together.ai alternative domain
+      "together.xyz",
+      "together.ai", // Together.ai short URLs
+      "replicate.delivery",
+      "replicate.com",
+      "pbxt.replicate.delivery",
+      "oaidalleapiprodscus.blob.core.windows.net",
+      "imgur.com",
+      "i.imgur.com",
+      "cloudflare-ipfs.com",
+      "ipfs.io",
+      "arweave.net",
     ];
 
     const isDomainTrusted = trustedDomains.some(
-      (domain) => parsedUrl.hostname === domain || parsedUrl.hostname.endsWith(`.${domain}`)
+      (domain) =>
+        parsedUrl.hostname === domain ||
+        parsedUrl.hostname.endsWith(`.${domain}`),
     );
 
     if (!isDomainTrusted) {
-      return new Response(JSON.stringify({ error: 'Domain not in allowlist' }), {
-        status: 403,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
+      return new Response(
+        JSON.stringify({ error: "Domain not in allowlist" }),
+        {
+          status: 403,
+          headers: {
+            ...corsHeaders,
+            "Content-Type": "application/json",
+          },
         },
-      });
+      );
     }
 
     // Fetch the image
     const response = await fetch(decodedUrl, {
       headers: {
-        'User-Agent': 'ArchitectAI-Proxy/1.0',
+        "User-Agent": "ArchitectAI-Proxy/1.0",
       },
     });
 
@@ -104,40 +121,40 @@ export default async function handler(req) {
         {
           status: response.status,
           headers: {
-            'Content-Type': 'application/json',
-            'Access-Control-Allow-Origin': '*',
+            ...corsHeaders,
+            "Content-Type": "application/json",
           },
-        }
+        },
       );
     }
 
     // Get content type
-    const contentType = response.headers.get('content-type') || 'image/png';
+    const contentType = response.headers.get("content-type") || "image/png";
 
     // Stream the response
     return new Response(response.body, {
       status: 200,
       headers: {
-        'Content-Type': contentType,
-        'Access-Control-Allow-Origin': '*',
-        'Cache-Control': 'public, max-age=86400', // Cache for 24 hours
-        'X-Proxy-Source': 'architect-ai',
+        ...corsHeaders,
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=86400", // Cache for 24 hours
+        "X-Proxy-Source": "architect-ai",
       },
     });
   } catch (error) {
-    console.error('[Proxy Image] Error:', error);
+    console.error("[Proxy Image] Error:", error);
     return new Response(
       JSON.stringify({
-        error: 'Proxy failed',
+        error: "Proxy failed",
         message: error.message,
       }),
       {
         status: 500,
         headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
+          ...corsHeaders,
+          "Content-Type": "application/json",
         },
-      }
+      },
     );
   }
 }

--- a/api/render.js
+++ b/api/render.js
@@ -1,29 +1,26 @@
 /**
  * Render API Endpoint - Vercel Serverless Function
- * 
+ *
  * REFACTORED: Renders 3D views from geometry
  * POST /api/render
- * 
+ *
  * Accepts design with geometry and returns rendered views
  */
 
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
+
 export const config = {
-  runtime: 'nodejs',
-  maxDuration: 60
+  runtime: "nodejs",
+  maxDuration: 60,
 };
 
 export default async function handler(req, res) {
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
-  if (req.method === 'OPTIONS') {
-    return res.status(200).end();
-  }
-
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
   }
 
   try {
@@ -31,26 +28,30 @@ export default async function handler(req, res) {
 
     if (!design || !design.dna) {
       return res.status(400).json({
-        error: 'Invalid request',
-        message: 'Design with DNA required'
+        error: "Invalid request",
+        message: "Design with DNA required",
       });
     }
 
-    console.log('[Render API] Rendering views for design:', design.id);
+    console.log("[Render API] Rendering views for design:", design.id);
 
     // Note: Server-side Three.js rendering requires canvas package
     // For now, return placeholder response indicating client-side rendering needed
-    
-    const viewTypes = options.viewTypes || ['axonometric', 'perspective', 'interior'];
+
+    const viewTypes = options.viewTypes || [
+      "axonometric",
+      "perspective",
+      "interior",
+    ];
     const views = {};
 
-    viewTypes.forEach(viewType => {
+    viewTypes.forEach((viewType) => {
       views[viewType] = {
         url: null,
         svg: null,
-        note: 'Server-side rendering requires @napi-rs/canvas. Use client-side rendering.',
+        note: "Server-side rendering requires @napi-rs/canvas. Use client-side rendering.",
         width: options.width || 1024,
-        height: options.height || 1024
+        height: options.height || 1024,
       };
     });
 
@@ -59,16 +60,15 @@ export default async function handler(req, res) {
       views,
       metadata: {
         renderTime: 0,
-        note: 'Placeholder response. Implement server-side Three.js rendering with canvas package.',
-        clientSideRenderingRecommended: true
-      }
+        note: "Placeholder response. Implement server-side Three.js rendering with canvas package.",
+        clientSideRenderingRecommended: true,
+      },
     });
-
   } catch (error) {
-    console.error('[Render API] Error:', error);
+    console.error("[Render API] Error:", error);
     return res.status(500).json({
-      error: 'Rendering failed',
-      message: error.message
+      error: "Rendering failed",
+      message: error.message,
     });
   }
 }

--- a/api/replicate-generate.js
+++ b/api/replicate-generate.js
@@ -1,31 +1,24 @@
 /**
  * Replicate SDXL Generation API
- * 
+ *
  * Proxies requests to Replicate API for SDXL image generation.
  * Used as fallback when Together.ai FLUX fails.
  */
 
-const fetch = require('node-fetch');
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
-module.exports = async (req, res) => {
-  // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
-  if (req.method === 'OPTIONS') {
-    res.status(200).end();
-    return;
-  }
-
-  if (req.method !== 'POST') {
-    res.status(405).json({ error: 'Method not allowed' });
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
     return;
   }
 
   try {
     const {
-      model = 'stability-ai/sdxl:latest',
+      model = "stability-ai/sdxl:latest",
       prompt,
       negative_prompt,
       width = 1024,
@@ -34,13 +27,14 @@ module.exports = async (req, res) => {
       num_inference_steps = 30,
       guidance_scale = 7.5,
       image = null,
-      controlnet_conditioning_scale = 0.7
+      controlnet_conditioning_scale = 0.7,
     } = req.body;
 
-    const replicateKey = process.env.REPLICATE_API_TOKEN || process.env.REPLICATE_API_KEY;
+    const replicateKey =
+      process.env.REPLICATE_API_TOKEN || process.env.REPLICATE_API_KEY;
 
     if (!replicateKey) {
-      res.status(500).json({ error: 'REPLICATE_API_KEY not configured' });
+      res.status(500).json({ error: "REPLICATE_API_KEY not configured" });
       return;
     }
 
@@ -54,7 +48,7 @@ module.exports = async (req, res) => {
       height,
       seed,
       num_inference_steps,
-      guidance_scale
+      guidance_scale,
     };
 
     // Add control image if provided
@@ -63,23 +57,28 @@ module.exports = async (req, res) => {
       input.controlnet_conditioning_scale = controlnet_conditioning_scale;
     }
 
-    const createResponse = await fetch('https://api.replicate.com/v1/predictions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Token ${replicateKey}`,
-        'Content-Type': 'application/json'
+    const createResponse = await fetch(
+      "https://api.replicate.com/v1/predictions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Token ${replicateKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          version: model.includes("controlnet")
+            ? "controlnet-1.1-x-realistic-vision-v2.0"
+            : "stability-ai/sdxl:39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b",
+          input,
+        }),
       },
-      body: JSON.stringify({
-        version: model.includes('controlnet') 
-          ? 'controlnet-1.1-x-realistic-vision-v2.0'
-          : 'stability-ai/sdxl:39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b',
-        input
-      })
-    });
+    );
 
     if (!createResponse.ok) {
       const errorText = await createResponse.text();
-      throw new Error(`Replicate create failed: ${createResponse.status} - ${errorText}`);
+      throw new Error(
+        `Replicate create failed: ${createResponse.status} - ${errorText}`,
+      );
     }
 
     const prediction = await createResponse.json();
@@ -88,53 +87,58 @@ module.exports = async (req, res) => {
     // Poll for completion
     let result = prediction;
     const maxAttempts = 60; // 60 attempts × 2s = 2 minutes max
-    
+
     for (let i = 0; i < maxAttempts; i++) {
-      if (result.status === 'succeeded') {
+      if (result.status === "succeeded") {
         console.log(`[Replicate] Generation complete`);
-        
+
         res.status(200).json({
           url: result.output?.[0] || result.output,
           seed,
           metadata: {
-            model: 'sdxl',
+            model: "sdxl",
             width,
             height,
-            prediction_id: result.id
-          }
+            prediction_id: result.id,
+          },
         });
         return;
       }
 
-      if (result.status === 'failed' || result.status === 'canceled') {
-        throw new Error(`Replicate generation failed: ${result.error || result.status}`);
+      if (result.status === "failed" || result.status === "canceled") {
+        throw new Error(
+          `Replicate generation failed: ${result.error || result.status}`,
+        );
       }
 
       // Wait 2 seconds before polling again
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      await new Promise((resolve) => setTimeout(resolve, 2000));
 
       // Poll status
-      const statusResponse = await fetch(`https://api.replicate.com/v1/predictions/${prediction.id}`, {
-        headers: {
-          'Authorization': `Token ${replicateKey}`
-        }
-      });
+      const statusResponse = await fetch(
+        `https://api.replicate.com/v1/predictions/${prediction.id}`,
+        {
+          headers: {
+            Authorization: `Token ${replicateKey}`,
+          },
+        },
+      );
 
       if (!statusResponse.ok) {
-        throw new Error(`Replicate status check failed: ${statusResponse.status}`);
+        throw new Error(
+          `Replicate status check failed: ${statusResponse.status}`,
+        );
       }
 
       result = await statusResponse.json();
     }
 
-    throw new Error('Replicate generation timed out after 2 minutes');
-
+    throw new Error("Replicate generation timed out after 2 minutes");
   } catch (error) {
-    console.error('[Replicate] Error:', error.message);
+    console.error("[Replicate] Error:", error.message);
     res.status(500).json({
       error: error.message,
-      details: 'SDXL generation via Replicate failed'
+      details: "SDXL generation via Replicate failed",
     });
   }
-};
-
+}

--- a/api/sheet.js
+++ b/api/sheet.js
@@ -11,6 +11,7 @@
  */
 
 import crypto from "crypto";
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
 export const config = {
   runtime: "nodejs",
@@ -27,13 +28,8 @@ const TITLE_BLOCK_HEIGHT = 60;
 
 export default async function handler(req, res) {
   // Enable CORS
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   if (req.method !== "POST") {
     return res.status(405).json({

--- a/api/together-chat.js
+++ b/api/together-chat.js
@@ -5,14 +5,12 @@
  * Uses Qwen 2.5 72B for architectural reasoning (DNA generation).
  */
 
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
+
 export default async function handler(req, res) {
-  // Handle OPTIONS for CORS preflight
-  if (req.method === "OPTIONS") {
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-    return res.status(200).end();
-  }
+  // CORS
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
   // Only allow POST requests
   if (req.method !== "POST") {
@@ -129,11 +127,6 @@ export default async function handler(req, res) {
 
     const latencyMs = Date.now() - startTime;
     console.log(`✅ [Together AI] Chat completion successful (${latencyMs}ms)`);
-
-    // Set CORS headers for browser requests
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
     // Return raw Together AI response - matches dev proxy (server.cjs) format
     // All client code expects response.choices[0].message.content

--- a/api/together-image.js
+++ b/api/together-image.js
@@ -1,10 +1,12 @@
 /**
  * Vercel Serverless Function for Together AI Image Generation (REFACTORED)
- * 
+ *
  * REFACTORED: Enforces deterministic seed handling, rate limiting, and normalized responses.
  * Uses FLUX.1-schnell (serverless) for A1 sheet generation with explicit seed propagation.
  * Override via TOGETHER_FLUX_MODEL env var (e.g. 'black-forest-labs/FLUX.1.1-pro').
  */
+
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 
 // Simple in-memory rate limiter for serverless
 let lastRequestTime = 0;
@@ -13,36 +15,39 @@ const MIN_INTERVAL_MS = 6000; // 6 seconds between requests
 async function enforceRateLimit() {
   const now = Date.now();
   const timeSinceLastRequest = now - lastRequestTime;
-  
+
   if (timeSinceLastRequest < MIN_INTERVAL_MS) {
     const waitTime = MIN_INTERVAL_MS - timeSinceLastRequest;
     console.log(`⏱️ Rate limiting: waiting ${waitTime}ms`);
-    await new Promise(resolve => setTimeout(resolve, waitTime));
+    await new Promise((resolve) => setTimeout(resolve, waitTime));
   }
-  
+
   lastRequestTime = Date.now();
 }
 
 export default async function handler(req, res) {
-  // Handle OPTIONS for CORS preflight
-  if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    res.setHeader('Access-Control-Expose-Headers', 'retry-after, x-ratelimit-remaining, x-ratelimit-reset');
-    return res.status(200).end();
-  }
+  // CORS
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
+  res.setHeader(
+    "Access-Control-Expose-Headers",
+    "retry-after, x-ratelimit-remaining, x-ratelimit-reset",
+  );
 
   // Only allow POST requests
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed. Use POST.' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed. Use POST." });
   }
 
   const togetherApiKey = process.env.TOGETHER_API_KEY;
 
   if (!togetherApiKey) {
-    console.error('TOGETHER_API_KEY not configured in Vercel environment variables');
-    return res.status(500).json({ error: 'Together AI API key not configured' });
+    console.error(
+      "TOGETHER_API_KEY not configured in Vercel environment variables",
+    );
+    return res
+      .status(500)
+      .json({ error: "Together AI API key not configured" });
   }
 
   try {
@@ -51,44 +56,52 @@ export default async function handler(req, res) {
 
     const body = req.body || {};
 
-    const model = body.model || process.env.TOGETHER_FLUX_MODEL || 'black-forest-labs/FLUX.1-schnell';
+    const model =
+      body.model ||
+      process.env.TOGETHER_FLUX_MODEL ||
+      "black-forest-labs/FLUX.1-schnell";
     const prompt = body.prompt;
-    const negativePrompt = body.negativePrompt ?? body.negative_prompt ?? '';
+    const negativePrompt = body.negativePrompt ?? body.negative_prompt ?? "";
     const width = body.width ?? 1792;
     const height = body.height ?? 1269;
     const seed = body.seed;
-    const numInferenceSteps = body.steps ?? body.numInferenceSteps ?? body.num_inference_steps ?? 48;
+    const numInferenceSteps =
+      body.steps ?? body.numInferenceSteps ?? body.num_inference_steps ?? 48;
     const guidanceScale = body.guidanceScale ?? body.guidance_scale ?? 7.8;
     const initImage = body.initImage ?? body.init_image ?? null;
     const imageStrength =
       body.imageStrength ?? body.image_strength ?? body.strength ?? 0.18;
 
     if (!prompt) {
-      return res.status(400).json({ 
+      return res.status(400).json({
         error: {
-          code: 'INVALID_INPUT',
-          message: 'Prompt is required',
-          details: null
-        }
+          code: "INVALID_INPUT",
+          message: "Prompt is required",
+          details: null,
+        },
       });
     }
 
     // Ensure seed is provided (deterministic requirement)
     const effectiveSeed = seed || Date.now();
     if (!seed) {
-      console.warn('⚠️ No seed provided, using timestamp. For deterministic behavior, always provide a seed.');
+      console.warn(
+        "⚠️ No seed provided, using timestamp. For deterministic behavior, always provide a seed.",
+      );
     }
 
     // Validate and cap parameters for FLUX.1
     const validatedWidth = Math.min(Math.max(width, 64), 1792);
     const validatedHeight = Math.min(Math.max(height, 64), 1792);
-    const isSchnell = model.includes('schnell');
-    const isPro = model.includes('pro');
+    const isSchnell = model.includes("schnell");
+    const isPro = model.includes("pro");
     const maxSteps = isSchnell ? 12 : isPro ? 50 : 50;
     const validatedSteps = Math.min(Math.max(numInferenceSteps, 1), maxSteps);
 
-    const generationMode = initImage ? 'image-to-image' : 'text-to-image';
-    console.log(`🎨 [FLUX.1] Generating image (${generationMode}) with model ${model}, seed ${effectiveSeed}...`);
+    const generationMode = initImage ? "image-to-image" : "text-to-image";
+    console.log(
+      `🎨 [FLUX.1] Generating image (${generationMode}) with model ${model}, seed ${effectiveSeed}...`,
+    );
 
     const startTime = Date.now();
     const traceId = `trace_${startTime}_${Math.random().toString(36).substring(2, 9)}`;
@@ -100,7 +113,7 @@ export default async function handler(req, res) {
       height: validatedHeight,
       seed: effectiveSeed,
       steps: validatedSteps,
-      n: 1
+      n: 1,
     };
 
     // Add negative prompt if provided
@@ -119,15 +132,20 @@ export default async function handler(req, res) {
       // Together.ai expects PNG/JPEG, not SVG. If we detect SVG, rasterize it with sharp.
       let normalizedInitImage = initImage;
 
-      if (typeof initImage === 'string' && initImage.startsWith('data:image/svg+xml')) {
+      if (
+        typeof initImage === "string" &&
+        initImage.startsWith("data:image/svg+xml")
+      ) {
         try {
-          const sharp = (await import('sharp')).default;
-          console.log('🎯 [Geometry Mode] Detected SVG init_image - rasterizing to PNG...');
+          const sharp = (await import("sharp")).default;
+          console.log(
+            "🎯 [Geometry Mode] Detected SVG init_image - rasterizing to PNG...",
+          );
 
           // Extract base64 SVG data
-          const svgBase64 = initImage.split(',')[1];
+          const svgBase64 = initImage.split(",")[1];
           if (svgBase64) {
-            const svgBuffer = Buffer.from(svgBase64, 'base64');
+            const svgBuffer = Buffer.from(svgBase64, "base64");
 
             // Determine target dimensions from request or use defaults
             const targetWidth = validatedWidth || 1500;
@@ -136,34 +154,45 @@ export default async function handler(req, res) {
             // Rasterize SVG to PNG at target dimensions
             const pngBuffer = await sharp(svgBuffer)
               .resize(targetWidth, targetHeight, {
-                fit: 'contain',
+                fit: "contain",
                 background: { r: 0, g: 0, b: 0, alpha: 1 }, // Black background
               })
               .png()
               .toBuffer();
 
-            normalizedInitImage = pngBuffer.toString('base64');
+            normalizedInitImage = pngBuffer.toString("base64");
             console.log(
-              `✅ [Geometry Mode] SVG rasterized to PNG: ${targetWidth}x${targetHeight}, ${(pngBuffer.length / 1024).toFixed(1)}KB`
+              `✅ [Geometry Mode] SVG rasterized to PNG: ${targetWidth}x${targetHeight}, ${(pngBuffer.length / 1024).toFixed(1)}KB`,
             );
           }
         } catch (svgError) {
-          console.warn('⚠️ [Geometry Mode] SVG rasterization failed:', svgError.message);
-          console.warn('⚠️ Falling back to original SVG (may fail with Together API)');
+          console.warn(
+            "⚠️ [Geometry Mode] SVG rasterization failed:",
+            svgError.message,
+          );
+          console.warn(
+            "⚠️ Falling back to original SVG (may fail with Together API)",
+          );
           // Fall through to standard normalization
         }
       }
 
       // Standard normalization: Strip data URL prefix if present (Together.ai prefers raw base64)
-      if (typeof normalizedInitImage === 'string' && normalizedInitImage.startsWith('data:')) {
+      if (
+        typeof normalizedInitImage === "string" &&
+        normalizedInitImage.startsWith("data:")
+      ) {
         try {
-          const base64Data = normalizedInitImage.split(',')[1];
+          const base64Data = normalizedInitImage.split(",")[1];
           if (base64Data) {
             normalizedInitImage = base64Data;
-            console.log('🔧 Normalized init_image: stripped data URL prefix');
+            console.log("🔧 Normalized init_image: stripped data URL prefix");
           }
         } catch (e) {
-          console.warn('⚠️ Failed to normalize init_image, using as-is:', e.message);
+          console.warn(
+            "⚠️ Failed to normalize init_image, using as-is:",
+            e.message,
+          );
         }
       }
 
@@ -172,42 +201,40 @@ export default async function handler(req, res) {
       console.log(`🔄 Image-to-image mode: strength ${imageStrength}`);
     }
 
-    const response = await fetch('https://api.together.xyz/v1/images/generations', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${togetherApiKey}`,
-        'Content-Type': 'application/json'
+    const response = await fetch(
+      "https://api.together.xyz/v1/images/generations",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${togetherApiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
       },
-      body: JSON.stringify(requestBody)
-    });
+    );
 
     // Extract rate limit headers
-    const retryAfter = response.headers.get('retry-after');
-    const rateLimitRemaining = response.headers.get('x-ratelimit-remaining');
-    const rateLimitReset = response.headers.get('x-ratelimit-reset');
+    const retryAfter = response.headers.get("retry-after");
+    const rateLimitRemaining = response.headers.get("x-ratelimit-remaining");
+    const rateLimitReset = response.headers.get("x-ratelimit-reset");
 
     // Expose rate limit headers to client
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    res.setHeader('Access-Control-Expose-Headers', 'retry-after, x-ratelimit-remaining, x-ratelimit-reset');
-    
     if (retryAfter) {
-      res.setHeader('retry-after', retryAfter);
+      res.setHeader("retry-after", retryAfter);
     }
     if (rateLimitRemaining) {
-      res.setHeader('x-ratelimit-remaining', rateLimitRemaining);
+      res.setHeader("x-ratelimit-remaining", rateLimitRemaining);
     }
     if (rateLimitReset) {
-      res.setHeader('x-ratelimit-reset', rateLimitReset);
+      res.setHeader("x-ratelimit-reset", rateLimitReset);
     }
 
     // Handle non-JSON responses (e.g., text error messages)
-    const contentType = response.headers.get('content-type') || '';
+    const contentType = response.headers.get("content-type") || "";
     let data;
-    
+
     try {
-      if (contentType.includes('application/json')) {
+      if (contentType.includes("application/json")) {
         data = await response.json();
       } else {
         // Handle text responses (normalize to JSON structure)
@@ -216,16 +243,18 @@ export default async function handler(req, res) {
       }
     } catch (parseError) {
       // If parsing fails, create structured error
-      const text = await response.text().catch(() => 'Unknown error');
+      const text = await response.text().catch(() => "Unknown error");
       data = { error: text, rawText: text, parseError: parseError.message };
     }
 
     if (!response.ok) {
       // Only log full error details for non-transient errors
       if (response.status === 500 || response.status === 503) {
-        console.warn(`⚠️  [FLUX.1] Together AI server error (${response.status}) - this is temporary`);
+        console.warn(
+          `⚠️  [FLUX.1] Together AI server error (${response.status}) - this is temporary`,
+        );
       } else {
-        console.error('❌ FLUX.1 generation error:', data);
+        console.error("❌ FLUX.1 generation error:", data);
       }
       return res.status(response.status).json(data);
     }
@@ -234,8 +263,10 @@ export default async function handler(req, res) {
 
     if (imageUrl) {
       const latencyMs = Date.now() - startTime;
-      console.log(`✅ FLUX.1 image generated successfully (${generationMode}, ${latencyMs}ms)`);
-      
+      console.log(
+        `✅ FLUX.1 image generated successfully (${generationMode}, ${latencyMs}ms)`,
+      );
+
       // Normalized response structure
       const normalizedResponse = {
         url: imageUrl,
@@ -250,33 +281,31 @@ export default async function handler(req, res) {
           guidanceScale,
           generationMode,
           hasInitImage: !!initImage,
-          imageStrength: initImage ? imageStrength : null
+          imageStrength: initImage ? imageStrength : null,
         },
         // Include raw data for backward compatibility
-        raw: data
+        raw: data,
       };
-      
+
       res.status(200).json(normalizedResponse);
     } else {
-      console.error('❌ No image URL in FLUX.1 response');
-      res.status(500).json({ 
+      console.error("❌ No image URL in FLUX.1 response");
+      res.status(500).json({
         error: {
-          code: 'NO_IMAGE_GENERATED',
-          message: 'No image URL in response',
-          details: data
-        }
+          code: "NO_IMAGE_GENERATED",
+          message: "No image URL in response",
+          details: data,
+        },
       });
     }
-
   } catch (error) {
-    console.error('FLUX.1 generation error:', error);
-    res.status(500).json({ 
+    console.error("FLUX.1 generation error:", error);
+    res.status(500).json({
       error: {
-        code: 'INTERNAL_ERROR',
+        code: "INTERNAL_ERROR",
         message: error.message,
-        details: null
-      }
+        details: null,
+      },
     });
   }
 }
-

--- a/api/upscale.js
+++ b/api/upscale.js
@@ -8,23 +8,20 @@
  * Body: { imageUrl: string, targetWidth: number, targetHeight: number }
  */
 
+import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
+
 export const config = {
-  runtime: 'nodejs',
-  maxDuration: 30 // 30 seconds for upscaling
+  runtime: "nodejs",
+  maxDuration: 30, // 30 seconds for upscaling
 };
 
 export default async function handler(req, res) {
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
 
-  if (req.method === 'OPTIONS') {
-    return res.status(200).end();
-  }
-
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed. Use POST.' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed. Use POST." });
   }
 
   try {
@@ -32,18 +29,24 @@ export default async function handler(req, res) {
     let { imageUrl, targetWidth = 9933, targetHeight = 7016 } = req.body;
 
     if (!imageUrl) {
-      return res.status(400).json({ error: 'imageUrl is required' });
+      return res.status(400).json({ error: "imageUrl is required" });
     }
 
     // Validate landscape orientation
     if (targetWidth <= targetHeight) {
-      console.warn(`⚠️  Warning: Target dimensions ${targetWidth}×${targetHeight} appear to be portrait. Forcing landscape...`);
+      console.warn(
+        `⚠️  Warning: Target dimensions ${targetWidth}×${targetHeight} appear to be portrait. Forcing landscape...`,
+      );
       // Swap if portrait dimensions were provided
       [targetWidth, targetHeight] = [targetHeight, targetWidth];
     }
 
-    console.log(`🔄 Upscaling image to ${targetWidth}×${targetHeight}px (300 DPI A1 landscape)...`);
-    console.log(`   📐 Target aspect ratio: ${(targetWidth/targetHeight).toFixed(3)} (A1 landscape: 1.414)`);
+    console.log(
+      `🔄 Upscaling image to ${targetWidth}×${targetHeight}px (300 DPI A1 landscape)...`,
+    );
+    console.log(
+      `   📐 Target aspect ratio: ${(targetWidth / targetHeight).toFixed(3)} (A1 landscape: 1.414)`,
+    );
 
     // Fetch the image
     const imageResponse = await fetch(imageUrl);
@@ -57,13 +60,14 @@ export default async function handler(req, res) {
     // Try to use sharp if available, otherwise return error
     let sharp;
     try {
-      sharp = require('sharp');
+      sharp = require("sharp");
     } catch (e) {
-      console.error('Sharp not available - upscaling requires sharp package');
+      console.error("Sharp not available - upscaling requires sharp package");
       return res.status(501).json({
-        error: 'Upscaling not available',
-        message: 'Sharp package required for upscaling. Install: npm install sharp',
-        fallback: 'Use client-side canvas upscaling or external service'
+        error: "Upscaling not available",
+        message:
+          "Sharp package required for upscaling. Install: npm install sharp",
+        fallback: "Use client-side canvas upscaling or external service",
       });
     }
 
@@ -71,16 +75,18 @@ export default async function handler(req, res) {
     const upscaledBuffer = await sharp(buffer)
       .resize(targetWidth, targetHeight, {
         kernel: sharp.kernel.lanczos3,
-        fit: 'fill',
-        withoutEnlargement: false
+        fit: "fill",
+        withoutEnlargement: false,
       })
       .png({ quality: 100, compressionLevel: 6 })
       .toBuffer();
 
-    console.log(`✅ Image upscaled successfully (${upscaledBuffer.length} bytes)`);
+    console.log(
+      `✅ Image upscaled successfully (${upscaledBuffer.length} bytes)`,
+    );
 
     // Convert to base64 data URL
-    const base64 = upscaledBuffer.toString('base64');
+    const base64 = upscaledBuffer.toString("base64");
     const dataUrl = `data:image/png;base64,${base64}`;
 
     res.status(200).json({
@@ -89,20 +95,18 @@ export default async function handler(req, res) {
       width: targetWidth,
       height: targetHeight,
       dpi: 300,
-      format: 'A1 landscape (841×594mm @ 300 DPI)',
-      orientation: 'landscape',
+      format: "A1 landscape (841×594mm @ 300 DPI)",
+      orientation: "landscape",
       aspectRatio: (targetWidth / targetHeight).toFixed(3),
-      isoStandard: '841×594mm',
+      isoStandard: "841×594mm",
       sizeBytes: upscaledBuffer.length,
-      sizeMB: (upscaledBuffer.length / 1024 / 1024).toFixed(2)
+      sizeMB: (upscaledBuffer.length / 1024 / 1024).toFixed(2),
     });
-
   } catch (error) {
-    console.error('Upscale error:', error);
+    console.error("Upscale error:", error);
     res.status(500).json({
-      error: 'Upscaling failed',
-      message: error.message
+      error: "Upscaling failed",
+      message: error.message,
     });
   }
 }
-


### PR DESCRIPTION
## Summary
- Created shared CORS utility (`api/_shared/cors.js`) that validates request `Origin` against an allowlist of production domains, localhost dev servers, and Vercel preview deployments
- Replaced hardcoded `Access-Control-Allow-Origin: *` in all 22 Vercel serverless API functions with the shared utility
- Converted 2 legacy CJS endpoints (`controlnet-render.js`, `replicate-generate.js`) to ESM for module compatibility
- Edge runtime function (`proxy-image.js`) uses `getCorsHeaders()` variant for Web API Response objects

## Details
**Before:** Every API endpoint blindly set `Access-Control-Allow-Origin: *`, allowing any website to make cross-origin requests to our APIs.

**After:** Origins are validated against:
- `https://www.archiaisolution.pro` and `https://archiaisolution.pro`
- `http://localhost:3000` and `http://localhost:3001` (dev)
- Vercel preview deployments matching `architect-ai-platform*.vercel.app`
- Additional origins configurable via `ALLOWED_ORIGINS` env var

**Files changed:** 22 API endpoints + 1 new shared utility

## Test plan
- [ ] Verify production site can still make API calls (origin matches allowlist)
- [ ] Verify `localhost:3000` dev server works with `npm run dev`
- [ ] Verify Vercel preview deployments work (origin matches regex)
- [ ] Verify requests from unauthorized origins get the production domain (not `*`)
- [ ] Run `curl -H "Origin: https://evil.com" /api/health` and confirm response does NOT echo back `evil.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)