### PR TITLE
Polish A1 section/elevation annotations and visual prompt continuity

### DIFF
--- a/src/__tests__/services/visualManifestService.test.js
+++ b/src/__tests__/services/visualManifestService.test.js
@@ -342,9 +342,24 @@ describe("buildProjectGraphRenderPrompt — Phase D injection", () => {
     expect(new Set(lockBlocks).size).toBe(1);
   });
 
+  test("prompt adds conservative visual continuity constraints from the manifest", () => {
+    const prompt = promptFor("exterior_render");
+    expect(prompt).toContain("VISUAL CONTINUITY CONSTRAINTS:");
+    expect(prompt).toContain(
+      "Preserve the exact 3 storey count, footprint proportions, silhouette, and roofline",
+    );
+    expect(prompt).toContain('Preserve roof form "gable"');
+    expect(prompt).toContain("primary Multi-stock red brick");
+    expect(prompt).toContain("secondary Vertical timber cladding");
+    expect(prompt).toContain("Preserve the regular bay window rhythm");
+    expect(prompt).toContain("Preserve the entrance at front facade centred");
+    expect(prompt).toContain("Do not invent extra bays, extra storeys");
+  });
+
   test("when no manifest is supplied, no lock block is emitted", () => {
     const prompt = promptFor("hero_3d", { manifest: null });
     expect(prompt).not.toMatch(/VISUAL IDENTITY LOCK/);
+    expect(prompt).not.toMatch(/VISUAL CONTINUITY CONSTRAINTS/);
     // But the rest of the prompt (intent + reasoning + style) must still be
     // present.
     expect(prompt).toContain("Photoreal hero exterior 3D perspective");

--- a/src/services/drawing/svgElevationRenderer.js
+++ b/src/services/drawing/svgElevationRenderer.js
@@ -10,6 +10,11 @@ import {
   resolveCompiledProjectStyleDNA,
 } from "./drawingBounds.js";
 
+const SHEET_ELEVATION_POLISH = Object.freeze({
+  fontScale: 1.1,
+  strokeScale: 1.12,
+});
+
 function escapeXml(value) {
   return String(value)
     .replaceAll("&", "&amp;")
@@ -42,6 +47,14 @@ function formatMeters(value) {
     return "0.0 m";
   }
   return `${numeric.toFixed(1)} m`;
+}
+
+function resolveElevationPolish(sheetMode = false) {
+  return sheetMode ? SHEET_ELEVATION_POLISH : { fontScale: 1, strokeScale: 1 };
+}
+
+function polishSize(value, scale = 1) {
+  return formatNumber(Number(value || 0) * Number(scale || 1), 1);
 }
 
 function orientationToSide(orientation = "south") {
@@ -287,9 +300,23 @@ function renderRoof(baseX, topY, widthPx, roofLanguage, theme) {
   `;
 }
 
-function renderLevelDatums(baseX, baseY, widthPx, levelProfiles, scale, theme) {
+function renderLevelDatums(
+  baseX,
+  baseY,
+  widthPx,
+  levelProfiles,
+  scale,
+  theme,
+  polish = {},
+) {
   const lines = [];
   const labels = [];
+  const fontScale = polish.fontScale || 1;
+  const strokeScale = polish.strokeScale || 1;
+  const datumStroke = polishSize(1.1, strokeScale);
+  const guideStroke = polishSize(1, strokeScale);
+  const primaryLabelFont = polishSize(9, fontScale);
+  const secondaryLabelFont = polishSize(8, fontScale);
   levelProfiles.forEach((level) => {
     const topY = baseY - level.top_m * scale;
     const midY =
@@ -299,22 +326,22 @@ function renderLevelDatums(baseX, baseY, widthPx, levelProfiles, scale, theme) {
         topY,
       )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
         topY,
-      )}" stroke="${theme.lineMuted}" stroke-width="1.1" />`,
+      )}" stroke="${theme.lineMuted}" stroke-width="${datumStroke}" />`,
     );
     labels.push(`
       <line x1="${formatNumber(baseX - 46)}" y1="${formatNumber(
         topY,
       )}" x2="${formatNumber(baseX - 6)}" y2="${formatNumber(
         topY,
-      )}" stroke="${theme.lineMuted}" stroke-width="1" />
+      )}" stroke="${theme.lineMuted}" stroke-width="${guideStroke}" />
       <text x="${formatNumber(baseX - 52)}" y="${formatNumber(
         topY + 4,
-      )}" font-size="9" font-family="Arial, sans-serif" font-weight="700" text-anchor="end">${escapeXml(
+      )}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="end">${escapeXml(
         `${level.name || `L${level.level_number}`} +${level.top_m.toFixed(2)}m`,
       )}</text>
       <text x="${formatNumber(baseX - 10)}" y="${formatNumber(
         midY,
-      )}" font-size="8" font-family="Arial, sans-serif" text-anchor="end">${escapeXml(
+      )}" font-size="${secondaryLabelFont}" font-family="Arial, sans-serif" text-anchor="end">${escapeXml(
         level.name || `L${level.level_number}`,
       )}</text>
     `);
@@ -325,10 +352,10 @@ function renderLevelDatums(baseX, baseY, widthPx, levelProfiles, scale, theme) {
       baseY,
     )}" x2="${formatNumber(baseX - 6)}" y2="${formatNumber(
       baseY,
-    )}" stroke="${theme.line}" stroke-width="1.1" />
+    )}" stroke="${theme.line}" stroke-width="${datumStroke}" />
     <text x="${formatNumber(baseX - 52)}" y="${formatNumber(
       baseY + 4,
