### PR TITLE
[codex] Add ProjectGraph OpenAI reasoning execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,14 @@ MODEL_SOURCE=hybrid
 MODEL_FALLBACK_POLICY=use_base_when_ft_missing
 
 # -----------------------------------------------------------------------------
-# OpenAI core API
+# OpenAI core API (server-side only)
+# All OPENAI_*_API_KEY values below are read by Node/Vercel server code.
+# Server resolution order:
+#   reasoning : OPENAI_REASONING_API_KEY -> OPENAI_API_KEY
+#   image gen : OPENAI_IMAGES_API_KEY    -> OPENAI_API_KEY -> OPENAI_REASONING_API_KEY
+# Never publish these in client builds. REACT_APP_OPENAI_API_KEY is for local
+# dev only and is ignored by the server unless OPENAI_ALLOW_REACT_APP_SERVER_KEY
+# is explicitly true outside production.
 # -----------------------------------------------------------------------------
 OPENAI_API_KEY=REPLACE_ME_OPENAI_API_KEY
 OPENAI_ORG_ID=
@@ -47,6 +54,10 @@ OPENAI_RETRY_MAX=4
 OPENAI_BATCH_ENABLED=true
 OPENAI_STRUCTURED_OUTPUTS=true
 
+# ProjectGraph OpenAI reasoning checkpoints
+# Default is required outside tests. Use disabled only for explicit local deterministic smoke runs.
+PROJECT_GRAPH_OPENAI_REASONING_MODE=required
+
 # ProjectGraph visual image generation
 # PROJECT_GRAPH_IMAGE_GEN_ENABLED=true is required for photoreal exterior,
 # interior, hero, and axonometric panels. When false, A1 uses deterministic
@@ -54,7 +65,11 @@ OPENAI_STRUCTURED_OUTPUTS=true
 PROJECT_GRAPH_IMAGE_GEN_ENABLED=false
 # If true, visual panels fail instead of silently falling back when OpenAI image generation fails.
 OPENAI_STRICT_IMAGE_GEN=false
-# Optional: material swatches later, separate from visual panels. Do not enable automatically.
+# Optional: enable AI texture thumbnails over the procedural material cards.
+# false = deterministic procedural SVG texture cards only (default, free, no OpenAI usage).
+# true  = request small texture thumbnails from a configured image provider per A1 sheet
+#         (max 8, keyed by materialSignature); on any failure falls back to the procedural pattern.
+# Independent of PROJECT_GRAPH_IMAGE_GEN_ENABLED. Do not enable automatically.
 MATERIAL_TEXTURE_THUMBNAILS_ENABLED=false
 # Local-dev compatibility only. Server-side OpenAI calls ignore REACT_APP_OPENAI_API_KEY unless this is true outside production.
 OPENAI_ALLOW_REACT_APP_SERVER_KEY=false

