### PR TITLE
Fix technical panel aspect fit for presentation-v3 A1 sheets

### DIFF
--- a/src/__tests__/services/compiledProjectTechnicalPackBuilder.renderSize.test.js
+++ b/src/__tests__/services/compiledProjectTechnicalPackBuilder.renderSize.test.js
@@ -1,0 +1,190 @@
+import { getTechnicalPanelRenderSize } from "../../services/canonical/compiledProjectTechnicalPackBuilder.js";
+import {
+  WORKING_HEIGHT,
+  WORKING_WIDTH,
+  resolveLayout,
+  toPixelRect,
+} from "../../services/a1/composeCore.js";
+
+// Per-panel readability minimums applied inside getTechnicalPanelRenderSize.
+const PLAN_MIN_WIDTH = 760;
+const PLAN_MIN_HEIGHT = 420;
+const SECTION_MIN_WIDTH = 720;
+const SECTION_MIN_HEIGHT = 400;
+const ELEVATION_MIN_WIDTH = 560;
+const ELEVATION_MIN_HEIGHT = 320;
+
+// roundEven rounds to even integers, so aspect ratios drift by a few tenths
+// of a percent. 2.5 % is comfortable headroom.
+const ASPECT_TOLERANCE = 0.025;
+
+function slotPixelAspect(panelType, floorCount, layoutTemplate) {
+  const { layout } = resolveLayout({ layoutTemplate, floorCount });
+  const slot = layout?.[panelType];
+  if (!slot) return null;
+  const slotRect = toPixelRect(slot, WORKING_WIDTH, WORKING_HEIGHT);
+  if (!(slotRect.width > 0 && slotRect.height > 0)) return null;
+  return slotRect.width / slotRect.height;
+}
+
+describe("getTechnicalPanelRenderSize — aspect preservation", () => {
+  describe("presentation-v3", () => {
+    test("floor_plan_ground (2-storey) keeps slot-like aspect ratio", () => {
+      const size = getTechnicalPanelRenderSize(
+        "floor_plan_ground",
+        2,
+        "presentation-v3",
+      );
+      const slotAspect = slotPixelAspect(
+        "floor_plan_ground",
+        2,
+        "presentation-v3",
+      );
+      const svgAspect = size.width / size.height;
+      expect(slotAspect).not.toBeNull();
+      expect(Math.abs(svgAspect - slotAspect)).toBeLessThan(ASPECT_TOLERANCE);
+      expect(size.width).toBeGreaterThanOrEqual(PLAN_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(PLAN_MIN_HEIGHT);
+    });
+
+    test("floor_plan_first (2-storey) keeps slot-like aspect ratio", () => {
+      const size = getTechnicalPanelRenderSize(
+        "floor_plan_first",
+        2,
+        "presentation-v3",
+      );
+      const slotAspect = slotPixelAspect(
+        "floor_plan_first",
+        2,
+        "presentation-v3",
+      );
+      const svgAspect = size.width / size.height;
+      expect(slotAspect).not.toBeNull();
+      expect(Math.abs(svgAspect - slotAspect)).toBeLessThan(ASPECT_TOLERANCE);
+      expect(size.width).toBeGreaterThanOrEqual(PLAN_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(PLAN_MIN_HEIGHT);
+    });
+
+    test("section_AA preserves slot aspect", () => {
+      const size = getTechnicalPanelRenderSize(
+        "section_AA",
+        2,
+        "presentation-v3",
+      );
+      const slotAspect = slotPixelAspect("section_AA", 2, "presentation-v3");
+      const svgAspect = size.width / size.height;
+      expect(Math.abs(svgAspect - slotAspect)).toBeLessThan(ASPECT_TOLERANCE);
+      expect(size.width).toBeGreaterThanOrEqual(SECTION_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(SECTION_MIN_HEIGHT);
+    });
+
+    test("section_BB preserves slot aspect", () => {
+      const size = getTechnicalPanelRenderSize(
+        "section_BB",
+        2,
+        "presentation-v3",
+      );
+      const slotAspect = slotPixelAspect("section_BB", 2, "presentation-v3");
+      const svgAspect = size.width / size.height;
+      expect(Math.abs(svgAspect - slotAspect)).toBeLessThan(ASPECT_TOLERANCE);
+      expect(size.width).toBeGreaterThanOrEqual(SECTION_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(SECTION_MIN_HEIGHT);
+    });
+
+    test.each([
+      "elevation_north",
+      "elevation_south",
+      "elevation_east",
+      "elevation_west",
+    ])("%s preserves slot aspect", (panelType) => {
+      const size = getTechnicalPanelRenderSize(panelType, 2, "presentation-v3");
+      const slotAspect = slotPixelAspect(panelType, 2, "presentation-v3");
+      const svgAspect = size.width / size.height;
+      expect(Math.abs(svgAspect - slotAspect)).toBeLessThan(ASPECT_TOLERANCE);
+      expect(size.width).toBeGreaterThanOrEqual(ELEVATION_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(ELEVATION_MIN_HEIGHT);
+    });
+
+    test("floor_plan_ground (1-storey) still preserves slot aspect after applyFloorRow re-tile", () => {
+      const size = getTechnicalPanelRenderSize(
+        "floor_plan_ground",
+        1,
+        "presentation-v3",
+      );
+      const slotAspect = slotPixelAspect(
+        "floor_plan_ground",
+        1,
+        "presentation-v3",
+      );
+      const svgAspect = size.width / size.height;
+      expect(Math.abs(svgAspect - slotAspect)).toBeLessThan(ASPECT_TOLERANCE);
+      expect(size.width).toBeGreaterThanOrEqual(PLAN_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(PLAN_MIN_HEIGHT);
+    });
+  });
+
+  describe("board-v2 — must remain stable", () => {
+    test.each([
+      ["floor_plan_ground", 1],
+      ["floor_plan_ground", 2],
+      ["floor_plan_first", 2],
+      ["section_AA", 2],
+      ["section_BB", 2],
+      ["elevation_north", 2],
+      ["elevation_south", 2],
+      ["elevation_east", 2],
+      ["elevation_west", 2],
+    ])("%s (floors=%i) preserves slot aspect on board-v2", (panelType, fc) => {
+      const size = getTechnicalPanelRenderSize(panelType, fc, "board-v2");
+      const slotAspect = slotPixelAspect(panelType, fc, "board-v2");
+      const svgAspect = size.width / size.height;
+      expect(slotAspect).not.toBeNull();
+      expect(Math.abs(svgAspect - slotAspect)).toBeLessThan(ASPECT_TOLERANCE);
+    });
+
+    test("plan render size meets the readability minimum without independently distorting axes", () => {
+      const size = getTechnicalPanelRenderSize("floor_plan_ground", 1);
+      expect(size.width).toBeGreaterThanOrEqual(PLAN_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(PLAN_MIN_HEIGHT);
+      // The previous (broken) behaviour clamped width to 760 while leaving
+      // height at the unscaled 542. Aspect at that point was ~1.40 (landscape)
+      // but the slot is square-ish. After the fix, the SVG aspect must follow
+      // the slot rather than the minimum-width clamp.
+      const slotAspect = slotPixelAspect("floor_plan_ground", 1, "board-v2");
+      expect(Math.abs(size.width / size.height - slotAspect)).toBeLessThan(
+        ASPECT_TOLERANCE,
+      );
+    });
+
+    test("section render size similarly preserves slot aspect", () => {
+      const size = getTechnicalPanelRenderSize("section_AA", 2);
+      expect(size.width).toBeGreaterThanOrEqual(SECTION_MIN_WIDTH);
+      expect(size.height).toBeGreaterThanOrEqual(SECTION_MIN_HEIGHT);
+      const slotAspect = slotPixelAspect("section_AA", 2, "board-v2");
+      expect(Math.abs(size.width / size.height - slotAspect)).toBeLessThan(
+        ASPECT_TOLERANCE,
+      );
+    });
+  });
+
+  describe("default behaviour", () => {
+    test("layoutTemplate defaults to board-v2", () => {
+      const fromDefault = getTechnicalPanelRenderSize("floor_plan_ground", 2);
+      const fromExplicit = getTechnicalPanelRenderSize(
+        "floor_plan_ground",
+        2,
+        "board-v2",
+      );
+      expect(fromDefault).toEqual(fromExplicit);
+    });
+
+    test("returns the documented fallback when the slot is absent", () => {
+      const size = getTechnicalPanelRenderSize(
+        "panel_that_does_not_exist",
+        1,
+        "board-v2",
+      );
+      expect(size).toEqual({ width: 1200, height: 760 });
+    });
+  });
+});

--- a/src/__tests__/services/compiledProjectTechnicalPackBuilder.renderSize.test.js
+++ b/src/__tests__/services/compiledProjectTechnicalPackBuilder.renderSize.test.js
@@ -187,4 +187,58 @@ describe("getTechnicalPanelRenderSize — aspect preservation", () => {
       expect(size).toEqual({ width: 1200, height: 760 });
     });
   });
+
+  describe("presentation-v3 vs board-v2 differ where it matters", () => {
+    // Verifies the wiring activates the aspect-fit fix on residential briefs:
+    // board-v2 floor_plan_ground (2-storey, wide slot) and presentation-v3
+    // floor_plan_ground (2-storey, square slot) produce DIFFERENT dimensions.
+    // If they were identical, the layoutTemplate plumbing would be a no-op.
+    test("floor_plan_ground (2-storey) differs between board-v2 and presentation-v3", () => {
+      const boardV2 = getTechnicalPanelRenderSize(
+        "floor_plan_ground",
+        2,
+        "board-v2",
+      );
+      const presV3 = getTechnicalPanelRenderSize(
+        "floor_plan_ground",
+        2,
+        "presentation-v3",
+      );
+      const boardAspect = boardV2.width / boardV2.height;
+      const presAspect = presV3.width / presV3.height;
+      // board-v2 floor row is wide (~2:1 or wider after applyFloorRow);
+      // presentation-v3 is closer to 1:1.
+      expect(boardAspect).toBeGreaterThan(1.5);
+      expect(presAspect).toBeLessThan(1.5);
+      expect(boardV2).not.toEqual(presV3);
+    });
+
+    test("section_AA differs between board-v2 and presentation-v3", () => {
+      const boardV2 = getTechnicalPanelRenderSize("section_AA", 2, "board-v2");
+      const presV3 = getTechnicalPanelRenderSize(
+        "section_AA",
+        2,
+        "presentation-v3",
+      );
+      expect(boardV2).not.toEqual(presV3);
+    });
+
+    test("storey routing intact: 1-storey omits floor_plan_first slot in both templates", () => {
+      // For 1-storey, floor_plan_first should not exist in the layout
+      // (returns the documented fallback). For 2-storey, it has a real slot.
+      const v3OneStorey = getTechnicalPanelRenderSize(
+        "floor_plan_first",
+        1,
+        "presentation-v3",
+      );
+      const v3TwoStorey = getTechnicalPanelRenderSize(
+        "floor_plan_first",
+        2,
+        "presentation-v3",
+      );
+      // 1-storey returns the absent-slot fallback {1200, 760}; 2-storey returns a real slot dim.
+      expect(v3OneStorey).toEqual({ width: 1200, height: 760 });
+      expect(v3TwoStorey).not.toEqual(v3OneStorey);
+    });
+  });
 });

--- a/src/services/canonical/compiledProjectTechnicalPackBuilder.js
+++ b/src/services/canonical/compiledProjectTechnicalPackBuilder.js
@@ -829,6 +829,13 @@ export function buildCompiledProjectTechnicalPanels(source = {}, options = {}) {
     options.elevationHeight || options.height,
   );
   const customSectionHeight = Number(options.sectionHeight || options.height);
+  // Default to board-v2 so non-residential / unspecified callers retain
+  // existing behaviour. Residential/presentation-v3 callers pass it
+  // explicitly so floor plans and sections render at slot aspect.
+  const layoutTemplate =
+    typeof options.layoutTemplate === "string" && options.layoutTemplate
+      ? options.layoutTemplate
+      : "board-v2";
 
   const levels = Array.isArray(compiledProject.levels)
     ? compiledProject.levels
@@ -837,7 +844,11 @@ export function buildCompiledProjectTechnicalPanels(source = {}, options = {}) {
 
   levels.forEach((level, index) => {
     const panelType = technicalFloorPanelType(index);
-    const slotRenderSize = getTechnicalPanelRenderSize(panelType, floorCount);
+    const slotRenderSize = getTechnicalPanelRenderSize(
+      panelType,
+      floorCount,
+      layoutTemplate,
+    );
     const renderSize = {
       width:
         Number.isFinite(customRenderWidth) && customRenderWidth > 0
@@ -872,7 +883,11 @@ export function buildCompiledProjectTechnicalPanels(source = {}, options = {}) {
 
   Object.entries(TECHNICAL_ELEVATION_PANELS).forEach(
     ([orientation, panelType]) => {
-      const slotRenderSize = getTechnicalPanelRenderSize(panelType, floorCount);
+      const slotRenderSize = getTechnicalPanelRenderSize(
+        panelType,
+        floorCount,
+        layoutTemplate,
+      );
       const renderSize = {
         width:
           Number.isFinite(customRenderWidth) && customRenderWidth > 0
@@ -907,7 +922,11 @@ export function buildCompiledProjectTechnicalPanels(source = {}, options = {}) {
 
   Object.entries(TECHNICAL_SECTION_PANELS).forEach(
     ([sectionType, panelType]) => {
-      const slotRenderSize = getTechnicalPanelRenderSize(panelType, floorCount);
+      const slotRenderSize = getTechnicalPanelRenderSize(
+        panelType,
+        floorCount,
+        layoutTemplate,
+      );
       const renderSize = {
         width:
           Number.isFinite(customRenderWidth) && customRenderWidth > 0

--- a/src/services/canonical/compiledProjectTechnicalPackBuilder.js
+++ b/src/services/canonical/compiledProjectTechnicalPackBuilder.js
@@ -67,9 +67,13 @@ function clamp(value, minimum, maximum) {
   return Math.max(minimum, Math.min(maximum, value));
 }
 
-function getTechnicalPanelRenderSize(panelType, floorCount = 1) {
+export function getTechnicalPanelRenderSize(
+  panelType,
+  floorCount = 1,
+  layoutTemplate = "board-v2",
+) {
   const { layout } = resolveComposeLayout({
-    layoutTemplate: "board-v2",
+    layoutTemplate,
     floorCount,
   });
   const slot = layout?.[panelType];

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -2340,8 +2340,17 @@ function drawingTypeForPanel(panelType) {
   return "diagram";
 }
 
-function buildDrawingSet(compiledProject) {
-  const technicalBuild = buildCompiledProjectTechnicalPanels(compiledProject);
+function buildDrawingSet(compiledProject, options = {}) {
+  // Pass layoutTemplate through so the technical pack renders at the slot
+  // aspect of the active sheet template (presentation-v3 for residential,
+  // board-v2 otherwise). Caller resolves via resolvePresentationLayoutTemplate.
+  const layoutTemplate =
+    typeof options.layoutTemplate === "string" && options.layoutTemplate
+      ? options.layoutTemplate
+      : "board-v2";
+  const technicalBuild = buildCompiledProjectTechnicalPanels(compiledProject, {
+    layoutTemplate,
+  });
   const technicalPanels = technicalBuild.technicalPanels || {};
   const drawingViews = Object.entries(technicalPanels).map(
     ([panelType, panel]) => {
@@ -7030,8 +7039,16 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     };
   }
   const selectedDesign = buildSelectedDesign(compiledProject, programme);
-  const { drawingSet, drawingArtifacts, technicalBuild } =
-    buildDrawingSet(compiledProject);
+  // Resolve the active sheet template for this brief (presentation-v3 for
+  // residential, board-v2 otherwise) BEFORE the technical pack runs so floor
+  // plans and sections render at the slot aspect of the layout that will
+  // ultimately receive them. Sheet-split overrides on individual sheetPlan
+  // entries continue to apply downstream in buildA1Sheet.
+  const drawingSetLayoutTemplate = resolvePresentationLayoutTemplate(brief);
+  const { drawingSet, drawingArtifacts, technicalBuild } = buildDrawingSet(
+    compiledProject,
+    { layoutTemplate: drawingSetLayoutTemplate },
+  );
   __vsMark = __vsLog(
     "build_drawing_set",
     __vsMark,


### PR DESCRIPTION
- Activates aspect-preserving technical render sizes for residential presentation-v3.
- Passes layoutTemplate through buildDrawingSet/buildCompiledProjectTechnicalPanels.
- Improves plan and section slot occupancy.
- Preserves board-v2 behavior.
- Does not touch OpenAI provider/env, export gate, visualManifest, material palette, programme/floor authority, or layout coordinates.

Validation:
- `npm run test:a1:tofu` - PASS
- `npm run test:compose:routing` - PASS, 22 passed / 0 failed
- `node scripts/tests/test-a1-layout-regression.mjs` - PASS, 27 passed / 0 failed
- `npm run build:active` - PASS, compiled successfully
- `npm test -- --watchAll=false compiledProjectTechnicalPackBuilder projectGraphPhaseBLayout` - PASS, 2 suites / 52 tests passed

Technical panel aspect evidence:
- `floor_plan_ground`: board-v2/default `1192x516 / 2.31` -> presentation-v3 `760x782 / 0.97`
- `floor_plan_first`: board-v2/default `1218x516 / 2.36` -> presentation-v3 `760x782 / 0.97`
- `section_AA`: board-v2/default `766x400 / 1.92` -> presentation-v3 `720x742 / 0.97`
- `section_BB`: board-v2/default `766x400 / 1.92` -> presentation-v3 `720x742 / 0.97`
- Floor plan rendered slot fill improves from the prior roughly 60% height behavior to roughly 96% height under presentation-v3.
- Section rendered slot fill improves by matching the square presentation-v3 technical slots.

Separate production photoreal smoke:
- Ran separately on `origin/main`, not inside this aspect-fit branch.
- HTTP 200, `success=true`, `qa.status=pass`.
- `openaiImageUsed=true`, `visualPanelsRenderMode=all_photoreal`.
- All 4 visual panels used `gpt-image-1.5`; no active fallback reason.
- `visualPanelsFallbackReasons` may contain panel keys with `null` values; treat those as no fallback and do not block this PR on exact `{}` shape.

Scope notes:
- Tracked diff is limited to `compiledProjectTechnicalPackBuilder.js`, `projectGraphVerticalSliceService.js`, and `compiledProjectTechnicalPackBuilder.renderSize.test.js`.
- No generated PDFs or outputs are staged or included.
- CLI PDFs may use deterministic visual panels; this PR is judged only on technical panel aspect/occupancy.