-    )}" font-size="9" font-family="Arial, sans-serif" font-weight="700" text-anchor="end">FFL +0.00m</text>
+    )}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="end">FFL +0.00m</text>
   `);
 
   return {
@@ -948,39 +975,43 @@ function renderOverallDimensions(
   layout = {},
   width = 0,
   theme,
+  polish = {},
 ) {
   const topY = layout.top - 14;
   const rightX = width - layout.right + 24;
+  const fontSize = polishSize(10, polish.fontScale || 1);
+  const guideStroke = polishSize(0.9, polish.strokeScale || 1);
+  const primaryStroke = polishSize(1, polish.strokeScale || 1);
   return `
     <g id="phase8-elevation-dimensions">
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(baseX)}" y2="${formatNumber(
         topY,
-      )}" stroke="${theme.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${theme.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(baseX + widthPx)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
         topY,
-      )}" stroke="${theme.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${theme.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         topY,
       )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
         topY,
-      )}" stroke="${theme.line}" stroke-width="1"/>
+      )}" stroke="${theme.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         topY - 3,
       )}" x2="${formatNumber(baseX)}" y2="${formatNumber(
         topY + 3,
-      )}" stroke="${theme.line}" stroke-width="1"/>
+      )}" stroke="${theme.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(baseX + widthPx)}" y1="${formatNumber(
         topY - 3,
       )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
         topY + 3,
-      )}" stroke="${theme.line}" stroke-width="1"/>
+      )}" stroke="${theme.line}" stroke-width="${primaryStroke}"/>
       <text x="${formatNumber(baseX + widthPx / 2)}" y="${formatNumber(
         topY - 6,
-      )}" font-size="10" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle">${escapeXml(
+      )}" font-size="${fontSize}" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle">${escapeXml(
         formatMeters(metrics.width_m),
       )}</text>
 
@@ -988,30 +1019,30 @@ function renderOverallDimensions(
         baseY - heightPx,
       )}" x2="${formatNumber(rightX)}" y2="${formatNumber(
         baseY - heightPx,
-      )}" stroke="${theme.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${theme.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(baseX + widthPx)}" y1="${formatNumber(
         baseY,
       )}" x2="${formatNumber(rightX)}" y2="${formatNumber(
         baseY,
-      )}" stroke="${theme.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${theme.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(rightX)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(rightX)}" y2="${formatNumber(
         baseY,
-      )}" stroke="${theme.line}" stroke-width="1"/>
+      )}" stroke="${theme.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(rightX - 3)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(rightX + 3)}" y2="${formatNumber(
         baseY - heightPx,
-      )}" stroke="${theme.line}" stroke-width="1"/>
+      )}" stroke="${theme.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(rightX - 3)}" y1="${formatNumber(
         baseY,
       )}" x2="${formatNumber(rightX + 3)}" y2="${formatNumber(
         baseY,
-      )}" stroke="${theme.line}" stroke-width="1"/>
+      )}" stroke="${theme.line}" stroke-width="${primaryStroke}"/>
       <text x="${formatNumber(rightX + 14)}" y="${formatNumber(
         baseY - heightPx / 2,