--- a/scripts/check-env.cjs
+++ b/scripts/check-env.cjs
@@ -94,6 +94,11 @@ const OPTIONAL_DATA = [
 
 const OPTIONAL_PRESENTATION = [
   {
+    name: "PROJECT_GRAPH_OPENAI_REASONING_MODE",
+    description:
+      "OpenAI semantic checkpoint execution mode; defaults to required outside tests",
+  },
+  {
     name: "PROJECT_GRAPH_IMAGE_GEN_ENABLED",
     description:
       "Set true to call OpenAI image generation for ProjectGraph visual panels",
@@ -174,7 +179,7 @@ function main() {
 
   const core = checkGroup("Core model-first pipeline", REQUIRED);
   const client = checkGroup("Client/site services", CLIENT_REQUIRED);
-  checkGroup("Optional ProjectGraph presentation image generation", OPTIONAL_PRESENTATION, {
+  checkGroup("Optional ProjectGraph OpenAI execution controls", OPTIONAL_PRESENTATION, {
     required: false,
   });
   checkOptionalList("Optional UK data providers", OPTIONAL_DATA);

--- a/server.cjs
+++ b/server.cjs
@@ -373,6 +373,7 @@ mountDynamicApiRoute('post', '/api/generations/complete',   'api/generations/com
 mountDynamicApiRoute('post', '/api/program/compile',        'api/program/compile.js');
 mountDynamicApiRoute('post', '/api/project/compile',        'api/project/compile.js');
 mountDynamicApiRoute('post', '/api/project/generate-sheet', 'api/project/generate-sheet.js');
+mountDynamicApiRoute('post', '/api/project/generate-vertical-slice', 'api/project/generate-vertical-slice.js');
 mountDynamicApiRoute('post', '/api/project/export/json',    'api/project/export/json.js');
 mountDynamicApiRoute('post', '/api/project/export/dxf',     'api/project/export/dxf.js');
 mountDynamicApiRoute('post', '/api/project/export/ifc',     'api/project/export/ifc.js');

--- a/src/__tests__/services/openaiReasoningExecutor.test.js
+++ b/src/__tests__/services/openaiReasoningExecutor.test.js
@@ -1,0 +1,146 @@
+import {
+  executeProjectGraphReasoningSteps,
+  getBlockedOpenAIReasoningCalls,
+} from "../../services/openaiReasoningExecutor.js";
+
+const route = {
+  stepId: "PROJECT_GRAPH",
+  provider: "openai",
+  model: "gpt-test",
+  apiKeyEnv: "OPENAI_API_KEY",
+};
+
+function okFetch({ requestId = "req_123", usage = { total_tokens: 3 } } = {}) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name) =>
+        ["x-request-id", "openai-request-id"].includes(name) ? requestId : null,
+    },
+    json: async () => ({
+      choices: [
+        {
+          message: {
+            content: '{"status":"ok","stepId":"PROJECT_GRAPH","notes":[]}',
+          },
+        },
+      ],
+      usage,
+    }),
+  });
+}
+
+describe("openaiReasoningExecutor", () => {
+  test("uses reasoning-key precedence, records request metadata, and redacts secrets", async () => {
+    const fetchImpl = okFetch();
+
+    const calls = await executeProjectGraphReasoningSteps({
+      modelRoutes: [route],
+      env: {
+        OPENAI_REASONING_API_KEY: "sk-reasoning-1234",
+        OPENAI_API_KEY: "sk-base-5678",
+        OPENAI_BASE_URL: "https://api.test/v1",
+        PROJECT_GRAPH_OPENAI_REASONING_MODE: "required",
+      },
+      execution: { fetchImpl },
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.test/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-reasoning-1234",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+    expect(calls[0]).toMatchObject({
+      stepId: "PROJECT_GRAPH",
+      status: "ok",
+      providerUsed: "openai",
+      reasoningProviderUsed: "openai",
+      openaiUsed: true,
+      requestId: "req_123",
+      usage: { total_tokens: 3 },
+      keySource: "OPENAI_REASONING_API_KEY",
+      secretsRedacted: true,
+    });
+    expect(JSON.stringify(calls)).not.toContain("sk-reasoning-1234");
+    expect(JSON.stringify(calls)).not.toContain("sk-base-5678");
+  });
+
+  test("blocks required execution when the reasoning key is missing", async () => {
+    const fetchImpl = okFetch();
+
+    const calls = await executeProjectGraphReasoningSteps({
+      modelRoutes: [route],
+      env: {
+        NODE_ENV: "production",
+        PROJECT_GRAPH_OPENAI_REASONING_MODE: "required",
+      },
+      execution: { fetchImpl },
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(calls[0]).toMatchObject({
+      status: "blocked",
+      providerUsed: "none",
+      fallbackReason: "missing_api_key",
+      errorCode: "OPENAI_REASONING_API_KEY_MISSING",
+      openaiUsed: false,
+    });
+    expect(getBlockedOpenAIReasoningCalls(calls)).toHaveLength(1);
+  });
+
+  test("blocks invalid OpenAI responses", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "req_invalid" },
+      json: async () => ({ choices: [], usage: { total_tokens: 1 } }),
+    });
+
+    const calls = await executeProjectGraphReasoningSteps({
+      modelRoutes: [route],
+      env: {
+        OPENAI_API_KEY: "sk-base-5678",
+        PROJECT_GRAPH_OPENAI_REASONING_MODE: "required",
+      },
+      execution: { fetchImpl },
+    });
+
+    expect(calls[0]).toMatchObject({
+      status: "blocked",
+      fallbackReason: "invalid_response",
+      errorCode: "OPENAI_REASONING_INVALID_RESPONSE",
+      requestId: "req_invalid",
+      usage: { total_tokens: 1 },
+    });
+  });
+
+  test("uses explicit deterministic metadata in test mode when no mock is supplied", async () => {
+    const fetchImpl = okFetch();
+
+    const calls = await executeProjectGraphReasoningSteps({
+      modelRoutes: [route],
+      env: {
+        NODE_ENV: "test",
+        JEST_WORKER_ID: "1",
+        OPENAI_API_KEY: "sk-base-5678",
+      },
+      execution: { fetchImpl },
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(calls[0]).toMatchObject({
+      status: "skipped",
+      providerUsed: "deterministic",
+      fallbackReason: "test_runtime_provider_mock_not_supplied",
+      deterministicReason: "test_runtime_provider_mock_not_supplied",
+      openaiUsed: false,
+      secretsRedacted: true,
+    });
+  });
+});

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -4,7 +4,7 @@ import {
   KNOWN_BUILDING_TYPES,
 } from "../../services/project/projectGraphVerticalSliceService.js";
 
-jest.setTimeout(180000);
+jest.setTimeout(420000);
 
 function createReadingRoomBrief() {
   const siteMapDataUrl =
@@ -79,6 +79,37 @@ function expectPanelPlacementsDoNotOverlap(placements) {
       });
     }
   }
