### PR TITLE
Keep building footprints out of authoritative site area

### DIFF
--- a/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
+++ b/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
@@ -202,6 +202,62 @@ describe("buildProjectGraphVerticalSliceRequest", () => {
     ]);
   });
 
+  test("keeps building footprint contextual when site boundary is estimated", () => {
+    const estimatedBoundary = [
+      { lat: 53.591, lng: -0.689 },
+      { lat: 53.591, lng: -0.687 },
+      { lat: 53.59, lng: -0.687 },
+    ];
+    const buildingFootprint = [
+      { lat: 53.5908, lng: -0.6886 },
+      { lat: 53.5908, lng: -0.6882 },
+      { lat: 53.5905, lng: -0.6882 },
+    ];
+
+    const request = buildProjectGraphVerticalSliceRequest({
+      designSpec: {
+        buildingCategory: "residential",
+        buildingSubType: "detached-house",
+        area: 250,
+        floorCount: 2,
+        location: {
+          address: "17 Kensington Road",
+          coordinates: { lat: 53.591237, lng: -0.688325 },
+          boundaryAuthoritative: false,
+          boundaryEstimated: true,
+          estimatedSiteBoundary: estimatedBoundary,
+          buildingFootprint,
+          siteAnalysis: {
+            boundarySource: "Intelligent Fallback",
+            boundaryConfidence: 0.4,
+            boundaryAuthoritative: false,
+            boundaryEstimated: true,
+            estimatedOnly: true,
+            estimatedSiteBoundary: estimatedBoundary,
+          },
+        },
+        sitePolygon: buildingFootprint,
+        siteMetrics: {
+          areaM2: 65,
+          source: "google_building_outline",
+        },
+      },
+    });
+
+    expect(request.sitePolygon).toEqual([]);
+    expect(request.siteMetrics.areaM2).toBeUndefined();
+    expect(request.siteMetrics.boundaryAuthoritative).toBe(false);
+    expect(request.locationData.boundaryAuthoritative).toBe(false);
+    expect(request.locationData.boundaryEstimated).toBe(true);
+    expect(request.locationData.estimatedSiteBoundary).toEqual(
+      estimatedBoundary,
+    );
+    expect(request.locationData.buildingFootprint).toEqual(buildingFootprint);
+    expect(request.locationData.siteAnalysis.boundarySource).toBe(
+      "Intelligent Fallback",
+    );
+  });
+
   test("normalizes ProjectGraph drawing artifact maps before panel mapping", () => {
     const drawingMap = {
       "asset-ground": {

--- a/src/__tests__/services/siteBoundaryUiAuthority.test.js
+++ b/src/__tests__/services/siteBoundaryUiAuthority.test.js
@@ -1,0 +1,78 @@
+import {
+  resolveUiSiteBoundaryAuthority,
+  isEstimatedSiteBoundary,
+} from "../../services/siteBoundaryUiAuthority.js";
+import { buildSiteContext } from "../../rings/ring1-site/siteContextBuilder.js";
+
+const fallbackBoundary = [
+  { lat: 53.591, lng: -0.689 },
+  { lat: 53.591, lng: -0.687 },
+  { lat: 53.59, lng: -0.687 },
+  { lat: 53.59, lng: -0.689 },
+];
+
+const buildingFootprint = [
+  { lat: 53.5908, lng: -0.6886 },
+  { lat: 53.5908, lng: -0.6882 },
+  { lat: 53.5905, lng: -0.6882 },
+  { lat: 53.5905, lng: -0.6886 },
+];
+
+describe("site boundary UI authority", () => {
+  test("keeps Intelligent Fallback boundary estimated and building footprint contextual", () => {
+    const result = resolveUiSiteBoundaryAuthority({
+      siteAnalysis: {
+        boundarySource: "Intelligent Fallback",
+        boundaryConfidence: 0.4,
+        boundaryAuthoritative: false,
+        estimatedOnly: true,
+      },
+      analysisBoundary: fallbackBoundary,
+      detectedBuildingFootprint: buildingFootprint,
+    });
+
+    expect(
+      isEstimatedSiteBoundary({ boundarySource: "Intelligent Fallback" }),
+    ).toBe(true);
+    expect(result.boundaryAuthoritative).toBe(false);
+    expect(result.boundaryEstimated).toBe(true);
+    expect(result.sitePolygon).toEqual([]);
+    expect(result.detectedBuildingFootprint).toEqual(buildingFootprint);
+    expect(result.contextualEstimatedBoundary).toEqual(fallbackBoundary);
+    expect(result.siteBoundaryWarning).toMatch(/estimated only/i);
+  });
+
+  test("uses high-confidence parcel boundary even when a building footprint exists", () => {
+    const result = resolveUiSiteBoundaryAuthority({
+      siteAnalysis: {
+        boundarySource: "OpenStreetMap",
+        boundaryConfidence: 0.92,
+        boundaryAuthoritative: true,
+      },
+      analysisBoundary: fallbackBoundary,
+      detectedBuildingFootprint: buildingFootprint,
+    });
+
+    expect(result.boundaryAuthoritative).toBe(true);
+    expect(result.boundaryEstimated).toBe(false);
+    expect(result.sitePolygon).toEqual(fallbackBoundary);
+    expect(result.contextualEstimatedBoundary).toEqual([]);
+    expect(result.detectedBuildingFootprint).toEqual(buildingFootprint);
+  });
+
+  test("site context can preserve a footprint without using it as site metrics", () => {
+    const siteContext = buildSiteContext({
+      location: {
+        address: "17 Kensington Road",
+        coordinates: { lat: 53.591237, lng: -0.688325 },
+      },
+      sitePolygon: [],
+      detectedBuildingFootprint: buildingFootprint,
+      siteAnalysis: {},
+      allowBuildingFootprintAsSitePolygon: false,
+    });
+
+    expect(siteContext.metrics).toBeNull();
+    expect(siteContext.location.address).toBe("17 Kensington Road");
+  });
+});

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -35,6 +35,7 @@ import {
   sanitizeDimensionInput,
 } from "../utils/promptSanitizer.js";
 import buildingFootprintService from "../services/buildingFootprintService.js";
+import { resolveUiSiteBoundaryAuthority } from "../services/siteBoundaryUiAuthority.js";
 import { buildSiteContext } from "../rings/ring1-site/siteContextBuilder.js";
 import { captureSnapshotForPersistence } from "../services/siteMapSnapshotService.js";
 import { buildProjectPipelineV2Bundle } from "../services/project/projectPipelineV2Service.js";
@@ -776,36 +777,17 @@ const ArchitectAIWizardContainer = () => {
           siteAnalysis.contextualSiteBoundary,
       );
       const normalizedExistingPolygon = normalizeSitePolygonForUi(sitePolygon);
-      const boundaryConfidence = Number(siteAnalysis?.boundaryConfidence);
-      const analysisBoundaryEstimated =
-        siteAnalysis?.boundaryAuthoritative === false ||
-        siteAnalysis?.boundaryEstimated === true ||
-        siteAnalysis?.estimatedOnly === true ||
-        /intelligent fallback|fallback/i.test(
-          String(siteAnalysis?.boundarySource || ""),
-        ) ||
-        (Number.isFinite(boundaryConfidence) && boundaryConfidence < 0.6);
-      const authoritativeAnalysisBoundary = analysisBoundaryEstimated
-        ? []
-        : normalizedAnalysisBoundary;
-      const contextualEstimatedBoundary = analysisBoundaryEstimated
-        ? normalizedEstimatedBoundary.length >= 3
-          ? normalizedEstimatedBoundary
-          : normalizedAnalysisBoundary
-        : [];
-
-      // Select best polygon: footprint -> analysis boundary -> existing
-      const polygon =
-        detectedFootprint ||
-        (authoritativeAnalysisBoundary.length >= 3
-          ? authoritativeAnalysisBoundary
-          : normalizedExistingPolygon);
-      const siteBoundaryWarning =
-        analysisBoundaryEstimated && siteAnalysis?.boundaryWarning
-          ? siteAnalysis.boundaryWarning
-          : analysisBoundaryEstimated
-            ? "Site boundary is estimated only; verify the parcel boundary by survey before treating area or setbacks as authoritative."
-            : null;
+      const boundaryResolution = resolveUiSiteBoundaryAuthority({
+        siteAnalysis,
+        analysisBoundary: normalizedAnalysisBoundary,
+        estimatedBoundary: normalizedEstimatedBoundary,
+        existingPolygon: normalizedExistingPolygon,
+        detectedBuildingFootprint: detectedFootprint,
+      });
+      const polygon = boundaryResolution.sitePolygon;
+      const contextualEstimatedBoundary =
+        boundaryResolution.contextualEstimatedBoundary;
+      const siteBoundaryWarning = boundaryResolution.siteBoundaryWarning;
 
       const siteDNA = buildSiteContext({
         location: { address, coordinates },
@@ -815,18 +797,21 @@ const ArchitectAIWizardContainer = () => {
         climate: climateBundle.climate,
         seasonalClimate: climateBundle,
         streetContext: siteAnalysis?.streetContext,
+        allowBuildingFootprintAsSitePolygon: false,
       });
 
       const hasAuthoritativePolygon =
-        Array.isArray(polygon) && polygon.length >= 3;
+        boundaryResolution.boundaryAuthoritative &&
+        Array.isArray(polygon) &&
+        polygon.length >= 3;
       if (hasAuthoritativePolygon) {
         setSitePolygon(polygon);
       } else {
         setSitePolygon([]);
       }
-      const derivedMetrics =
-        siteDNA?.metrics ||
-        (hasAuthoritativePolygon ? computeSiteMetrics(polygon) : null);
+      const derivedMetrics = hasAuthoritativePolygon
+        ? siteDNA?.metrics || computeSiteMetrics(polygon)
+        : null;
       if (derivedMetrics) {
         setSiteMetrics(derivedMetrics);
       } else if (!hasAuthoritativePolygon) {
@@ -866,9 +851,8 @@ const ArchitectAIWizardContainer = () => {
         siteAnalysis,
         buildingFootprint: detectedFootprint,
         detectedShape,
-        boundaryAuthoritative:
-          hasAuthoritativePolygon && !analysisBoundaryEstimated,
-        boundaryEstimated: analysisBoundaryEstimated,
+        boundaryAuthoritative: boundaryResolution.boundaryAuthoritative,
+        boundaryEstimated: boundaryResolution.boundaryEstimated,
         boundaryWarning: siteBoundaryWarning,
         boundaryWarningCode: siteAnalysis?.boundaryWarningCode || null,
         estimatedSiteBoundary: contextualEstimatedBoundary,
@@ -880,7 +864,9 @@ const ArchitectAIWizardContainer = () => {
         materialContext: styleRecommendations.materialContext || {},
         zoning: siteAnalysis.constraints || {},
         siteBoundary: polygon,
-        surfaceArea: siteAnalysis.surfaceArea,
+        surfaceArea: boundaryResolution.boundaryAuthoritative
+          ? siteAnalysis.surfaceArea
+          : null,
         climateSummary: {
           prevailingWind: climateBundle.wind.direction,
           avgSummerTemp: climateBundle.climate?.seasonal?.summer?.avgTemp || "",

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -246,12 +246,60 @@ function compactLocationDataForRequest(locationData = {}) {
     wind: locationData.wind || null,
     recommendedStyle: locationData.recommendedStyle || null,
     localMaterials: locationData.localMaterials || [],
+    boundaryAuthoritative:
+      locationData.boundaryAuthoritative === true
+        ? true
+        : locationData.boundaryAuthoritative === false
+          ? false
+          : null,
+    boundaryEstimated: locationData.boundaryEstimated === true,
+    boundaryWarningCode: locationData.boundaryWarningCode || null,
+    boundarySource:
+      locationData.boundarySource ||
+      locationData.siteAnalysis?.boundarySource ||
+      null,
+    boundaryConfidence:
+      locationData.boundaryConfidence ??
+      locationData.siteAnalysis?.boundaryConfidence ??
+      null,
+    estimatedSiteBoundary: compactLatLngPolygon(
+      locationData.estimatedSiteBoundary || [],
+    ),
+    contextualSiteBoundary: compactLatLngPolygon(
+      locationData.contextualSiteBoundary || [],
+    ),
+    buildingFootprint: compactLatLngPolygon(
+      locationData.buildingFootprint || [],
+    ),
     siteAnalysis: locationData.siteAnalysis
       ? {
           area: locationData.siteAnalysis.area || null,
           shape: locationData.siteAnalysis.shape || null,
           confidence: locationData.siteAnalysis.confidence || null,
           source: locationData.siteAnalysis.source || null,
+          boundarySource: locationData.siteAnalysis.boundarySource || null,
+          boundaryConfidence:
+            locationData.siteAnalysis.boundaryConfidence ?? null,
+          boundaryAuthoritative:
+            locationData.siteAnalysis.boundaryAuthoritative === true
+              ? true
+              : locationData.siteAnalysis.boundaryAuthoritative === false
+                ? false
+                : null,
+          boundaryEstimated:
+            locationData.siteAnalysis.boundaryEstimated === true ||
+            locationData.siteAnalysis.estimatedOnly === true,
+          estimatedOnly: locationData.siteAnalysis.estimatedOnly === true,
+          fallbackReason: locationData.siteAnalysis.fallbackReason || null,
+          surfaceArea: locationData.siteAnalysis.surfaceArea || null,
+          estimatedSurfaceArea:
+            locationData.siteAnalysis.estimatedSurfaceArea || null,
+          estimatedSiteBoundary: compactLatLngPolygon(
+            locationData.siteAnalysis.estimatedSiteBoundary || [],
+          ),
+          contextualSiteBoundary: compactLatLngPolygon(
+            locationData.siteAnalysis.contextualSiteBoundary || [],
+          ),
         }
       : null,
   };
@@ -451,6 +499,27 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
         reference_match: referenceMatch,
         renderIntent: referenceMatch ? "reference_match_a1" : undefined,
       };
+  const rawSiteMetrics =
+    designSpec.siteMetrics ||
+    designSpec.sitePolygonMetrics ||
+    compactSiteSnapshot?.metadata?.siteMetrics ||
+    {};
+  const siteMetricsNonAuthoritative =
+    rawSiteMetrics?.boundaryAuthoritative === false ||
+    rawSiteMetrics?.estimatedOnly === true ||
+    rawSiteMetrics?.source === "google_building_outline";
+  const requestSiteMetrics = siteMetricsNonAuthoritative
+    ? {
+        ...rawSiteMetrics,
+        areaM2: undefined,
+        boundaryAuthoritative: false,
+      }
+    : rawSiteMetrics;
+  const requestSitePolygon = siteMetricsNonAuthoritative
+    ? []
+    : compactSitePolygon.length >= 3
+      ? compactSitePolygon
+      : compactSiteSnapshot?.sitePolygon || [];
 
   return {
     referenceMatch,
@@ -488,15 +557,8 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
     },
     locationData: compactLocationDataForRequest(locationData),
     siteSnapshot: compactSiteSnapshot,
-    sitePolygon:
-      compactSitePolygon.length >= 3
-        ? compactSitePolygon
-        : compactSiteSnapshot?.sitePolygon || [],
-    siteMetrics:
-      designSpec.siteMetrics ||
-      designSpec.sitePolygonMetrics ||
-      compactSiteSnapshot?.metadata?.siteMetrics ||
-      {},
+    sitePolygon: requestSitePolygon,
+    siteMetrics: requestSiteMetrics,
     programSpaces: compactProgramSpacesForRequest(
       programSpaces,
       resolvedFloorCount,

--- a/src/hooks/useLocationData.js
+++ b/src/hooks/useLocationData.js
@@ -5,6 +5,7 @@ import { locationIntelligence } from "../services/locationIntelligence.js";
 import siteAnalysisService from "../services/siteAnalysisService.js";
 import logger from "../utils/logger.js";
 import { buildSiteContext } from "../rings/ring1-site/siteContextBuilder.js";
+import { resolveUiSiteBoundaryAuthority } from "../services/siteBoundaryUiAuthority.js";
 
 /**
  * useLocationData - Location Analysis Hook
@@ -331,19 +332,6 @@ export const useLocationData = () => {
 
         detectedBuildingFootprint = footprintResult.polygon;
         detectedShapeType = footprintResult.shape;
-
-        // Auto-populate site polygon
-        setSitePolygon(footprintResult.polygon);
-        setSiteMetrics({
-          areaM2: footprintResult.area,
-          shapeType: footprintResult.shape.name,
-          shapeDescription: footprintResult.shape.description,
-          vertexCount: footprintResult.shape.vertexCount,
-          isConvex: footprintResult.shape.isConvex,
-          source: "google_building_outline",
-          confidence: 0.95, // High confidence for Google Building API
-          detectedAt: footprintResult.metadata.detectedAt,
-        });
       } else {
         logger.warn("Building footprint not available, trying site analysis");
       }
@@ -355,26 +343,47 @@ export const useLocationData = () => {
         { lat, lng },
       );
 
-      if (siteAnalysisResult.success && !detectedBuildingFootprint) {
-        logger.info(
-          "Site analysis complete (fallback)",
-          siteAnalysisResult.siteAnalysis,
-        );
-
-        if (siteAnalysisResult.siteAnalysis.siteBoundary) {
-          setSitePolygon(siteAnalysisResult.siteAnalysis.siteBoundary);
-          setSiteMetrics({
-            areaM2: siteAnalysisResult.siteAnalysis.surfaceArea,
-            unit: siteAnalysisResult.siteAnalysis.surfaceAreaUnit,
-            source: siteAnalysisResult.siteAnalysis.boundarySource,
-            shapeType: siteAnalysisResult.siteAnalysis.boundaryShapeType,
-            confidence:
-              siteAnalysisResult.siteAnalysis.boundaryConfidence || 0.4,
-            vertexCount: siteAnalysisResult.siteAnalysis.siteBoundary?.length,
-          });
-        }
+      if (siteAnalysisResult.success) {
+        logger.info("Site analysis complete", siteAnalysisResult.siteAnalysis);
       } else if (!siteAnalysisResult.success && !detectedBuildingFootprint) {
         logger.warn("Both building footprint and site analysis failed");
+      }
+
+      const siteAnalysis = siteAnalysisResult.success
+        ? siteAnalysisResult.siteAnalysis
+        : {};
+      const boundaryResolution = resolveUiSiteBoundaryAuthority({
+        siteAnalysis,
+        analysisBoundary: siteAnalysis?.siteBoundary || [],
+        estimatedBoundary:
+          siteAnalysis?.estimatedSiteBoundary ||
+          siteAnalysis?.contextualSiteBoundary ||
+          [],
+        existingPolygon: sitePolygon || [],
+        detectedBuildingFootprint,
+      });
+      const authoritativeSitePolygon = boundaryResolution.sitePolygon;
+
+      if (boundaryResolution.boundaryAuthoritative) {
+        setSitePolygon(authoritativeSitePolygon);
+        setSiteMetrics({
+          areaM2: siteAnalysis.surfaceArea,
+          unit: siteAnalysis.surfaceAreaUnit,
+          source: siteAnalysis.boundarySource,
+          shapeType: siteAnalysis.boundaryShapeType,
+          confidence: siteAnalysis.boundaryConfidence || 0.4,
+          vertexCount: siteAnalysis.siteBoundary?.length,
+          boundaryAuthoritative: true,
+        });
+      } else {
+        setSitePolygon([]);
+        setSiteMetrics(null);
+        if (boundaryResolution.siteBoundaryWarning) {
+          logger.warn(boundaryResolution.siteBoundaryWarning, {
+            boundarySource: siteAnalysis?.boundarySource,
+            boundaryConfidence: siteAnalysis?.boundaryConfidence,
+          });
+        }
       }
 
       // Step 8: Generate site map snapshot
@@ -388,8 +397,9 @@ export const useLocationData = () => {
         const { getSiteSnapshotWithMetadata } =
           await import("../services/siteMapSnapshotService");
 
-        const sitePolygonForMap =
-          sitePolygon || detectedBuildingFootprint || null;
+        const sitePolygonForMap = boundaryResolution.boundaryAuthoritative
+          ? authoritativeSitePolygon
+          : null;
 
         const snapshotResult = await getSiteSnapshotWithMetadata({
           coordinates: { lat, lng },
@@ -412,20 +422,19 @@ export const useLocationData = () => {
       }
 
       // Step 9: Save location data and advance to next step
-      const sitePolygonForMap =
-        sitePolygon ||
-        detectedBuildingFootprint ||
-        siteAnalysisResult?.siteAnalysis?.siteBoundary ||
-        null;
+      const sitePolygonForMap = boundaryResolution.boundaryAuthoritative
+        ? authoritativeSitePolygon
+        : null;
 
       const siteDNA = buildSiteContext({
         location: { address: formattedAddress, coordinates: { lat, lng } },
         sitePolygon: sitePolygonForMap,
         detectedBuildingFootprint,
-        siteAnalysis: siteAnalysisResult.siteAnalysis,
+        siteAnalysis,
         climate: seasonalClimateData.climate,
         seasonalClimate: seasonalClimateData,
-        streetContext: siteAnalysisResult.siteAnalysis?.streetContext,
+        streetContext: siteAnalysis?.streetContext,
+        allowBuildingFootprintAsSitePolygon: false,
       });
 
       const newLocationData = {
@@ -440,11 +449,20 @@ export const useLocationData = () => {
         sustainabilityScore: 85,
         marketContext: marketContext,
         architecturalProfile: architecturalStyle,
-        siteAnalysis: siteAnalysisResult.success
-          ? siteAnalysisResult.siteAnalysis
-          : null,
+        siteAnalysis: siteAnalysisResult.success ? siteAnalysis : null,
         buildingFootprint: detectedBuildingFootprint,
         detectedShape: detectedShapeType,
+        boundaryAuthoritative: boundaryResolution.boundaryAuthoritative,
+        boundaryEstimated: boundaryResolution.boundaryEstimated,
+        boundaryWarning: boundaryResolution.siteBoundaryWarning,
+        boundaryWarningCode: siteAnalysis?.boundaryWarningCode || null,
+        estimatedSiteBoundary: boundaryResolution.contextualEstimatedBoundary,
+        contextualSiteBoundary: boundaryResolution.contextualEstimatedBoundary,
+        estimatedSurfaceArea: siteAnalysis?.estimatedSurfaceArea || null,
+        siteBoundary: authoritativeSitePolygon,
+        surfaceArea: boundaryResolution.boundaryAuthoritative
+          ? siteAnalysis?.surfaceArea
+          : null,
         siteMapUrl: siteMapUrl,
         mapImageUrl: siteMapUrl,
         siteDNA,

--- a/src/rings/ring1-site/siteContextBuilder.js
+++ b/src/rings/ring1-site/siteContextBuilder.js
@@ -1,17 +1,22 @@
-import { computeSunPath, deriveFacadeOrientation } from './solarEngine.js';
-import { buildBoundaryContext } from './boundaryValidator.js';
-import { getClimateDesignRules } from './climateRules.js';
-import { computeSiteMetrics } from '../../utils/geometry.js';
+import { computeSunPath, deriveFacadeOrientation } from "./solarEngine.js";
+import { buildBoundaryContext } from "./boundaryValidator.js";
+import { getClimateDesignRules } from "./climateRules.js";
+import { computeSiteMetrics } from "../../utils/geometry.js";
 
 function resolveSitePolygon({
   sitePolygon,
   detectedBuildingFootprint,
-  siteAnalysis
+  siteAnalysis,
+  allowBuildingFootprintAsSitePolygon = true,
 }) {
   if (sitePolygon && sitePolygon.length >= 3) {
     return sitePolygon;
   }
-  if (detectedBuildingFootprint && detectedBuildingFootprint.length >= 3) {
+  if (
+    allowBuildingFootprintAsSitePolygon &&
+    detectedBuildingFootprint &&
+    detectedBuildingFootprint.length >= 3
+  ) {
     return detectedBuildingFootprint;
   }
   if (siteAnalysis?.siteBoundary && siteAnalysis.siteBoundary.length >= 3) {
@@ -27,7 +32,8 @@ export function buildSiteContext({
   siteAnalysis,
   climate,
   seasonalClimate,
-  streetContext
+  streetContext,
+  allowBuildingFootprintAsSitePolygon = true,
 } = {}) {
   if (!location?.coordinates) {
     return null;
@@ -37,7 +43,8 @@ export function buildSiteContext({
   const polygon = resolveSitePolygon({
     sitePolygon,
     detectedBuildingFootprint,
-    siteAnalysis
+    siteAnalysis,
+    allowBuildingFootprintAsSitePolygon,
   });
 
   const boundaryContext = buildBoundaryContext({
@@ -45,44 +52,39 @@ export function buildSiteContext({
     coordinates,
     siteAnalysis,
     setbacks: siteAnalysis?.constraints,
-    orientationDeg: siteAnalysis?.orientationDeg
+    orientationDeg: siteAnalysis?.orientationDeg,
   });
 
-  const solar = computeSunPath(
-    coordinates.lat,
-    coordinates.lng,
-    {
-      preferredOrientationDeg: siteAnalysis?.optimalBuildingOrientation
-    }
-  );
+  const solar = computeSunPath(coordinates.lat, coordinates.lng, {
+    preferredOrientationDeg: siteAnalysis?.optimalBuildingOrientation,
+  });
 
   const climateRules = getClimateDesignRules(climate?.type, {
     solar,
-    boundaryContext
+    boundaryContext,
   });
 
   const computedMetrics = polygon ? computeSiteMetrics(polygon) : null;
   const facadeOrientation = deriveFacadeOrientation({
     solar,
-    streetContext
+    streetContext,
   });
 
   return {
     location: {
       address: location.address,
-      coordinates
+      coordinates,
     },
     boundaries: boundaryContext,
     solar,
     climate: {
-      type: climate?.type || 'Temperate Oceanic',
+      type: climate?.type || "Temperate Oceanic",
       seasonal: seasonalClimate?.seasonal || climate?.seasonal || {},
-      rules: climateRules
+      rules: climateRules,
     },
     street: streetContext || null,
     metrics: computedMetrics,
     facadeOrientation,
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
   };
 }
-

--- a/src/services/siteBoundaryUiAuthority.js
+++ b/src/services/siteBoundaryUiAuthority.js
@@ -1,0 +1,77 @@
+export const ESTIMATED_SITE_BOUNDARY_WARNING =
+  "Site boundary is estimated only; verify the parcel boundary by survey before treating area or setbacks as authoritative.";
+
+function hasUsablePolygon(polygon = []) {
+  return Array.isArray(polygon) && polygon.length >= 3;
+}
+
+function boundarySourceLooksEstimated(source = "") {
+  return /intelligent fallback|fallback|estimated/i.test(String(source || ""));
+}
+
+export function isEstimatedSiteBoundary(siteAnalysis = {}) {
+  const confidence = Number(
+    siteAnalysis?.boundaryConfidence ?? siteAnalysis?.confidence,
+  );
+  return (
+    siteAnalysis?.boundaryAuthoritative === false ||
+    siteAnalysis?.boundaryEstimated === true ||
+    siteAnalysis?.estimatedOnly === true ||
+    boundarySourceLooksEstimated(
+      siteAnalysis?.boundarySource || siteAnalysis?.source,
+    ) ||
+    (Number.isFinite(confidence) && confidence < 0.6)
+  );
+}
+
+export function resolveUiSiteBoundaryAuthority({
+  siteAnalysis = {},
+  analysisBoundary = [],
+  estimatedBoundary = [],
+  existingPolygon = [],
+  detectedBuildingFootprint = [],
+} = {}) {
+  const analysisBoundaryEstimated = isEstimatedSiteBoundary(siteAnalysis);
+  const authoritativeAnalysisBoundary =
+    !analysisBoundaryEstimated && hasUsablePolygon(analysisBoundary)
+      ? analysisBoundary
+      : [];
+  const contextualEstimatedBoundary = analysisBoundaryEstimated
+    ? hasUsablePolygon(estimatedBoundary)
+      ? estimatedBoundary
+      : hasUsablePolygon(analysisBoundary)
+        ? analysisBoundary
+        : []
+    : [];
+  const existingAuthoritativeFallback =
+    !analysisBoundaryEstimated &&
+    !hasUsablePolygon(authoritativeAnalysisBoundary) &&
+    !hasUsablePolygon(detectedBuildingFootprint) &&
+    hasUsablePolygon(existingPolygon)
+      ? existingPolygon
+      : [];
+  const sitePolygon = hasUsablePolygon(authoritativeAnalysisBoundary)
+    ? authoritativeAnalysisBoundary
+    : existingAuthoritativeFallback;
+  const boundaryAuthoritative =
+    hasUsablePolygon(sitePolygon) && !analysisBoundaryEstimated;
+
+  return {
+    sitePolygon,
+    boundaryAuthoritative,
+    boundaryEstimated: analysisBoundaryEstimated,
+    contextualEstimatedBoundary,
+    detectedBuildingFootprint: hasUsablePolygon(detectedBuildingFootprint)
+      ? detectedBuildingFootprint
+      : [],
+    siteBoundaryWarning: analysisBoundaryEstimated
+      ? siteAnalysis?.boundaryWarning || ESTIMATED_SITE_BOUNDARY_WARNING
+      : null,
+  };
+}
+
+export default {
+  ESTIMATED_SITE_BOUNDARY_WARNING,
+  isEstimatedSiteBoundary,
+  resolveUiSiteBoundaryAuthority,
+};


### PR DESCRIPTION
## Summary

- Prevents detected Google building footprints from becoming authoritative `sitePolygon` / `siteMetrics` when parcel boundary confidence is low or estimated.
- Keeps building footprints as contextual geometry only, while preserving estimated parcel boundaries for contextual site-plan warnings.
- Clears browser-side authoritative site metrics when the parcel boundary is estimated, so a footprint area such as `65m²` is not used as plot/site area for auto floor-count logic.
- Adds ProjectGraph request compaction guards so `google_building_outline` metrics are not posted as authoritative site area.

## Why

The 17 Kensington Road browser run correctly flagged an `Intelligent Fallback` parcel boundary as non-authoritative, but then promoted the detected 4-vertex building footprint into `siteMetrics.areaM2`. The UI floor-count logic then treated `65m²` as the plot area, producing impossible coverage such as `128%` to `157%` and a 3-floor cap for a 250m² detached-house brief.

## Scope guardrails

- No PR #61 renderer polish changes.
- No OpenAI provider/env changes.
- No export gate changes.
- No presentation-v3 layout changes.
- No material palette changes.
- No programme/floor authority changes beyond preventing non-authoritative footprint/site-area input.
- No generated outputs included.

## Validation

- `npm test -- --watchAll=false --runInBand siteBoundaryUiAuthority useArchitectAIWorkflow.projectGraphPayload siteAnalysis.propertyBoundary.siteBoundary` passed: 3 suites, 23 tests.
- `npm run lint` passed.
- `npm run build:active` passed.
- `npm run test:a1:tofu` passed.
- `npm run test:compose:routing` passed: 22 checks.
- `node scripts/tests/test-a1-layout-regression.mjs` passed: 27 checks.

## Expected behavior after this PR

For low-confidence fallback parcel data plus a detected building footprint:

- `boundaryAuthoritative=false` is preserved.
- Building footprint remains available as contextual/proposed-footprint geometry.
- `sitePolygon` is not set to the building footprint.
- `siteMetrics.areaM2` is not set to the building footprint area.
- ProjectGraph still receives estimated-boundary metadata for contextual site-plan warning/disclaimer behavior.