### PR TITLE
Fix contextual site map background for estimated boundaries

### DIFF
--- a/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
+++ b/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
@@ -242,9 +242,31 @@ describe("buildProjectGraphVerticalSliceRequest", () => {
           source: "google_building_outline",
         },
       },
+      siteSnapshot: {
+        sitePolygon: estimatedBoundary,
+        metadata: {
+          sitePlanMode: "contextual_estimated_boundary",
+          boundaryAuthoritative: false,
+          boundaryEstimated: true,
+          contextualBoundaryOverlayUsed: true,
+          contextualBoundaryPolygon: estimatedBoundary,
+        },
+      },
     });
 
     expect(request.sitePolygon).toEqual([]);
+    expect(request.siteSnapshot.sitePolygon).toEqual(estimatedBoundary);
+    expect(request.siteSnapshot.metadata.sitePlanMode).toBe(
+      "contextual_estimated_boundary",
+    );
+    expect(request.siteSnapshot.metadata.boundaryAuthoritative).toBe(false);
+    expect(request.siteSnapshot.metadata.boundaryEstimated).toBe(true);
+    expect(request.siteSnapshot.metadata.contextualBoundaryOverlayUsed).toBe(
+      true,
+    );
+    expect(request.siteSnapshot.metadata.contextualBoundaryPolygon).toEqual(
+      estimatedBoundary,
+    );
     expect(request.siteMetrics.areaM2).toBeUndefined();
     expect(request.siteMetrics.boundaryAuthoritative).toBe(false);
     expect(request.locationData.boundaryAuthoritative).toBe(false);