+}
+
+function createOpenAIReasoningFetchMock() {
+  let count = 0;
+  return jest.fn().mockImplementation(async () => {
+    count += 1;
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name) =>
+          ["x-request-id", "openai-request-id"].includes(name)
+            ? `req_projectgraph_${count}`
+            : null,
+      },
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: `{"status":"ok","checkpoint":${count}}`,
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 2,
+          completion_tokens: 1,
+          total_tokens: 3,
+        },
+      }),
+    };
+  });
 }
 
 describe("projectGraphVerticalSliceService", () => {
@@ -427,8 +458,9 @@ describe("projectGraphVerticalSliceService", () => {
         providerCalls: expect.arrayContaining([
           expect.objectContaining({
             stepId: "PROJECT_GRAPH",
-            status: "route_resolved",
+            status: "skipped",
             providerUsed: "deterministic",
+            fallbackReason: "test_runtime_provider_mock_not_supplied",
             openaiUsed: false,
             secretsRedacted: true,
           }),
@@ -503,6 +535,112 @@ describe("projectGraphVerticalSliceService", () => {
     expect(result.qa.categoryScores.regulation.max).toBe(10);
     expect(result.qa.categoryScores.architecture.max).toBe(10);
     expect(result.qa.categoryScores.graphic.max).toBe(10);
+  });
+
+  test("executes OpenAI reasoning checkpoints when a provider mock is supplied", async () => {
+    const fetchImpl = createOpenAIReasoningFetchMock();
+
+    const result = await buildArchitectureProjectVerticalSlice({
+      ...createReadingRoomBrief(),
+      providerExecution: {
+        openaiReasoning: {
+          mode: "required",
+          fetchImpl,
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(8);
+    expect(result.artifacts.openaiReasoningUsed).toBe(true);
+    expect(result.artifacts.openaiImageUsed).toBe(false);
+    expect(result.artifacts.openaiRequestIds).toHaveLength(8);
+    expect(result.artifacts.openaiUsage).toHaveLength(8);
+    expect(result.artifacts.openaiModelsUsed).toEqual(
+      expect.arrayContaining(["gpt-5.4", "gpt-5.4-mini"]),
+    );
+    expect(result.qa.openai).toEqual(
+      expect.objectContaining({
+        openaiReasoningUsed: true,
+        reasoningProviderUsed: "openai",
+      }),
+    );
+    for (const stepId of [
+      "BRIEF",
+      "SITE",
+      "CLIMATE",
+      "REGS",
+      "PROGRAMME",
+      "PROJECT_GRAPH",
+      "A1_SHEET",
+      "QA",
+    ]) {
+      expect(result.artifacts.executionTrace.providerCalls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            stepId,
+            status: "ok",
+            providerUsed: "openai",
+            openaiUsed: true,
+            requestId: expect.stringMatching(/^req_projectgraph_/),
+            usage: expect.objectContaining({ total_tokens: 3 }),
+            secretsRedacted: true,
+          }),
+        ]),
+      );
+    }
+    expect(JSON.stringify(result.artifacts.executionTrace)).not.toContain(
+      "sk-",
+    );
+  });
+
+  test("fails closed when required OpenAI reasoning has no server key", async () => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_REASONING_API_KEY;
+    const fetchImpl = createOpenAIReasoningFetchMock();
+
+    const result = await buildArchitectureProjectVerticalSlice({
+      ...createReadingRoomBrief(),
+      providerExecution: {
+        openaiReasoning: {
+          mode: "required",
+          fetchImpl,
+        },
+      },
+    });
+
+    const blockedCalls = result.artifacts.executionTrace.providerCalls.filter(
+      (call) => call.status === "blocked",
+    );
+    expect(result.success).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(blockedCalls).toHaveLength(8);
+    expect(blockedCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stepId: "PROJECT_GRAPH",
+          fallbackReason: "missing_api_key",
+          errorCode: "OPENAI_REASONING_API_KEY_MISSING",
+          openaiUsed: false,
+        }),
+      ]),
+    );
+    expect(result.qa.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "OPENAI_REASONING_PROVIDER_BLOCKED",
+          severity: "error",
+        }),
+      ]),
+    );
+    expect(result.qa.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "OPENAI_REASONING_PROVIDER_EXECUTED",
+          status: "fail",
+        }),
+      ]),
+    );
   });
 
   test("uses Google Static Maps metadata when no provided site map is supplied", async () => {
@@ -644,9 +782,20 @@ describe("projectGraphVerticalSliceService", () => {
     );
     expect(levelIndexes.has(0)).toBe(true);
     expect(Math.max(...levelIndexes)).toBeGreaterThanOrEqual(2);
-    // Master A1 sheet inlines every floor-plan panel.
+    // Split 4+ storey outputs may move upper floor plans to companion sheets,
+    // but the complete sheet series must still include every floor-plan panel.
+    const sheetSeriesPanelTypes = (result.artifacts.sheetSeries || []).flatMap(
+      (sheet) => sheet.panel_types || [],
+    );
     expect(result.artifacts.a1Sheet.svgString).toContain("floor_plan_level2");
-    expect(result.artifacts.a1Sheet.svgString).toContain("floor_plan_level3");
+    expect(sheetSeriesPanelTypes).toEqual(
+      expect.arrayContaining([
+        "floor_plan_ground",
+        "floor_plan_first",
+        "floor_plan_level2",
+        "floor_plan_level3",
+      ]),
+    );
   });
 
   test("keeps uneven user programme GIA within tolerance across multi-storey geometry", async () => {

--- a/src/services/openaiReasoningExecutor.js
+++ b/src/services/openaiReasoningExecutor.js
@@ -1,0 +1,490 @@
+import openaiEnv from "./openaiProviderEnv.cjs";
+
+export const PROJECT_GRAPH_REASONING_STEP_IDS = [
+  "BRIEF",
+  "SITE",
+  "CLIMATE",
+  "REGS",
+  "PROGRAMME",
+  "PROJECT_GRAPH",
+  "A1_SHEET",
+  "QA",
+];
+
+const REASONING_STEP_SET = new Set(PROJECT_GRAPH_REASONING_STEP_IDS);
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_MAX_COMPLETION_TOKENS = 160;
+
+function readEnv(env = {}, name) {
+  return openaiEnv.readEnv(env, name);
+}
+
+function normalizeExecutionMode(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (!normalized) return null;
+  if (
+    ["1", "true", "on", "required", "live", "openai", "mock"].includes(
+      normalized,
+    )
+  ) {
+    return "required";
+  }
+  if (
+    ["0", "false", "off", "disabled", "skip", "deterministic"].includes(
+      normalized,
+    )
+  ) {
+    return "disabled";
+  }
+  return null;
+}
+
+function isTestRuntime(env = {}) {
+  return (
+    readEnv(env, "NODE_ENV") === "test" ||
+    Boolean(readEnv(env, "JEST_WORKER_ID"))
+  );
+}
+
+export function resolveOpenAIReasoningExecutionConfig({
+  env = process.env,
+  execution = {},
+} = {}) {
+  const testRuntime = isTestRuntime(env);
+  const explicitExecutionMode = normalizeExecutionMode(execution.mode);
+  const explicitEnvMode = testRuntime
+    ? null
+    : normalizeExecutionMode(
+        readEnv(env, "PROJECT_GRAPH_OPENAI_REASONING_MODE"),
+      ) ||
+      normalizeExecutionMode(
+        readEnv(env, "PROJECT_GRAPH_OPENAI_EXECUTION_MODE"),
+      );
+  const explicitMode = explicitExecutionMode || explicitEnvMode;
+  const mode = explicitMode || (testRuntime ? "disabled" : "required");
+  const productionDisabled =
+    readEnv(env, "NODE_ENV") === "production" && mode === "disabled";
+  return {
+    mode,
+    explicitMode: Boolean(explicitMode),
+    required: mode === "required" || productionDisabled,
+    productionDisabled,
+    skipReason: testRuntime
+      ? "test_runtime_provider_mock_not_supplied"
+      : "project_graph_openai_reasoning_disabled",
+  };
+}
+
+function compactString(value, maxLength = 600) {
+  const text = String(value || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}
+
+function safeJson(value, maxLength = 5000) {
+  try {
+    const json = JSON.stringify(value, (_key, entry) => {
+      if (typeof entry === "string") return compactString(entry, 900);
+      return entry;
+    });
+    return json.length > maxLength ? `${json.slice(0, maxLength)}...` : json;
+  } catch {
+    return "{}";
+  }
+}
+
+function baseCall(route, overrides = {}) {
+  return {
+    stepId: route.stepId,
+    provider: route.provider,
+    model: route.model,
+    apiKeyEnv: route.apiKeyEnv,
+    keySource: null,
+    providerUsed: "deterministic",
+    reasoningProviderUsed: "deterministic",
+    imageProviderUsed: null,
+    status: "skipped",
+    openaiUsed: false,
+    deterministicFallback: false,
+    deterministicReason: null,
+    fallbackReason: null,
+    requestId: null,
+    usage: null,
+    errorCode: null,
+    httpStatus: null,
+    secretsRedacted: true,
+    ...overrides,
+  };
+}
+
+function skippedCall(route, reason, details = {}) {
+  return baseCall(route, {
+    status: "skipped",
+    providerUsed: "deterministic",
+    reasoningProviderUsed: "deterministic",
+    deterministicFallback: true,
+    deterministicReason: reason,
+    fallbackReason: reason,
+    ...details,
+  });
+}
+
+function blockedCall(route, reason, errorCode, details = {}) {
+  return baseCall(route, {
+    status: "blocked",
+    providerUsed: "none",
+    reasoningProviderUsed: "blocked",
+    deterministicFallback: false,
+    fallbackReason: reason,
+    errorCode,
+    ...details,
+  });
+}
+
+function okCall(route, keyInfo, details = {}) {
+  return baseCall(route, {
+    status: "ok",
+    providerUsed: "openai",
+    reasoningProviderUsed: "openai",
+    openaiUsed: true,
+    deterministicFallback: false,
+    deterministicReason: null,
+    fallbackReason: null,
+    keySource: keyInfo.keySource,
+    ...details,
+  });
+}
+
+function normalizeContent(content) {
+  if (typeof content === "string") return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === "string"
+          ? part
+          : part?.text || part?.content || part?.value || "",
+      )
+      .join(" ")
+      .trim();
+  }
+  return "";
+}
+
+function stepPayload(stepId, context = {}) {
+  const {
+    brief = {},
+    site = {},
+    climate = {},
+    regulations = {},
+    programme = {},
+    compiledProject = {},
+    projectGraphId = null,
+    geometryHash = null,
+    programmeSummary = null,
+    splitDecision = null,
+    primarySheet = null,
+    pdfArtifact = null,
+    technicalBuild = null,
+    visualFidelityStatus = null,
+  } = context;
+  const base = {
+    projectGraphId,
+    geometryHash,
+    projectName: brief.project_name || null,
+    buildingType: brief.building_type || null,
+    targetGiaM2: brief.target_gia_m2 || null,
+    targetStoreys: brief.target_storeys || null,
+  };
+
+  if (stepId === "BRIEF") {
+    return {
+      ...base,
+      clientGoals: brief.client_goals || [],
+      siteInput: brief.site_input || {},
+      sustainabilityAmbition: brief.sustainability_ambition || null,
+    };
+  }
+  if (stepId === "SITE") {
+    return {
+      ...base,
+      site: {
+        postcode: site.postcode || brief.site_input?.postcode || null,
+        lat: site.lat ?? brief.site_input?.lat ?? null,
+        lon: site.lon ?? brief.site_input?.lon ?? null,
+        region: site.region || site.locationProfile?.region || null,
+        areaM2: site.area_m2 || site.areaM2 || null,
+      },
+    };
+  }
+  if (stepId === "CLIMATE") {
+    return {
+      ...base,
+      climate: {
+        zone: climate.zone || climate.koppen || null,
+        weatherSource: climate.weather_source || null,
+        wind: climate.wind || null,
+        sunPath: climate.sun_path || climate.sunPath || null,
+        designRecommendations:
+          climate.design_recommendations || climate.recommendations || null,
+      },
+    };
+  }
+  if (stepId === "REGS") {
+    return {
+      ...base,
+      regulations: {
+        jurisdiction: regulations.jurisdiction || null,
+        applicableParts:
+          regulations.applicable_parts || regulations.parts || [],
+        ruleSummary: regulations.rule_summary || regulations.summary || null,
+      },
+    };
+  }
+  if (stepId === "PROGRAMME") {
+    return {
+      ...base,
+      programme: {
+        spaceCount: programme.spaces?.length || 0,
+        grossInternalAreaM2:
+          programme.area_summary?.gross_internal_area_m2 || null,
+        levels: programmeSummary?.levels || programmeSummary || null,
+      },
+    };
+  }
+  if (stepId === "PROJECT_GRAPH") {
+    return {
+      ...base,
+      compiledProject: {
+        schemaVersion: compiledProject.schema_version || null,
+        levelCount: compiledProject.levels?.length || 0,
+        roomCount: compiledProject.rooms?.length || 0,
+        wallCount: compiledProject.walls?.length || 0,
+        openingCount: compiledProject.openings?.length || 0,
+      },
+    };
+  }
+  if (stepId === "A1_SHEET") {
+    return {
+      ...base,
+      sheet: {
+        splitReason: splitDecision?.reason || null,
+        sheetCount: splitDecision?.sheets?.length || 0,
+        layoutVersion: primarySheet?.layoutVersion || null,
+        visualFidelityStatus,
+        textRenderStatus: primarySheet?.textRenderStatus || null,
+        pdfRenderPassed: pdfArtifact?.renderedProof?.passed ?? null,
+      },
+    };
+  }
+  if (stepId === "QA") {
+    return {
+      ...base,
+      qaInputs: {
+        technicalBuildOk: technicalBuild?.ok ?? null,
+        technicalFailures: technicalBuild?.failures || [],
+        pdfRenderPassed: pdfArtifact?.renderedProof?.passed ?? null,
+        requiredMissingPanelCount:
+          pdfArtifact?.renderedProof?.requiredMissingPanelCount ?? null,
+      },
+    };
+  }
+  return base;
+}
+
+function buildMessages(route, context) {
+  const payload = stepPayload(route.stepId, context);
+  return [
+    {
+      role: "system",
+      content:
+        "You are the OpenAI reasoning checkpoint for the ProjectGraph architecture pipeline. Do not create or alter 2D or 3D geometry. Verify only semantic consistency, labels, narrative intent, and QA readiness. Return concise JSON.",
+    },
+    {
+      role: "user",
+      content: `Checkpoint ${route.stepId}: review this ProjectGraph summary and return JSON with status, stepId, and notes. Summary: ${safeJson(payload)}`,
+    },
+  ];
+}
+
+async function postOpenAIChatCompletion({
+  route,
+  keyInfo,
+  env,
+  fetchImpl,
+  context,
+}) {
+  const baseUrl = readEnv(env, "OPENAI_BASE_URL") || DEFAULT_OPENAI_BASE_URL;
+  const maxTokens =
+    Number.parseInt(readEnv(env, "PROJECT_GRAPH_OPENAI_MAX_TOKENS"), 10) ||
+    DEFAULT_MAX_COMPLETION_TOKENS;
+  const response = await fetchImpl(
+    `${baseUrl.replace(/\/$/, "")}/chat/completions`,
+    {
+      method: "POST",
+      headers: openaiEnv.buildOpenAIRequestHeaders(keyInfo, env, {
+        json: true,
+      }),
+      body: JSON.stringify({
+        model: route.model,
+        messages: buildMessages(route, context),
+        max_completion_tokens: maxTokens,
+      }),
+    },
+  );
+  const requestId =
+    response.headers?.get?.("x-request-id") ||
+    response.headers?.get?.("openai-request-id") ||
+    null;
+  const data = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    return blockedCall(
+      route,
+      "openai_error",
+      data?.error?.code || "OPENAI_REASONING_REQUEST_FAILED",
+      {
+        httpStatus: response.status,
+        requestId,
+        usage: data?.usage || null,
+        keySource: keyInfo.keySource,
+        errorMessage: compactString(
+          data?.error?.message || `OpenAI request failed: ${response.status}`,
+        ),
+      },
+    );
+  }
+
+  const content = normalizeContent(data?.choices?.[0]?.message?.content);
+  if (!content) {
+    return blockedCall(
+      route,
+      "invalid_response",
+      "OPENAI_REASONING_INVALID_RESPONSE",
+      {
+        httpStatus: response.status,
+        requestId,
+        usage: data?.usage || null,
+        keySource: keyInfo.keySource,
+      },
+    );
+  }
+
+  return okCall(route, keyInfo, {
+    requestId,
+    usage: data?.usage || null,
+  });
+}
+
+export async function executeProjectGraphReasoningSteps({
+  modelRoutes = [],
+  context = {},
+  execution = {},
+  env = process.env,
+} = {}) {
+  const config = resolveOpenAIReasoningExecutionConfig({ env, execution });
+  const keyInfo = openaiEnv.resolveOpenAIReasoningApiKeyInfo(env);
+  const fetchImpl = execution.fetchImpl || execution.fetch || global.fetch;
+  const calls = [];
+
+  for (const route of modelRoutes) {
+    if (!REASONING_STEP_SET.has(route.stepId)) {
+      calls.push(
+        skippedCall(route, "project_graph_compiled_geometry_authority", {
+          deterministicGeometry: route.deterministicGeometry === true,
+        }),
+      );
+      continue;
+    }
+
+    if (config.productionDisabled) {
+      calls.push(
+        blockedCall(
+          route,
+          "disabled_not_allowed_production",
+          "OPENAI_REASONING_DISABLED_IN_PRODUCTION",
+        ),
+      );
+      continue;
+    }
+
+    if (config.mode === "disabled") {
+      calls.push(
+        skippedCall(route, config.skipReason, {
+          executionMode: config.mode,
+        }),
+      );
+      continue;
+    }
+
+    if (route.provider !== "openai") {
+      calls.push(
+        blockedCall(
+          route,
+          "unsupported_provider",
+          "OPENAI_REASONING_UNSUPPORTED_PROVIDER",
+        ),
+      );
+      continue;
+    }
+
+    if (!keyInfo.hasKey) {
+      calls.push(
+        blockedCall(
+          route,
+          "missing_api_key",
+          "OPENAI_REASONING_API_KEY_MISSING",
+          {
+            warning: keyInfo.warning,
+          },
+        ),
+      );
+      continue;
+    }
+
+    if (typeof fetchImpl !== "function") {
+      calls.push(
+        blockedCall(
+          route,
+          "fetch_unavailable",
+          "OPENAI_REASONING_FETCH_UNAVAILABLE",
+          {
+            keySource: keyInfo.keySource,
+          },
+        ),
+      );
+      continue;
+    }
+
+    try {
+      calls.push(
+        await postOpenAIChatCompletion({
+          route,
+          keyInfo,
+          env,
+          fetchImpl,
+          context,
+        }),
+      );
+    } catch (error) {
+      calls.push(
+        blockedCall(route, "network_error", "OPENAI_REASONING_NETWORK_ERROR", {
+          keySource: keyInfo.keySource,
+          errorMessage: compactString(error?.message || String(error)),
+        }),
+      );
+    }
+  }
+
+  return calls;
+}
+
+export function getBlockedOpenAIReasoningCalls(providerCalls = []) {
+  return providerCalls.filter(
+    (call) =>
+      PROJECT_GRAPH_REASONING_STEP_IDS.includes(call.stepId) &&
+      call.status === "blocked",
+  );
+}

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -16,6 +16,10 @@ import { compileProject } from "../compiler/index.js";
 import { ensureCompiledProjectRenderInputs } from "../compiler/compiledProjectRenderInputs.js";
 import { resolveArchitectureModelRegistry } from "../modelStepResolver.js";
 import openaiEnv from "../openaiProviderEnv.cjs";
+import {
+  executeProjectGraphReasoningSteps,
+  getBlockedOpenAIReasoningCalls,
+} from "../openaiReasoningExecutor.js";
 import { computeCDSHashSync } from "../validation/cdsHash.js";
 import { rasteriseSheetArtifact } from "../render/svgRasteriser.js";
 import { getSiteSnapshotWithMetadata } from "../siteMapSnapshotService.js";
@@ -3952,6 +3956,53 @@ function logProjectGraphProviderTrace(providerCalls = []) {
   }
 }
 
