### PR TITLE
Fix low-confidence site boundary authority and contextual site plan

### DIFF
--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -114,6 +114,64 @@ function createKensingtonReferenceMatchBrief() {
   };
 }
 
+function createLowConfidenceBradfordBoundaryBrief() {
+  const estimatedBoundary = [
+    { lat: 53.79224, lng: -1.75556 },
+    { lat: 53.79224, lng: -1.75474 },
+    { lat: 53.79162, lng: -1.75474 },
+    { lat: 53.79162, lng: -1.75556 },
+  ];
+  const fallbackArea = 119408;
+
+  return {
+    projectDetails: {
+      projectName: "Cherish Bradford Street",
+      address: "97 Bradford Street, Bradford",
+      area: 250,
+      floorCount: 2,
+      subType: "detached-house",
+    },
+    brief: {
+      project_name: "Cherish Bradford Street",
+      building_type: "dwelling",
+      site_input: {
+        address: "97 Bradford Street, Bradford",
+        postcode: "BD1",
+        lat: 53.79203,
+        lon: -1.75524,
+      },
+      target_gia_m2: 250,
+      target_storeys: 2,
+      client_goals: ["family dwelling", "RIBA A1 site plan"],
+      style_keywords: ["contextual brick", "residential"],
+      sustainability_ambition: "low_energy",
+    },
+    sitePolygon: estimatedBoundary,
+    siteMetrics: {
+      areaM2: fallbackArea,
+      orientationDeg: 10,
+      boundaryAuthoritative: false,
+      boundarySource: "Intelligent Fallback",
+      boundaryConfidence: 0.4,
+    },
+    locationData: {
+      coordinates: { lat: 53.79203, lng: -1.75524 },
+      siteAnalysis: {
+        siteBoundary: null,
+        estimatedSiteBoundary: estimatedBoundary,
+        surfaceArea: fallbackArea,
+        estimatedSurfaceArea: fallbackArea,
+        boundaryAuthoritative: false,
+        boundaryEstimated: true,
+        estimatedOnly: true,
+        boundarySource: "Intelligent Fallback",
+        boundaryConfidence: 0.4,
+        fallbackReason: "No real boundary data available",
+      },
+    },
+  };
+}
+
 function cloneForTest(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -864,6 +922,66 @@ describe("projectGraphVerticalSliceService", () => {
     );
     expect(result.qa.issues.map((issue) => issue.code)).toContain(
       "SITE_MAP_FALLBACK_USED",
+    );
+  });
+
+  test("does not propagate low-confidence fallback boundary area into ProjectGraph site authority", async () => {
+    const result = await buildArchitectureProjectVerticalSlice(
+      createLowConfidenceBradfordBoundaryBrief(),
+    );
+    const issueCodes = result.qa.issues.map((issue) => issue.code);
+
+    expect(result.success).toBe(true);
+    expect(result.projectGraph.site.boundary_authoritative).toBe(false);
+    expect(result.projectGraph.site.boundary_source).toBe(
+      "Intelligent Fallback",
+    );
+    expect(result.projectGraph.site.boundary_confidence).toBe(0.4);
+    expect(result.projectGraph.site.estimated_area_m2).toBe(119408);
+    expect(result.projectGraph.site.area_m2).toBeLessThan(1000);
+    expect(result.projectGraph.site.area_m2).not.toBe(119408);
+    expect(result.artifacts.projectGeometry.site.area_m2).toBe(
+      result.projectGraph.site.area_m2,
+    );
+    expect(
+      result.projectGraph.site.data_quality.map((issue) => issue.code),
+    ).toContain("SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE");
+    expect(issueCodes).toContain("SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE");
+    expect(result.artifacts.siteMap.metadata.boundaryAuthoritative).toBe(false);
+    expect(result.artifacts.siteMap.metadata.sitePlanMode).toBe(
+      "contextual_estimated_boundary",
+    );
+    expect(result.artifacts.siteMap.svgString).toContain(
+      "CONTEXTUAL SITE PLAN",
+    );
+    expect(result.artifacts.siteMap.svgString).toContain("Boundary estimated");
+    expect(result.artifacts.siteMap.svgString).toContain(
+      "parcel area not authoritative",
+    );
+  });
+
+  test("preserves high-confidence boundary behavior", async () => {
+    const briefInput = createReadingRoomBrief();
+    briefInput.locationData = {
+      siteAnalysis: {
+        siteBoundary: briefInput.sitePolygon,
+        surfaceArea: 1040,
+        boundaryAuthoritative: true,
+        boundarySource: "OpenStreetMap",
+        boundaryConfidence: 0.92,
+      },
+    };
+
+    const result = await buildArchitectureProjectVerticalSlice(briefInput);
+
+    expect(result.success).toBe(true);
+    expect(result.projectGraph.site.boundary_authoritative).toBe(true);
+    expect(result.projectGraph.site.area_m2).toBe(1040);
+    expect(result.artifacts.siteMap.metadata.sitePlanMode).toBe(
+      "authoritative_boundary",
+    );
+    expect(result.qa.issues.map((issue) => issue.code)).not.toContain(
+      "SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE",
     );
   });
 

