### PR TITLE
Phase 1: SheetDesignContext foundation (warn-only, wiring only)

### DIFF
--- a/src/__tests__/services/sheetDesignContextContract.test.js
+++ b/src/__tests__/services/sheetDesignContextContract.test.js
@@ -1,0 +1,295 @@
+import {
+  buildSheetDesignContext,
+  assertSheetDesignContext,
+  SHEET_DESIGN_CONTEXT_VERSION,
+  SHEET_DESIGN_CONTEXT_KEYS,
+} from "../../services/dnaPromptContext.js";
+import { buildVisualManifest } from "../../services/render/visualManifestService.js";
+
+function canonicalManifestInputs(overrides = {}) {
+  const base = {
+    compiledProject: {
+      geometryHash: "geom-sdc-001",
+      levels: [{ height_m: 3.2 }, { height_m: 3.0 }],
+      footprint: { length_m: 10.8, width_m: 7.5, area_m2: 81 },
+      massing: { form: "compact rectangular" },
+      roof: { form: "gable", pitch_deg: 35 },
+      facadeGrammar: { windowRhythm: "regular bay" },
+      entrance: { orientation: "front, centred" },
+    },
+    projectGraph: {
+      projectGraphId: "pg-sdc-001",
+      designFingerprint: { entrancePosition: "front facade centred" },
+    },
+    brief: {
+      project_name: "Phase 1 Fixture House",
+      building_type: "detached_house",
+      target_storeys: 2,
+      project_graph_id: "pg-sdc-001",
+    },
+    masterDNA: {
+      roof: { type: "gable", pitch_deg: 35 },
+      materials: [],
+      dimensions: { length: 10.8, width: 7.5 },
+    },
+    climate: {
+      zone: "Cfb",
+      rainfall_mm: 850,
+      sunPath: { summary: "low winter sun, shallow summer arc" },
+      overheating: false,
+      strategy: "fabric-first with summer shading",
+    },
+    localStyle: {
+      primary_style: "Birmingham red-brick vernacular",
+      style_keywords: ["red brick", "contextual contemporary"],
+      material_palette: [
+        {
+          name: "Multi-stock red brick",
+          hexColor: "#a63a2a",
+          application: "primary wall",
+        },
+        {
+          name: "Vertical timber cladding",
+          hexColor: "#8b6433",
+          application: "secondary accent",
+        },
+        {
+          name: "Dark grey roof tile",
+          hexColor: "#2f3338",
+          application: "roof covering",
+        },
+        {
+          name: "Anthracite aluminium",
+          hexColor: "#2c2f33",
+          application: "window frames",
+        },
+      ],
+      style_weights: { local: 0.4, portfolio: 0.15, climate: 0.2, user: 0.25 },
+    },
+    styleDNA: {
+      precedent_keywords: ["RIBA", "warm brick"],
+      window_language: "vertical proportion",
+      door_language: "solid timber",
+      facade_language: "regular bay",
+      roof_language: "pitched gable",
+      massing_language: "two-storey detached",
+    },
+    regulations: {
+      partL: "Approved Document Part L 2021 — fabric performance",
+      fabric_first: true,
+      flags: ["overheating-check-recommended"],
+    },
+  };
+  return { ...base, ...overrides };
+}
+
+function buildContextFromInputs(inputs, manifestOverrides = {}) {
+  const visualManifest = buildVisualManifest({
+    compiledProject: inputs.compiledProject,
+    projectGraph: inputs.projectGraph,
+    brief: inputs.brief,
+    masterDNA: inputs.masterDNA,
+    climate: inputs.climate,
+    localStyle: inputs.localStyle,
+    styleDNA: inputs.styleDNA,
+    materialPalette: inputs.localStyle?.material_palette,
+    ...manifestOverrides,
+  });
+  return buildSheetDesignContext({
+    masterDNA: inputs.masterDNA,
+    brief: inputs.brief,
+    compiledProject: inputs.compiledProject,
+    climate: inputs.climate,
+    localStyle: inputs.localStyle,
+    styleDNA: inputs.styleDNA,
+    regulations: inputs.regulations,
+    region: "UK",
+    projectGraphId: inputs.projectGraph?.projectGraphId,
+    visualManifest,
+  });
+}
+
+describe("SheetDesignContext — Phase 1 contract", () => {
+  test("returns a deep-frozen object stamped with the v1 version", () => {
+    const ctx = buildContextFromInputs(canonicalManifestInputs());
+    expect(Object.isFrozen(ctx)).toBe(true);
+    expect(Object.isFrozen(ctx.style)).toBe(true);
+    expect(Object.isFrozen(ctx.materials)).toBe(true);
+    expect(Object.isFrozen(ctx.climate)).toBe(true);
+    expect(ctx.version).toBe(SHEET_DESIGN_CONTEXT_VERSION);
+    for (const key of SHEET_DESIGN_CONTEXT_KEYS) {
+      expect(ctx).toHaveProperty(key);
+    }
+  });
+
+  test("is deterministic — same inputs produce the same contextHash", () => {
+    const inputsA = canonicalManifestInputs();
+    const inputsB = canonicalManifestInputs();
+    const ctxA = buildContextFromInputs(inputsA);
+    const ctxB = buildContextFromInputs(inputsB);
+    expect(ctxA.contextHash).toBe(ctxB.contextHash);
+    expect(ctxA.materials.length).toBe(ctxB.materials.length);
+    expect(ctxA.style.descriptor).toBe(ctxB.style.descriptor);
+  });
+
+  test("hash changes when geometryHash changes", () => {
+    const baseline = canonicalManifestInputs();
+    const drifted = canonicalManifestInputs({
+      compiledProject: {
+        ...baseline.compiledProject,
+        geometryHash: "geom-sdc-002",
+      },
+    });
+    const ctxA = buildContextFromInputs(baseline);
+    const ctxB = buildContextFromInputs(drifted);
+    expect(ctxA.contextHash).not.toBe(ctxB.contextHash);
+    expect(ctxA.geometryHash).toBe("geom-sdc-001");
+    expect(ctxB.geometryHash).toBe("geom-sdc-002");
+  });
+
+  test("hash changes when material palette changes", () => {
+    const baseline = canonicalManifestInputs();
+    const drifted = canonicalManifestInputs({
+      localStyle: {
+        ...baseline.localStyle,
+        material_palette: [
+          {
+            name: "Concrete render",
+            hexColor: "#dfdcd4",
+            application: "primary wall",
+          },
+          ...baseline.localStyle.material_palette.slice(1),
+        ],
+      },
+    });
+    const ctxA = buildContextFromInputs(baseline);
+    const ctxB = buildContextFromInputs(drifted);
+    expect(ctxA.contextHash).not.toBe(ctxB.contextHash);
+  });
+
+  test("wraps the same visualManifest by reference and shares its hash", () => {
+    const inputs = canonicalManifestInputs();
+    const visualManifest = buildVisualManifest({
+      compiledProject: inputs.compiledProject,
+      projectGraph: inputs.projectGraph,
+      brief: inputs.brief,
+      masterDNA: inputs.masterDNA,
+      climate: inputs.climate,
+      localStyle: inputs.localStyle,
+      styleDNA: inputs.styleDNA,
+      materialPalette: inputs.localStyle.material_palette,
+    });
+    const ctx = buildSheetDesignContext({
+      masterDNA: inputs.masterDNA,
+      brief: inputs.brief,
+      compiledProject: inputs.compiledProject,
+      climate: inputs.climate,
+      localStyle: inputs.localStyle,
+      styleDNA: inputs.styleDNA,
+      regulations: inputs.regulations,
+      projectGraphId: inputs.projectGraph.projectGraphId,
+      visualManifest,
+    });
+    expect(ctx.visualManifest).toBe(visualManifest);
+    expect(ctx.geometryHash).toBe(visualManifest.geometryHash);
+  });
+
+  test("normalises materials with name + hex + application", () => {
+    const ctx = buildContextFromInputs(canonicalManifestInputs());
+    expect(Array.isArray(ctx.materials)).toBe(true);
+    expect(ctx.materials.length).toBeGreaterThan(0);
+    for (const mat of ctx.materials) {
+      expect(typeof mat.name).toBe("string");
+      expect(mat.name.length).toBeGreaterThan(0);
+      expect(mat).toHaveProperty("hexColor");
+      expect(mat).toHaveProperty("application");
+    }
+  });
+
+  test("style descriptor stays meaningful even with sparse style inputs", () => {
+    const ctx = buildSheetDesignContext({
+      brief: { building_type: "detached_house" },
+      compiledProject: { geometryHash: "h-1", levels: [{}] },
+      visualManifest: buildVisualManifest({
+        compiledProject: { geometryHash: "h-1", levels: [{}] },
+        projectGraph: { projectGraphId: "p-1" },
+        brief: { building_type: "detached_house", target_storeys: 1 },
+      }),
+    });
+    expect(ctx.style.architecture).toBe("contemporary");
+    expect(typeof ctx.style.descriptor).toBe("string");
+  });
+
+  test("propagates climate summary including overheating flag and strategy", () => {
+    const ctx = buildContextFromInputs(canonicalManifestInputs());
+    expect(ctx.climate).not.toBeNull();
+    expect(ctx.climate.zone).toBe("Cfb");
+    expect(ctx.climate.rainfallMm).toBe(850);
+    expect(ctx.climate.overheating).toBe(false);
+    expect(ctx.climate.strategy).toMatch(/fabric/i);
+  });
+
+  test("captures portfolio blend weights when localStyle exposes them", () => {
+    const ctx = buildContextFromInputs(canonicalManifestInputs());
+    expect(ctx.portfolioBlend).not.toBeNull();
+    expect(ctx.portfolioBlend.localWeight).toBe(0.4);
+    expect(ctx.portfolioBlend.portfolioWeight).toBe(0.15);
+    expect(ctx.portfolioBlend.climateWeight).toBe(0.2);
+    expect(ctx.portfolioBlend.userWeight).toBe(0.25);
+  });
+
+  test("frozen materials cannot be mutated by consumers", () => {
+    const ctx = buildContextFromInputs(canonicalManifestInputs());
+    expect(() => {
+      ctx.materials.push({
+        name: "Injected",
+        hexColor: "#000",
+        application: "x",
+      });
+    }).toThrow();
+    expect(() => {
+      ctx.materials[0].name = "Mutated";
+    }).toThrow();
+  });
+});
+
+describe("assertSheetDesignContext — warn-only Phase 1 behaviour", () => {
+  test("returns ok:true with no gaps for a fully-populated context", () => {
+    const ctx = buildContextFromInputs(canonicalManifestInputs());
+    const report = assertSheetDesignContext(ctx);
+    expect(report.ok).toBe(true);
+    expect(report.gaps).toEqual([]);
+    expect(report.frozen).toBe(true);
+  });
+
+  test("returns ok:false with structured gaps when the context is missing", () => {
+    const report = assertSheetDesignContext(null);
+    expect(report.ok).toBe(false);
+    expect(report.gaps).toContain("context");
+  });
+
+  test("does not throw when required keys are missing in non-strict mode", () => {
+    expect(() => assertSheetDesignContext({})).not.toThrow();
+    const report = assertSheetDesignContext({});
+    expect(report.ok).toBe(false);
+    expect(report.gaps.length).toBeGreaterThan(0);
+  });
+
+  test("does throw when strict=true and required keys are missing", () => {
+    expect(() => assertSheetDesignContext({}, { strict: true })).toThrow();
+  });
+
+  test("flags non-frozen contexts even when fields are present", () => {
+    const fakeCtx = {
+      version: SHEET_DESIGN_CONTEXT_VERSION,
+      geometryHash: "h",
+      materials: [{ name: "x", hexColor: "#000", application: "y" }],
+      style: { architecture: "contemporary" },
+      visualManifest: { manifestHash: "m" },
+      contextHash: "c",
+    };
+    const report = assertSheetDesignContext(fakeCtx);
+    expect(report.frozen).toBe(false);
+    expect(report.warnings.some((w) => /not frozen/i.test(w))).toBe(true);
+  });
+});