+function applyOpenAIReasoningBlockersToQa(qa, blockedCalls = []) {
+  if (!blockedCalls.length) return qa;
+  const blockedSteps = blockedCalls.map((call) => call.stepId);
+  const checks = [...(qa.checks || [])];
+  addCheck(
+    checks,
+    "OPENAI_REASONING_PROVIDER_EXECUTED",
+    false,
+    {
+      blockedSteps,
+      blockedCalls: blockedCalls.map((call) => ({
+        stepId: call.stepId,
+        status: call.status,
+        fallbackReason: call.fallbackReason,
+        errorCode: call.errorCode,
+        httpStatus: call.httpStatus || null,
+        requestId: call.requestId || null,
+      })),
+    },
+    "provider",
+    0,
+  );
+  const issues = [
+    ...(qa.issues || []),
+    buildIssue(
+      "OPENAI_REASONING_PROVIDER_BLOCKED",
+      "error",
+      "OpenAI reasoning provider execution failed for required ProjectGraph steps.",
+      { blockedSteps },
+    ),
+  ];
+  const warningCount = issues.filter(
+    (issue) => issue.severity === "warning",
+  ).length;
+  const errorCount = issues.filter(
+    (issue) => issue.severity === "error",
+  ).length;
+  return {
+    ...qa,
+    status: "fail",
+    checks,
+    issues,
+    score: Math.max(0, 100 - errorCount * 18 - warningCount * 6),
+    openaiBlocked: true,
+  };
+}
+
 // Phase B closeout: per-panel-type fit policy for presentation-v3.
 // Technical drawings cropped tight to contentBounds (with small padding) so
 // drawings fill 80–92% of the slot; site/3D/data panels keep the previous
