### PR TITLE
Phase 2: Improve A1 material palette, key notes, and RIBA title block

### DIFF
--- a/src/__tests__/services/a1/dataPanelsPhase2.test.js
+++ b/src/__tests__/services/a1/dataPanelsPhase2.test.js
@@ -1,0 +1,377 @@
+import {
+  buildMaterialPalettePanelArtifact,
+  buildKeyNoteItems,
+  buildKeyNotesPanelArtifact,
+  buildTitleBlockPanelArtifact,
+} from "../../../services/project/projectGraphVerticalSliceService.js";
+import { buildSheetDesignContext } from "../../../services/dnaPromptContext.js";
+import { buildVisualManifest } from "../../../services/render/visualManifestService.js";
+import { normalizeKey } from "../../../services/a1/composeCore.js";
+
+function fixtureBrief(overrides = {}) {
+  return {
+    project_name: "Phase 2 Fixture House",
+    project_graph_id: "pg-phase2-fixture-001",
+    building_type: "detached_house",
+    target_gia_m2: 162,
+    target_storeys: 2,
+    sustainability_ambition: "fabric-first",
+    site_input: {
+      address: "Test Lane, Birmingham, UK",
+      postcode: "B1 1AA",
+      lat: 52.48,
+      lon: -1.9,
+    },
+    user_intent: { portfolio_mood: "riba_stage3" },
+    brief_input_hash: "brief-hash-001",
+    architect: "ArchAI Studio",
+    studio_footer: "Architecture | Design | Planning",
+    revision: "P02",
+    status: "Issued for Comment",
+    brief_date: "2026-05-01",
+    ...overrides,
+  };
+}
+
+function fixtureLocalStyle() {
+  return {
+    primary_style: "Birmingham red-brick vernacular",
+    style_keywords: ["red brick", "contextual contemporary"],
+    material_palette: [
+      {
+        name: "Multi-stock red brick",
+        hexColor: "#a63a2a",
+        application: "primary wall",
+      },
+      {
+        name: "Vertical timber cladding",
+        hexColor: "#8b6433",
+        application: "secondary accent",
+      },
+      {
+        name: "Dark grey roof tile",
+        hexColor: "#2f3338",
+        application: "roof covering",
+      },
+      {
+        name: "Anthracite aluminium",
+        hexColor: "#2c2f33",
+        application: "window frames",
+      },
+    ],
+    style_weights: { local: 0.4, portfolio: 0.15, climate: 0.2, user: 0.25 },
+    facade_grammar: { windowRhythm: "regular bay" },
+  };
+}
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geom-phase2-fixture-001",
+    levels: [{ height_m: 3.2 }, { height_m: 3.0 }],
+    footprint: { length_m: 10.8, width_m: 7.5, area_m2: 81 },
+    massing: { form: "compact rectangular" },
+    roof: { form: "gable", pitch_deg: 35 },
+    facadeGrammar: { windowRhythm: "regular bay" },
+  };
+}
+
+function fixtureClimate() {
+  return {
+    zone: "Cfb",
+    rainfall_mm: 850,
+    sunPath: { summary: "low winter sun, shallow summer arc" },
+    overheating: false,
+    strategy: "fabric-first with summer shading",
+  };
+}
+
+function fixtureRegulations() {
+  return {
+    partL: "Approved Document Part L 2021 fabric performance",
+    fabric_first: true,
+    flags: [],
+    jurisdiction: "England",
+  };
+}
+
+function fixtureSheetDesignContext() {
+  const compiledProject = fixtureCompiledProject();
+  const localStyle = fixtureLocalStyle();
+  const climate = fixtureClimate();
+  const regulations = fixtureRegulations();
+  const brief = fixtureBrief();
+  const visualManifest = buildVisualManifest({
+    compiledProject,
+    projectGraph: { projectGraphId: brief.project_graph_id },
+    brief,
+    masterDNA: null,
+    climate,
+    localStyle,
+    materialPalette: localStyle.material_palette,
+  });
+  return buildSheetDesignContext({
+    masterDNA: null,
+    brief,
+    compiledProject,
+    climate,
+    localStyle,
+    regulations,
+    region: "UK",
+    projectGraphId: brief.project_graph_id,
+    visualManifest,
+  });
+}
+
+describe("Phase 2 — Material Palette panel", () => {
+  test("renders 8 cards even when localStyle palette has fewer entries (canonical fallback top-up)", () => {
+    const artifact = buildMaterialPalettePanelArtifact({
+      projectGraphId: "pg-1",
+      localStyle: fixtureLocalStyle(),
+      compiledProject: fixtureCompiledProject(),
+      styleDNA: null,
+      brief: fixtureBrief(),
+      geometryHash: "geom-1",
+    });
+    expect(artifact.panel_type).toBe("material_palette");
+    expect(artifact.metadata.cardCount).toBe(8);
+    expect(artifact.cardMetadata).toHaveLength(8);
+  });
+
+  test("renders 8 cards from SheetDesignContext when canonical palette delivers ≥8 entries", () => {
+    const ctx = fixtureSheetDesignContext();
+    const artifact = buildMaterialPalettePanelArtifact({
+      projectGraphId: "pg-1",
+      localStyle: fixtureLocalStyle(),
+      compiledProject: fixtureCompiledProject(),
+      styleDNA: null,
+      brief: fixtureBrief(),
+      geometryHash: "geom-1",
+      sheetDesignContext: ctx,
+    });
+    expect(artifact.cardMetadata).toHaveLength(8);
+    expect(artifact.metadata.sourceContext).toBe("sheet_design_context");
+    expect(artifact.metadata.sheetDesignContextHash).toBe(ctx.contextHash);
+  });
+
+  test("each card metadata exposes a category label drawn from KIND_CATEGORY/application hints", () => {
+    const artifact = buildMaterialPalettePanelArtifact({
+      projectGraphId: "pg-1",
+      localStyle: fixtureLocalStyle(),
+      compiledProject: fixtureCompiledProject(),
+      styleDNA: null,
+      brief: fixtureBrief(),
+      geometryHash: "geom-1",
+    });
+    const allowed = new Set([
+      "EXTERIOR",
+      "ROOF",
+      "OPENINGS",
+      "DETAIL",
+      "LANDSCAPE",
+    ]);
+    artifact.cardMetadata.forEach((card) => {
+      expect(typeof card.category).toBe("string");
+      expect(allowed.has(card.category)).toBe(true);
+    });
+    expect(artifact.metadata.categoryCount).toBeGreaterThanOrEqual(3);
+  });
+
+  test("emits category label markup ABOVE each swatch (data-material-category attribute)", () => {
+    const artifact = buildMaterialPalettePanelArtifact({
+      projectGraphId: "pg-1",
+      localStyle: fixtureLocalStyle(),
+      compiledProject: fixtureCompiledProject(),
+      styleDNA: null,
+      brief: fixtureBrief(),
+      geometryHash: "geom-1",
+    });
+    const matches =
+      artifact.svgString.match(/data-material-category="[A-Z]+"/g) || [];
+    expect(matches.length).toBe(8);
+  });
+});
+
+describe("Phase 2 — Key Notes panel", () => {
+  const expectedOrder = [
+    "external_walls",
+    "roof",
+    "windows_doors",
+    "heating_ventilation",
+    "drainage",
+    "sustainability",
+    "climate_strategy",
+    "dimensions_tolerances",
+    "copyright",
+  ];
+
+  test("buildKeyNoteItems returns the canonical 9-group structure in deterministic order", () => {
+    const groups = buildKeyNoteItems({
+      brief: fixtureBrief(),
+      site: { area_m2: 320 },
+      climate: fixtureClimate(),
+      regulations: fixtureRegulations(),
+      localStyle: fixtureLocalStyle(),
+    });
+    expect(groups.map((g) => g.id)).toEqual(expectedOrder);
+    groups.forEach((group) => {
+      expect(typeof group.heading).toBe("string");
+      expect(group.heading.length).toBeGreaterThan(0);
+      expect(Array.isArray(group.lines)).toBe(true);
+      expect(group.lines.length).toBeGreaterThan(0);
+    });
+  });
+
+  test("Climate strategy is folded into Key Notes (not a separate panel) and includes a meaningful body line", () => {
+    const groups = buildKeyNoteItems({
+      brief: fixtureBrief(),
+      site: { area_m2: 320 },
+      climate: fixtureClimate(),
+      regulations: fixtureRegulations(),
+      localStyle: fixtureLocalStyle(),
+      sheetDesignContext: fixtureSheetDesignContext(),
+    });
+    const climate = groups.find((g) => g.id === "climate_strategy");
+    expect(climate).toBeTruthy();
+    expect(climate.heading).toMatch(/Climate strategy/i);
+    expect(climate.lines.length).toBeGreaterThanOrEqual(1);
+    expect(climate.lines.join(" ")).toMatch(
+      /cfb|temperate|fabric|passive|rainfall|overheating|shading|ventilation/i,
+    );
+  });
+
+  test("buildKeyNotesPanelArtifact stamps groupOrder + groupIds + sourceContext metadata", () => {
+    const ctx = fixtureSheetDesignContext();
+    const artifact = buildKeyNotesPanelArtifact({
+      projectGraphId: "pg-1",
+      brief: fixtureBrief(),
+      site: { area_m2: 320 },
+      climate: fixtureClimate(),
+      regulations: fixtureRegulations(),
+      localStyle: fixtureLocalStyle(),
+      geometryHash: "geom-1",
+      sheetDesignContext: ctx,
+    });
+    expect(artifact.panel_type).toBe("key_notes");
+    expect(artifact.metadata.noteCount).toBe(9);
+    expect(artifact.metadata.groupIds).toEqual(expectedOrder);
+    expect(artifact.metadata.groupOrder).toEqual(expectedOrder);
+    expect(artifact.metadata.sourceContext).toBe("sheet_design_context");
+    expect(artifact.metadata.sheetDesignContextHash).toBe(ctx.contextHash);
+    expect(artifact.svgString).toMatch(/data-key-note-id="climate_strategy"/);
+  });
+
+  test("Key notes ordering is stable across two consecutive runs with identical inputs", () => {
+    const fixedInputs = () => ({
+      brief: fixtureBrief(),
+      site: { area_m2: 320 },
+      climate: fixtureClimate(),
+      regulations: fixtureRegulations(),
+      localStyle: fixtureLocalStyle(),
+    });
+    const groupsA = buildKeyNoteItems(fixedInputs());
+    const groupsB = buildKeyNoteItems(fixedInputs());
+    expect(groupsA.map((g) => g.id)).toEqual(groupsB.map((g) => g.id));
+    expect(groupsA.map((g) => g.heading)).toEqual(
+      groupsB.map((g) => g.heading),
+    );
+  });
+
+  test("falls back gracefully when no SheetDesignContext is provided (legacy path)", () => {
+    const artifact = buildKeyNotesPanelArtifact({
+      projectGraphId: "pg-1",
+      brief: fixtureBrief(),
+      site: { area_m2: 320 },
+      climate: fixtureClimate(),
+      regulations: fixtureRegulations(),
+      localStyle: fixtureLocalStyle(),
+      geometryHash: "geom-1",
+    });
+    expect(artifact.metadata.sourceContext).toBe("legacy_dna");
+    expect(artifact.metadata.noteCount).toBe(9);
+  });
+});
+
+describe("Phase 2 — Title Block panel", () => {
+  test("includes RIBA Stage / Status / Revision / Date / Drawing No. row keys", () => {
+    const artifact = buildTitleBlockPanelArtifact({
+      projectGraphId: "pg-1",
+      brief: fixtureBrief(),
+      geometryHash: "geom-1",
+      sheetPlan: { sheet_number: "A1-001", label: "RIBA Stage 3 Master" },
+    });
+    expect(artifact.panel_type).toBe("title_block");
+    const required = [
+      "Project",
+      "Location",
+      "RIBA Stage",
+      "Status",
+      "Revision",
+      "Date",
+      "Drawing No.",
+    ];
+    required.forEach((key) => {
+      expect(artifact.metadata.rowKeys).toContain(key);
+    });
+    expect(artifact.metadata.ribaStage).toBe("RIBA Stage 3");
+    expect(artifact.metadata.revision).toBe("P02");
+    expect(artifact.metadata.status).toBe("Issued for Comment");
+    expect(artifact.metadata.date).toBe("2026-05-01");
+    expect(artifact.metadata.drawingNumber).toBe("A1-001");
+  });
+
+  test("falls back to RIBA Stage 2 when brief has no portfolio_mood/riba_stage", () => {
+    const briefSparse = fixtureBrief({
+      user_intent: undefined,
+      riba_stage: undefined,
+    });
+    const artifact = buildTitleBlockPanelArtifact({
+      projectGraphId: "pg-1",
+      brief: briefSparse,
+      geometryHash: "geom-1",
+      sheetPlan: null,
+    });
+    expect(artifact.metadata.ribaStage).toBe("RIBA Stage 2");
+    expect(artifact.metadata.revision).toBe("P02");
+  });
+
+  test("renders architect name and studio footer in the SVG", () => {
+    const artifact = buildTitleBlockPanelArtifact({
+      projectGraphId: "pg-1",
+      brief: fixtureBrief(),
+      geometryHash: "geom-1",
+      sheetPlan: { sheet_number: "A1-001", label: "RIBA Stage 3 Master" },
+    });
+    expect(artifact.svgString).toContain("ARCHAI STUDIO");
+    expect(artifact.svgString).toContain("Architecture | Design | Planning");
+    expect(artifact.metadata.architect).toBe("ArchAI Studio");
+  });
+
+  test("propagates SheetDesignContext hash and region into metadata when supplied", () => {
+    const ctx = fixtureSheetDesignContext();
+    const artifact = buildTitleBlockPanelArtifact({
+      projectGraphId: "pg-1",
+      brief: fixtureBrief(),
+      geometryHash: "geom-1",
+      sheetPlan: { sheet_number: "A1-001", label: "RIBA Stage 3 Master" },
+      sheetDesignContext: ctx,
+    });
+    expect(artifact.metadata.sheetDesignContextHash).toBe(ctx.contextHash);
+    expect(artifact.metadata.sourceContext).toBe("sheet_design_context");
+    expect(artifact.metadata.location).toMatch(/UK/);
+  });
+});
+
+describe("Phase 2 — schedules_notes / key_notes compose-routing compatibility", () => {
+  test("normalizeKey('key_notes') routes to the schedules_notes legacy slot", () => {
+    expect(normalizeKey("key_notes")).toBe("schedules_notes");
+  });
+
+  test("normalizeKey('schedules_notes') stays canonical", () => {
+    expect(normalizeKey("schedules_notes")).toBe("schedules_notes");
+  });
+
+  test("normalizeKey legacy aliases ('schedules', 'notes') still resolve to schedules_notes", () => {
+    expect(normalizeKey("schedules")).toBe("schedules_notes");
+    expect(normalizeKey("notes")).toBe("schedules_notes");
+  });
+});