-      )}" font-size="10" font-family="Arial, sans-serif" font-weight="700" transform="rotate(90 ${formatNumber(
+      )}" font-size="${fontSize}" font-family="Arial, sans-serif" font-weight="700" transform="rotate(90 ${formatNumber(
         rightX + 14,
       )} ${formatNumber(baseY - heightPx / 2)})" text-anchor="middle">${escapeXml(
         formatMeters(metrics.total_height_m),
@@ -1034,12 +1065,15 @@ function renderScaleBar(
   const y = Number.isFinite(options.y)
     ? options.y
     : height - layout.bottom + 44;
+  const fontScale = options.fontScale || 1;
+  const strokeScale = options.strokeScale || 1;
   const labelYOffset = Number.isFinite(options.labelYOffset)
     ? options.labelYOffset
     : 16;
   const labelFontSize = Number.isFinite(options.fontSize)
     ? options.fontSize
-    : 10;
+    : 10 * fontScale;
+  const strokeWidth = polishSize(1.6, strokeScale);
   return {
     barMeters,
     markup: `
@@ -1048,25 +1082,25 @@ function renderScaleBar(
           y,
         )}" x2="${formatNumber(x + barWidthPx)}" y2="${formatNumber(
           y,
-        )}" stroke="${theme.line}" stroke-width="1.6"/>
+        )}" stroke="${theme.line}" stroke-width="${strokeWidth}"/>
         <line x1="${formatNumber(x)}" y1="${formatNumber(
           y - 4,
         )}" x2="${formatNumber(x)}" y2="${formatNumber(
           y + 4,
-        )}" stroke="${theme.line}" stroke-width="1.6"/>
+        )}" stroke="${theme.line}" stroke-width="${strokeWidth}"/>
         <line x1="${formatNumber(x + barWidthPx / 2)}" y1="${formatNumber(
           y - 4,
         )}" x2="${formatNumber(x + barWidthPx / 2)}" y2="${formatNumber(
           y + 4,
-        )}" stroke="${theme.line}" stroke-width="1.6"/>
+        )}" stroke="${theme.line}" stroke-width="${strokeWidth}"/>
         <line x1="${formatNumber(x + barWidthPx)}" y1="${formatNumber(
           y - 4,
         )}" x2="${formatNumber(x + barWidthPx)}" y2="${formatNumber(
           y + 4,
-        )}" stroke="${theme.line}" stroke-width="1.6"/>
+        )}" stroke="${theme.line}" stroke-width="${strokeWidth}"/>
         <text x="${formatNumber(x + barWidthPx / 2)}" y="${formatNumber(
           y + labelYOffset,
-        )}" font-size="${labelFontSize}" font-family="Arial, sans-serif" text-anchor="middle">${escapeXml(
+        )}" font-size="${formatNumber(labelFontSize, 1)}" font-family="Arial, sans-serif" text-anchor="middle">${escapeXml(
           `${barMeters} m`,
         )}</text>
       </g>
@@ -1084,19 +1118,23 @@ function renderTitleBlock(
 ) {
   const x = layout.left;
   const y = height - layout.bottom + 16;
+  const polish = metadata.polish || {};
+  const titleFont = polishSize(14, polish.fontScale || 1);
+  const metaFont = polishSize(10, polish.fontScale || 1);
+  const titleStroke = polishSize(1.1, polish.strokeScale || 1);
   return `
     <g id="phase7-elevation-title-block">
       <rect x="${formatNumber(x)}" y="${formatNumber(
         y,
-      )}" width="328" height="46" fill="${theme.paper}" stroke="${theme.line}" stroke-width="1.1"/>
+      )}" width="328" height="46" fill="${theme.paper}" stroke="${theme.line}" stroke-width="${titleStroke}"/>
       <text x="${formatNumber(x + 12)}" y="${formatNumber(
         y + 17,
-      )}" font-size="14" font-family="Arial, sans-serif" font-weight="700" class="sheet-critical-label" data-text-role="critical">${escapeXml(
+      )}" font-size="${titleFont}" font-family="Arial, sans-serif" font-weight="700" class="sheet-critical-label" data-text-role="critical">${escapeXml(
         `ELEVATION - ${String(orientation || "south").toUpperCase()}`,
       )}</text>
       <text x="${formatNumber(x + 12)}" y="${formatNumber(
         y + 34,