@@ -6097,21 +6148,6 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     fineTunedModelUsed: entry.fineTunedModelUsed || null,
     deterministicGeometry: entry.deterministicGeometry === true,
   }));
-  const providerCalls = modelRoutes.map((route) => ({
-    stepId: route.stepId,
-    provider: route.provider,
-    providerUsed: "deterministic",
-    reasoningProviderUsed: "deterministic",
-    imageProviderUsed: null,
-    model: route.model,
-    apiKeyEnv: route.apiKeyEnv,
-    status: "route_resolved",
-    openaiUsed: false,
-    deterministicFallback: false,
-    deterministicReason: "project_graph_vertical_slice_deterministic",
-    fallbackReason: null,
-    secretsRedacted: true,
-  }));
   const projectGraphId = createStableId(
     "project-graph",
     brief.project_name,
@@ -6201,6 +6237,31 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       )
       .map((artifact) => [artifact.panel_type, artifact]),
   );
+  const openaiReasoningExecution =
+    input.openaiReasoningExecution ||
+    input.providerExecution?.openaiReasoning ||
+    input.contextProviders?.openaiReasoning ||
+    {};
+  const providerCalls = await executeProjectGraphReasoningSteps({
+    modelRoutes,
+    context: {
+      brief,
+      site,
+      climate,
+      regulations,
+      programme,
+      compiledProject,
+      projectGraphId,
+      geometryHash: compiledProject.geometryHash,
+      programmeSummary,
+      splitDecision,
+      primarySheet: sheetArtifact,
+      pdfArtifact,
+      technicalBuild,
+      visualFidelityStatus: sheetArtifact.visualFidelityStatus,
+    },
+    execution: openaiReasoningExecution,
+  });
   const imageProviderCalls = buildImageProviderCalls(visuals3d);
   const allProviderCalls = [...providerCalls, ...imageProviderCalls];
   const openaiQaMetadata = buildOpenAIQaMetadata({
@@ -6346,10 +6407,14 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       exportSteps,
     },
   };