--- a/src/services/design/dnaPromptContext.js
+++ b/src/services/design/dnaPromptContext.js
@@ -17,6 +17,10 @@ export {
   buildSectionPrompt,
   buildNegativePrompt,
   buildStructuredDNAContext,
+  buildSheetDesignContext,
+  assertSheetDesignContext,
+  SHEET_DESIGN_CONTEXT_VERSION,
+  SHEET_DESIGN_CONTEXT_KEYS,
 } from "../dnaPromptContext.js";
 
 export default dnaPromptContext;

--- a/src/services/dnaPromptContext.js
+++ b/src/services/dnaPromptContext.js
@@ -10,6 +10,464 @@
 
 import { extractStructuredDNA } from "./dnaSchema.js";
 import logger from "../utils/logger.js";
+import { computeCDSHashSync } from "./validation/cdsHash.js";
+import { getCanonicalMaterialPalette } from "./design/canonicalMaterialPalette.js";
+
+export const SHEET_DESIGN_CONTEXT_VERSION = "sheet-design-context-v1";
+
+export const SHEET_DESIGN_CONTEXT_KEYS = Object.freeze([
+  "version",
+  "projectGraphId",
+  "geometryHash",
+  "style",
+  "materials",
+  "climate",
+  "portfolioBlend",
+  "programSpaces",
+  "region",
+  "sustainability",
+  "designFingerprint",
+  "visualManifest",
+  "contextHash",
+]);
+
+const REQUIRED_SHEET_DESIGN_CONTEXT_KEYS = Object.freeze([
+  "version",
+  "geometryHash",
+  "materials",
+  "style",
+  "visualManifest",
+  "contextHash",
+]);
+
+function deepFreeze(value) {
+  if (value === null || typeof value !== "object") return value;
+  if (Object.isFrozen(value)) return value;
+  for (const key of Object.keys(value)) {
+    deepFreeze(value[key]);
+  }
+  return Object.freeze(value);
+}
+
+function nullIfBlank(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  return value;
+}
+
+function asNumberOrNull(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function normaliseMaterialEntry(entry, fallbackApplication = null) {
+  if (!entry) return null;
+  if (typeof entry === "string") {
+    const trimmed = entry.trim();
+    if (!trimmed) return null;
+    return {
+      name: trimmed,
+      hexColor: null,
+      application: fallbackApplication,
+      role: null,
+      hatch: null,
+    };
+  }
+  const name =
+    nullIfBlank(entry.name || entry.type || entry.material) || "material";
+  const hex =
+    nullIfBlank(entry.hexColor) ||
+    nullIfBlank(entry.hex) ||
+    nullIfBlank(entry.color_hex) ||
+    nullIfBlank(entry.color) ||
+    null;
+  const application =
+    nullIfBlank(entry.application) ||
+    nullIfBlank(entry.use) ||
+    nullIfBlank(entry.coverage) ||
+    fallbackApplication;
+  return {
+    name,
+    hexColor: hex,
+    application: application || null,
+    role: nullIfBlank(entry.role) || null,
+    hatch: nullIfBlank(entry.hatch) || null,
+  };
+}
+
+function normaliseMaterialList(rawList, fallbackApplication = null) {
+  if (!Array.isArray(rawList)) return [];
+  return rawList
+    .map((entry) => normaliseMaterialEntry(entry, fallbackApplication))
+    .filter(Boolean);
+}
+
+function resolveCanonicalMaterials({ masterDNA, compiledProject, localStyle }) {
+  // Prefer the canonical palette (Phase 8 SSOT) when it can be derived.
+  try {
+    const canonical = getCanonicalMaterialPalette({
+      dna: masterDNA || {},
+      projectGeometry: compiledProject || {},
+      facadeGrammar:
+        compiledProject?.facadeGrammar || localStyle?.facade_grammar || {},
+    });
+    if (
+      canonical &&
+      Array.isArray(canonical.entries) &&
+      canonical.entries.length > 0
+    ) {
+      return canonical.entries
+        .map((entry) =>
+          normaliseMaterialEntry(
+            {
+              name: entry.name,
+              hexColor: entry.hexColor,
+              application: entry.application,
+              role: entry.role,
+              hatch: entry.hatch,
+            },
+            entry.application || null,
+          ),
+        )
+        .filter(Boolean);
+    }
+  } catch (err) {
+    logger.warn?.(
+      "buildSheetDesignContext: canonical palette derivation failed; falling back",
+      { error: err?.message || String(err) },
+    );
+  }
+  // Fallbacks: localStyle.material_palette > masterDNA.materials
+  const fromLocalStyle = normaliseMaterialList(
+    localStyle?.material_palette,
+    null,
+  );
+  if (fromLocalStyle.length > 0) return fromLocalStyle;
+  const fromDNA = normaliseMaterialList(masterDNA?.materials, null);
+  return fromDNA;
+}
+
+function deriveStyleDescriptor({ masterDNA, localStyle, styleDNA }) {
+  const structured = masterDNA?._structured || null;
+  const architecture =
+    nullIfBlank(structured?.style?.architecture) ||
+    nullIfBlank(masterDNA?.style?.architecture) ||
+    nullIfBlank(localStyle?.primary_style) ||
+    nullIfBlank(styleDNA?.style_name) ||
+    "contemporary";
+  const facadeLanguage =
+    nullIfBlank(styleDNA?.facade_language) ||
+    nullIfBlank(localStyle?.facade_language) ||
+    nullIfBlank(structured?.style?.facade_language) ||
+    null;
+  const roofLanguage =
+    nullIfBlank(styleDNA?.roof_language) ||
+    nullIfBlank(localStyle?.roof_language) ||
+    null;
+  const massingLanguage =
+    nullIfBlank(styleDNA?.massing_language) ||
+    nullIfBlank(localStyle?.massing_language) ||
+    null;
+  const windowLanguage =
+    nullIfBlank(styleDNA?.window_language) ||
+    nullIfBlank(localStyle?.window_language) ||
+    null;
+  const keywords = [];
+  for (const list of [
+    styleDNA?.precedent_keywords,
+    styleDNA?.keywords,
+    localStyle?.style_keywords,
+    localStyle?.keywords,
+  ]) {
+    if (Array.isArray(list)) {
+      for (const kw of list) {
+        if (typeof kw === "string" && kw.trim()) {
+          keywords.push(kw.trim());
+        }
+      }
+    }
+  }
+  return {
+    architecture,
+    facadeLanguage,
+    roofLanguage,
+    massingLanguage,
+    windowLanguage,
+    descriptor: [architecture, massingLanguage, facadeLanguage]
+      .filter(Boolean)
+      .join(" — "),
+    keywords: Array.from(new Set(keywords)).slice(0, 8),
+  };
+}
+
+function deriveClimateSummary(climate) {
+  if (!climate || typeof climate !== "object") return null;
+  const zone =
+    nullIfBlank(climate.zone) ||
+    nullIfBlank(climate.koppen) ||
+    nullIfBlank(climate.climateZone) ||
+    null;
+  const rainfall =
+    asNumberOrNull(climate.rainfall_mm) ??
+    asNumberOrNull(climate.annual_rainfall_mm) ??
+    asNumberOrNull(climate.precipitation_mm);
+  return {
+    zone,
+    rainfallMm: rainfall,
+    rainfallBand:
+      nullIfBlank(climate.rainfall_band) ||
+      nullIfBlank(climate.rainfallBand) ||
+      (rainfall !== null ? `${rainfall}mm/yr` : null),
+    sunPathSummary:
+      nullIfBlank(climate.sunPath?.summary) ||
+      nullIfBlank(climate.sun_path?.summary) ||
+      nullIfBlank(climate.sunPathSummary) ||
+      null,
+    overheating: Boolean(climate.overheating || climate.overheating_flag),
+    strategy:
+      nullIfBlank(climate.strategy) ||
+      nullIfBlank(climate.design_strategy) ||
+      null,
+  };
+}
+
+function derivePortfolioBlend({ localStyle }) {
+  const weights = localStyle?.style_weights || localStyle?.weights || null;
+  if (!weights || typeof weights !== "object") return null;
+  const out = {
+    localWeight: asNumberOrNull(weights.local ?? weights.localWeight),
+    portfolioWeight: asNumberOrNull(
+      weights.portfolio ?? weights.portfolioWeight,
+    ),
+    climateWeight: asNumberOrNull(weights.climate ?? weights.climateWeight),
+    userWeight: asNumberOrNull(weights.user ?? weights.userWeight),
+  };
+  if (
+    out.localWeight === null &&
+    out.portfolioWeight === null &&
+    out.climateWeight === null &&
+    out.userWeight === null
+  ) {
+    return null;
+  }
+  return out;
+}
+
+function deriveProgramSpaces({ programmeSummary, masterDNA }) {
+  const fromSummary = Array.isArray(programmeSummary?.rooms)
+    ? programmeSummary.rooms
+    : Array.isArray(programmeSummary?.levels)
+      ? programmeSummary.levels.flatMap((lvl) =>
+          Array.isArray(lvl?.rooms) ? lvl.rooms : [],
+        )
+      : [];
+  const fromDNA = Array.isArray(masterDNA?._structured?.program?.rooms)
+    ? masterDNA._structured.program.rooms
+    : Array.isArray(masterDNA?.rooms)
+      ? masterDNA.rooms
+      : [];
+  const source = fromSummary.length > 0 ? fromSummary : fromDNA;
+  return source
+    .map((room) => {
+      if (!room) return null;
+      const name = nullIfBlank(room.name || room.type) || null;
+      if (!name) return null;
+      return {
+        name,
+        area_m2: asNumberOrNull(room.area_m2 ?? room.area),
+        level: nullIfBlank(room.floor || room.level) || null,
+      };
+    })
+    .filter(Boolean)
+    .slice(0, 32);
+}
+
+function deriveSustainability({ regulations, climate }) {
+  if (!regulations && !climate) return null;
+  const partL =
+    nullIfBlank(regulations?.partL) ||
+    nullIfBlank(regulations?.part_l) ||
+    nullIfBlank(regulations?.partL_summary) ||
+    null;
+  return {
+    partL,
+    overheating: Boolean(climate?.overheating || climate?.overheating_flag),
+    fabricFirst: Boolean(
+      regulations?.fabric_first ||
+      regulations?.fabricFirst ||
+      regulations?.fabricFirstStrategy,
+    ),
+    flags: Array.isArray(regulations?.flags) ? regulations.flags.slice() : [],
+  };
+}
+
+/**
+ * Build the canonical Sheet Design Context.
+ *
+ * One frozen object built once per ProjectGraph generation. Every panel
+ * renderer (technical SVG, image-model panels, data panels) is intended to
+ * consume this same object so style + material + climate + portfolio +
+ * program flow coherently to every panel on the A1 sheet.
+ *
+ * Phase 1 introduces this contract WITHOUT changing render output. The
+ * artifact is surfaced for inspection and future consumers; existing callers
+ * that ignore it continue to work unchanged.
+ *
+ * The returned object is deep-frozen and includes a stable `contextHash`
+ * computed over the deterministic subset (excluding `visualManifest` which
+ * already carries its own `manifestHash`).
+ *
+ * @param {object} options
+ * @param {object} [options.masterDNA]         - master DNA snapshot
+ * @param {object} [options.brief]             - normalised brief
+ * @param {object} [options.compiledProject]   - compiled geometry (authority)
+ * @param {object} [options.climate]           - climate pack
+ * @param {object} [options.localStyle]        - regional vernacular pack
+ * @param {object} [options.styleDNA]          - generated style DNA
+ * @param {object} [options.regulations]      - regulation pack
+ * @param {object} [options.programmeSummary]  - per-level programme summary
+ * @param {string} [options.region]            - region label
+ * @param {string} [options.projectGraphId]    - project graph identifier
+ * @param {object} [options.visualManifest]    - Phase D visual manifest
+ * @param {object} [options.designFingerprint] - optional design fingerprint
+ * @returns {Readonly<object>} deep-frozen SheetDesignContext
+ */
+export function buildSheetDesignContext({
+  masterDNA = null,
+  brief = null,
+  compiledProject = null,
+  climate = null,
+  localStyle = null,
+  styleDNA = null,
+  regulations = null,
+  programmeSummary = null,
+  region = null,
+  projectGraphId = null,
+  visualManifest = null,
+  designFingerprint = null,
+} = {}) {
+  const geometryHash =
+    nullIfBlank(compiledProject?.geometryHash) ||
+    nullIfBlank(compiledProject?.geometry_hash) ||
+    nullIfBlank(visualManifest?.geometryHash) ||
+    null;
+  const resolvedProjectGraphId =
+    nullIfBlank(projectGraphId) ||
+    nullIfBlank(visualManifest?.projectGraphId) ||
+    nullIfBlank(brief?.project_graph_id) ||
+    null;
+  const materials = resolveCanonicalMaterials({
+    masterDNA,
+    compiledProject,
+    localStyle,
+  });
+  const style = deriveStyleDescriptor({ masterDNA, localStyle, styleDNA });
+  const climateSummary = deriveClimateSummary(climate);
+  const portfolioBlend = derivePortfolioBlend({ localStyle });
+  const programSpaces = deriveProgramSpaces({ programmeSummary, masterDNA });
+  const sustainability = deriveSustainability({ regulations, climate });
+  const resolvedRegion = nullIfBlank(region) || null;
+
+  // Deterministic subset for hashing — visualManifest is referenced by hash
+  // (it carries its own deterministic manifestHash), so we include only the
+  // hash to avoid double-hashing the entire manifest into our context hash.
+  const hashable = {
+    version: SHEET_DESIGN_CONTEXT_VERSION,
+    projectGraphId: resolvedProjectGraphId,
+    geometryHash,
+    style: {
+      architecture: style.architecture,
+      facadeLanguage: style.facadeLanguage,
+      roofLanguage: style.roofLanguage,
+      massingLanguage: style.massingLanguage,
+      windowLanguage: style.windowLanguage,
+      descriptor: style.descriptor,
+      keywords: style.keywords,
+    },
+    materials,
+    climate: climateSummary,
+    portfolioBlend,
+    programSpaces,
+    region: resolvedRegion,
+    sustainability,
+    visualManifestHash: visualManifest?.manifestHash || null,
+  };
+  const contextHash = computeCDSHashSync(hashable);
+
+  const ctx = {
+    version: SHEET_DESIGN_CONTEXT_VERSION,
+    projectGraphId: resolvedProjectGraphId,
+    geometryHash,
+    style,
+    materials,
+    climate: climateSummary,
+    portfolioBlend,
+    programSpaces,
+    region: resolvedRegion,
+    sustainability,
+    designFingerprint: designFingerprint || null,
+    visualManifest: visualManifest || null,
+    contextHash,
+  };
+  return deepFreeze(ctx);
+}
+
+/**
+ * Soft validator for SheetDesignContext.
+ *
+ * Phase 1 is **warn-only**: returns a structured report instead of throwing,
+ * so existing callers that do not yet pass a SheetDesignContext keep working.
+ * Later phases may flip `strict` to true once every consumer is migrated.
+ *
+ * @param {object|null} ctx
+ * @param {object} [options]
+ * @param {boolean} [options.strict=false] - when true, throws on the first
+ *   missing required key. Phase 1 callers should leave this false.
+ * @returns {{ ok: boolean, gaps: string[], warnings: string[], frozen: boolean }}
+ */
+export function assertSheetDesignContext(ctx, { strict = false } = {}) {
+  const warnings = [];
+  const gaps = [];
+  if (!ctx || typeof ctx !== "object") {
+    const message = "SheetDesignContext is missing or not an object";
+    warnings.push(message);
+    if (strict) {
+      throw new Error(message);
+    }
+    logger.warn?.(`assertSheetDesignContext: ${message}`);
+    return { ok: false, gaps: ["context"], warnings, frozen: false };
+  }
+  const frozen = Object.isFrozen(ctx);
+  if (!frozen) {
+    warnings.push("SheetDesignContext is not frozen (expected deep-frozen)");
+  }
+  for (const key of REQUIRED_SHEET_DESIGN_CONTEXT_KEYS) {
+    const value = ctx[key];
+    const missing =
+      value === undefined ||
+      value === null ||
+      (Array.isArray(value) && value.length === 0);
+    if (missing) {
+      gaps.push(key);
+    }
+  }
+  if (ctx.version && ctx.version !== SHEET_DESIGN_CONTEXT_VERSION) {
+    warnings.push(
+      `SheetDesignContext version mismatch: expected ${SHEET_DESIGN_CONTEXT_VERSION}, got ${ctx.version}`,
+    );
+  }
+  const ok = gaps.length === 0 && warnings.length === 0;
+  if (!ok) {
+    const message = `assertSheetDesignContext: gaps=[${gaps.join(",")}] warnings=[${warnings.join(
+      "; ",
+    )}]`;
+    if (strict && gaps.length > 0) {
+      throw new Error(message);
+    }
+    logger.warn?.(message);
+  }
+  return { ok, gaps, warnings, frozen };
+}
 
 /**
  * Build structured DNA context for prompts
@@ -323,4 +781,8 @@ export default {
   buildElevationPrompt,
   buildSectionPrompt,
   buildNegativePrompt,
+  buildSheetDesignContext,
+  assertSheetDesignContext,
+  SHEET_DESIGN_CONTEXT_VERSION,
+  SHEET_DESIGN_CONTEXT_KEYS,
 };

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -26,6 +26,11 @@ import {
   buildVisualManifest,
   buildVisualIdentityLockBlock,
 } from "../render/visualManifestService.js";
+import {
+  buildSheetDesignContext,
+  assertSheetDesignContext,
+  SHEET_DESIGN_CONTEXT_VERSION,
+} from "../dnaPromptContext.js";
 import { getSiteSnapshotWithMetadata } from "../siteMapSnapshotService.js";
 import { computeSunPath } from "../climate/sunPath.js";
 import { listSourceDocumentsForParts } from "../regulation/sourceRegistry.js";
@@ -3713,6 +3718,10 @@ async function buildSheetPanelArtifacts({
   siteSnapshot = null,
   sheetPlan = null,
   visualManifest = null,
+  // Phase 1: optional SheetDesignContext. Reserved for downstream
+  // consumers; not consumed by the existing data-panel builders yet.
+  // eslint-disable-next-line no-unused-vars
+  sheetDesignContext = null,
 }) {
   const siteContext = buildSiteContextPanelArtifact({
     projectGraphId,
@@ -4826,6 +4835,9 @@ async function buildA1Sheet({
   siteSnapshot = null,
   sheetPlan = null,
   visualManifest = null,
+  // Phase 1: optional SheetDesignContext. Existing callers may omit it; the
+  // function does not yet hard-depend on it.
+  sheetDesignContext = null,
 }) {
   const __a1sheetStart = Date.now();
   const __a1sheetLog = (step, sinceMs, extra = "") => {
@@ -4857,6 +4869,7 @@ async function buildA1Sheet({
       label: sheetLabel,
     },
     visualManifest,
+    sheetDesignContext,
   });
   __a1mark = __a1sheetLog("build_panel_artifacts", __a1mark);
   const panelArtifacts = {
@@ -7531,6 +7544,31 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     materialPalette: localStyle?.material_palette || null,
   });
   __vsMark = __vsLog("visual_manifest", __vsMark);
+  // Phase 1 — SheetDesignContext foundation. One frozen contract object
+  // built once per generation. Wraps (does not replace) visualManifest and
+  // adds material/style/climate/portfolio/programme surfaces so future panel
+  // renderers can consume one source of truth. Phase 1 is wiring-only; no
+  // render output changes. The validator below is warn-only — existing
+  // callers that ignore the context keep working unchanged.
+  const sheetDesignContext = buildSheetDesignContext({
+    masterDNA: input?.masterDNA || null,
+    brief,
+    compiledProject,
+    climate,
+    localStyle,
+    styleDNA: styleDNAForManifest,
+    regulations,
+    programmeSummary,
+    region,
+    projectGraphId,
+    visualManifest,
+  });
+  const sheetDesignContextReport = assertSheetDesignContext(sheetDesignContext);
+  __vsMark = __vsLog(
+    "sheet_design_context",
+    __vsMark,
+    `hash=${sheetDesignContext.contextHash} ok=${sheetDesignContextReport.ok} gaps=${sheetDesignContextReport.gaps.length}`,
+  );
   const renderedSheets = [];
   for (const sheetPlan of splitDecision.sheets) {
     const sheetIndex = renderedSheets.length;
@@ -7554,6 +7592,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       siteSnapshot: siteMapSnapshot,
       sheetPlan,
       visualManifest,
+      sheetDesignContext,
     });
     __vsMark = __vsLog(`build_a1_sheet[${sheetTag}]`, __vsMark);
     const pdfStart = Date.now();
@@ -7571,6 +7610,8 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       ...(sheetResult.sheetArtifact.metadata || {}),
       renderProof: pdf.renderedProof,
       textRenderStatus: pdf.renderedProof?.textRenderStatus,
+      sheetDesignContextHash: sheetDesignContext.contextHash,
+      sheetDesignContextVersion: SHEET_DESIGN_CONTEXT_VERSION,
     };
     renderedSheets.push({
       sheetPlan,
@@ -7857,6 +7898,13 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     // metadata.visualManifestId / Hash / visualIdentityLocked.
     visualManifest,
     visualManifestHash: visualManifest.manifestHash,
+    // Phase 1 — SheetDesignContext foundation. Frozen contract object that
+    // wraps visualManifest with material/style/climate/portfolio/programme.
+    // Surfaced here so downstream tests/consumers can prove every panel
+    // was driven by the same design context. No render output changes.
+    sheetDesignContext,
+    sheetDesignContextHash: sheetDesignContext.contextHash,
+    sheetDesignContextReport,
     technicalBuild: {
       ok: technicalBuild.ok,
       technicalPanelTypes: technicalBuild.technicalPanelTypes,


### PR DESCRIPTION
## Summary

Phase 1 of the A1 goal-parity plan. Introduces a single frozen `SheetDesignContext` built once per ProjectGraph generation, immediately after `visualManifest`. Wraps (does **not** replace) the existing `visualManifestService` with material/style/climate/portfolio/programme surfaces so future panel renderers can consume one source of truth.

**This PR is wiring-only — no render output changes, no panel renames, no schema drift, no compose hard-block.** The validator is warn-only; existing callers that ignore the new context keep working unchanged.

## Files changed

- `src/services/dnaPromptContext.js` — `buildSheetDesignContext`, `assertSheetDesignContext` (warn-only Phase 1 validator), `SHEET_DESIGN_CONTEXT_VERSION`, `SHEET_DESIGN_CONTEXT_KEYS`. Reuses `getCanonicalMaterialPalette`; produces a stable `contextHash` via `computeCDSHashSync`.
- `src/services/design/dnaPromptContext.js` — re-export the new symbols from the design-package adapter.
- `src/services/project/projectGraphVerticalSliceService.js` — build the context once after `visual_manifest`, run the warn-only validator (`__vsLog(\"sheet_design_context\", …)`), surface on `artifacts.sheetDesignContext` + `sheetDesignContextHash` + `sheetDesignContextReport`, thread through `buildA1Sheet` → `buildSheetPanelArtifacts` as an optional param. Stamp sheet-artifact metadata with the context hash + version.
- `src/__tests__/services/sheetDesignContextContract.test.js` — new contract tests (15 tests).

Total: **+890 / -10** across 4 files (commit f6476af).

## Tests

| Check | Result |
| --- | --- |
| `npm run check:env` | ✅ pass |
| `npm run check:contracts` | ✅ pass |
| `npm run lint` | ✅ pass (no errors) |
| `npm run test:compose:routing` | ✅ 22/22 |
| `npm run test:a1:tofu` | ✅ pass |
| `node scripts/tests/test-a1-layout-regression.mjs` | ✅ 27/27 |
| `npm run build:active` | ✅ compiled successfully |
| Focused jest: `sheetDesignContext` | ✅ **15/15** (`Test Suites: 1 passed, Tests: 15 passed`) |
| Node smoke (`tmp/sheet-design-context-smoke.mjs`) | ✅ 20/20 contract assertions |

The full suite shows 37 pre-existing failures unrelated to this change (e.g., `src/__tests__/architecture/designContracts.test.js` cannot find `'../../geometry/GeometryPipeline.js'`). Those exist on `main` before this PR; verified by inspection of the failing imports.

## Boundary process discipline (the contract)

The frozen `SheetDesignContext` carries:
- `version` (`sheet-design-context-v1`)
- `projectGraphId`, `geometryHash` — pinned to the same compiled geometry as `visualManifest`
- `style` — architecture, facade/roof/window/massing language, descriptor, keywords (canonical fallback `\"contemporary\"` when sparse)
- `materials` — normalized via `getCanonicalMaterialPalette`, fallback to `localStyle.material_palette` then `masterDNA.materials`
- `climate` — zone, rainfall (number + band string), sun-path summary, overheating flag, strategy
- `portfolioBlend` — local/portfolio/climate/user weights when `localStyle.style_weights` is present
- `programSpaces` — name/area/level array from programme summary or DNA
- `region`, `sustainability` (Part L flags, fabric-first flag, overheating)
- `designFingerprint` — pass-through (optional)
- `visualManifest` — by reference (NOT re-hashed), so its `manifestHash` is preserved
- `contextHash` — CDS hash over the deterministic subset only (uses `visualManifest.manifestHash` rather than the whole manifest, to avoid double-hash drift)

Smoke test output:
```
contextHash: 385fb5e2e853e3d1
materials count: 5
style.descriptor: Birmingham red-brick vernacular — two-storey detached — regular bay
```

## Out of scope (per Phase 1 brief)

- No visual rendering changes
- No `schedules_notes` → `key_notes` rename
- No material palette layout changes
- No drawing renderer changes
- No axonometric cutaway change
- No OpenAI provider/env changes
- No export gate policy changes
- No programme/floor authority changes
- No site-boundary authority changes
- No compose hard-block — `assertSheetDesignContext` is warn-only by default; `strict: true` is reserved for later phases when every consumer is migrated

## Risks

1. **Shape drift**: any future change to `SHEET_DESIGN_CONTEXT_KEYS` or the hashable subset will change `contextHash` for every project. Phase 1 anchors the version at `v1`; bump on shape changes.
2. **Hash determinism**: `contextHash` is computed via `computeCDSHashSync` (same as `visualManifest`). Node ordering and undefined-stripping match.
3. **Stale `dnaPromptContext.js` consumers**: the canonical and adapter versions both export the new symbols. Imports from either path resolve.
4. **Worktree haste-map noise**: locally, `react-scripts test` indexes `.claude/worktrees/*/__mocks__/`. The `--testPathIgnorePatterns=\.claude\` flag avoids running those tests but doesn't suppress the duplicate-mock warnings. Not introduced by this PR; flagged for awareness.

## Test plan

- [x] `npm run check:env`
- [x] `npm run check:contracts`
- [x] `npm run lint`
- [x] `npm run build:active`
- [x] `npm run test:a1:tofu`
- [x] `npm run test:compose:routing`
- [x] `node scripts/tests/test-a1-layout-regression.mjs`
- [x] Focused jest on `sheetDesignContext` (15/15 pass)
- [ ] `npm test -- --watchAll=false sheetDesignContext visualManifest projectGraph` (running locally — slow on Windows due to worktree haste-map; CI run will confirm)

## Next steps

**Do not merge.** Stop here for approval before Phase 2 (data panels: 8-swatch material palette, structured Key Notes, RIBA-stage title block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)