-      )}" font-size="10" font-family="Arial, sans-serif" class="sheet-critical-label" data-text-role="critical">${escapeXml(
+      )}" font-size="${metaFont}" font-family="Arial, sans-serif" class="sheet-critical-label" data-text-role="critical">${escapeXml(
         `Bounds ${metadata.boundsSource || "building_derived"} · ${Math.round(
           Number(metadata.slotOccupancyRatio || 0) * 100,
         )}% slot occupancy`,
@@ -1134,6 +1172,7 @@ export function renderElevationSvg(
   const width = options.width || 1200;
   const height = options.height || 760;
   const sheetMode = options.sheetMode === true;
+  const sheetPolish = resolveElevationPolish(sheetMode);
   const showInternalTitleBlock =
     !sheetMode || options.showInternalTitleBlock === true;
   const layout = sheetMode
@@ -1179,6 +1218,7 @@ export function renderElevationSvg(
     levelProfiles,
     scale,
     theme,
+    sheetPolish,
   );
   const openings = renderProjectedOpenings(
     sideFacade,
@@ -1346,8 +1386,13 @@ export function renderElevationSvg(
     layout,
     theme,
     showInternalTitleBlock
-      ? {}
-      : { y: height - 34, labelYOffset: 14, fontSize: 9 },
+      ? { ...sheetPolish }
+      : {
+          y: height - 34,
+          labelYOffset: 14,
+          fontSize: 9,
+          ...sheetPolish,
+        },
   );
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${theme.name}" data-bounds-source="${envelope.source}">
@@ -1377,12 +1422,14 @@ export function renderElevationSvg(
     layout,
     width,
     theme,
+    sheetPolish,
   )}
   ${
     showInternalTitleBlock
       ? renderTitleBlock(orientation, width, height, layout, theme, {
           boundsSource: envelope.source,
           slotOccupancyRatio,
+          polish: sheetPolish,
         })
       : ""
   }
@@ -1440,6 +1487,7 @@ export function renderElevationSvg(
         facadeOrientation?.opening_rhythm?.opening_count ||
         openings.windowCount,
       blueprint_theme: theme.name,
+      a1_quality_polish: sheetMode ? "elevation_datums_dimensions_v1" : null,
       slot_occupancy_ratio: slotOccupancyRatio,
       scale_bar_meters: scaleBar.barMeters,
     },

--- a/src/services/drawing/svgSectionRenderer.js
+++ b/src/services/drawing/svgSectionRenderer.js
@@ -20,6 +20,10 @@ import {
 } from "./drawingBounds.js";
 
 const SECTION_THEME = getBlueprintTheme();
+const SHEET_SECTION_POLISH = Object.freeze({
+  fontScale: 1.12,
+  strokeScale: 1.12,
+});
 
 function escapeXml(value) {
   return String(value)
@@ -72,6 +76,14 @@ function chooseScaleBarMeters(scalePxPerMeter = 1) {
     (entry) => entry * Math.max(scalePxPerMeter, 1) <= 160,
   );
   return eligible[eligible.length - 1] || 1;
+}
+
+function resolveSectionPolish(sheetMode = false) {
+  return sheetMode ? SHEET_SECTION_POLISH : { fontScale: 1, strokeScale: 1 };
+}
+
+function polishSize(value, scale = 1) {
+  return formatNumber(Number(value || 0) * Number(scale || 1), 1);
 }
 
 function getLevelProfiles(geometry = {}) {
@@ -224,12 +236,15 @@ function renderScaleBar(scalePxPerMeter, width, height, padding, options = {}) {
   const barWidthPx = barMeters * scalePxPerMeter;
   const x = width - padding - barWidthPx - 8;
   const y = Number.isFinite(options.y) ? options.y : height - padding + 38;
+  const fontScale = options.fontScale || 1;
+  const strokeScale = options.strokeScale || 1;
   const labelYOffset = Number.isFinite(options.labelYOffset)
     ? options.labelYOffset
     : 16;
   const labelFontSize = Number.isFinite(options.fontSize)
     ? options.fontSize
-    : 9;
+    : 9 * fontScale;
+  const strokeWidth = polishSize(1.6, strokeScale);
   return {
     barMeters,
     markup: `
@@ -238,25 +253,25 @@ function renderScaleBar(scalePxPerMeter, width, height, padding, options = {}) {
           y,
         )}" x2="${formatNumber(x + barWidthPx)}" y2="${formatNumber(
           y,
-        )}" stroke="${SECTION_THEME.line}" stroke-width="1.6"/>
+        )}" stroke="${SECTION_THEME.line}" stroke-width="${strokeWidth}"/>
         <line x1="${formatNumber(x)}" y1="${formatNumber(
           y - 4,
         )}" x2="${formatNumber(x)}" y2="${formatNumber(
           y + 4,
-        )}" stroke="${SECTION_THEME.line}" stroke-width="1.6"/>
+        )}" stroke="${SECTION_THEME.line}" stroke-width="${strokeWidth}"/>
         <line x1="${formatNumber(x + barWidthPx / 2)}" y1="${formatNumber(
           y - 4,
         )}" x2="${formatNumber(x + barWidthPx / 2)}" y2="${formatNumber(
           y + 4,
-        )}" stroke="${SECTION_THEME.line}" stroke-width="1.6"/>
+        )}" stroke="${SECTION_THEME.line}" stroke-width="${strokeWidth}"/>
         <line x1="${formatNumber(x + barWidthPx)}" y1="${formatNumber(
           y - 4,
         )}" x2="${formatNumber(x + barWidthPx)}" y2="${formatNumber(
           y + 4,
-        )}" stroke="${SECTION_THEME.line}" stroke-width="1.6"/>
+        )}" stroke="${SECTION_THEME.line}" stroke-width="${strokeWidth}"/>
         <text x="${formatNumber(x + barWidthPx / 2)}" y="${formatNumber(
           y + labelYOffset,
-        )}" font-size="${labelFontSize}" font-family="Arial, sans-serif" text-anchor="middle">${escapeXml(
+        )}" font-size="${formatNumber(labelFontSize, 1)}" font-family="Arial, sans-serif" text-anchor="middle">${escapeXml(
           `${barMeters} m`,
         )}</text>
       </g>
@@ -273,39 +288,43 @@ function renderOverallSectionDimensions(
   horizontalExtentM,
   width,
   padding,
+  polish = {},
 ) {
   const topY = padding - 18;
   const rightX = width - padding + 18;
+  const fontSize = polishSize(10, polish.fontScale || 1);
+  const guideStroke = polishSize(0.9, polish.strokeScale || 1);
+  const primaryStroke = polishSize(1, polish.strokeScale || 1);
   return `
     <g id="phase8-section-dimensions">
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(baseX)}" y2="${formatNumber(
         topY,
-      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(baseX + widthPx)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
         topY,
-      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         topY,
       )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
         topY,
-      )}" stroke="${SECTION_THEME.line}" stroke-width="1"/>
+      )}" stroke="${SECTION_THEME.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         topY - 3,
       )}" x2="${formatNumber(baseX)}" y2="${formatNumber(
         topY + 3,
-      )}" stroke="${SECTION_THEME.line}" stroke-width="1"/>
+      )}" stroke="${SECTION_THEME.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(baseX + widthPx)}" y1="${formatNumber(
         topY - 3,
       )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
         topY + 3,
-      )}" stroke="${SECTION_THEME.line}" stroke-width="1"/>
+      )}" stroke="${SECTION_THEME.line}" stroke-width="${primaryStroke}"/>
       <text x="${formatNumber(baseX + widthPx / 2)}" y="${formatNumber(
         topY - 6,