-  const qa = validateProjectGraphVerticalSlice({
+  let qa = validateProjectGraphVerticalSlice({
     projectGraph: graphWithStableId,
     artifacts,
   });
+  qa = applyOpenAIReasoningBlockersToQa(
+    qa,
+    getBlockedOpenAIReasoningCalls(providerCalls),
+  );
   qa.openai = openaiQaMetadata;
 
   // Phase 5: structured reasoning chain — Brief → Site → Climate → Style →


### PR DESCRIPTION
## Summary
- Adds a central ProjectGraph OpenAI reasoning executor using the existing server key precedence: OPENAI_REASONING_API_KEY then OPENAI_API_KEY.
- Wires semantic ProjectGraph checkpoints through real provider execution while keeping 2D/3D geometry deterministic and compiled-geometry authoritative.
- Replaces route-only provider traces with executed/skipped/blocked states, request IDs, usage, key source metadata, redacted diagnostics, and fail-closed QA blockers.

## Validation
- npm run check:env
- npm run check:model-routes -- --json
- npx react-scripts test --watchAll=false --runInBand --no-cache --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/openaiReasoningExecutor.test.js src/__tests__/services/modelStepResolver.test.js src/__tests__/services/projectGraphVerticalSliceService.test.js src/__tests__/services/envDrivenProviderGuards.test.js
- npm run lint
- npm run check:contracts
- npm run build:active

## Vercel Notes
- Production/Preview require OPENAI_API_KEY or OPENAI_REASONING_API_KEY for ProjectGraph reasoning.
- OPENAI_IMAGES_API_KEY and PROJECT_GRAPH_IMAGE_GEN_ENABLED remain optional image-panel controls.
- REACT_APP_OPENAI_API_KEY is not used as the default server pipeline secret.