--- a/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
+++ b/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
@@ -244,6 +244,8 @@ describe("buildProjectGraphVerticalSliceRequest", () => {
       },
       siteSnapshot: {
         sitePolygon: estimatedBoundary,
+        mapType: "roadmap",
+        drawPolygonOverlay: false,
         metadata: {
           sitePlanMode: "contextual_estimated_boundary",
           boundaryAuthoritative: false,
@@ -256,6 +258,8 @@ describe("buildProjectGraphVerticalSliceRequest", () => {
 
     expect(request.sitePolygon).toEqual([]);
     expect(request.siteSnapshot.sitePolygon).toEqual(estimatedBoundary);
+    expect(request.siteSnapshot.mapType).toBe("roadmap");
+    expect(request.siteSnapshot.drawPolygonOverlay).toBe(false);
     expect(request.siteSnapshot.metadata.sitePlanMode).toBe(
       "contextual_estimated_boundary",
     );

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -926,11 +926,35 @@ describe("projectGraphVerticalSliceService", () => {
   });
 
   test("does not propagate low-confidence fallback boundary area into ProjectGraph site authority", async () => {
+    process.env.GOOGLE_MAPS_API_KEY = "test-google-key";
+    const pngBlob = new Blob(
+      [
+        Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFklEQVR42mNk+M9Qz0AEYBxVSFIAAAeSAi8BTyQ1AAAAAElFTkSuQmCC",
+          "base64",
+        ),
+      ],
+      {
+        type: "image/png",
+      },
+    );
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      blob: async () => pngBlob,
+    });
+
     const result = await buildArchitectureProjectVerticalSlice(
       createLowConfidenceBradfordBoundaryBrief(),
     );
     const issueCodes = result.qa.issues.map((issue) => issue.code);
+    const staticMapUrl = global.fetch.mock.calls[0][0];
 
+    expect(global.fetch).toHaveBeenCalled();
+    expect(staticMapUrl).toContain("path=");
+    expect(staticMapUrl).toContain("visible=");
+    expect(staticMapUrl).toContain("53.79224,-1.75556");
     expect(result.success).toBe(true);
     expect(result.projectGraph.site.boundary_authoritative).toBe(false);
     expect(result.projectGraph.site.boundary_source).toBe(
@@ -947,6 +971,10 @@ describe("projectGraphVerticalSliceService", () => {
       result.projectGraph.site.data_quality.map((issue) => issue.code),
     ).toContain("SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE");
     expect(issueCodes).toContain("SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE");
+    expect(result.artifacts.siteMap.metadata.hasMapImage).toBe(true);
+    expect(result.artifacts.siteMap.metadata.siteMapSource).toBe(
+      "google-static-maps",
+    );
     expect(result.artifacts.siteMap.metadata.boundaryAuthoritative).toBe(false);
     expect(result.artifacts.siteMap.metadata.sitePlanMode).toBe(
       "contextual_estimated_boundary",
@@ -954,6 +982,8 @@ describe("projectGraphVerticalSliceService", () => {
     expect(result.artifacts.siteMap.svgString).toContain(
       "CONTEXTUAL SITE PLAN",
     );
+    expect(result.artifacts.siteMap.svgString).toContain("Google Static Maps");
+    expect(result.artifacts.siteMap.svgString).not.toContain('opacity="0.38"');
     expect(result.artifacts.siteMap.svgString).toContain("Boundary estimated");
     expect(result.artifacts.siteMap.svgString).toContain(
       "parcel area not authoritative",

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -945,15 +945,30 @@ describe("projectGraphVerticalSliceService", () => {
       blob: async () => pngBlob,
     });
 
-    const result = await buildArchitectureProjectVerticalSlice(
-      createLowConfidenceBradfordBoundaryBrief(),
-    );
+    const input = createLowConfidenceBradfordBoundaryBrief();
+    input.siteSnapshot = {
+      mapType: "hybrid",
+      sitePolygon: input.locationData.siteAnalysis.estimatedSiteBoundary,
+      metadata: {
+        sitePlanMode: "contextual_estimated_boundary",
+        boundaryAuthoritative: false,
+        boundaryEstimated: true,
+        contextualBoundaryOverlayUsed: true,
+        contextualBoundaryPolygon:
+          input.locationData.siteAnalysis.estimatedSiteBoundary,
+      },
+    };
+
+    const result = await buildArchitectureProjectVerticalSlice(input);
     const issueCodes = result.qa.issues.map((issue) => issue.code);
     const staticMapUrl = global.fetch.mock.calls[0][0];
 
     expect(global.fetch).toHaveBeenCalled();
-    expect(staticMapUrl).toContain("path=");
     expect(staticMapUrl).toContain("visible=");
+    expect(staticMapUrl).toContain("maptype=roadmap");
+    expect(staticMapUrl).not.toContain("maptype=hybrid");
+    expect(staticMapUrl).not.toContain("maptype=satellite");
+    expect(staticMapUrl).not.toContain("path=");
     expect(staticMapUrl).toContain("53.79224,-1.75556");
     expect(result.success).toBe(true);
     expect(result.projectGraph.site.boundary_authoritative).toBe(false);
@@ -975,6 +990,7 @@ describe("projectGraphVerticalSliceService", () => {
     expect(result.artifacts.siteMap.metadata.siteMapSource).toBe(
       "google-static-maps",
     );
+    expect(result.artifacts.siteMap.metadata.mapType).toBe("roadmap");
     expect(result.artifacts.siteMap.metadata.boundaryAuthoritative).toBe(false);
     expect(result.artifacts.siteMap.metadata.sitePlanMode).toBe(
       "contextual_estimated_boundary",
@@ -984,6 +1000,8 @@ describe("projectGraphVerticalSliceService", () => {
     );
     expect(result.artifacts.siteMap.svgString).toContain("Google Static Maps");
     expect(result.artifacts.siteMap.svgString).not.toContain('opacity="0.38"');
+    expect(result.artifacts.siteMap.svgString).toContain('fill="#b7d7a833"');
+    expect(result.artifacts.siteMap.svgString).toContain('stroke="#e87524"');
     expect(result.artifacts.siteMap.svgString).toContain("Boundary estimated");
     expect(result.artifacts.siteMap.svgString).toContain(
       "parcel area not authoritative",

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -1754,14 +1754,29 @@ const ArchitectAIWizardContainer = () => {
         : siteSnapshotDisplayPolygon.length >= 3
           ? "contextual_estimated_boundary"
           : "context_only";
+      const siteSnapshotMapType = "roadmap";
 
       let capturedSnapshot = null;
       try {
         capturedSnapshot = await captureSnapshotForPersistence({
           coordinates: locationData?.coordinates,
           polygon: siteSnapshotDisplayPolygon,
+          drawPolygonOverlay: siteSnapshotBoundaryAuthoritative,
+          polygonStyle: siteSnapshotBoundaryAuthoritative
+            ? {
+                strokeColor: "#d64d35",
+                strokeWeight: 3,
+                fillColor: "#b7d7a8",
+                fillOpacity: 0.18,
+              }
+            : {
+                strokeColor: "#e87524",
+                strokeWeight: 3,
+                fillColor: "#b7d7a8",
+                fillOpacity: 0.18,
+              },
           zoom: locationData?.mapZoom || 17,
-          mapType: "hybrid",
+          mapType: siteSnapshotMapType,
           size: { width: 640, height: 400 },
         });
       } catch (snapshotError) {
@@ -1780,8 +1795,11 @@ const ArchitectAIWizardContainer = () => {
         dataUrl: capturedSnapshot?.dataUrl || null,
         center: capturedSnapshot?.center || locationData.coordinates,
         zoom: capturedSnapshot?.zoom || locationData?.mapZoom || 17,
-        mapType: capturedSnapshot?.mapType || "hybrid",
+        mapType: capturedSnapshot?.mapType || siteSnapshotMapType,
         size: capturedSnapshot?.size || { width: 640, height: 400 },
+        drawPolygonOverlay:
+          capturedSnapshot?.drawPolygonOverlay ??
+          siteSnapshotBoundaryAuthoritative,
         sha256: capturedSnapshot?.sha256 || null,
         source: capturedSnapshot?.source || "google-static-maps-api",
         sourceUrl: capturedSnapshot?.source || "google-static-maps-api",

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -36,6 +36,7 @@ import {
 } from "../utils/promptSanitizer.js";
 import buildingFootprintService from "../services/buildingFootprintService.js";
 import { resolveUiSiteBoundaryAuthority } from "../services/siteBoundaryUiAuthority.js";
+import { selectContextualBoundaryPolygon } from "../services/siteBoundaryAutoDetectPolicy.js";
 import { buildSiteContext } from "../rings/ring1-site/siteContextBuilder.js";
 import { captureSnapshotForPersistence } from "../services/siteMapSnapshotService.js";
 import { buildProjectPipelineV2Bundle } from "../services/project/projectPipelineV2Service.js";
@@ -1737,11 +1738,28 @@ const ArchitectAIWizardContainer = () => {
 
       logger.info("Starting generation workflow", null, "🚀");
 
+      const authoritativeSnapshotPolygon =
+        normalizeSitePolygonForUi(sitePolygon);
+      const contextualSnapshotPolygon = normalizeSitePolygonForUi(
+        selectContextualBoundaryPolygon(locationData),
+      );
+      const hasAuthoritativeSnapshotPolygon =
+        authoritativeSnapshotPolygon.length >= 3;
+      const siteSnapshotDisplayPolygon = hasAuthoritativeSnapshotPolygon
+        ? authoritativeSnapshotPolygon
+        : contextualSnapshotPolygon;
+      const siteSnapshotBoundaryAuthoritative = hasAuthoritativeSnapshotPolygon;
+      const siteSnapshotMode = siteSnapshotBoundaryAuthoritative
+        ? "authoritative_boundary"
+        : siteSnapshotDisplayPolygon.length >= 3
+          ? "contextual_estimated_boundary"
+          : "context_only";
+
       let capturedSnapshot = null;
       try {
         capturedSnapshot = await captureSnapshotForPersistence({
           coordinates: locationData?.coordinates,
-          polygon: sitePolygon,
+          polygon: siteSnapshotDisplayPolygon,
           zoom: locationData?.mapZoom || 17,
           mapType: "hybrid",
           size: { width: 640, height: 400 },
@@ -1756,7 +1774,7 @@ const ArchitectAIWizardContainer = () => {
       const siteSnapshot = normalizeSiteSnapshot({
         address: locationData.address,
         coordinates: locationData.coordinates,
-        sitePolygon,
+        sitePolygon: siteSnapshotDisplayPolygon,
         climate: locationData.climate,
         zoning: locationData.zoning,
         dataUrl: capturedSnapshot?.dataUrl || null,
@@ -1765,8 +1783,24 @@ const ArchitectAIWizardContainer = () => {
         mapType: capturedSnapshot?.mapType || "hybrid",
         size: capturedSnapshot?.size || { width: 640, height: 400 },
         sha256: capturedSnapshot?.sha256 || null,
+        source: capturedSnapshot?.source || "google-static-maps-api",
+        sourceUrl: capturedSnapshot?.source || "google-static-maps-api",
+        attribution: "Map data © Google",
         metadata: {
           siteMetrics,
+          sitePlanMode: siteSnapshotMode,
+          boundaryAuthoritative: siteSnapshotBoundaryAuthoritative,
+          boundaryEstimated:
+            !siteSnapshotBoundaryAuthoritative &&
+            siteSnapshotDisplayPolygon.length >= 3,
+          siteSnapshotPolygonRole: siteSnapshotMode,
+          contextualBoundaryOverlayUsed:
+            !siteSnapshotBoundaryAuthoritative &&
+            siteSnapshotDisplayPolygon.length >= 3,
+          contextualBoundaryPolygon: contextualSnapshotPolygon,
+          source: capturedSnapshot?.source || "google-static-maps-api",
+          attribution: "Map data © Google",
+          capturedAt: capturedSnapshot?.capturedAt || null,
           sunPath: locationData.sunPath,
           wind: locationData.wind,
           climateAnalysis: locationData.climate,

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -205,6 +205,7 @@ function compactSiteSnapshotForRequest(siteSnapshot = null) {
     center: siteSnapshot.center || siteSnapshot.coordinates || null,
     zoom: siteSnapshot.zoom || null,
     mapType: siteSnapshot.mapType || null,
+    drawPolygonOverlay: siteSnapshot.drawPolygonOverlay !== false,
     size: siteSnapshot.size || null,
     sha256: siteSnapshot.sha256 || null,
     dataUrl,

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -222,6 +222,21 @@ function compactSiteSnapshotForRequest(siteSnapshot = null) {
           ? sourceLabel
           : null,
       siteMetrics: siteSnapshot.metadata?.siteMetrics || null,
+      sitePlanMode: siteSnapshot.metadata?.sitePlanMode || null,
+      boundaryAuthoritative:
+        siteSnapshot.metadata?.boundaryAuthoritative === true
+          ? true
+          : siteSnapshot.metadata?.boundaryAuthoritative === false
+            ? false
+            : null,
+      boundaryEstimated: siteSnapshot.metadata?.boundaryEstimated === true,
+      siteSnapshotPolygonRole:
+        siteSnapshot.metadata?.siteSnapshotPolygonRole || null,
+      contextualBoundaryOverlayUsed:
+        siteSnapshot.metadata?.contextualBoundaryOverlayUsed === true,
+      contextualBoundaryPolygon: compactLatLngPolygon(
+        siteSnapshot.metadata?.contextualBoundaryPolygon || [],
+      ),
       sunPath: siteSnapshot.metadata?.sunPath || null,
       wind: siteSnapshot.metadata?.wind || null,
       climateSummary: siteSnapshot.metadata?.climateSummary || null,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -1749,6 +1749,47 @@ function normalizeProvidedSiteSnapshot(siteSnapshot = null) {
   };
 }
 
+function firstUsableGeoPolygonForMap(candidates = []) {
+  for (const candidate of candidates) {
+    const polygon = normalizeGeoPolygonForMap(candidate);
+    if (polygon.length >= 3) {
+      return polygon;
+    }
+  }
+  return [];
+}
+
+function resolveSiteMapDisplayPolygon({ input = {}, brief = {}, site = {} }) {
+  const siteAnalysis =
+    input.siteAnalysis ||
+    input.locationData?.siteAnalysis ||
+    input.siteSnapshot?.metadata?.siteAnalysis ||
+    {};
+  const snapshotMetadata = input.siteSnapshot?.metadata || {};
+  const authoritativeCandidates = [
+    input.sitePolygon,
+    input.site_boundary,
+    input.siteSnapshot?.sitePolygon,
+    input.siteSnapshot?.polygon,
+    brief.site_input?.boundary_geojson,
+  ];
+
+  if (site?.boundary_authoritative !== false) {
+    return firstUsableGeoPolygonForMap(authoritativeCandidates);
+  }
+
+  return firstUsableGeoPolygonForMap([
+    input.siteSnapshot?.sitePolygon,
+    input.siteSnapshot?.polygon,
+    snapshotMetadata.contextualBoundaryPolygon,
+    input.locationData?.contextualSiteBoundary,
+    input.locationData?.estimatedSiteBoundary,
+    siteAnalysis.contextualSiteBoundary,
+    siteAnalysis.estimatedSiteBoundary,
+    siteAnalysis.siteBoundary,
+  ]);
+}
+
 async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
   const provided = normalizeProvidedSiteSnapshot(
     input.siteSnapshot || input.siteMapSnapshot || input.siteMap || null,
@@ -1761,18 +1802,16 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
     };
   }
 
-  const polygon = normalizeGeoPolygonForMap(
-    site?.boundary_authoritative === false
-      ? null
-      : input.sitePolygon ||
-          input.site_boundary ||
-          input.siteSnapshot?.sitePolygon ||
-          input.siteSnapshot?.polygon ||
-          brief.site_input.boundary_geojson,
-  );
+  const boundaryAuthoritative = site?.boundary_authoritative !== false;
+  const polygon = resolveSiteMapDisplayPolygon({ input, brief, site });
   const center = input.siteSnapshot?.center ||
     input.siteSnapshot?.coordinates ||
     input.locationData?.coordinates || { lat: site.lat, lng: site.lon };
+  const sitePlanMode = boundaryAuthoritative
+    ? "authoritative_boundary"
+    : polygon.length >= 3
+      ? "contextual_estimated_boundary"
+      : "context_only";
 
   try {
     const snapshot = await getSiteSnapshotWithMetadata({
@@ -1790,6 +1829,15 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
           ...snapshot,
           captureStatus: "google_static_maps",
           sourceUrl: snapshot.sourceUrl || "google-static-maps",
+          metadata: {
+            ...(snapshot.metadata || {}),
+            sitePlanMode,
+            boundaryAuthoritative,
+            boundaryEstimated: !boundaryAuthoritative,
+            contextualBoundaryOverlayUsed:
+              !boundaryAuthoritative && polygon.length >= 3,
+            polygonPointCount: polygon.length,
+          },
         }
       : null;
   } catch {
@@ -2961,7 +3009,17 @@ function buildSiteContextPanelArtifact({
     ? siteSnapshot.attribution || "Map image supplied by request"
     : "No map snapshot available";
   const mapLayer = boundaryEstimated
-    ? `${hasMapImage ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice" opacity="0.38"/>` : `<rect x="28" y="52" width="844" height="676" fill="#f7f6f0"/>`}
+    ? hasMapImage
+      ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice"/>
+  <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
+  <g transform="translate(44 66)">
+    <path d="${sitePath}" fill="none" stroke="#f59e0b" stroke-width="5" stroke-dasharray="16 10"/>
+    <path d="${buildablePath}" fill="none" stroke="#111111" stroke-width="3" stroke-dasharray="8 8"/>
+    <path d="${proposedFootprintPath}" fill="#11111118" stroke="#111111" stroke-width="4"/>
+  </g>
+  <text x="450" y="104" font-family="Arial, sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#111111">CONTEXTUAL SITE PLAN</text>
+  <text x="450" y="136" font-family="Arial, sans-serif" font-size="16" text-anchor="middle" fill="#555555">Boundary estimated - verify with measured survey before planning submission</text>`
+      : `<rect x="28" y="52" width="844" height="676" fill="#f7f6f0"/>
   <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
   <path d="M 78 636 C 186 586 272 612 354 562 C 456 500 584 520 824 462" fill="none" stroke="#d7d7d7" stroke-width="34" opacity="0.8"/>
   <path d="M 78 636 C 186 586 272 612 354 562 C 456 500 584 520 824 462" fill="none" stroke="#ffffff" stroke-width="22" opacity="0.96"/>

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -1739,6 +1739,8 @@ function normalizeProvidedSiteSnapshot(siteSnapshot = null) {
         ? "Map data © Google"
         : "Provided site map"),
     sourceUrl: normalizedSource,
+    mapType: siteSnapshot.mapType || siteSnapshot.metadata?.mapType || null,
+    drawPolygonOverlay: siteSnapshot.drawPolygonOverlay !== false,
     hasPolygon: Boolean(
       (Array.isArray(siteSnapshot.polygon) && siteSnapshot.polygon.length) ||
       (Array.isArray(siteSnapshot.sitePolygon) &&
@@ -1791,10 +1793,16 @@ function resolveSiteMapDisplayPolygon({ input = {}, brief = {}, site = {} }) {
 }
 
 async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
-  const provided = normalizeProvidedSiteSnapshot(
-    input.siteSnapshot || input.siteMapSnapshot || input.siteMap || null,
-  );
-  if (provided) {
+  const boundaryAuthoritative = site?.boundary_authoritative !== false;
+  const providedSnapshot =
+    input.siteSnapshot || input.siteMapSnapshot || input.siteMap || null;
+  const provided = normalizeProvidedSiteSnapshot(providedSnapshot);
+  const providedMapType = String(
+    provided?.mapType || providedSnapshot?.mapType || "",
+  ).toLowerCase();
+  const requiresRoadmapRecapture =
+    provided && ["hybrid", "satellite"].includes(providedMapType);
+  if (provided && !requiresRoadmapRecapture) {
     return {
       ...provided,
       sourceUrl: provided.sourceUrl || "provided-site-snapshot",
@@ -1802,7 +1810,6 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
     };
   }
 
-  const boundaryAuthoritative = site?.boundary_authoritative !== false;
   const polygon = resolveSiteMapDisplayPolygon({ input, brief, site });
   const center = input.siteSnapshot?.center ||
     input.siteSnapshot?.coordinates ||
@@ -1820,9 +1827,23 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
         lng: Number(center?.lng ?? center?.lon ?? site.lon),
       },
       polygon: polygon.length >= 3 ? polygon : null,
+      drawPolygonOverlay: boundaryAuthoritative,
+      polygonStyle: boundaryAuthoritative
+        ? {
+            strokeColor: "#d64d35",
+            strokeWeight: 3,
+            fillColor: "#b7d7a8",
+            fillOpacity: 0.18,
+          }
+        : {
+            strokeColor: "#e87524",
+            strokeWeight: 3,
+            fillColor: "#b7d7a8",
+            fillOpacity: 0.18,
+          },
       zoom: Number(input.siteSnapshot?.zoom || 18),
       size: [1200, 780],
-      mapType: input.siteSnapshot?.mapType || "roadmap",
+      mapType: "roadmap",
     });
     return snapshot
       ? {
@@ -3013,9 +3034,9 @@ function buildSiteContextPanelArtifact({
       ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice"/>
   <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
   <g transform="translate(44 66)">
-    <path d="${sitePath}" fill="none" stroke="#f59e0b" stroke-width="5" stroke-dasharray="16 10"/>
+    <path d="${sitePath}" fill="#b7d7a833" stroke="#e87524" stroke-width="4" stroke-dasharray="16 10"/>
     <path d="${buildablePath}" fill="none" stroke="#111111" stroke-width="3" stroke-dasharray="8 8"/>
-    <path d="${proposedFootprintPath}" fill="#11111118" stroke="#111111" stroke-width="4"/>
+    <path d="${proposedFootprintPath}" fill="#facc1533" stroke="#d9a300" stroke-width="4"/>
   </g>
   <text x="450" y="104" font-family="Arial, sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#111111">CONTEXTUAL SITE PLAN</text>
   <text x="450" y="136" font-family="Arial, sans-serif" font-size="16" text-anchor="middle" fill="#555555">Boundary estimated - verify with measured survey before planning submission</text>`
@@ -3094,6 +3115,7 @@ function buildSiteContextPanelArtifact({
       source: hasMapImage ? mapSource : "deterministic_site_context_fallback",
       siteMapSource: mapSource,
       hasMapImage,
+      mapType: siteSnapshot?.mapType || null,
       attribution,
       sitePlanMode,
       boundaryAuthoritative: site.boundary_authoritative === true,

--- a/src/services/siteMapSnapshotService.js
+++ b/src/services/siteMapSnapshotService.js
@@ -31,11 +31,48 @@ async function blobToDataUrl(blob) {
   return `data:${mimeType};base64,${base64}`;
 }
 
+const STATIC_MAP_COLOR_NAMES = {
+  red: "0xff0000ff",
+  orange: "0xf59e0bff",
+  yellow: "0xffcc00ff",
+  paleGreen: "0xb7d7a833",
+  paleBlue: "0xb7d8f033",
+};
+
+function opacityToAlpha(opacity, fallback = "ff") {
+  const numeric = Number(opacity);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.round(Math.max(0, Math.min(1, numeric)) * 255)
+    .toString(16)
+    .padStart(2, "0");
+}
+
+function normalizeStaticMapColor(value, fallback, alpha = "ff") {
+  if (!value) return fallback;
+  const raw = String(value).trim();
+  const named = STATIC_MAP_COLOR_NAMES[raw];
+  if (named) return named;
+
+  const googleHex = raw.match(/^0x([0-9a-f]{6})([0-9a-f]{2})?$/i);
+  if (googleHex) {
+    return `0x${googleHex[1]}${googleHex[2] || alpha}`;
+  }
+
+  const cssHex = raw.match(/^#?([0-9a-f]{6})([0-9a-f]{2})?$/i);
+  if (cssHex) {
+    return `0x${cssHex[1]}${cssHex[2] || alpha}`;
+  }
+
+  return fallback;
+}
+
 /**
  * Get site snapshot from Google Static Maps API
  * @param {Object} params - Snapshot parameters
  * @param {Object} params.coordinates - { lat, lng } coordinates
  * @param {Array} params.polygon - Optional array of { lat, lng } points for site boundary overlay
+ * @param {Object} params.polygonStyle - Optional Google Static Maps path style
+ * @param {boolean} params.drawPolygonOverlay - Whether to draw the polygon into the static map image
  * @param {number} params.zoom - Zoom level (default 19, used if polygon not provided)
  * @param {Array} params.size - [width, height] in pixels (default [640, 400])
  * @param {string} params.mapType - Map type: 'roadmap' (default), 'satellite', 'hybrid', 'terrain'
@@ -44,6 +81,8 @@ async function blobToDataUrl(blob) {
 export async function getSiteSnapshot({
   coordinates,
   polygon = null,
+  polygonStyle = null,
+  drawPolygonOverlay = true,
   zoom = 19,
   size = [640, 400],
   mapType = "roadmap",
@@ -66,11 +105,31 @@ export async function getSiteSnapshot({
 
   // Build polygon path if provided
   let pathParam = "";
-  if (polygon && Array.isArray(polygon) && polygon.length > 0) {
+  if (
+    drawPolygonOverlay &&
+    polygon &&
+    Array.isArray(polygon) &&
+    polygon.length > 0
+  ) {
     const pathPoints = polygon.map(({ lat, lng }) => `${lat},${lng}`).join("|");
+    const fillAlpha = opacityToAlpha(polygonStyle?.fillOpacity, "33");
+    const fillColor = normalizeStaticMapColor(
+      polygonStyle?.fillColor,
+      "0xB7D7A833",
+      fillAlpha,
+    );
+    const strokeColor = normalizeStaticMapColor(
+      polygonStyle?.strokeColor || polygonStyle?.color,
+      "0xf59e0bff",
+    );
+    const strokeWeight = Math.max(
+      1,
+      Math.round(
+        Number(polygonStyle?.strokeWeight ?? polygonStyle?.weight) || 3,
+      ),
+    );
 
-    // Yellow semi-transparent fill with yellow border
-    pathParam = `&path=fillcolor:0xFFFF0033|color:0xffcc00ff|weight:4|${pathPoints}`;
+    pathParam = `&path=fillcolor:${fillColor}|color:${strokeColor}|weight:${strokeWeight}|${pathPoints}`;
   }
 
   // Build visible parameter if polygon provided (auto-fit view to polygon)
@@ -103,7 +162,11 @@ export async function getSiteSnapshot({
     );
     logger.info(`   Size: ${size[0]}×${size[1]}px`);
     logger.info(
-      `   Polygon overlay: ${polygon ? `${polygon.length} points` : "none"}`,
+      `   Polygon: ${
+        polygon
+          ? `${polygon.length} points (${drawPolygonOverlay ? "drawn" : "bounds only"})`
+          : "none"
+      }`,
     );
 
     const response = await fetch(url);
@@ -150,6 +213,9 @@ export async function getSiteSnapshotWithMetadata(params) {
     attribution: "Map data © Google",
     sourceUrl: "google-static-maps",
     hasPolygon: params.polygon && params.polygon.length > 0,
+    mapType: params.mapType || "roadmap",
+    polygonStyle: params.polygonStyle || null,
+    drawPolygonOverlay: params.drawPolygonOverlay !== false,
   };
 }
 
@@ -162,6 +228,7 @@ export async function getSiteSnapshotWithMetadata(params) {
  * @param {Object} params.size - Image size { width, height } (default: { width: 400, height: 300 })
  * @param {Array} params.polygon - Polygon coordinates [{ lat, lng }, ...]
  * @param {Object} params.polygonStyle - Polygon style { strokeColor, strokeWeight, fillColor, fillOpacity }
+ * @param {boolean} params.drawPolygonOverlay - Whether to draw the polygon into the static map image
  * @returns {Promise<Object>} Snapshot with { dataUrl, sha256, center, zoom, mapType, size, polygon, polygonStyle, capturedAt }
  */
 export async function captureSnapshotForPersistence({
@@ -177,6 +244,7 @@ export async function captureSnapshotForPersistence({
     fillColor: "red",
     fillOpacity: 0.2,
   },
+  drawPolygonOverlay = true,
 }) {
   // Accept both 'center' and 'coordinates' for backward compatibility
   const resolvedCenter = center || coordinates;
@@ -202,6 +270,8 @@ export async function captureSnapshotForPersistence({
     const dataUrl = await getSiteSnapshot({
       coordinates: resolvedCenter,
       polygon,
+      polygonStyle,
+      drawPolygonOverlay,
       zoom,
       size: sizeArray,
       mapType,
@@ -228,6 +298,7 @@ export async function captureSnapshotForPersistence({
       size: { width: sizeArray[0], height: sizeArray[1] },
       polygon,
       polygonStyle,
+      drawPolygonOverlay,
       capturedAt: new Date().toISOString(),
       source: "google-static-maps-api",
     };

--- a/src/types/schemas.js
+++ b/src/types/schemas.js
@@ -388,6 +388,7 @@ export function normalizeSiteSnapshot(snapshot) {
     source: snapshot.source || snapshot.sourceUrl || null,
     sourceUrl: snapshot.sourceUrl || snapshot.source || null,
     attribution: snapshot.attribution || null,
+    drawPolygonOverlay: snapshot.drawPolygonOverlay !== false,
     sitePolygon: Array.isArray(snapshot.sitePolygon)
       ? snapshot.sitePolygon
       : Array.isArray(snapshot.polygon)

--- a/src/types/schemas.js
+++ b/src/types/schemas.js
@@ -380,6 +380,14 @@ export function normalizeSiteSnapshot(snapshot) {
   return {
     address: snapshot.address || "",
     coordinates: snapshot.coordinates || snapshot.center || { lat: 0, lng: 0 },
+    center: snapshot.center || snapshot.coordinates || { lat: 0, lng: 0 },
+    zoom: snapshot.zoom || null,
+    mapType: snapshot.mapType || null,
+    size: snapshot.size || null,
+    sha256: snapshot.sha256 || null,
+    source: snapshot.source || snapshot.sourceUrl || null,
+    sourceUrl: snapshot.sourceUrl || snapshot.source || null,
+    attribution: snapshot.attribution || null,
     sitePolygon: Array.isArray(snapshot.sitePolygon)
       ? snapshot.sitePolygon
       : Array.isArray(snapshot.polygon)


### PR DESCRIPTION
## Summary
- preserve Google Static Maps as the A1 site panel background when the parcel boundary is estimated
- carry the display-only contextual boundary through the site snapshot without making `designSpec.sitePolygon` authoritative
- keep low-confidence boundary metadata and `SITE_BOUNDARY_ESTIMATED_NOT_AUTHORITATIVE` warnings intact

## Validation
- npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js src/__tests__/services/projectGraphVerticalSliceService.test.js --testNamePattern="site|boundary|Google|building footprint"
- npm run lint
- npm run build:active
- npm run test:a1:tofu
- npm run test:compose:routing
- node scripts/tests/test-a1-layout-regression.mjs

## Smoke
Fresh A1 generated outside the repo temp folder:
`C:\Users\21366\AppData\Local\Temp\architect-ai-site-map-smoke-1777663832109\a1-sheet.pdf`

Confirmed:
- Google Static Maps background is present in the site panel
- estimated boundary is dashed and labelled
- proposed footprint remains visible
- survey disclaimer remains visible
- exportGate.allowed is true
- fallback area remains non-authoritative