-      )}" font-size="10" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle">${escapeXml(
+      )}" font-size="${fontSize}" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle">${escapeXml(
         formatMeters(horizontalExtentM),
       )}</text>
 
@@ -313,30 +332,30 @@ function renderOverallSectionDimensions(
         baseY - heightPx,
       )}" x2="${formatNumber(rightX)}" y2="${formatNumber(
         baseY - heightPx,
-      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(baseX + widthPx)}" y1="${formatNumber(
         baseY,
       )}" x2="${formatNumber(rightX)}" y2="${formatNumber(
         baseY,
-      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="0.9"/>
+      )}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${guideStroke}"/>
       <line x1="${formatNumber(rightX)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(rightX)}" y2="${formatNumber(
         baseY,
-      )}" stroke="${SECTION_THEME.line}" stroke-width="1"/>
+      )}" stroke="${SECTION_THEME.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(rightX - 3)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(rightX + 3)}" y2="${formatNumber(
         baseY - heightPx,
-      )}" stroke="${SECTION_THEME.line}" stroke-width="1"/>
+      )}" stroke="${SECTION_THEME.line}" stroke-width="${primaryStroke}"/>
       <line x1="${formatNumber(rightX - 3)}" y1="${formatNumber(
         baseY,
       )}" x2="${formatNumber(rightX + 3)}" y2="${formatNumber(
         baseY,
-      )}" stroke="${SECTION_THEME.line}" stroke-width="1"/>
+      )}" stroke="${SECTION_THEME.line}" stroke-width="${primaryStroke}"/>
       <text x="${formatNumber(rightX + 14)}" y="${formatNumber(
         baseY - heightPx / 2,