--- a/src/services/a1/composeCore.js
+++ b/src/services/a1/composeCore.js
@@ -309,6 +309,12 @@ const CANONICAL_KEY_MAP = {
   climate: "climate_card",
   schedules: "schedules_notes",
   notes: "schedules_notes",
+  // Phase 2 — `key_notes` is the active canonical name for the panel that
+  // the ProjectGraph vertical slice builds (`buildKeyNotesPanelArtifact`).
+  // Compose-grid lookups still resolve to the existing `schedules_notes`
+  // slot during the one-release shim window so existing fixtures, sheet
+  // splitter consumers, and final-export contract paths keep working.
+  key_notes: "schedules_notes",
 
   // Legacy image-generation types used by panelOrchestrator PANEL_DEFINITIONS
   exterior_front_3d: "hero_3d",

--- a/src/services/a1/materialTexturePatterns.js
+++ b/src/services/a1/materialTexturePatterns.js
@@ -26,14 +26,43 @@ const CANONICAL_TEXTURE_KINDS = Object.freeze([
 // the broader `timber`/`metal` rules; otherwise "timber front door" would
 // classify as cladding and "metal rainwater downpipe" as a window frame.
 const MATERIAL_KEYWORD_MAP = Object.freeze([
-  { kind: "timber_front_door", pattern: /\b(front|entrance|main)\s*door\b|\b(timber|wood(en)?)\s+door\b|\bdoor\b/i },
-  { kind: "dark_metal_rainwater_goods", pattern: /\brainwater\b|\bgutter(s|ing)?\b|\bdownpipe\b|\bmetal\s+trim\b/i },
-  { kind: "red_multi_brick", pattern: /\b(red\s+|multi[-\s]?)?brick(work)?\b|\bmasonry\b|\bterracotta\b/i },
-  { kind: "dark_grey_roof_tile", pattern: /\broof\b|\bslate\b|\b(roof\s+)?tile\b|\bshingle\b|\bstanding\s+seam\b/i },
-  { kind: "anthracite_aluminium_frame", pattern: /\baluminium\b|\baluminum\b|\banthracite\b|\bwindow(\s+frame)?\b|\bglazing\b|\bglass\b|\bzinc\b/i },
-  { kind: "vertical_timber_cladding", pattern: /\btimber\b|\bwood(en)?\b|\boak\b|\bcedar\b|\bboarding\b|\bcladding\b/i },
-  { kind: "natural_stone_paving", pattern: /\bstone\b|\bpaving\b|\bflagstone\b/i },
-  { kind: "light_render", pattern: /\brender\b|\bstucco\b|\blime\b|\bplaster\b/i },
+  {
+    kind: "timber_front_door",
+    pattern:
+      /\b(front|entrance|main)\s*door\b|\b(timber|wood(en)?)\s+door\b|\bdoor\b/i,
+  },
+  {
+    kind: "dark_metal_rainwater_goods",
+    pattern: /\brainwater\b|\bgutter(s|ing)?\b|\bdownpipe\b|\bmetal\s+trim\b/i,
+  },
+  {
+    kind: "red_multi_brick",
+    pattern:
+      /\b(red\s+|multi[-\s]?)?brick(work)?\b|\bmasonry\b|\bterracotta\b/i,
+  },
+  {
+    kind: "dark_grey_roof_tile",
+    pattern:
+      /\broof\b|\bslate\b|\b(roof\s+)?tile\b|\bshingle\b|\bstanding\s+seam\b/i,
+  },
+  {
+    kind: "anthracite_aluminium_frame",
+    pattern:
+      /\baluminium\b|\baluminum\b|\banthracite\b|\bwindow(\s+frame)?\b|\bglazing\b|\bglass\b|\bzinc\b/i,
+  },
+  {
+    kind: "vertical_timber_cladding",
+    pattern:
+      /\btimber\b|\bwood(en)?\b|\boak\b|\bcedar\b|\bboarding\b|\bcladding\b/i,
+  },
+  {
+    kind: "natural_stone_paving",
+    pattern: /\bstone\b|\bpaving\b|\bflagstone\b/i,
+  },
+  {
+    kind: "light_render",
+    pattern: /\brender\b|\bstucco\b|\blime\b|\bplaster\b/i,
+  },
 ]);
 
 const KIND_HEX = Object.freeze({
@@ -57,6 +86,55 @@ const KIND_APPLICATION = Object.freeze({
   light_render: "external wall",
   natural_stone_paving: "landscape / plinth",
 });
+
+// Phase 2 — high-level category labels that appear above each swatch on the
+// presentation-v3 material palette panel ("EXTERIOR", "ROOF", "OPENINGS",
+// "DETAIL", "LANDSCAPE"). Mapped from the canonical texture kind so callers
+// don't have to guess.
+const KIND_CATEGORY = Object.freeze({
+  red_multi_brick: "EXTERIOR",
+  vertical_timber_cladding: "EXTERIOR",
+  light_render: "EXTERIOR",
+  dark_grey_roof_tile: "ROOF",
+  anthracite_aluminium_frame: "OPENINGS",
+  timber_front_door: "OPENINGS",
+  dark_metal_rainwater_goods: "DETAIL",
+  natural_stone_paving: "LANDSCAPE",
+});
+
+const APPLICATION_CATEGORY_HINTS = Object.freeze([
+  {
+    pattern: /\b(roof|tile|slate|shingle|standing\s+seam)\b/i,
+    category: "ROOF",
+  },
+  { pattern: /\b(window|opening|glaz|frame|door)\b/i, category: "OPENINGS" },
+  {
+    pattern: /\b(rainwater|gutter|downpipe|trim|detail|fitting)\b/i,
+    category: "DETAIL",
+  },
+  {
+    pattern: /\b(landscape|paving|plinth|stone|garden|hard\s*standing)\b/i,
+    category: "LANDSCAPE",
+  },
+  {
+    pattern: /\b(wall|facade|cladding|render|brick|stucco|exterior)\b/i,
+    category: "EXTERIOR",
+  },
+]);
+
+export function inferMaterialCategory(material = {}) {
+  const kind = materialTextureKind(
+    material.name || material,
+    material.application || "",
+  );
+  if (KIND_CATEGORY[kind]) return KIND_CATEGORY[kind];
+  const haystack =
+    `${material.application || ""} ${material.name || ""}`.toLowerCase();
+  for (const hint of APPLICATION_CATEGORY_HINTS) {
+    if (hint.pattern.test(haystack)) return hint.category;
+  }
+  return "DETAIL";
+}
 
 const CANONICAL_FALLBACK_MATERIALS = Object.freeze([
   { name: "Red Multi Brick", kind: "red_multi_brick" },
@@ -116,7 +194,8 @@ function fnv1aHash(str) {
 }
 
 export function materialTextureKind(name = "", application = "") {
-  const haystack = `${String(name ?? "")} ${String(application ?? "")}`.toLowerCase();
+  const haystack =
+    `${String(name ?? "")} ${String(application ?? "")}`.toLowerCase();
   for (const rule of MATERIAL_KEYWORD_MAP) {
     if (rule.pattern.test(haystack)) return rule.kind;
   }
@@ -131,7 +210,8 @@ export function inferMaterialHex(name = "", index = 0, application = "") {
 }
 
 export function inferMaterialApplication(name = "", application = "") {
-  if (application && String(application).trim()) return String(application).trim();
+  if (application && String(application).trim())
+    return String(application).trim();
   const kind = materialTextureKind(name);
   return KIND_APPLICATION[kind] || "finish";
 }
@@ -142,7 +222,8 @@ export function inferMaterialApplication(name = "", application = "") {
  * signatures.
  */
 export function materialSignature(material) {
-  const source = material && typeof material === "object" ? material : { name: material };
+  const source =
+    material && typeof material === "object" ? material : { name: material };
   const name = toAsciiLabel(source.name || source.material || "")
     .toLowerCase()
     .replace(/\s+/g, " ")
@@ -190,7 +271,13 @@ export function buildMaterialTexturePattern(material, options = {}) {
   const id = options.id || patternIdFor(signature);
   const kind = materialTextureKind(material?.name, material?.application);
   const baseHex = escapeXml(
-    material?.hexColor || material?.hex || inferMaterialHex(material?.name, options.index ?? 0, material?.application),
+    material?.hexColor ||
+      material?.hex ||
+      inferMaterialHex(
+        material?.name,
+        options.index ?? 0,
+        material?.application,
+      ),
   );
   const overlay = KIND_OVERLAY[kind] || KIND_OVERLAY.light_render;
   const svg = `<pattern id="${id}" width="72" height="72" patternUnits="userSpaceOnUse" data-material-texture="${kind}" data-material-signature="${signature}"><rect width="72" height="72" fill="${baseHex}"/>${overlay}</pattern>`;
@@ -243,7 +330,14 @@ function pushAll(target, value, source) {
     return;
   }
   if (typeof value === "object") {
-    if (value.name || value.material || value.label || value.type || value.primary || value.finish) {
+    if (
+      value.name ||
+      value.material ||
+      value.label ||
+      value.type ||
+      value.primary ||
+      value.finish
+    ) {
       target.push({ raw: value, source });
       return;
     }
@@ -275,7 +369,11 @@ export function normalizeMaterialPaletteEntries({
 } = {}) {
   const collected = [];
   pushAll(collected, materials, "project_graph");
-  pushAll(collected, localStyle?.material_palette_with_provenance, "local_style");
+  pushAll(
+    collected,
+    localStyle?.material_palette_with_provenance,
+    "local_style",
+  );
   pushAll(collected, localStyle?.material_palette, "local_style");
   pushAll(collected, localStyle?.materials_local, "local_style");
   pushAll(collected, localStyle?.local_materials, "local_style");
@@ -300,7 +398,9 @@ export function normalizeMaterialPaletteEntries({
     CANONICAL_FALLBACK_MATERIALS.forEach((entry, index) => {
       byName.set(entry.name.toLowerCase(), {
         name: entry.name,
-        hexColor: KIND_HEX[entry.kind] || HEX_INDEX_FALLBACKS[index % HEX_INDEX_FALLBACKS.length],
+        hexColor:
+          KIND_HEX[entry.kind] ||
+          HEX_INDEX_FALLBACKS[index % HEX_INDEX_FALLBACKS.length],
         application: KIND_APPLICATION[entry.kind] || "finish",
         source: "deterministic_fallback",
       });
@@ -310,25 +410,88 @@ export function normalizeMaterialPaletteEntries({
   return Array.from(byName.values()).slice(0, 8);
 }
 
+/**
+ * Phase 2 — top up an existing materials list to a target size using the
+ * canonical 8-material fallback set. Used by the presentation-v3 material
+ * palette panel so the 2×4 grid always renders 8 cards even when the
+ * SheetDesignContext / DNA collection is shorter.
+ *
+ * Existing entries are kept verbatim and dedupe against the fallback by
+ * lowercase name. Returns at most `targetSize` entries.
+ */
+export function topUpMaterialPaletteWithCanonical(
+  materials = [],
+  targetSize = 8,
+) {
+  const result = Array.isArray(materials) ? materials.filter(Boolean) : [];
+  if (result.length >= targetSize) return result.slice(0, targetSize);
+  const known = new Set(
+    result.map((entry) => String(entry?.name || "").toLowerCase()),
+  );
+  for (
+    let i = 0;
+    i < CANONICAL_FALLBACK_MATERIALS.length && result.length < targetSize;
+    i += 1
+  ) {
+    const fallback = CANONICAL_FALLBACK_MATERIALS[i];
+    const key = fallback.name.toLowerCase();
+    if (known.has(key)) continue;
+    known.add(key);
+    result.push({
+      name: fallback.name,
+      hexColor:
+        KIND_HEX[fallback.kind] ||
+        HEX_INDEX_FALLBACKS[i % HEX_INDEX_FALLBACKS.length],
+      application: KIND_APPLICATION[fallback.kind] || "finish",
+      source: "deterministic_fallback_topup",
+    });
+  }
+  return result.slice(0, targetSize);
+}
+
 function buildSingleCard({ material, index, layout, sourceTag, thumbnailUrl }) {
   const signature = materialSignature(material);
   const pattern = buildMaterialTexturePattern(material, { signature, index });
   const x = layout.startX + layout.col * (layout.cardWidth + layout.gapX);
   const y = layout.startY + layout.row * (layout.cardHeight + layout.gapY);
   const labelOffset = layout.labelOffset ?? 22;
-  const subLabelOffset = layout.subLabelOffset ?? labelOffset + (layout.subLabelGap ?? 22);
+  const subLabelOffset =
+    layout.subLabelOffset ?? labelOffset + (layout.subLabelGap ?? 22);
   const labelFontSize = layout.labelFontSize ?? 18;
   const subLabelFontSize = layout.subLabelFontSize ?? 14;
   const fontFamily = layout.fontFamily || "Arial, Helvetica, sans-serif";
-  const labelText = clampText(String(material.name || "").toUpperCase(), layout.labelMaxChars ?? 28);
-  const application = clampText(material.application || "", layout.subLabelMaxChars ?? 32);
-  const safeFill = thumbnailUrl
-    ? `url(#${pattern.id})`
-    : `url(#${pattern.id})`;
+  const labelText = clampText(
+    String(material.name || "").toUpperCase(),
+    layout.labelMaxChars ?? 28,
+  );
+  const application = clampText(
+    material.application || "",
+    layout.subLabelMaxChars ?? 32,
+  );
+  const safeFill = thumbnailUrl ? `url(#${pattern.id})` : `url(#${pattern.id})`;
   const overlayImage = thumbnailUrl
     ? `<image href="${escapeXml(thumbnailUrl)}" x="${x}" y="${y}" width="${layout.cardWidth}" height="${layout.cardHeight}" preserveAspectRatio="xMidYMid slice" data-material-thumbnail="true"/>`
     : "";
-  const cardSvg = `<g data-material-index="${index + 1}" data-material-signature="${signature}" data-material-source="${sourceTag}">
+  // Phase 2 — optional small category label rendered above each swatch
+  // ("EXTERIOR" / "ROOF" / "OPENINGS" / "DETAIL" / "LANDSCAPE"). Driven by
+  // either an explicit `material.category` or inferred from kind/application.
+  const showCategoryLabel = layout.showCategoryLabel === true;
+  const categoryFromMaterial = material.category
+    ? String(material.category).trim().toUpperCase()
+    : null;
+  const category =
+    categoryFromMaterial ||
+    (showCategoryLabel ? inferMaterialCategory(material) : null);
+  const categoryFontSize =
+    layout.categoryFontSize ?? Math.max(9, subLabelFontSize - 2);
+  const categoryOffset =
+    layout.categoryOffset ?? Math.max(8, categoryFontSize + 2);
+  const categorySvg =
+    showCategoryLabel && category
+      ? `<text x="${x}" y="${y - categoryOffset / 2}" font-size="${categoryFontSize}" font-family="${fontFamily}" font-weight="700" fill="#666666" letter-spacing="1.5" class="sheet-critical-label" data-text-role="critical">${escapeXml(category)}</text>`
+      : "";
+  const cardSvg = `<g data-material-index="${index + 1}" data-material-signature="${signature}" data-material-source="${sourceTag}"${category ? ` data-material-category="${escapeXml(category)}"` : ""}>
+  ${categorySvg}
   <rect x="${x}" y="${y}" width="${layout.cardWidth}" height="${layout.cardHeight}" fill="${safeFill}" stroke="#111111" stroke-width="${layout.strokeWidth ?? 2}" data-material-texture="${escapeXml(pattern.kind)}"/>
   ${overlayImage}
   <text x="${x}" y="${y + layout.cardHeight + labelOffset}" font-size="${labelFontSize}" font-family="${fontFamily}" font-weight="700" fill="#111111" class="sheet-critical-label" data-text-role="critical">${escapeXml(labelText)}</text>
@@ -341,10 +504,14 @@ function buildSingleCard({ material, index, layout, sourceTag, thumbnailUrl }) {
       materialSignature: signature,
       label: labelText,
       application: application || "",
+      category: category || null,
       textureKind: pattern.kind,
       source: sourceTag,
       fallbackAvailable: true,
-      hex: material.hexColor || material.hex || inferMaterialHex(material.name, index, material.application),
+      hex:
+        material.hexColor ||
+        material.hex ||
+        inferMaterialHex(material.name, index, material.application),
     },
   };
 }
@@ -372,6 +539,10 @@ function resolveLayout(layout = {}) {
     labelMaxChars: layout.labelMaxChars,
     subLabelMaxChars: layout.subLabelMaxChars,
     strokeWidth: layout.strokeWidth,
+    // Phase 2 — optional category label band above each swatch.
+    showCategoryLabel: layout.showCategoryLabel === true,
+    categoryFontSize: layout.categoryFontSize,
+    categoryOffset: layout.categoryOffset,
   };
 }
 
@@ -389,7 +560,10 @@ function resolveLayout(layout = {}) {
  *                           fallbackAvailable: true, hex }>
  *   }
  */
-export function buildMaterialPaletteCards({ materials, layout: layoutInput } = {}) {
+export function buildMaterialPaletteCards({
+  materials,
+  layout: layoutInput,
+} = {}) {
   const layout = resolveLayout(layoutInput);
   const list = (Array.isArray(materials) ? materials : []).slice(0, layout.max);
   const defs = [];
@@ -416,7 +590,12 @@ export function buildMaterialPaletteCards({ materials, layout: layoutInput } = {
 }
 
 function isThumbnailFlagEnabled(env) {
-  const source = env && typeof env === "object" ? env : (typeof process !== "undefined" ? process.env : {});
+  const source =
+    env && typeof env === "object"
+      ? env
+      : typeof process !== "undefined"
+        ? process.env
+        : {};
   const value = source?.MATERIAL_TEXTURE_THUMBNAILS_ENABLED;
   return String(value ?? "").toLowerCase() === "true";
 }
@@ -461,9 +640,17 @@ export async function buildMaterialPaletteCardsAsync({
           label: material.name,
           application: material.application || "",
           textureKind: materialTextureKind(material.name, material.application),
-          hex: material.hexColor || material.hex || inferMaterialHex(material.name, index, material.application),
+          hex:
+            material.hexColor ||
+            material.hex ||
+            inferMaterialHex(material.name, index, material.application),
         });
-        if (result && typeof result === "object" && typeof result.url === "string" && result.url.trim()) {
+        if (
+          result &&
+          typeof result === "object" &&
+          typeof result.url === "string" &&
+          result.url.trim()
+        ) {
           thumbnailUrl = result.url.trim();
           sourceTag = "ai_texture_thumbnail";
         }
@@ -498,4 +685,5 @@ export {
   CANONICAL_FALLBACK_MATERIALS,
   KIND_HEX,
   KIND_APPLICATION,
+  KIND_CATEGORY,
 };

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -69,6 +69,7 @@ import {
 import {
   buildMaterialPaletteCards,
   normalizeMaterialPaletteEntries as normalizeMaterialPaletteEntriesShared,
+  topUpMaterialPaletteWithCanonical,
 } from "../a1/materialTexturePatterns.js";
 import {
   buildClimateRenderContext,
@@ -3136,42 +3137,63 @@ function buildSiteContextPanelArtifact({
   };
 }
 
-function buildMaterialPalettePanelArtifact({
+export function buildMaterialPalettePanelArtifact({
   projectGraphId,
   localStyle,
   compiledProject,
   styleDNA,
   brief,
   geometryHash,
+  // Phase 2 — when present, the SheetDesignContext supplies the canonical
+  // materials list (normalized via getCanonicalMaterialPalette + DNA fallback).
+  // We prefer ctx.materials over the localStyle / DNA collection so style +
+  // material + climate stay coherent across panels. When absent, fall back to
+  // the legacy Phase E collection logic.
+  sheetDesignContext = null,
 }) {
   const width = 700;
   const height = 900;
-  const materials = normalizeMaterialPaletteEntriesShared({
-    localStyle,
-    compiledProject,
-    styleDNA,
-    brief,
-  });
+  const ctxMaterials = Array.isArray(sheetDesignContext?.materials)
+    ? sheetDesignContext.materials.filter(
+        (entry) => entry && (entry.name || entry.hexColor || entry.hex),
+      )
+    : [];
+  const baseMaterials =
+    ctxMaterials.length > 0
+      ? ctxMaterials
+      : normalizeMaterialPaletteEntriesShared({
+          localStyle,
+          compiledProject,
+          styleDNA,
+          brief,
+        });
+  // Always render up to 8 cards; if the collection is short, top up from the
+  // canonical 8-material fallback so the 2×4 grid stays visually balanced.
+  const materials = topUpMaterialPaletteWithCanonical(baseMaterials, 8);
   const { defs, cards, cardMetadata } = buildMaterialPaletteCards({
     materials,
     layout: {
+      // Phase 2: 2 cols × 4 rows = 8 cards on the presentation-v3 row-3 slot.
       cols: 2,
-      rows: 3,
-      max: 6,
-      cardWidth: 250,
-      cardHeight: 112,
-      gapX: 54,
-      gapY: 116,
-      startX: 54,
-      startY: 92,
-      labelOffset: 28,
-      subLabelOffset: 54,
-      labelFontSize: 18,
-      subLabelFontSize: 14,
+      rows: 4,
+      max: 8,
+      cardWidth: 270,
+      cardHeight: 120,
+      gapX: 42,
+      gapY: 60,
+      startX: 58,
+      startY: 110,
+      labelOffset: 20,
+      subLabelOffset: 38,
+      labelFontSize: 17,
+      subLabelFontSize: 13,
       fontFamily: "Arial, sans-serif",
-      labelMaxChars: 18,
-      subLabelMaxChars: 24,
+      labelMaxChars: 22,
+      subLabelMaxChars: 26,
       strokeWidth: 2,
+      showCategoryLabel: true,
+      categoryFontSize: 11,
+      categoryOffset: 10,
     },
   });
   const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="material_palette" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}">
@@ -3213,6 +3235,14 @@ function buildMaterialPalettePanelArtifact({
       materialCount: materials.length,
       materials,
       cardMetadata,
+      // Phase 2 surfaces:
+      cardCount: cardMetadata.length,
+      categoryCount: new Set(
+        cardMetadata.map((card) => card.category).filter(Boolean),
+      ).size,
+      categories: cardMetadata.map((card) => card.category || null),
+      sheetDesignContextHash: sheetDesignContext?.contextHash || null,
+      sourceContext: sheetDesignContext ? "sheet_design_context" : "legacy_dna",
     },
   };
 }
@@ -3237,32 +3267,231 @@ function splitNoteLines(note = "", maxChars = 36, maxLines = 3) {
   return lines.slice(0, maxLines);
 }
 
-function buildKeyNoteItems({ brief, site, climate, regulations, localStyle }) {
-  const notes = [
-    `Active programme: ${brief?.target_gia_m2 || "target"} sq m across ${brief?.target_storeys || 1} storey(s).`,
-    brief?.site_input?.address
-      ? `Active site: ${brief.site_input.address}.`
-      : null,
-    site?.area_m2
-      ? `Site area ${site.area_m2} sq m; boundary and context sourced from ProjectGraph site analysis.`
-      : "Site boundary is held in the ProjectGraph site model.",
-    `Sustainability ambition: ${brief?.sustainability_ambition || "low_energy"}.`,
-    climate?.overheating?.risk_level
-      ? `Climate precheck: overheating risk ${climate.overheating.risk_level}.`
-      : "Climate precheck uses deterministic fallback where live data is unavailable.",
-    regulations?.jurisdiction
-      ? `Regulation precheck jurisdiction: ${regulations.jurisdiction}.`
-      : "Regulation checks are preliminary and require professional review.",
-    Array.isArray(localStyle?.material_palette) &&
-    localStyle.material_palette.length
-      ? `Facade palette: ${localStyle.material_palette.slice(0, 3).join(", ")}.`
-      : "Facade palette is derived from local style and user intent.",
-    "All dimensions are in metres unless noted; verify before construction.",
-  ];
-  return notes.filter(Boolean).slice(0, 7);
+// Phase 2 — canonical Key Notes group order. The structure stays stable
+// across runs so the panel order is deterministic regardless of input.
+const KEY_NOTE_GROUP_ORDER = Object.freeze([
+  "external_walls",
+  "roof",
+  "windows_doors",
+  "heating_ventilation",
+  "drainage",
+  "sustainability",
+  "climate_strategy",
+  "dimensions_tolerances",
+  "copyright",
+]);
+
+function pickMaterialByCategory(materials, predicate) {
+  if (!Array.isArray(materials)) return null;
+  return materials.find((m) => m && predicate(m)) || null;
 }
 
-function buildKeyNotesPanelArtifact({
+function describeMaterial(material) {
+  if (!material) return null;
+  const name = String(material.name || "").trim();
+  if (!name) return null;
+  const hex = material.hexColor || material.hex || null;
+  const application = String(material.application || "").trim();
+  const tail = [];
+  if (hex) tail.push(hex);
+  if (application) tail.push(application);
+  return tail.length ? `${name} (${tail.join(" / ")})` : name;
+}
+
+export function buildKeyNoteItems({
+  brief,
+  site,
+  climate,
+  regulations,
+  localStyle,
+  sheetDesignContext = null,
+}) {
+  const ctxMaterials =
+    Array.isArray(sheetDesignContext?.materials) &&
+    sheetDesignContext.materials.length
+      ? sheetDesignContext.materials
+      : null;
+  const localPalette = Array.isArray(localStyle?.material_palette)
+    ? localStyle.material_palette
+    : [];
+  const ctxClimate =
+    sheetDesignContext?.climate ||
+    (climate && typeof climate === "object" ? null : null);
+  const climateZone =
+    sheetDesignContext?.climate?.zone ||
+    climate?.zone ||
+    climate?.koppen ||
+    null;
+  const climateRainfall =
+    sheetDesignContext?.climate?.rainfallBand ||
+    sheetDesignContext?.climate?.rainfallMm ||
+    climate?.rainfall_mm ||
+    climate?.annual_rainfall_mm ||
+    null;
+  const climateStrategy =
+    sheetDesignContext?.climate?.strategy ||
+    climate?.strategy ||
+    climate?.design_strategy ||
+    null;
+  const overheatingFlag =
+    sheetDesignContext?.climate?.overheating === true ||
+    climate?.overheating === true ||
+    climate?.overheating?.risk_level === "high" ||
+    climate?.overheating?.risk_level === "moderate";
+
+  const wallMaterial =
+    pickMaterialByCategory(ctxMaterials, (m) =>
+      /external|wall|brick|render|stone|cladding|facade/i.test(
+        `${m.application} ${m.name}`,
+      ),
+    ) ||
+    (ctxMaterials && ctxMaterials[0]) ||
+    null;
+  const roofMaterial = pickMaterialByCategory(ctxMaterials, (m) =>
+    /roof|tile|slate|standing\s*seam/i.test(`${m.application} ${m.name}`),
+  );
+  const openingMaterial = pickMaterialByCategory(ctxMaterials, (m) =>
+    /window|opening|glaz|frame|aluminium|aluminum/i.test(
+      `${m.application} ${m.name}`,
+    ),
+  );
+  const doorMaterial = pickMaterialByCategory(ctxMaterials, (m) =>
+    /door/i.test(`${m.application} ${m.name}`),
+  );
+
+  const wallPrimaryDesc = describeMaterial(wallMaterial);
+  const roofDesc = describeMaterial(roofMaterial);
+  const openingDesc = describeMaterial(openingMaterial);
+  const doorDesc = describeMaterial(doorMaterial);
+  const facadeFallback = localPalette.length
+    ? localPalette
+        .slice(0, 3)
+        .map((entry) =>
+          typeof entry === "string"
+            ? entry
+            : entry?.name || entry?.material || "",
+        )
+        .filter(Boolean)
+        .join(", ")
+    : null;
+
+  const partL =
+    sheetDesignContext?.sustainability?.partL ||
+    regulations?.partL ||
+    regulations?.part_l ||
+    null;
+  const fabricFirst =
+    sheetDesignContext?.sustainability?.fabricFirst === true ||
+    regulations?.fabric_first === true ||
+    regulations?.fabricFirst === true;
+  const sustainabilityAmbition =
+    brief?.sustainability_ambition || "low energy / fabric-first";
+
+  const region =
+    sheetDesignContext?.region ||
+    site?.region ||
+    site?.country ||
+    brief?.site_input?.region ||
+    "UK";
+  const dateLabel = brief?.brief_date || brief?.date || null;
+
+  const groups = {
+    external_walls: {
+      heading: "External walls",
+      lines: [
+        wallPrimaryDesc
+          ? `Primary wall: ${wallPrimaryDesc}.`
+          : facadeFallback
+            ? `Facade palette: ${facadeFallback}.`
+            : "Primary wall finish per local-style pack.",
+        "Insulated cavity construction; verify U-values against Part L 2021.",
+      ],
+    },
+    roof: {
+      heading: "Roof",
+      lines: [
+        roofDesc
+          ? `Roof: ${roofDesc}.`
+          : "Pitched roof per regional vernacular.",
+        "Concealed gutters; rooflights where indicated on plan.",
+      ],
+    },
+    windows_doors: {
+      heading: "Windows / Doors",
+      lines: [
+        openingDesc
+          ? `Windows: ${openingDesc}.`
+          : "Aluminium-framed double glazing, anthracite finish.",
+        doorDesc
+          ? `Front door: ${doorDesc}.`
+          : "Solid timber front door with weather seal.",
+      ],
+    },
+    heating_ventilation: {
+      heading: "Heating / Ventilation",
+      lines: [
+        "Air-source heat pump with underfloor heating to ground floor.",
+        "MVHR (mechanical ventilation with heat recovery) ducted through ceiling void.",
+      ],
+    },
+    drainage: {
+      heading: "Drainage",
+      lines: [
+        "Foul to public sewer; surface water to soakaway / SuDS where appropriate.",
+        "Verify connections with local water authority before construction.",
+      ],
+    },
+    sustainability: {
+      heading: "Sustainability",
+      lines: [
+        partL
+          ? `Compliance: ${String(partL).slice(0, 80)}.`
+          : `Ambition: ${sustainabilityAmbition}; Part L 2021 fabric performance.`,
+        fabricFirst
+          ? "Fabric-first strategy: airtightness, continuous insulation, thermal bridging mitigation."
+          : "Low-energy strategy with fabric performance prioritised over add-on services.",
+      ],
+    },
+    climate_strategy: {
+      heading: "Climate strategy",
+      lines: [
+        climateZone
+          ? `Climate zone ${climateZone}${climateRainfall ? ` / rainfall ${typeof climateRainfall === "number" ? `${climateRainfall} mm/yr` : climateRainfall}` : ""}.`
+          : "Climate strategy uses deterministic UK temperate defaults.",
+        climateStrategy
+          ? `${climateStrategy}.`
+          : overheatingFlag
+            ? "Overheating risk flagged; specify external solar shading and night purge."
+            : "Passive solar + cross-ventilation; minimise summer gain on south-west glazing.",
+      ],
+    },
+    dimensions_tolerances: {
+      heading: "Dimensions / Tolerances",
+      lines: [
+        "All dimensions in millimetres unless otherwise noted.",
+        "Do not scale from drawing. Verify on site before construction.",
+      ],
+    },
+    copyright: {
+      heading: "Copyright / Disclaimer",
+      lines: [
+        `© Architecture AI Platform${dateLabel ? ` — ${dateLabel}` : ""}. RIBA Stage concept package, ${region}.`,
+        "Drawings issued for early-stage design; require professional architectural / structural / planning review before construction.",
+      ],
+    },
+  };
+
+  return KEY_NOTE_GROUP_ORDER.map((id) => {
+    const group = groups[id];
+    return {
+      id,
+      heading: group.heading,
+      lines: (group.lines || []).filter(Boolean),
+    };
+  });
+}
+
+export function buildKeyNotesPanelArtifact({
   projectGraphId,
   brief,
   site,
@@ -3270,38 +3499,48 @@ function buildKeyNotesPanelArtifact({
   regulations,
   localStyle,
   geometryHash,
+  sheetDesignContext = null,
 }) {
   const width = 560;
   const height = 900;
-  const notes = buildKeyNoteItems({
+  const groups = buildKeyNoteItems({
     brief,
     site,
     climate,
     regulations,
     localStyle,
+    sheetDesignContext,
   });
-  let cursorY = 98;
-  const noteGroups = notes
-    .map((note, index) => {
-      const lines = splitNoteLines(note, 34);
-      const groupY = cursorY;
-      cursorY += 36 + lines.length * 25;
-      return `<g data-key-note="${index + 1}">
-  <text x="34" y="${groupY}" font-size="18" font-family="Arial, sans-serif" font-weight="700" fill="#111111">${index + 1}.</text>
-  ${lines
-    .map(
-      (line, lineIndex) =>
-        `<text x="72" y="${groupY + lineIndex * 25}" font-size="17" font-family="Arial, sans-serif" fill="#222222">${escapeXml(line)}</text>`,
-    )
-    .join("\n  ")}
+  let cursorY = 102;
+  const groupSvg = groups
+    .map((group, index) => {
+      const headingY = cursorY;
+      const headingFontSize = 15;
+      const bodyFontSize = 13;
+      const lineHeight = 18;
+      const bodyLines = group.lines.flatMap((line) =>
+        splitNoteLines(line, 60, 2),
+      );
+      const blockHeight = 22 + bodyLines.length * lineHeight + 12;
+      const bodyTextSvg = bodyLines
+        .map(
+          (line, lineIndex) =>
+            `<text x="48" y="${headingY + 22 + lineIndex * lineHeight}" font-size="${bodyFontSize}" font-family="Arial, sans-serif" fill="#222222">${escapeXml(line)}</text>`,
+        )
+        .join("\n  ");
+      const block = `<g data-key-note-id="${escapeXml(group.id)}" data-key-note-index="${index + 1}">
+  <text x="34" y="${headingY}" font-size="${headingFontSize}" font-family="Arial, sans-serif" font-weight="700" fill="#111111" class="sheet-critical-label" data-text-role="critical">${index + 1}. ${escapeXml(group.heading)}</text>
+  ${bodyTextSvg}
 </g>`;
+      cursorY += blockHeight;
+      return block;
     })
     .join("\n");
   const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="key_notes" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}">
   <rect width="${width}" height="${height}" fill="#ffffff"/>
-  <text x="30" y="48" font-family="Arial, sans-serif" font-size="32" font-weight="700" fill="#111111">KEY NOTES</text>
+  <text x="30" y="48" font-family="Arial, sans-serif" font-size="28" font-weight="700" fill="#111111">KEY NOTES</text>
   <line x1="30" y1="66" x2="530" y2="66" stroke="#111111" stroke-width="2"/>
-  ${noteGroups}
+  ${groupSvg}
 </svg>`;
   const svgHash = computeCDSHashSync({
     panelType: "key_notes",
@@ -3331,21 +3570,62 @@ function buildKeyNotesPanelArtifact({
       source: "project_graph_key_notes",
       panelType: "key_notes",
       geometryHash,
-      noteCount: notes.length,
+      noteCount: groups.length,
+      groupOrder: KEY_NOTE_GROUP_ORDER.slice(),
+      groupIds: groups.map((g) => g.id),
+      groupHeadings: groups.map((g) => g.heading),
+      sheetDesignContextHash: sheetDesignContext?.contextHash || null,
+      sourceContext: sheetDesignContext ? "sheet_design_context" : "legacy_dna",
     },
   };
 }
 
-function buildTitleBlockPanelArtifact({
+// Phase 2 — parse RIBA stage label from brief.user_intent.portfolio_mood,
+// brief.riba_stage, or sheetPlan label fallback.
+function resolveRibaStageLabel(brief, sheetPlan) {
+  const fromBrief =
+    brief?.riba_stage ||
+    brief?.user_intent?.portfolio_mood ||
+    brief?.user_intent?.riba_stage ||
+    null;
+  if (typeof fromBrief === "string") {
+    const match = fromBrief.match(/(?:riba[_\s]*stage[_\s]*)?(\d)\b/i);
+    if (match) return `RIBA Stage ${match[1]}`;
+  }
+  if (typeof fromBrief === "number" && Number.isFinite(fromBrief)) {
+    return `RIBA Stage ${fromBrief}`;
+  }
+  if (sheetPlan?.label) {
+    const match = String(sheetPlan.label).match(/RIBA\s*Stage\s*(\d)/i);
+    if (match) return `RIBA Stage ${match[1]}`;
+  }
+  return "RIBA Stage 2";
+}
+
+function todayIsoDate() {
+  try {
+    return new Date().toISOString().slice(0, 10);
+  } catch {
+    return "";
+  }
+}
+
+export function buildTitleBlockPanelArtifact({
   projectGraphId,
   brief,
   geometryHash,
   sheetPlan,
+  sheetDesignContext = null,
 }) {
   const width = 620;
   const height = 900;
   const location =
-    brief?.site_input?.address || brief?.site_input?.postcode || "Project site";
+    sheetDesignContext?.region && brief?.site_input?.address
+      ? `${brief.site_input.address}, ${sheetDesignContext.region}`
+      : brief?.site_input?.address ||
+        brief?.site_input?.postcode ||
+        sheetDesignContext?.region ||
+        "Project site";
   const drawingNumber = sheetPlan?.sheet_number || "A1-00";
   const sheetLabel = sheetPlan?.label || "RIBA Stage 2 Master";
   const projectTitle = String(brief?.project_name || "ArchiAI Project")
@@ -3356,30 +3636,62 @@ function buildTitleBlockPanelArtifact({
   const programmeLabel = String(brief?.building_type || "architecture")
     .replace(/[_-]+/g, " ")
     .trim();
+  const ribaStageLabel = resolveRibaStageLabel(brief, sheetPlan);
+  const status = String(
+    brief?.status ||
+      brief?.delivery_status ||
+      sheetPlan?.status ||
+      "Draft for review",
+  ).trim();
+  const revision = String(
+    brief?.revision || brief?.rev || sheetPlan?.revision || "P01",
+  ).trim();
+  const dateLabel = String(
+    brief?.brief_date || brief?.date || sheetPlan?.date || todayIsoDate(),
+  ).trim();
+  const architectName = String(
+    brief?.architect ||
+      sheetDesignContext?.architect ||
+      "Architecture AI Platform",
+  ).trim();
+  const studioFooter = String(
+    brief?.studio_footer ||
+      sheetDesignContext?.studio_footer ||
+      "Architecture | Design | Planning",
+  ).trim();
+  // Phase 2 — broader RIBA-style metadata. The first 5 rows preserve the
+  // existing data source (so existing tests and downstream readers continue
+  // working). The new rows surface RIBA Stage / Status / Revision / Date /
+  // Drawing No. so reviewers get the full set on the sheet.
   const rows = [
     ["Project", brief?.project_name || "ArchiAI Project"],
     ["Location", location],
     ["Programme", programmeLabel],
     ["Target GIA", `${round(brief?.target_gia_m2 || 0, 1)} m²`],
     ["Storeys", `${brief?.target_storeys || 1}`],
-    ["Stage", sheetLabel],
+    ["RIBA Stage", ribaStageLabel],
+    ["Status", status],
+    ["Revision", revision],
+    ["Date", dateLabel],
     ["Drawing No.", drawingNumber],
   ];
+  const rowStartY = 232;
+  const rowGap = 50;
   const rowSvg = rows
     .map((row, index) => {
-      const y = 276 + index * 62;
+      const y = rowStartY + index * rowGap;
       const rawValue = String(row[1] || "");
       const valueMaxChars = index <= 1 ? 34 : 28;
       const valueLines = splitNoteLines(rawValue, valueMaxChars, 2);
       const valueFontSize =
-        rawValue.length > 54 ? 13 : rawValue.length > 38 ? 15 : 17;
+        rawValue.length > 54 ? 12 : rawValue.length > 38 ? 14 : 16;
       return `<g>
-  <line x1="34" y1="${y - 28}" x2="586" y2="${y - 28}" stroke="#999999" stroke-width="1"/>
-  <text x="42" y="${y}" font-size="18" font-family="Arial, sans-serif" fill="#222222">${escapeXml(row[0])}</text>
+  <line x1="34" y1="${y - 24}" x2="586" y2="${y - 24}" stroke="#999999" stroke-width="1"/>
+  <text x="42" y="${y}" font-size="15" font-family="Arial, sans-serif" fill="#222222">${escapeXml(row[0])}</text>
   ${valueLines
     .map(
       (line, lineIndex) =>
-        `<text x="236" y="${y + lineIndex * (valueFontSize + 4)}" font-size="${valueFontSize}" font-family="Arial, sans-serif" font-weight="700" fill="#111111">${escapeXml(line)}</text>`,
+        `<text x="220" y="${y + lineIndex * (valueFontSize + 3)}" font-size="${valueFontSize}" font-family="Arial, sans-serif" font-weight="700" fill="#111111">${escapeXml(line)}</text>`,
     )
     .join("\n  ")}
 </g>`;
@@ -3398,8 +3710,11 @@ function buildTitleBlockPanelArtifact({
   <text x="34" y="170" font-family="Arial, sans-serif" font-size="20" fill="#333333">${escapeXml((brief?.building_type || "architecture").replace(/_/g, " ").toUpperCase())}</text>
   <line x1="34" y1="206" x2="586" y2="206" stroke="#111111" stroke-width="2"/>
   ${rowSvg}
-  <text x="34" y="850" font-family="Arial, sans-serif" font-size="15" fill="#555555">source_model_hash ${escapeXml(String(geometryHash || "").slice(0, 16))}</text>
-  <text x="586" y="850" font-family="Arial, sans-serif" font-size="15" text-anchor="end" fill="#555555">ARCHITECT AI PLATFORM</text>
+  <line x1="34" y1="780" x2="586" y2="780" stroke="#111111" stroke-width="1"/>
+  <text x="34" y="808" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#222222">${escapeXml(architectName.toUpperCase())}</text>
+  <text x="34" y="828" font-family="Arial, sans-serif" font-size="12" fill="#555555">${escapeXml(studioFooter)}</text>
+  <text x="34" y="862" font-family="Arial, sans-serif" font-size="11" fill="#888888">source_model_hash ${escapeXml(String(geometryHash || "").slice(0, 16))}</text>
+  <text x="586" y="862" font-family="Arial, sans-serif" font-size="11" text-anchor="end" fill="#888888">${escapeXml(`${ribaStageLabel} • Rev ${revision}`)}</text>
 </svg>`;
   const svgHash = computeCDSHashSync({
     panelType: "title_block",
@@ -3438,6 +3753,18 @@ function buildTitleBlockPanelArtifact({
       buildingType: brief?.building_type || null,
       drawingNumber,
       sheetLabel,
+      // Phase 2 — RIBA-style metadata fields
+      ribaStage: ribaStageLabel,
+      status,
+      revision,
+      date: dateLabel,
+      architect: architectName,
+      studioFooter,
+      rowKeys: rows.map((r) => r[0]),
+      sheetDesignContextHash: sheetDesignContext?.contextHash || null,
+      sourceContext: sheetDesignContext
+        ? "sheet_design_context"
+        : "legacy_brief",
     },
   };
 }
@@ -3739,6 +4066,7 @@ async function buildSheetPanelArtifacts({
     styleDNA,
     brief,
     geometryHash,
+    sheetDesignContext,
   });
   const keyNotes = buildKeyNotesPanelArtifact({
     projectGraphId,
@@ -3748,12 +4076,14 @@ async function buildSheetPanelArtifacts({
     regulations,
     localStyle,
     geometryHash,
+    sheetDesignContext,
   });
   const titleBlock = buildTitleBlockPanelArtifact({
     projectGraphId,
     brief,
     geometryHash,
     sheetPlan,
+    sheetDesignContext,
   });
   const visual3d = await buildVisual3DPanelArtifacts({
     compiledProject,


### PR DESCRIPTION
## Summary

Phase 2 of the A1 goal-parity plan. Improves A1 row-3 data panels to better match the reference board.

### Scope of this PR
- **8-card material palette** with category labels (EXTERIOR / ROOF / OPENINGS / DETAIL / LANDSCAPE) above each swatch (was 6 cards, no category band).
- **SheetDesignContext-driven palette source**: when a SheetDesignContext is present its `materials[]` drives the palette; otherwise the existing localStyle / DNA collection logic is used. A new `topUpMaterialPaletteWithCanonical` helper pads short collections from the canonical 8-material set so the 2x4 grid always renders 8 cards.
- **Structured Key Notes with climate strategy folded in** — 9 deterministic groups (`external_walls`, `roof`, `windows_doors`, `heating_ventilation`, `drainage`, `sustainability`, `climate_strategy`, `dimensions_tolerances`, `copyright`). Climate is folded into Key Notes; no separate climate card.
- **RIBA-style title block rows** — 10 rows total: Project, Location, Programme, Target GIA, Storeys, RIBA Stage, Status, Revision, Date, Drawing No., plus an architect + studio footer band and a small RIBA-stage strip in the bottom-right. RIBA stage is parsed from `brief.user_intent.portfolio_mood` (e.g. `riba_stage3` -> `RIBA Stage 3`).
- **`key_notes` / `schedules_notes` compatibility shim** — `composeCore.CANONICAL_KEY_MAP` maps `key_notes -> schedules_notes` so any caller using the new canonical name still resolves to the existing presentation-v3 grid slot.

### Forbidden / not in this PR
- **No slot rename** (compat shim only; presentation-v3 slot key stays `schedules_notes`).
- **No Phase 3 drawing renderer work** (no plan / elevation / section / site-plan changes).
- **No Phase 4 axonometric / cross-view work**.
- **No OpenAI provider / env changes**.
- **No site-boundary changes**.
- **No export-gate broad policy changes** (only the panel-key compat alias touches that area).
- **No generated outputs included** (`tmp/pdfs/`, `tmp/jest-*.log`, `tmp/phase2-*.mjs` stay gitignored).

## Files changed (4 files, +1001 / -100)

- `src/services/a1/composeCore.js` — +6 lines (compat shim only).
- `src/services/a1/materialTexturePatterns.js` — adds `KIND_CATEGORY`, `inferMaterialCategory`, `topUpMaterialPaletteWithCanonical`, category-label rendering in `buildSingleCard`, layout pass-through in `resolveLayout`.
- `src/services/project/projectGraphVerticalSliceService.js` — material-palette layout to 2x4, exports `buildMaterialPalettePanelArtifact / buildKeyNoteItems / buildKeyNotesPanelArtifact / buildTitleBlockPanelArtifact`, restructures key-note groups, RIBA-style title-block rows, propagates `sheetDesignContext` through `buildSheetPanelArtifacts`.
- `src/__tests__/services/a1/dataPanelsPhase2.test.js` — 15 specs covering 8-card palette, category labels, key-notes order + climate strategy, title-block RIBA fields, SheetDesignContext consumption, and `key_notes / schedules_notes` compose routing compatibility.

## Validation

| Check | Result |
| --- | --- |
| `npm run check:env` | pass |
| `npm run check:contracts` | pass |
| `npm run lint` | pass |
| `npm run build:active` | compiled |
| `npm run test:a1:tofu` | pass |
| `npm run test:compose:routing` | 22/22 |
| `node scripts/tests/test-a1-layout-regression.mjs` | 27/27 |
| Focused jest (`dataPanelsPhase2` + `sheetDesignContextContract` + `projectGraphPhaseBLayout`) | **58/58** in 2.7s |
| Node smoke harness | **25/25** |

`projectGraphVerticalSliceService.test.js` is still running locally (Windows haste-map slow). The Phase 1 baseline showed 1 pre-existing failure in that file (`reference-match QA passes when visual panels are geometry-locked image renders`), confirmed pre-existing on `main` independently of this PR.

## Fresh A1 generation report

End-to-end vertical-slice run on a Birmingham 2-storey detached-house fixture (no OpenAI keys, deterministic path):

- **Fresh A1 PDF generated locally at**: `tmp/pdfs/phase2-fresh-a1-1777674382665.pdf` (7,072,560 bytes, ~7.1 MB) — gitignored.
- **`exportGate.allowed`**: `true`
- **`exportGate.status`**: `warning` with **no blockers** (`blockers: []`)
- **`sheetDesignContextHash`** present: `10c65ca3a6ef0770`
- **Row 3 confirmed**: 8-card material palette (4 distinct categories observed: EXTERIOR / ROOF / OPENINGS / DETAIL), 9 key-note groups in canonical order with `climate_strategy` present, RIBA title block rows (RIBA Stage 3 / Status: Draft for review / Revision: P01 / Date: 2026-05-01 / Drawing No.).
- **Local `qa.status` fail is pre-existing** due to missing OpenAI API keys locally, not Phase 2 (matches the same baseline behaviour observed on `main` before this PR).

```json
{
  "materialPalette": {
    "cardCount": 8,
    "categoryCount": 4,
    "categories": ["EXTERIOR", "EXTERIOR", "ROOF", "DETAIL",
                   "OPENINGS", "EXTERIOR", "EXTERIOR", "ROOF"],
    "sourceContext": "sheet_design_context"
  },
  "keyNotes": {
    "noteCount": 9,
    "groupIds": ["external_walls", "roof", "windows_doors",
                 "heating_ventilation", "drainage", "sustainability",
                 "climate_strategy", "dimensions_tolerances", "copyright"],
    "sourceContext": "sheet_design_context"
  },
  "titleBlock": {
    "rowKeys": ["Project", "Location", "Programme", "Target GIA",
                "Storeys", "RIBA Stage", "Status", "Revision",
                "Date", "Drawing No."],
    "ribaStage": "RIBA Stage 3",
    "revision": "P01",
    "status": "Draft for review",
    "date": "2026-05-01",
    "sourceContext": "sheet_design_context"
  }
}
```

**Do not merge. No Phase 3 work begun. Awaiting approval.**

Generated with [Claude Code](https://claude.com/claude-code)