--- a/src/__tests__/services/siteAnalysis.propertyBoundary.siteBoundary.test.js
+++ b/src/__tests__/services/siteAnalysis.propertyBoundary.siteBoundary.test.js
@@ -1,0 +1,89 @@
+import {
+  buildEstimatedBoundaryMetadata,
+  detectPropertyBoundary,
+  INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE,
+  INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
+} from "../../services/propertyBoundaryService.js";
+import { assessSiteBoundaryAuthority } from "../../services/siteAnalysisService.js";
+
+const samplePolygon = [
+  { lat: 53.79215, lng: -1.7554 },
+  { lat: 53.79215, lng: -1.7551 },
+  { lat: 53.79192, lng: -1.7551 },
+  { lat: 53.79192, lng: -1.7554 },
+];
+
+describe("site boundary authority", () => {
+  test("marks Intelligent Fallback metadata as estimated and non-authoritative", () => {
+    const metadata = buildEstimatedBoundaryMetadata();
+
+    expect(metadata).toMatchObject({
+      boundaryAuthoritative: false,
+      boundaryConfidence: INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE,
+      boundarySource: INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
+      fallbackReason: "No real boundary data available",
+      estimatedOnly: true,
+    });
+  });
+
+  test("does not treat Intelligent Fallback confidence 0.4 as authoritative", () => {
+    const assessment = assessSiteBoundaryAuthority(
+      {
+        polygon: samplePolygon,
+        source: INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
+        confidence: 0.4,
+        area: 119408,
+        metadata: buildEstimatedBoundaryMetadata(),
+      },
+      { plotAreaM2: 450 },
+    );
+
+    expect(assessment.boundaryAuthoritative).toBe(false);
+    expect(assessment.estimatedOnly).toBe(true);
+    expect(assessment.boundaryWarningCode).toBe(
+      "SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE",
+    );
+    expect(assessment.reasons).toEqual(
+      expect.arrayContaining([
+        "fallback_source",
+        "low_confidence",
+        "area_outlier",
+      ]),
+    );
+    expect(assessment.authoritativeAreaM2).toBeNull();
+    expect(assessment.estimatedAreaM2).toBe(119408);
+  });
+
+  test("keeps normal high-confidence boundaries authoritative", () => {
+    const assessment = assessSiteBoundaryAuthority(
+      {
+        polygon: samplePolygon,
+        source: "OpenStreetMap",
+        confidence: 0.92,
+        area: 520,
+      },
+      { plotAreaM2: 450 },
+    );
+
+    expect(assessment.boundaryAuthoritative).toBe(true);
+    expect(assessment.estimatedOnly).toBe(false);
+    expect(assessment.boundaryWarningCode).toBeNull();
+    expect(assessment.authoritativeAreaM2).toBe(520);
+  });
+
+  test("browser-safe detection returns fallback with non-authoritative metadata", async () => {
+    const boundary = await detectPropertyBoundary(
+      { lat: 53.79203, lng: -1.75524 },
+      "97 Bradford Street, Bradford",
+    );
+
+    expect(boundary.source).toBe(INTELLIGENT_FALLBACK_BOUNDARY_SOURCE);
+    expect(boundary.confidence).toBe(INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE);
+    expect(boundary.boundaryAuthoritative).toBe(false);
+    expect(boundary.estimatedOnly).toBe(true);
+    expect(boundary.metadata).toMatchObject({
+      boundaryAuthoritative: false,
+      estimatedOnly: true,
+    });
+  });
+});

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -771,14 +771,41 @@ const ArchitectAIWizardContainer = () => {
       const normalizedAnalysisBoundary = normalizeSitePolygonForUi(
         siteAnalysis.siteBoundary,
       );
+      const normalizedEstimatedBoundary = normalizeSitePolygonForUi(
+        siteAnalysis.estimatedSiteBoundary ||
+          siteAnalysis.contextualSiteBoundary,
+      );
       const normalizedExistingPolygon = normalizeSitePolygonForUi(sitePolygon);
+      const boundaryConfidence = Number(siteAnalysis?.boundaryConfidence);
+      const analysisBoundaryEstimated =
+        siteAnalysis?.boundaryAuthoritative === false ||
+        siteAnalysis?.boundaryEstimated === true ||
+        siteAnalysis?.estimatedOnly === true ||
+        /intelligent fallback|fallback/i.test(
+          String(siteAnalysis?.boundarySource || ""),
+        ) ||
+        (Number.isFinite(boundaryConfidence) && boundaryConfidence < 0.6);
+      const authoritativeAnalysisBoundary = analysisBoundaryEstimated
+        ? []
+        : normalizedAnalysisBoundary;
+      const contextualEstimatedBoundary = analysisBoundaryEstimated
+        ? normalizedEstimatedBoundary.length >= 3
+          ? normalizedEstimatedBoundary
+          : normalizedAnalysisBoundary
+        : [];
 
       // Select best polygon: footprint -> analysis boundary -> existing
       const polygon =
         detectedFootprint ||
-        (normalizedAnalysisBoundary.length >= 3
-          ? normalizedAnalysisBoundary
+        (authoritativeAnalysisBoundary.length >= 3
+          ? authoritativeAnalysisBoundary
           : normalizedExistingPolygon);
+      const siteBoundaryWarning =
+        analysisBoundaryEstimated && siteAnalysis?.boundaryWarning
+          ? siteAnalysis.boundaryWarning
+          : analysisBoundaryEstimated
+            ? "Site boundary is estimated only; verify the parcel boundary by survey before treating area or setbacks as authoritative."
+            : null;
 
       const siteDNA = buildSiteContext({
         location: { address, coordinates },
@@ -790,15 +817,32 @@ const ArchitectAIWizardContainer = () => {
         streetContext: siteAnalysis?.streetContext,
       });
 
-      if (polygon && polygon.length > 0) {
+      const hasAuthoritativePolygon =
+        Array.isArray(polygon) && polygon.length >= 3;
+      if (hasAuthoritativePolygon) {
         setSitePolygon(polygon);
+      } else {
+        setSitePolygon([]);
       }
       const derivedMetrics =
-        siteDNA?.metrics || (polygon ? computeSiteMetrics(polygon) : null);
+        siteDNA?.metrics ||
+        (hasAuthoritativePolygon ? computeSiteMetrics(polygon) : null);
       if (derivedMetrics) {
         setSiteMetrics(derivedMetrics);
-      } else if (!polygon) {
+      } else if (!hasAuthoritativePolygon) {
         setSiteMetrics(null);
+      }
+      if (siteBoundaryWarning) {
+        logger.warn(siteBoundaryWarning, {
+          boundarySource: siteAnalysis?.boundarySource,
+          boundaryConfidence: siteAnalysis?.boundaryConfidence,
+          fallbackReason: siteAnalysis?.fallbackReason,
+        });
+        setProgramWarnings((prev) =>
+          prev.includes(siteBoundaryWarning)
+            ? prev
+            : [...prev, siteBoundaryWarning],
+        );
       }
 
       const styleRecommendations =
@@ -822,6 +866,14 @@ const ArchitectAIWizardContainer = () => {
         siteAnalysis,
         buildingFootprint: detectedFootprint,
         detectedShape,
+        boundaryAuthoritative:
+          hasAuthoritativePolygon && !analysisBoundaryEstimated,
+        boundaryEstimated: analysisBoundaryEstimated,
+        boundaryWarning: siteBoundaryWarning,
+        boundaryWarningCode: siteAnalysis?.boundaryWarningCode || null,
+        estimatedSiteBoundary: contextualEstimatedBoundary,
+        contextualSiteBoundary: contextualEstimatedBoundary,
+        estimatedSurfaceArea: siteAnalysis.estimatedSurfaceArea || null,
         recommendedStyle: styleRecommendations.recommendedStyle,
         localStyles: styleRecommendations.localStyles || [],
         localMaterials: styleRecommendations.materials || [],
@@ -853,6 +905,7 @@ const ArchitectAIWizardContainer = () => {
     fetchClimateWindSun,
     setIsDetectingLocation,
     setLocationData,
+    setProgramWarnings,
     setSiteMetrics,
     setSitePolygon,
     sitePolygon,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -134,11 +134,20 @@ const TECHNICAL_A1_PANEL_TYPES_BASE = [
   "section_BB",
 ];
 
-function buildRequiredA1PanelTypes(targetStoreys = 1) {
+export function buildRequiredA1PanelTypes(
+  targetStoreys = 1,
+  layoutTemplate = "board-v2",
+) {
   const dynamicFloorPlans = floorPlanPanelTypes(targetStoreys).filter(
     (type) => type !== "floor_plan_ground",
   );
-  return [...REQUIRED_A1_PANEL_TYPES_BASE, ...dynamicFloorPlans];
+  const basePanelTypes =
+    layoutTemplate === "presentation-v3"
+      ? REQUIRED_A1_PANEL_TYPES_BASE.filter(
+          (panelType) => panelType !== "exterior_render",
+        )
+      : REQUIRED_A1_PANEL_TYPES_BASE;
+  return [...basePanelTypes, ...dynamicFloorPlans];
 }
 
 function buildTechnicalA1PanelTypes(targetStoreys = 1) {
@@ -1420,11 +1429,43 @@ function insetRectFromBbox(bbox, inset = 2) {
   );
 }
 
-function buildSiteContext({ brief, sitePolygon = [], siteMetrics = {} } = {}) {
-  const geoBoundary =
+const SITE_BOUNDARY_AUTHORITY_CONFIDENCE_THRESHOLD = 0.6;
+const SITE_BOUNDARY_ESTIMATED_WARNING_CODE =
+  "SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE";
+
+function toFiniteMetric(value, fallback = null) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function boundarySourceLooksEstimated(source) {
+  return /intelligent fallback|fallback/i.test(String(source || ""));
+}
+
+function siteAreaOutlierLimitForBrief(brief = {}) {
+  const targetGia = Math.max(0, Number(brief.target_gia_m2 || 0));
+  return Math.max(2500, targetGia * 24);
+}
+
+function isSiteAreaOutlierForBrief(areaM2, brief = {}) {
+  const numericArea = Number(areaM2 || 0);
+  return numericArea > 0 && numericArea > siteAreaOutlierLimitForBrief(brief);
+}
+
+function buildSiteContext({
+  brief,
+  sitePolygon = [],
+  siteMetrics = {},
+  siteBoundarySanity = null,
+} = {}) {
+  const boundarySanity = siteBoundarySanity || {};
+  const authoritativeBoundaryAllowed =
+    boundarySanity.boundaryAuthoritative !== false;
+  const suppliedGeoBoundary =
     Array.isArray(sitePolygon) && sitePolygon.length >= 3
       ? sitePolygon
       : polygonFromGeoJson(brief.site_input.boundary_geojson);
+  const geoBoundary = authoritativeBoundaryAllowed ? suppliedGeoBoundary : [];
   const hasGeoBoundary =
     geoBoundary.length >= 3 &&
     Number.isFinite(Number(geoBoundary[0]?.lat)) &&
@@ -1432,34 +1473,100 @@ function buildSiteContext({ brief, sitePolygon = [], siteMetrics = {} } = {}) {
   const origin = hasGeoBoundary
     ? computeGeoCentroid(geoBoundary)
     : { lat: brief.site_input.lat, lng: brief.site_input.lon };
+  const fallbackAreaM2 = Math.max(brief.target_gia_m2 * 2.2, 320);
   const localBoundary = hasGeoBoundary
     ? polygonToLocalXY(geoBoundary, origin).map((point) => ({
         x: roundMetric(point.x),
         y: roundMetric(point.y),
       }))
-    : buildFallbackSitePolygon(Math.max(brief.target_gia_m2 * 2.2, 320));
+    : buildFallbackSitePolygon(fallbackAreaM2);
   const boundaryBbox = buildBoundingBoxFromPolygon(localBoundary);
   const buildablePolygon = insetRectFromBbox(boundaryBbox, 2);
+  const metricAreaM2 = authoritativeBoundaryAllowed
+    ? Number(siteMetrics.areaM2 || 0)
+    : 0;
   const areaM2 =
-    Number(siteMetrics.areaM2 || 0) ||
-    computePolygonArea(localBoundary) ||
-    Math.max(brief.target_gia_m2 * 2.2, 320);
+    metricAreaM2 || computePolygonArea(localBoundary) || fallbackAreaM2;
+  const boundaryAuthoritative = hasGeoBoundary && authoritativeBoundaryAllowed;
+  const boundaryConfidence =
+    toFiniteMetric(boundarySanity.boundaryConfidence, null) ??
+    (boundaryAuthoritative ? 1 : 0.4);
+  const boundarySource =
+    boundarySanity.boundarySource ||
+    (boundaryAuthoritative ? "site_polygon" : "deterministic_context");
+  const estimatedAreaM2 =
+    boundarySanity.estimatedAreaM2 ||
+    (!boundaryAuthoritative && Number(boundarySanity.sourceAreaM2 || 0) > 0
+      ? Number(boundarySanity.sourceAreaM2)
+      : null);
+  const fallbackReason =
+    boundarySanity.fallbackReason ||
+    (!boundaryAuthoritative
+      ? "No authoritative site boundary was supplied; using deterministic context geometry."
+      : null);
+  const dataQuality = boundaryAuthoritative
+    ? [
+        {
+          code: "SITE_BOUNDARY_PROVIDED",
+          severity: "info",
+          message: "Site boundary was supplied by the request.",
+        },
+      ]
+    : [
+        {
+          code: SITE_BOUNDARY_ESTIMATED_WARNING_CODE,
+          severity: "warning",
+          message:
+            "Site boundary is estimated and is not treated as an authoritative parcel boundary or plot area.",
+          details: {
+            boundarySource,
+            boundaryConfidence,
+            fallbackReason,
+            estimatedAreaM2,
+            areaOutlier: boundarySanity.areaOutlier === true,
+          },
+        },
+        {
+          code: "SITE_BOUNDARY_FALLBACK",
+          severity: "warning",
+          message:
+            "No authoritative site boundary was supplied; deterministic fallback boundary used for contextual rendering only.",
+        },
+      ];
 
   return {
     site_id: createStableId("site", brief.project_name, origin.lat, origin.lng),
     address_normalised: brief.site_input.address || null,
     lat: round(origin.lat, 6),
     lon: round(origin.lng ?? origin.lon, 6),
-    boundary: brief.site_input.boundary_geojson || null,
+    boundary: boundaryAuthoritative
+      ? brief.site_input.boundary_geojson || null
+      : null,
     local_boundary_polygon: localBoundary,
     buildable_polygon: buildablePolygon,
     north_angle_degrees: Number(siteMetrics.orientationDeg || 0),
     area_m2: round(areaM2, 2),
+    authoritative_area_m2: boundaryAuthoritative ? round(areaM2, 2) : null,
+    estimated_area_m2:
+      Number(estimatedAreaM2 || 0) > 0 ? round(estimatedAreaM2, 2) : null,
+    boundary_authoritative: boundaryAuthoritative,
+    boundary_confidence: round(boundaryConfidence, 3),
+    boundary_source: boundarySource,
+    boundary_estimated: !boundaryAuthoritative,
+    estimated_only: !boundaryAuthoritative,
+    fallback_reason: fallbackReason,
+    boundary_warning_code: boundaryAuthoritative
+      ? null
+      : SITE_BOUNDARY_ESTIMATED_WARNING_CODE,
+    estimated_geo_boundary: boundaryAuthoritative
+      ? []
+      : boundarySanity.estimatedGeoBoundary || [],
+    boundary_authority_reasons: boundarySanity.reasons || [],
     access_edges: [
       {
         edge_id: "street-edge-primary",
         label: "Assumed primary street edge",
-        source: hasGeoBoundary ? "site_polygon" : "fallback",
+        source: boundaryAuthoritative ? "site_polygon" : "estimated_context",
       },
     ],
     adjacent_roads: [],
@@ -1473,17 +1580,7 @@ function buildSiteContext({ brief, sitePolygon = [], siteMetrics = {} } = {}) {
     },
     heritage_flags: [],
     planning_policy_refs: [],
-    data_quality: [
-      {
-        code: hasGeoBoundary
-          ? "SITE_BOUNDARY_PROVIDED"
-          : "SITE_BOUNDARY_FALLBACK",
-        severity: hasGeoBoundary ? "info" : "warning",
-        message: hasGeoBoundary
-          ? "Site boundary was supplied by the request."
-          : "No authoritative site boundary was supplied; deterministic fallback boundary used.",
-      },
-    ],
+    data_quality: dataQuality,
   };
 }
 
@@ -1497,6 +1594,117 @@ function normalizeGeoPolygonForMap(input = null) {
     .filter(
       (point) => Number.isFinite(point.lat) && Number.isFinite(point.lng),
     );
+}
+
+function resolveSiteBoundarySanity(input = {}, brief = {}) {
+  const siteAnalysis =
+    input.siteAnalysis ||
+    input.locationData?.siteAnalysis ||
+    input.siteSnapshot?.metadata?.siteAnalysis ||
+    {};
+  const siteMetrics = {
+    ...(input.siteSnapshot?.metadata?.siteMetrics || {}),
+    ...(input.sitePolygonMetrics || {}),
+    ...(input.siteMetrics || {}),
+  };
+  const submittedGeoBoundary = normalizeGeoPolygonForMap(
+    input.sitePolygon ||
+      input.site_boundary ||
+      brief.site_input?.boundary_geojson,
+  );
+  const estimatedGeoBoundary = normalizeGeoPolygonForMap(
+    siteAnalysis.estimatedSiteBoundary ||
+      siteAnalysis.contextualSiteBoundary ||
+      siteAnalysis.siteBoundary ||
+      input.locationData?.estimatedSiteBoundary ||
+      input.locationData?.contextualSiteBoundary ||
+      input.siteSnapshot?.polygon ||
+      input.siteSnapshot?.sitePolygon,
+  );
+  const boundarySource =
+    siteAnalysis.boundarySource ||
+    siteMetrics.boundarySource ||
+    input.locationData?.boundarySource ||
+    (submittedGeoBoundary.length >= 3
+      ? "site_polygon"
+      : "deterministic_context");
+  const boundaryConfidence =
+    toFiniteMetric(
+      siteAnalysis.boundaryConfidence ??
+        siteMetrics.boundaryConfidence ??
+        input.locationData?.boundaryConfidence,
+      null,
+    ) ?? (submittedGeoBoundary.length >= 3 ? 1 : 0.4);
+  const sourceAreaM2 = toFiniteMetric(
+    siteMetrics.areaM2 ??
+      siteAnalysis.surfaceArea ??
+      siteAnalysis.estimatedSurfaceArea ??
+      input.locationData?.surfaceArea,
+    null,
+  );
+  const explicitNonAuthoritative =
+    siteAnalysis.boundaryAuthoritative === false ||
+    siteMetrics.boundaryAuthoritative === false ||
+    input.locationData?.boundaryAuthoritative === false ||
+    siteAnalysis.boundaryEstimated === true ||
+    siteAnalysis.estimatedOnly === true ||
+    input.locationData?.boundaryEstimated === true;
+  const lowConfidence =
+    boundaryConfidence < SITE_BOUNDARY_AUTHORITY_CONFIDENCE_THRESHOLD;
+  const fallbackSource = boundarySourceLooksEstimated(boundarySource);
+  const areaOutlier = isSiteAreaOutlierForBrief(sourceAreaM2, brief);
+  const hasSubmittedBoundary = submittedGeoBoundary.length >= 3;
+  const reasons = [];
+
+  if (!hasSubmittedBoundary) reasons.push("missing_boundary_polygon");
+  if (explicitNonAuthoritative) reasons.push("explicitly_estimated");
+  if (fallbackSource) reasons.push("fallback_source");
+  if (lowConfidence) reasons.push("low_confidence");
+  if (areaOutlier) reasons.push("area_outlier");
+
+  const boundaryAuthoritative =
+    hasSubmittedBoundary &&
+    !explicitNonAuthoritative &&
+    !fallbackSource &&
+    !lowConfidence &&
+    !areaOutlier;
+  const sanitizedSiteMetrics = { ...siteMetrics };
+  if (!boundaryAuthoritative) {
+    delete sanitizedSiteMetrics.areaM2;
+  }
+  sanitizedSiteMetrics.boundaryAuthoritative = boundaryAuthoritative;
+  sanitizedSiteMetrics.boundaryConfidence = boundaryConfidence;
+  sanitizedSiteMetrics.boundarySource = boundarySource;
+
+  return {
+    boundaryAuthoritative,
+    boundaryConfidence,
+    boundarySource,
+    fallbackReason:
+      siteAnalysis.fallbackReason ||
+      siteMetrics.fallbackReason ||
+      input.locationData?.fallbackReason ||
+      (boundaryAuthoritative
+        ? null
+        : "Boundary is estimated and must be verified by survey."),
+    estimatedOnly: !boundaryAuthoritative,
+    areaOutlier,
+    reasons,
+    sourceAreaM2,
+    estimatedAreaM2:
+      !boundaryAuthoritative && Number(sourceAreaM2 || 0) > 0
+        ? sourceAreaM2
+        : null,
+    authoritativeAreaM2:
+      boundaryAuthoritative && Number(sourceAreaM2 || 0) > 0
+        ? sourceAreaM2
+        : null,
+    estimatedGeoBoundary:
+      !boundaryAuthoritative && estimatedGeoBoundary.length >= 3
+        ? estimatedGeoBoundary
+        : [],
+    siteMetrics: sanitizedSiteMetrics,
+  };
 }
 
 function normalizeProvidedSiteSnapshot(siteSnapshot = null) {
@@ -1554,11 +1762,13 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
   }
 
   const polygon = normalizeGeoPolygonForMap(
-    input.sitePolygon ||
-      input.site_boundary ||
-      input.siteSnapshot?.sitePolygon ||
-      input.siteSnapshot?.polygon ||
-      brief.site_input.boundary_geojson,
+    site?.boundary_authoritative === false
+      ? null
+      : input.sitePolygon ||
+          input.site_boundary ||
+          input.siteSnapshot?.sitePolygon ||
+          input.siteSnapshot?.polygon ||
+          brief.site_input.boundary_geojson,
   );
   const center = input.siteSnapshot?.center ||
     input.siteSnapshot?.coordinates ||
@@ -2722,6 +2932,21 @@ function buildSiteContextPanelArtifact({
   const bbox = buildBoundingBoxFromPolygon(site.local_boundary_polygon || []);
   const sitePath = polygonPath(site.local_boundary_polygon, bbox, 812, 646);
   const buildablePath = polygonPath(site.buildable_polygon, bbox, 812, 646);
+  const buildableBbox = buildBoundingBoxFromPolygon(
+    site.buildable_polygon || site.local_boundary_polygon || [],
+  );
+  const proposedFootprint = rectangleToPolygon(
+    Number(buildableBbox.min_x || 0) + Number(buildableBbox.width || 0) * 0.24,
+    Number(buildableBbox.min_y || 0) + Number(buildableBbox.height || 0) * 0.3,
+    Math.max(8, Number(buildableBbox.width || 0) * 0.52),
+    Math.max(8, Number(buildableBbox.height || 0) * 0.36),
+  );
+  const proposedFootprintPath = polygonPath(proposedFootprint, bbox, 812, 646);
+  const boundaryEstimated =
+    site?.boundary_authoritative === false || site?.boundary_estimated === true;
+  const sitePlanMode = boundaryEstimated
+    ? "contextual_estimated_boundary"
+    : "authoritative_boundary";
   const hasMapImage = Boolean(siteSnapshot?.dataUrl);
   const mapSource = hasMapImage
     ? siteSnapshot.sourceUrl || siteSnapshot.source || "provided-site-snapshot"
@@ -2735,29 +2960,46 @@ function buildSiteContextPanelArtifact({
   const attribution = hasMapImage
     ? siteSnapshot.attribution || "Map image supplied by request"
     : "No map snapshot available";
-  const mapLayer = hasMapImage
-    ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice"/>
+  const mapLayer = boundaryEstimated
+    ? `${hasMapImage ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice" opacity="0.38"/>` : `<rect x="28" y="52" width="844" height="676" fill="#f7f6f0"/>`}
+  <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
+  <path d="M 78 636 C 186 586 272 612 354 562 C 456 500 584 520 824 462" fill="none" stroke="#d7d7d7" stroke-width="34" opacity="0.8"/>
+  <path d="M 78 636 C 186 586 272 612 354 562 C 456 500 584 520 824 462" fill="none" stroke="#ffffff" stroke-width="22" opacity="0.96"/>
+  <path d="M 112 142 L 196 186 L 282 152 L 372 206 L 470 166 L 590 222 L 770 190" fill="none" stroke="#c7cfbf" stroke-width="14" opacity="0.7"/>
+  <path d="M 130 506 L 246 452 L 372 474 L 520 424 L 712 444" fill="none" stroke="#c7cfbf" stroke-width="12" opacity="0.6"/>
+  <g transform="translate(44 66)">
+    <path d="${sitePath}" fill="#f9fbf7" stroke="#5d6657" stroke-width="4" stroke-dasharray="16 10"/>
+    <path d="${buildablePath}" fill="none" stroke="#29332a" stroke-width="3" stroke-dasharray="8 8"/>
+    <path d="${proposedFootprintPath}" fill="#11111122" stroke="#111111" stroke-width="4"/>
+  </g>
+  <text x="450" y="104" font-family="Arial, sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#111111">CONTEXTUAL SITE PLAN</text>
+  <text x="450" y="136" font-family="Arial, sans-serif" font-size="16" text-anchor="middle" fill="#555555">Boundary estimated - verify with measured survey before planning submission</text>`
+    : hasMapImage
+      ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice"/>
   <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
   <g transform="translate(44 66)" opacity="0.88">
     <path d="${sitePath}" fill="#a9c58d66" stroke="#d64d35" stroke-width="5" stroke-dasharray="18 10"/>
     <path d="${buildablePath}" fill="none" stroke="#111111" stroke-width="3"/>
   </g>`
-    : `<rect x="28" y="52" width="844" height="676" fill="#f3efe4" stroke="#111111" stroke-width="3"/>
+      : `<rect x="28" y="52" width="844" height="676" fill="#f3efe4" stroke="#111111" stroke-width="3"/>
   <g transform="translate(44 66)">
     <path d="${sitePath}" fill="#dfe8d0" stroke="#d64d35" stroke-width="5" stroke-dasharray="18 10"/>
     <path d="${buildablePath}" fill="none" stroke="#111111" stroke-width="3"/>
   </g>
   <path d="M 64 642 C 186 600 272 620 354 574 C 440 526 552 540 806 488" fill="none" stroke="#c8c8c8" stroke-width="28" opacity="0.55"/>
   <path d="M 64 642 C 186 600 272 620 354 574 C 440 526 552 540 806 488" fill="none" stroke="#ffffff" stroke-width="18" opacity="0.85"/>`;
+  const areaLabel = boundaryEstimated
+    ? `Context area ${site.area_m2} m2; parcel area not authoritative`
+    : `Area ${site.area_m2} m2`;
   const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="site_context" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-site-map-source="${escapeXml(mapSource)}" data-site-map-image="${hasMapImage ? "true" : "false"}">
   <rect width="${width}" height="${height}" fill="#ffffff"/>
   ${mapLayer}
   <path d="M 806 142 L 806 70 L 784 116 M 806 70 L 828 116" fill="none" stroke="#111111" stroke-width="5" stroke-linecap="round"/>
   <circle cx="806" cy="112" r="46" fill="none" stroke="#111111" stroke-width="2"/>
   <text x="806" y="58" font-family="Arial, sans-serif" font-size="32" font-weight="700" text-anchor="middle" fill="#111111">N</text>
-  <text x="450" y="342" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333333">Rear Garden</text>
-  <text x="450" y="682" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333333">Front Garden</text>
-  <text x="82" y="690" font-family="Arial, sans-serif" font-size="20" fill="#333333">Driveway</text>
+  <text x="450" y="342" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333333">${boundaryEstimated ? "Proposed Footprint" : "Rear Garden"}</text>
+  <text x="450" y="682" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333333">${boundaryEstimated ? "Estimated Boundary" : "Front Garden"}</text>
+  <text x="82" y="690" font-family="Arial, sans-serif" font-size="20" fill="#333333">${boundaryEstimated ? "Context Street" : "Driveway"}</text>
   <line x1="48" y1="790" x2="348" y2="790" stroke="#111111" stroke-width="5"/>
   <line x1="48" y1="780" x2="48" y2="800" stroke="#111111" stroke-width="3"/>
   <line x1="168" y1="780" x2="168" y2="800" stroke="#111111" stroke-width="3"/>
@@ -2768,7 +3010,7 @@ function buildSiteContextPanelArtifact({
   <text x="48" y="860" font-family="Arial, sans-serif" font-size="17" fill="#333333">Scale 1:500</text>
   <text x="852" y="824" font-family="Arial, sans-serif" font-size="15" text-anchor="end" fill="#555555">${escapeXml(mapLabel)}</text>
   <text x="852" y="852" font-family="Arial, sans-serif" font-size="13" text-anchor="end" fill="#777777">${escapeXml(attribution)}</text>
-  <text x="852" y="878" font-family="Arial, sans-serif" font-size="13" text-anchor="end" fill="#777777">Area ${escapeXml(site.area_m2)} m2 | ${escapeXml(geometryHash.slice(0, 12))}</text>
+  <text x="852" y="878" font-family="Arial, sans-serif" font-size="13" text-anchor="end" fill="#777777">${escapeXml(areaLabel)} | ${escapeXml(geometryHash.slice(0, 12))}</text>
 </svg>`;
   const svgHash = computeCDSHashSync({ panelType: "site_context", svgString });
   const assetId = createStableId(
@@ -2795,6 +3037,15 @@ function buildSiteContextPanelArtifact({
       siteMapSource: mapSource,
       hasMapImage,
       attribution,
+      sitePlanMode,
+      boundaryAuthoritative: site.boundary_authoritative === true,
+      boundaryEstimated,
+      boundaryConfidence: site.boundary_confidence ?? null,
+      boundarySource: site.boundary_source || null,
+      boundaryWarningCode: site.boundary_warning_code || null,
+      fallbackReason: site.fallback_reason || null,
+      authoritativeAreaM2: site.authoritative_area_m2 || null,
+      estimatedAreaM2: site.estimated_area_m2 || null,
       svgHash,
     },
   };
@@ -4577,7 +4828,10 @@ async function buildA1Sheet({
   const presentationSummary = summarizePresentationMode(panelArtifacts);
   const svgHash = computeCDSHashSync({ svg: svgString });
   const sheetAssetId = createStableId("asset-a1-svg", sheetId, svgHash);
-  const requiredPlacementTypes = buildRequiredA1PanelTypes(targetStoreys);
+  const requiredPlacementTypes = buildRequiredA1PanelTypes(
+    targetStoreys,
+    layoutTemplate,
+  );
   const requiredPlacements = panelPlacements.filter((placement) =>
     requiredPlacementTypes.includes(placement.panelType),
   );
@@ -5142,8 +5396,11 @@ function addCheck(
   });
 }
 
-function expectedRequiredPanelTypes(targetStoreys = 1) {
-  return buildRequiredA1PanelTypes(targetStoreys);
+function expectedRequiredPanelTypes(
+  targetStoreys = 1,
+  layoutTemplate = "board-v2",
+) {
+  return buildRequiredA1PanelTypes(targetStoreys, layoutTemplate);
 }
 
 function artifactArray(artifacts = {}) {
@@ -5914,6 +6171,8 @@ export function validateProjectGraphVerticalSlice({
   );
   const expectedPanels = expectedRequiredPanelTypes(
     projectGraph?.brief?.target_storeys || 1,
+    artifacts.a1Sheet?.layoutTemplate ||
+      resolvePresentationLayoutTemplate(projectGraph?.brief || {}),
   );
   const panelRenderabilityRecords = expectedPanels.map((panelType) => {
     const artifact = findPanelArtifact(panelArtifacts, panelType);
@@ -6274,6 +6533,23 @@ export function validateProjectGraphVerticalSlice({
         "warning",
         "No Google/provided site map snapshot was available; deterministic site diagram fallback was used.",
         { siteMapSource },
+      ),
+    );
+  }
+  if (siteMapArtifact?.metadata?.boundaryAuthoritative === false) {
+    issues.push(
+      buildIssue(
+        SITE_BOUNDARY_ESTIMATED_WARNING_CODE,
+        "warning",
+        "Site boundary is estimated only and was not treated as authoritative plot area.",
+        {
+          boundarySource: siteMapArtifact.metadata.boundarySource || null,
+          boundaryConfidence:
+            siteMapArtifact.metadata.boundaryConfidence ?? null,
+          fallbackReason: siteMapArtifact.metadata.fallbackReason || null,
+          estimatedAreaM2: siteMapArtifact.metadata.estimatedAreaM2 || null,
+          sitePlanMode: siteMapArtifact.metadata.sitePlanMode || null,
+        },
       ),
     );
   }
@@ -6928,10 +7204,14 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       };
     }
   }
+  const siteBoundarySanity = resolveSiteBoundarySanity(input, brief);
   const deterministicSite = buildSiteContext({
     brief,
-    sitePolygon: input.sitePolygon || input.site_boundary || [],
-    siteMetrics: input.siteMetrics || {},
+    sitePolygon: siteBoundarySanity.boundaryAuthoritative
+      ? input.sitePolygon || input.site_boundary || []
+      : [],
+    siteMetrics: siteBoundarySanity.siteMetrics,
+    siteBoundarySanity,
   });
   // Plan §6.2 / §14: opt-in enrichment via Planning Data, EA flood, OSM. The
   // slice stays offline-safe by default; callers pass fetchImpl or
@@ -7268,8 +7548,10 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       1,
       Number(brief?.target_storeys || 1),
     );
-    const phaseFRequiredPanels =
-      buildRequiredA1PanelTypes(targetStoreysForGate);
+    const phaseFRequiredPanels = buildRequiredA1PanelTypes(
+      targetStoreysForGate,
+      sheetArtifact.layoutTemplate || resolvePresentationLayoutTemplate(brief),
+    );
     const visualPanelArtifacts = Object.values(primaryPanelArtifacts).filter(
       (artifact) =>
         REQUIRED_3D_A1_PANEL_TYPES.includes(artifact?.panel_type) ||

--- a/src/services/propertyBoundaryService.js
+++ b/src/services/propertyBoundaryService.js
@@ -9,6 +9,27 @@ const API_ENDPOINTS = {
   NOMINATIM: "https://nominatim.openstreetmap.org/search",
 };
 
+export const INTELLIGENT_FALLBACK_BOUNDARY_SOURCE = "Intelligent Fallback";
+export const INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE = 0.4;
+
+export function buildEstimatedBoundaryMetadata({
+  source = INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
+  confidence = INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE,
+  reason = "No real boundary data available",
+  extra = {},
+  ...rest
+} = {}) {
+  return {
+    ...rest,
+    ...extra,
+    boundaryAuthoritative: false,
+    boundaryConfidence: confidence,
+    boundarySource: source,
+    fallbackReason: reason,
+    estimatedOnly: true,
+  };
+}
+
 function isBrowserRuntime() {
   return (
     typeof window !== "undefined" && typeof window.document !== "undefined"
@@ -315,13 +336,18 @@ function generateIntelligentFallback(coordinates, address) {
   return {
     polygon,
     shapeType,
-    source: "Intelligent Fallback",
-    confidence: 0.4,
+    source: INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
+    confidence: INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE,
+    boundaryAuthoritative: false,
+    boundaryConfidence: INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE,
+    boundarySource: INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
+    fallbackReason: "No real boundary data available",
+    estimatedOnly: true,
     area: calculatePolygonArea(polygon),
-    metadata: {
+    metadata: buildEstimatedBoundaryMetadata({
       reason: "No real boundary data available",
       addressAnalysis: { isUrban, isCorner },
-    },
+    }),
   };
 }
 

--- a/src/services/siteAnalysisService.js
+++ b/src/services/siteAnalysisService.js
@@ -27,6 +27,106 @@ import {
 import runtimeEnv from "../utils/runtimeEnv.js";
 import logger from "../utils/logger.js";
 
+const BOUNDARY_AUTHORITY_CONFIDENCE_THRESHOLD = 0.6;
+const SITE_BOUNDARY_ESTIMATED_WARNING_CODE =
+  "SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE";
+
+function toFiniteNumber(value, fallback = null) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function normaliseBoundarySource(boundary = {}) {
+  return (
+    boundary?.boundarySource ||
+    boundary?.source ||
+    boundary?.metadata?.boundarySource ||
+    boundary?.metadata?.source ||
+    "estimated"
+  );
+}
+
+function isFallbackBoundarySource(source) {
+  return /intelligent fallback|fallback/i.test(String(source || ""));
+}
+
+export function assessSiteBoundaryAuthority(boundary = null, options = {}) {
+  const source = normaliseBoundarySource(boundary || {});
+  const confidence = toFiniteNumber(
+    boundary?.boundaryConfidence ??
+      boundary?.confidence ??
+      boundary?.metadata?.boundaryConfidence,
+    0.4,
+  );
+  const areaM2 = toFiniteNumber(
+    boundary?.area ?? boundary?.surfaceArea ?? boundary?.areaM2,
+    null,
+  );
+  const plotAreaEstimateM2 = toFiniteNumber(options.plotAreaM2, null);
+  const areaOutlierLimit = Math.max(
+    10000,
+    Number(plotAreaEstimateM2 || 0) > 0 ? plotAreaEstimateM2 * 25 : 0,
+  );
+  const areaOutlier =
+    Number(areaM2 || 0) > 0 && Number(areaM2) > areaOutlierLimit;
+  const explicitNonAuthoritative =
+    boundary?.boundaryAuthoritative === false ||
+    boundary?.metadata?.boundaryAuthoritative === false ||
+    boundary?.estimatedOnly === true ||
+    boundary?.metadata?.estimatedOnly === true;
+  const fallbackSource = isFallbackBoundarySource(source);
+  const lowConfidence =
+    Number(confidence || 0) < BOUNDARY_AUTHORITY_CONFIDENCE_THRESHOLD;
+  const hasPolygon =
+    Array.isArray(boundary?.polygon) && boundary.polygon.length >= 3;
+  const reasons = [];
+
+  if (!hasPolygon) reasons.push("missing_boundary_polygon");
+  if (explicitNonAuthoritative) reasons.push("explicitly_estimated");
+  if (fallbackSource) reasons.push("fallback_source");
+  if (lowConfidence) reasons.push("low_confidence");
+  if (areaOutlier) reasons.push("area_outlier");
+
+  const boundaryAuthoritative =
+    hasPolygon &&
+    !explicitNonAuthoritative &&
+    !fallbackSource &&
+    !lowConfidence &&
+    !areaOutlier;
+
+  const fallbackReason =
+    boundary?.fallbackReason ||
+    boundary?.metadata?.fallbackReason ||
+    boundary?.metadata?.reason ||
+    (boundaryAuthoritative
+      ? null
+      : "Boundary is estimated and must be verified by survey.");
+
+  return {
+    boundaryAuthoritative,
+    boundaryConfidence: confidence,
+    boundarySource: source,
+    fallbackReason,
+    estimatedOnly: !boundaryAuthoritative,
+    boundaryEstimated: !boundaryAuthoritative,
+    boundaryWarningCode: boundaryAuthoritative
+      ? null
+      : SITE_BOUNDARY_ESTIMATED_WARNING_CODE,
+    boundaryWarning: boundaryAuthoritative
+      ? null
+      : "Site boundary is estimated only; verify the parcel boundary by survey before treating area or setbacks as authoritative.",
+    lowConfidence,
+    fallbackSource,
+    areaOutlier,
+    reasons,
+    authoritativeAreaM2:
+      boundaryAuthoritative && Number(areaM2 || 0) > 0 ? areaM2 : null,
+    estimatedAreaM2:
+      !boundaryAuthoritative && Number(areaM2 || 0) > 0 ? areaM2 : null,
+    areaOutlierLimit,
+  };
+}
+
 function getGooglePlacesProxyBaseUrl() {
   const explicitBase = (process.env.REACT_APP_API_PROXY_URL || "").trim();
 
@@ -160,12 +260,38 @@ class SiteAnalysisService {
       // Analyze street view and orientation
       const streetContext = await this.analyzeStreetContext(coordinates);
 
-      // Determine plot characteristics (enhanced with actual boundary data)
-      const plotAnalysis = this.analyzePlotCharacteristics(
+      const estimatedPlotAnalysis = this.analyzePlotCharacteristics(
         geocodeData,
         streetContext,
-        propertyBoundary,
+        null,
       );
+      const estimatedPlotArea =
+        estimatedPlotAnalysis.dimensions.width *
+        estimatedPlotAnalysis.dimensions.depth;
+      const boundaryAuthority = assessSiteBoundaryAuthority(propertyBoundary, {
+        plotAreaM2: estimatedPlotArea,
+      });
+
+      // Determine plot characteristics. Only surveyed/high-confidence boundary
+      // geometry is allowed to override the estimate used by programme logic.
+      const authoritativeBoundary = boundaryAuthority.boundaryAuthoritative
+        ? propertyBoundary
+        : null;
+      const plotAnalysis = authoritativeBoundary
+        ? this.analyzePlotCharacteristics(
+            geocodeData,
+            streetContext,
+            authoritativeBoundary,
+          )
+        : estimatedPlotAnalysis;
+      const plotArea =
+        plotAnalysis.dimensions.width * plotAnalysis.dimensions.depth;
+      const surfaceArea =
+        boundaryAuthority.authoritativeAreaM2 || plotArea || estimatedPlotArea;
+      const estimatedBoundary =
+        !boundaryAuthority.boundaryAuthoritative && propertyBoundary?.polygon
+          ? propertyBoundary.polygon
+          : null;
 
       // Generate site-specific design constraints
       const designConstraints = this.generateDesignConstraints(
@@ -186,18 +312,30 @@ class SiteAnalysisService {
           coordinates: coordinates,
 
           // NEW: Actual site boundary data with enhanced shape detection
-          siteBoundary: propertyBoundary?.polygon || null,
-          surfaceArea:
-            propertyBoundary?.area ||
-            plotAnalysis.dimensions.width * plotAnalysis.dimensions.depth,
+          siteBoundary: authoritativeBoundary?.polygon || null,
+          authoritativeSiteBoundary: authoritativeBoundary?.polygon || null,
+          estimatedSiteBoundary: estimatedBoundary,
+          surfaceArea,
+          authoritativeSurfaceArea: boundaryAuthority.boundaryAuthoritative
+            ? surfaceArea
+            : null,
+          estimatedSurfaceArea: boundaryAuthority.estimatedAreaM2,
           surfaceAreaUnit: propertyBoundary?.unit || "m²",
-          boundarySource: propertyBoundary?.source || "estimated",
+          boundaryAuthoritative: boundaryAuthority.boundaryAuthoritative,
+          boundaryEstimated: boundaryAuthority.boundaryEstimated,
+          estimatedOnly: boundaryAuthority.estimatedOnly,
+          boundarySource: boundaryAuthority.boundarySource,
           boundaryShapeType:
-            propertyBoundary?.shapeType || plotAnalysis.plotShape,
-          boundaryConfidence: propertyBoundary?.confidence || 0.4,
+            authoritativeBoundary?.shapeType || plotAnalysis.plotShape,
+          boundaryConfidence: boundaryAuthority.boundaryConfidence,
+          fallbackReason: boundaryAuthority.fallbackReason,
+          boundaryWarningCode: boundaryAuthority.boundaryWarningCode,
+          boundaryWarning: boundaryAuthority.boundaryWarning,
+          boundaryAreaOutlier: boundaryAuthority.areaOutlier,
+          boundaryAuthorityReasons: boundaryAuthority.reasons,
 
           plotType: plotAnalysis.plotType,
-          plotShape: propertyBoundary?.shapeType || plotAnalysis.plotShape, // Use detected shape
+          plotShape: authoritativeBoundary?.shapeType || plotAnalysis.plotShape,
           plotDimensions: plotAnalysis.dimensions,
           streetOrientation: streetContext.orientation,
           roadType: streetContext.roadType,
@@ -215,27 +353,26 @@ class SiteAnalysisService {
 
           // 🆕 plotGeometry - formatted for locationAwareDNAModifier compatibility
           plotGeometry: {
-            shape: propertyBoundary?.shapeType || plotAnalysis.plotShape,
+            shape: authoritativeBoundary?.shapeType || plotAnalysis.plotShape,
             dimensions: {
               width: plotAnalysis.dimensions.width,
               length: plotAnalysis.dimensions.depth, // depth is same as length
-              area:
-                propertyBoundary?.area ||
-                plotAnalysis.dimensions.width * plotAnalysis.dimensions.depth,
+              area: surfaceArea,
             },
             slope: 0, // TODO: Add slope detection from elevation API
             orientation: optimalOrientation,
-            shapeType: propertyBoundary?.shapeType,
-            confidence: propertyBoundary?.confidence,
+            shapeType: authoritativeBoundary?.shapeType,
+            confidence: boundaryAuthority.boundaryConfidence,
+            boundaryAuthoritative: boundaryAuthority.boundaryAuthoritative,
           },
 
           // 🆕 PlanJSON-compatible site geometry
           siteGeometry: this.convertToSiteGeometry(
-            propertyBoundary?.polygon || null,
+            authoritativeBoundary?.polygon || null,
             plotAnalysis,
             streetContext,
-            propertyBoundary?.area,
-            propertyBoundary?.shapeType,
+            surfaceArea,
+            authoritativeBoundary?.shapeType,
           ),
         },
       };
@@ -323,6 +460,20 @@ class SiteAnalysisService {
           source: enhancedBoundary.source,
           shapeType: enhancedBoundary.shapeType,
           confidence: enhancedBoundary.confidence,
+          boundaryAuthoritative:
+            enhancedBoundary.boundaryAuthoritative ??
+            enhancedBoundary.metadata?.boundaryAuthoritative,
+          boundaryConfidence:
+            enhancedBoundary.boundaryConfidence ?? enhancedBoundary.confidence,
+          boundarySource:
+            enhancedBoundary.boundarySource ?? enhancedBoundary.source,
+          fallbackReason:
+            enhancedBoundary.fallbackReason ??
+            enhancedBoundary.metadata?.fallbackReason ??
+            enhancedBoundary.metadata?.reason,
+          estimatedOnly:
+            enhancedBoundary.estimatedOnly ??
+            enhancedBoundary.metadata?.estimatedOnly,
           metadata: enhancedBoundary.metadata || {},
         };
       }
@@ -359,6 +510,10 @@ class SiteAnalysisService {
           ...osmBoundary,
           shapeType,
           confidence: 0.9,
+          boundaryAuthoritative: true,
+          boundaryConfidence: 0.9,
+          boundarySource: osmBoundary.source || "OpenStreetMap",
+          estimatedOnly: false,
         };
       }
 
@@ -376,6 +531,10 @@ class SiteAnalysisService {
           ...placesBoundary,
           shapeType,
           confidence: 0.6,
+          boundaryAuthoritative: true,
+          boundaryConfidence: 0.6,
+          boundarySource: placesBoundary.source || "Google Places",
+          estimatedOnly: false,
         };
       }
 
@@ -1412,6 +1571,22 @@ class SiteAnalysisService {
       plotType: "suburban_residential",
       plotShape: "rectangular",
       plotDimensions: { width: 15, depth: 30 },
+      siteBoundary: null,
+      authoritativeSiteBoundary: null,
+      estimatedSiteBoundary: null,
+      surfaceArea: 450,
+      authoritativeSurfaceArea: null,
+      estimatedSurfaceArea: 450,
+      surfaceAreaUnit: "m²",
+      boundaryAuthoritative: false,
+      boundaryEstimated: true,
+      estimatedOnly: true,
+      boundarySource: "Fallback Site Analysis",
+      boundaryConfidence: 0.4,
+      fallbackReason: "Site analysis API failed; using estimated context.",
+      boundaryWarningCode: SITE_BOUNDARY_ESTIMATED_WARNING_CODE,
+      boundaryWarning:
+        "Site boundary is estimated only; verify the parcel boundary by survey before treating area or setbacks as authoritative.",
       streetOrientation: "north_south",
       roadType: "local_street",
       roadCurvature: "straight",


### PR DESCRIPTION
## Summary
- Intelligent Fallback boundaries are marked non-authoritative.
- Low-confidence fallback polygons are preserved as contextual/estimated geometry only.
- Huge fallback areas no longer become real site area or programme/floor authority input.
- ProjectGraph emits SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE for estimated boundaries.
- Contextual estimated site plan mode renders a boundary disclaimer and survey verification note.
- Cherish/Bradford test now reports exportGate status=warning and allowed=true, with no missing required panels.

## Scope
- No OpenAI env/provider changes.
- No broad export-gate policy changes.
- No material palette changes.
- No presentation-v3 layout coordinate changes.
- No generated outputs included.

## Validation
- npm run lint
- npm run build:active
- npm run test:a1:tofu
- npm run test:compose:routing
- node scripts/tests/test-a1-layout-regression.mjs
- npm test -- --watchAll=false --runInBand siteAnalysis propertyBoundary siteBoundary
- npm test -- --watchAll=false --runInBand projectGraphVerticalSliceService --testNamePattern="low-confidence fallback boundary|preserves high-confidence boundary"
- Cherish/Bradford A1 smoke: QA pass; exportGate warning/allowed; SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE present.