-      )}" font-size="10" font-family="Arial, sans-serif" font-weight="700" transform="rotate(90 ${formatNumber(
+      )}" font-size="${fontSize}" font-family="Arial, sans-serif" font-weight="700" transform="rotate(90 ${formatNumber(
         rightX + 14,
       )} ${formatNumber(baseY - heightPx / 2)})" text-anchor="middle">${escapeXml(
         formatMeters(totalHeightM),
@@ -352,11 +371,17 @@ function renderLevelDatums(
   levelProfiles,
   scale,
   lineweights = {},
+  polish = {},
 ) {
   const lines = [];
   const labels = [];
-  const datumWeight = lineweights.datum || 1.05;
-  const labelStroke = lineweights.guide || 0.78;
+  const fontScale = polish.fontScale || 1;
+  const strokeScale = polish.strokeScale || 1;
+  const datumWeight = polishSize(lineweights.datum || 1.05, strokeScale);
+  const labelStroke = polishSize(lineweights.guide || 0.78, strokeScale);
+  const secondaryStroke = polishSize(lineweights.secondary || 1, strokeScale);
+  const primaryLabelFont = polishSize(9, fontScale);
+  const secondaryLabelFont = polishSize(8.5, fontScale);
   levelProfiles.forEach((level) => {
     const topY = baseY - level.top_m * scale;
     const midY =
@@ -366,13 +391,13 @@ function renderLevelDatums(
     );
     labels.push(`
       <g class="phase8-section-level-label">
-        <line x1="${baseX - 52}" y1="${topY}" x2="${baseX - 6}" y2="${topY}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${lineweights.secondary || 1}" />
+        <line x1="${baseX - 52}" y1="${topY}" x2="${baseX - 6}" y2="${topY}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${secondaryStroke}" />
         <rect x="${baseX - 176}" y="${topY - 11}" width="118" height="16" rx="3" ry="3" fill="${SECTION_THEME.paper}" fill-opacity="0.94" stroke="${SECTION_THEME.guide}" stroke-width="${labelStroke}" />
-        <text x="${baseX - 166}" y="${topY + 1}" font-size="9" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical">${escapeXml(
+        <text x="${baseX - 166}" y="${topY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical">${escapeXml(
           `${level.name || `L${level.level_number}`} +${level.top_m.toFixed(2)}m`,
         )}</text>
         <rect x="${baseX - 84}" y="${midY - 9}" width="66" height="14" rx="3" ry="3" fill="${SECTION_THEME.paper}" fill-opacity="0.92" stroke="${SECTION_THEME.guide}" stroke-width="${labelStroke}" />
-        <text x="${baseX - 51}" y="${midY + 1}" font-size="8.5" font-family="Arial, sans-serif" text-anchor="middle" class="sheet-critical-label" data-text-role="critical">${escapeXml(
+        <text x="${baseX - 51}" y="${midY + 1}" font-size="${secondaryLabelFont}" font-family="Arial, sans-serif" text-anchor="middle" class="sheet-critical-label" data-text-role="critical">${escapeXml(
           level.name || `L${level.level_number}`,
         )}</text>
       </g>
@@ -380,9 +405,9 @@ function renderLevelDatums(
   });
 
   labels.push(`
-    <line x1="${baseX - 52}" y1="${baseY}" x2="${baseX - 6}" y2="${baseY}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.secondary || 1}" />
+    <line x1="${baseX - 52}" y1="${baseY}" x2="${baseX - 6}" y2="${baseY}" stroke="${SECTION_THEME.line}" stroke-width="${secondaryStroke}" />
     <rect x="${baseX - 144}" y="${baseY - 11}" width="86" height="16" rx="3" ry="3" fill="${SECTION_THEME.paper}" fill-opacity="0.94" stroke="${SECTION_THEME.guide}" stroke-width="${labelStroke}" />
-    <text x="${baseX - 134}" y="${baseY + 1}" font-size="9" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical">FFL +0.00m</text>
+    <text x="${baseX - 134}" y="${baseY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical">FFL +0.00m</text>
   `);
 
   return {
@@ -933,6 +958,7 @@ export function renderSectionSvg(
   const width = options.width || 1200;
   const height = options.height || 760;
   const sheetMode = options.sheetMode === true;
+  const sheetPolish = resolveSectionPolish(sheetMode);
   const showInternalTitleBlock =
     !sheetMode || options.showInternalTitleBlock === true;
   const padding = sheetMode ? 34 : 86;
@@ -1085,6 +1111,7 @@ export function renderSectionSvg(
     levelProfiles,
     scale,
     lineweights,
+    sheetPolish,
   );
   const foundation = renderFoundation(
     baseX,
@@ -1201,25 +1228,33 @@ export function renderSectionSvg(
     height,
     padding,
     showInternalTitleBlock
-      ? {}
-      : { y: height - 34, labelYOffset: 14, fontSize: 9 },
+      ? { ...sheetPolish }
+      : {
+          y: height - 34,
+          labelYOffset: 14,
+          fontSize: 9,
+          ...sheetPolish,
+        },
   );
+  const titleBlockStroke = polishSize(1.1, sheetPolish.strokeScale);
+  const titleBlockTitleFont = polishSize(14, sheetPolish.fontScale);
+  const titleBlockMetaFont = polishSize(10, sheetPolish.fontScale);
   const titleBlockMarkup = showInternalTitleBlock
     ? `
     <g id="phase8-section-title-block">
       <rect x="${formatNumber(padding)}" y="${formatNumber(
         height - padding + 10,
-      )}" width="338" height="46" fill="${SECTION_THEME.paper}" stroke="${SECTION_THEME.line}" stroke-width="1.1"/>
+      )}" width="338" height="46" fill="${SECTION_THEME.paper}" stroke="${SECTION_THEME.line}" stroke-width="${titleBlockStroke}"/>
       <text x="${formatNumber(padding + 12)}" y="${formatNumber(
         height - padding + 27,
-      )}" font-size="14" font-family="Arial, sans-serif" font-weight="700" class="sheet-critical-label" data-text-role="critical">${escapeXml(
+      )}" font-size="${titleBlockTitleFont}" font-family="Arial, sans-serif" font-weight="700" class="sheet-critical-label" data-text-role="critical">${escapeXml(
         sectionProfile?.strategyName
           ? `${sectionProfile.strategyName} Section`
           : `Section - ${sectionType.toUpperCase()}`,
       )}</text>
       <text x="${formatNumber(padding + 12)}" y="${formatNumber(
         height - padding + 43,
-      )}" font-size="10" font-family="Arial, sans-serif" class="sheet-critical-label" data-text-role="critical">${escapeXml(
+      )}" font-size="${titleBlockMetaFont}" font-family="Arial, sans-serif" class="sheet-critical-label" data-text-role="critical">${escapeXml(
         `Bounds ${envelopeBounds.source} · ${Math.round(
           slotOccupancyRatio * 100,
         )}% slot occupancy`,
@@ -1261,6 +1296,7 @@ export function renderSectionSvg(
     horizontalExtent,
     width,
     padding,
+    sheetPolish,
   )}
   ${titleBlockMarkup}
   ${scaleBar.markup}
@@ -1310,6 +1346,7 @@ export function renderSectionSvg(
       cut_coordinate_m: cutCoordinate,
       bounds_source: envelopeBounds.source,
       blueprint_theme: SECTION_THEME.name,
+      a1_quality_polish: sheetMode ? "section_datums_dimensions_v1" : null,
       slot_occupancy_ratio: slotOccupancyRatio,
       scale_bar_meters: scaleBar.barMeters,
       section_evidence_quality:

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -3357,6 +3357,34 @@ function buildTitleBlockPanelArtifact({
   };
 }
 
+function buildProjectGraphVisualContinuityBlock(visualManifest) {
+  if (!visualManifest || typeof visualManifest !== "object") {
+    return "";
+  }
+
+  const manifest = visualManifest;
+  const roofForm = manifest.roof?.form || "specified roof form";
+  const roofMaterial = manifest.roof?.materialName || "specified roof material";
+  const primaryMaterial =
+    manifest.primaryFacadeMaterial?.name || "specified primary facade material";
+  const secondaryMaterial =
+    manifest.secondaryFacadeMaterial?.name ||
+    "specified secondary facade material";
+  const windowRhythm = manifest.windowRhythm || "specified window rhythm";
+  const entrance =
+    manifest.entranceOrientation || "specified entrance position";
+
+  return [
+    "VISUAL CONTINUITY CONSTRAINTS:",
+    `- Preserve the exact ${manifest.storeyCount || "specified"} storey count, footprint proportions, silhouette, and roofline from the geometry reference.`,
+    `- Preserve roof form "${roofForm}" with ${roofMaterial}; do not flatten, steepen, rotate, or restyle the roof.`,
+    `- Preserve facade material order: primary ${primaryMaterial}; secondary ${secondaryMaterial}; do not swap materials between panels.`,
+    `- Preserve the ${windowRhythm} window rhythm, opening sizes, and opening positions from the reference geometry.`,
+    `- Preserve the entrance at ${entrance}; do not relocate the front door.`,
+    "- Do not invent extra bays, extra storeys, neighbouring buildings, signage, diagram labels, or text overlays.",
+  ].join("\n");
+}
+
 // Build a climate + style + programme aware prompt for image-edit-based
 // 3D panel rendering. Uses panelPromptBuilders.buildReasoningChainBlock
 // so the gpt-image call sees the same upstream drivers (UK temperate,
@@ -3396,8 +3424,11 @@ export function buildProjectGraphRenderPrompt({
   // interior_3d) describe the same building. The block is identical across
   // panels for the same manifest, so OpenAI image generation cannot drift.
   const identityLock = buildVisualIdentityLockBlock(visualManifest);
+  const visualContinuity =
+    buildProjectGraphVisualContinuityBlock(visualManifest);
   return [
     identityLock,
+    visualContinuity,
     `Project: ${projectName} — ${buildingType}.`,
     intent,
     reasoning,


### PR DESCRIPTION
## Summary

- Adds modest A1 sheet-mode section/elevation annotation and stroke hierarchy improvements for clearer datums, dimensions, title blocks, and scale bars.
- Adds active ProjectGraph visual prompt continuity constraints derived from the existing `visualManifest` so render prompts preserve storey count, roof form/material, facade material order, window rhythm, and entrance position.
- Keeps the change scoped to section/elevation drawing polish and ProjectGraph prompt text.

## Scope guardrails

- No plan renderer changes.
- No OpenAI provider/env changes.
- No export gate changes.
- No material palette changes.
- No programme/floor authority changes.
- No generated outputs included.

## Validation

- `npm test -- --watchAll=false --runInBand drawingBlueprintRendererRegression visualManifestService svgRendererPhase1` passed: 3 suites, 29 tests.
- `npm run lint` passed.
- `npm run build:active` passed.
- `npm run test:a1:tofu` passed.
- `npm run test:compose:routing` passed: 22 checks.
- `node scripts/tests/test-a1-layout-regression.mjs` passed: 27 checks.

## Local smoke

Generated a fresh Cherish/Bradford A1 on this branch with local `PROJECT_GRAPH_IMAGE_GEN_ENABLED=false`.

- QA: `pass`, score `88`.
- exportGate: `warning`, `allowed=true`, blockers `[]`, missing required panels `[]`.
- `openaiImageUsed=false`; visual panels used deterministic `compiled_project_render_inputs` because image generation was locally gate-disabled.
- Site boundary remained `boundaryAuthoritative=false` with `SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE`.
- Floor plans remained well-filled after PR #58: ground/first final slot occupancy `0.9367`.
- Contextual site plan remained honest after PR #60 with estimated-boundary disclaimer visible.