### PR TITLE
Phase 4: Axonometric cutaway prompt (flag-gated) + cross-view identity lock

### DIFF
--- a/src/__tests__/services/axonometricCutawayPhase4.test.js
+++ b/src/__tests__/services/axonometricCutawayPhase4.test.js
@@ -1,0 +1,296 @@
+import {
+  buildProjectGraphRenderPrompt,
+  RENDER_PROMPT_IDENTITY_VERSION,
+} from "../../services/project/projectGraphVerticalSliceService.js";
+import { buildSheetDesignContext } from "../../services/dnaPromptContext.js";
+import { buildVisualManifest } from "../../services/render/visualManifestService.js";
+import {
+  isFeatureEnabled,
+  setFeatureFlag,
+  resetFeatureFlags,
+} from "../../config/featureFlags.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geom-phase4-001",
+    levels: [{ height_m: 3.2 }, { height_m: 3.0 }],
+    footprint: { length_m: 10.8, width_m: 7.5, area_m2: 81 },
+    massing: { form: "compact rectangular" },
+    roof: { form: "gable", pitch_deg: 35 },
+    facadeGrammar: { windowRhythm: "regular bay" },
+  };
+}
+
+function fixtureBrief() {
+  return {
+    // Avoid the words "cutaway" / "cut-away" in fixture strings so the
+    // flag-off prompt assertions do not get false positives from the
+    // project name being echoed into the prompt header.
+    project_name: "Phase 4 Identity Fixture",
+    project_graph_id: "pg-phase4-001",
+    building_type: "detached_house",
+    target_storeys: 2,
+    target_gia_m2: 162,
+    site_input: {
+      address: "Test Lane, Birmingham",
+      postcode: "B1 1AA",
+      lat: 52.48,
+      lon: -1.9,
+    },
+    user_intent: { portfolio_mood: "riba_stage3" },
+  };
+}
+
+function fixtureLocalStyle() {
+  return {
+    primary_style: "Birmingham red-brick vernacular",
+    style_keywords: ["red brick"],
+    material_palette: [
+      {
+        name: "Multi-stock red brick",
+        hexColor: "#a63a2a",
+        application: "primary wall",
+      },
+      {
+        name: "Vertical timber cladding",
+        hexColor: "#8b6433",
+        application: "secondary accent",
+      },
+      {
+        name: "Dark grey roof tile",
+        hexColor: "#2f3338",
+        application: "roof covering",
+      },
+    ],
+  };
+}
+
+function fixtureClimate() {
+  return { zone: "Cfb", rainfall_mm: 850, strategy: "fabric-first" };
+}
+
+function fixtureSheetDesignContext({ withProgrammeSpaces = true } = {}) {
+  const compiledProject = fixtureCompiledProject();
+  const brief = fixtureBrief();
+  const localStyle = fixtureLocalStyle();
+  const climate = fixtureClimate();
+  const programmeSummary = withProgrammeSpaces
+    ? {
+        rooms: [
+          { name: "Living Room", area_m2: 24, floor: "Ground" },
+          { name: "Kitchen with Island", area_m2: 22, floor: "Ground" },
+          { name: "Master Bedroom", area_m2: 18, floor: "First" },
+          { name: "Bedroom 2", area_m2: 12, floor: "First" },
+        ],
+      }
+    : { rooms: [] };
+  const visualManifest = buildVisualManifest({
+    compiledProject,
+    projectGraph: { projectGraphId: brief.project_graph_id },
+    brief,
+    masterDNA: null,
+    climate,
+    localStyle,
+    materialPalette: localStyle.material_palette,
+  });
+  return buildSheetDesignContext({
+    masterDNA: { _structured: { program: { rooms: programmeSummary.rooms } } },
+    brief,
+    compiledProject,
+    climate,
+    localStyle,
+    region: "UK",
+    projectGraphId: brief.project_graph_id,
+    visualManifest,
+  });
+}
+
+function buildVisualManifestForFixture() {
+  const compiledProject = fixtureCompiledProject();
+  const brief = fixtureBrief();
+  const localStyle = fixtureLocalStyle();
+  const climate = fixtureClimate();
+  return buildVisualManifest({
+    compiledProject,
+    projectGraph: { projectGraphId: brief.project_graph_id },
+    brief,
+    masterDNA: null,
+    climate,
+    localStyle,
+    materialPalette: localStyle.material_palette,
+  });
+}
+
+function buildPromptArgs(overrides = {}) {
+  const brief = fixtureBrief();
+  const visualManifest = buildVisualManifestForFixture();
+  return {
+    panelType: "axonometric",
+    brief,
+    compiledProject: fixtureCompiledProject(),
+    climate: fixtureClimate(),
+    localStyle: fixtureLocalStyle(),
+    styleDNA: null,
+    programmeSummary: null,
+    region: "UK",
+    visualManifest,
+    sheetDesignContext: null,
+    axonometricCutawayEnabled: false,
+    ...overrides,
+  };
+}
+
+describe("Phase 4 — feature flag wiring", () => {
+  beforeEach(() => {
+    resetFeatureFlags();
+  });
+  afterEach(() => {
+    resetFeatureFlags();
+  });
+
+  test("axonometricCutawayEnabled is registered in FEATURE_FLAGS and defaults to false", () => {
+    expect(isFeatureEnabled("axonometricCutawayEnabled")).toBe(false);
+  });
+
+  test("setFeatureFlag('axonometricCutawayEnabled', true) flips the flag at runtime", () => {
+    setFeatureFlag("axonometricCutawayEnabled", true);
+    expect(isFeatureEnabled("axonometricCutawayEnabled")).toBe(true);
+  });
+});
+
+describe("Phase 4 — buildProjectGraphRenderPrompt cutaway gating", () => {
+  test("flag OFF preserves the original axonometric prompt (no cutaway language)", () => {
+    const prompt = buildProjectGraphRenderPrompt(
+      buildPromptArgs({
+        axonometricCutawayEnabled: false,
+        sheetDesignContext: fixtureSheetDesignContext(),
+      }),
+    );
+    expect(prompt).toContain("axonometric");
+    expect(prompt).not.toMatch(/cutaway/i);
+    expect(prompt).not.toMatch(/cut.away/i);
+    expect(prompt).not.toMatch(/sectional axonometric/i);
+  });
+
+  test("flag ON adds cutaway / interior-exposed requirements to the axonometric prompt", () => {
+    const prompt = buildProjectGraphRenderPrompt(
+      buildPromptArgs({
+        axonometricCutawayEnabled: true,
+        sheetDesignContext: fixtureSheetDesignContext(),
+      }),
+    );
+    expect(prompt).toMatch(/CUTAWAY axonometric/);
+    expect(prompt).toMatch(/sectional axonometric/i);
+    expect(prompt).toMatch(/cut-?away/i);
+    expect(prompt).toMatch(/interior rooms.*visible|rooms.*visible/i);
+  });
+
+  test("flag ON injects programme/rooms from SheetDesignContext when available", () => {
+    const prompt = buildProjectGraphRenderPrompt(
+      buildPromptArgs({
+        axonometricCutawayEnabled: true,
+        sheetDesignContext: fixtureSheetDesignContext({
+          withProgrammeSpaces: true,
+        }),
+      }),
+    );
+    // Programme rooms should appear in the cutaway intent
+    expect(prompt).toMatch(/Living Room/);
+    expect(prompt).toMatch(/Master Bedroom/);
+    expect(prompt).toMatch(/programme/i);
+  });
+
+  test("flag ON preserves identity constraints from visualManifest (storeys/roof/materials/window/entrance)", () => {
+    const prompt = buildProjectGraphRenderPrompt(
+      buildPromptArgs({
+        axonometricCutawayEnabled: true,
+        sheetDesignContext: fixtureSheetDesignContext(),
+      }),
+    );
+    expect(prompt).toMatch(/VISUAL IDENTITY LOCK/i);
+    expect(prompt).toMatch(/2-storey/);
+    expect(prompt).toMatch(/gable|roof/i);
+    expect(prompt).toMatch(/Multi-stock red brick|brick/);
+    expect(prompt).toMatch(/regular bay|window rhythm/i);
+    expect(prompt).toMatch(/entrance/i);
+    // Identity constraints from visualContinuity block
+    expect(prompt).toMatch(/Preserve roof form/);
+    expect(prompt).toMatch(/Preserve facade material order/);
+  });
+
+  test("flag ON only mutates the axonometric panel — hero_3d / exterior_render / interior_3d are unchanged", () => {
+    for (const panelType of ["hero_3d", "exterior_render", "interior_3d"]) {
+      const flagOff = buildProjectGraphRenderPrompt(
+        buildPromptArgs({
+          panelType,
+          axonometricCutawayEnabled: false,
+          sheetDesignContext: fixtureSheetDesignContext(),
+        }),
+      );
+      const flagOn = buildProjectGraphRenderPrompt(
+        buildPromptArgs({
+          panelType,
+          axonometricCutawayEnabled: true,
+          sheetDesignContext: fixtureSheetDesignContext(),
+        }),
+      );
+      expect(flagOn).toBe(flagOff);
+    }
+  });
+
+  test("RENDER_PROMPT_IDENTITY_VERSION export is stable v1", () => {
+    expect(RENDER_PROMPT_IDENTITY_VERSION).toBe(
+      "phase4-render-prompt-identity-v1",
+    );
+  });
+});
+
+describe("Phase 4 — visual identity metadata surface", () => {
+  test("buildProjectGraphRenderPrompt emits the visual continuity block (manifest-driven)", () => {
+    const prompt = buildProjectGraphRenderPrompt(buildPromptArgs());
+    expect(prompt).toMatch(/VISUAL IDENTITY LOCK/i);
+    expect(prompt).toMatch(/VISUAL CONTINUITY CONSTRAINTS/);
+    // The identity lock includes the manifestHash so all four panels share
+    // a single deterministic identity surface.
+    expect(prompt).toMatch(/manifestHash:\s*[a-f0-9]+/);
+  });
+
+  test("flag-on cutaway path still emits identity lock + continuity constraints", () => {
+    const prompt = buildProjectGraphRenderPrompt(
+      buildPromptArgs({
+        axonometricCutawayEnabled: true,
+        sheetDesignContext: fixtureSheetDesignContext(),
+      }),
+    );
+    expect(prompt).toMatch(/VISUAL IDENTITY LOCK/i);
+    expect(prompt).toMatch(/VISUAL CONTINUITY CONSTRAINTS/);
+    expect(prompt).toMatch(/Preserve facade material order/);
+  });
+});
+
+describe("Phase 4 — defensive behaviour", () => {
+  test("flag ON without programmeSummary falls back to a generic 'principal rooms' line (no crash)", () => {
+    const prompt = buildProjectGraphRenderPrompt(
+      buildPromptArgs({
+        axonometricCutawayEnabled: true,
+        sheetDesignContext: fixtureSheetDesignContext({
+          withProgrammeSpaces: false,
+        }),
+      }),
+    );
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(500);
+    expect(prompt).toMatch(/programme/i);
+  });
+
+  test("flag ON without sheetDesignContext does not crash; uses generic interior reveal text", () => {
+    const prompt = buildProjectGraphRenderPrompt(
+      buildPromptArgs({
+        axonometricCutawayEnabled: true,
+        sheetDesignContext: null,
+      }),
+    );
+    expect(typeof prompt).toBe("string");
+    expect(prompt).toMatch(/CUTAWAY axonometric/);
+  });
+});

--- a/src/config/featureFlags.js
+++ b/src/config/featureFlags.js
@@ -207,6 +207,29 @@ export const FEATURE_FLAGS = {
   togetherImageMinIntervalMs: 9000,
 
   /**
+   * Phase 4 — Axonometric cutaway prompt (EXPERIMENTAL)
+   *
+   * When enabled (true) AND `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true`, the
+   * axonometric panel prompt switches from a standard exterior 30-degree
+   * isometric to a CUTAWAY axonometric that exposes interior rooms /
+   * furniture from `sheetDesignContext.programSpaces`. The same identity
+   * lock (visualManifest) is preserved across hero_3d / exterior_render /
+   * axonometric / interior_3d so all four panels still describe the same
+   * building.
+   *
+   * When disabled (default), production behaviour is unchanged: the
+   * standard solid-axonometric prompt is used and the deterministic SVG
+   * fallback is identical to what was shipped before this flag.
+   *
+   * Server-side env override: `PROJECT_GRAPH_AXONOMETRIC_CUTAWAY_ENABLED=true`
+   * (read in `projectGraphVerticalSliceService.buildVisual3DPanelArtifacts`).
+   *
+   * @type {boolean}
+   * @default false
+   */
+  axonometricCutawayEnabled: false,
+
+  /**
    * Cooldown delay between panel batches (ms)
    *
    * Default: 30000ms (30 seconds) to give API breathing room

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -31,6 +31,7 @@ import {
   assertSheetDesignContext,
   SHEET_DESIGN_CONTEXT_VERSION,
 } from "../dnaPromptContext.js";
+import { isFeatureEnabled } from "../../config/featureFlags.js";
 import { getSiteSnapshotWithMetadata } from "../siteMapSnapshotService.js";
 import { computeSunPath } from "../climate/sunPath.js";
 import { listSourceDocumentsForParts } from "../regulation/sourceRegistry.js";
@@ -3802,6 +3803,50 @@ function buildProjectGraphVisualContinuityBlock(visualManifest) {
 // so the gpt-image call sees the same upstream drivers (UK temperate,
 // red brick + timber vernacular, 3-storey detached programme, etc.) that
 // the deterministic pipeline already computed.
+// Phase 4 — version stamp for the visual-panel render prompt + identity lock
+// surface. Bump when the prompt structure or identity metadata changes so QA
+// and tests can detect drift.
+export const RENDER_PROMPT_IDENTITY_VERSION =
+  "phase4-render-prompt-identity-v1";
+
+function summariseProgramSpacesForCutaway(programSpaces) {
+  if (!Array.isArray(programSpaces) || programSpaces.length === 0) return "";
+  const grouped = new Map();
+  for (const space of programSpaces) {
+    if (!space || !space.name) continue;
+    const level = String(space.level || space.floor || "Ground");
+    if (!grouped.has(level)) grouped.set(level, []);
+    grouped.get(level).push(String(space.name).trim());
+  }
+  if (grouped.size === 0) return "";
+  const parts = [];
+  for (const [level, rooms] of grouped) {
+    const top = rooms.slice(0, 6).join(", ");
+    parts.push(`${level}: ${top}`);
+  }
+  return parts.join(" | ");
+}
+
+function buildAxonometricCutawayIntent({ sheetDesignContext, brief }) {
+  const programSummary = summariseProgramSpacesForCutaway(
+    sheetDesignContext?.programSpaces,
+  );
+  const programmeLine = programSummary
+    ? `Reveal the rooms and furniture as compositionally indicated by the programme — ${programSummary}.`
+    : "Reveal the principal rooms and furniture as indicated by the programme.";
+  const storeysHint = brief?.target_storeys
+    ? `Show ${brief.target_storeys} storey(s) cleanly stacked with the upper slab cut away to expose the floors below.`
+    : "Show all storeys cleanly stacked with each upper slab cut away to expose the floor below.";
+  return [
+    "Photoreal CUTAWAY axonometric 3D projection (30 degrees isometric) — architectural sectional axonometric.",
+    "The roof and the upper portion of the building are partially removed (cut-away) so interior rooms, walls, doors, and key furniture are visible from above.",
+    storeysHint,
+    programmeLine,
+    "Match the reference massing, roof outline, opening layout, materials, and entrance position exactly — only the cut-away reveal differs from the standard axonometric.",
+    "Material textures legible on the remaining facades and on visible interior surfaces.",
+  ].join(" ");
+}
+
 export function buildProjectGraphRenderPrompt({
   panelType,
   brief,
@@ -3812,13 +3857,19 @@ export function buildProjectGraphRenderPrompt({
   programmeSummary,
   region,
   visualManifest = null,
+  // Phase 4 — optional SheetDesignContext for cutaway programme injection
+  // and stable identity hashing on every visual panel.
+  sheetDesignContext = null,
+  axonometricCutawayEnabled = false,
 }) {
   const reasoning = buildReasoningChainBlock({
     locationData: { climate, region },
     masterDNA: { localStyle, styleDNA },
     projectContext: { programmeSummary, targetStoreys: brief?.target_storeys },
   });
-  const intent =
+  const cutawayActive =
+    axonometricCutawayEnabled === true && panelType === "axonometric";
+  const baseIntent =
     {
       hero_3d:
         "Photoreal hero exterior 3D perspective — magazine-cover quality. Match the silhouette of the reference image exactly (same massing, same roof shape, same opening positions, same storey count). Apply the materials, lighting, and detailing from the reasoning chain below.",
@@ -3829,6 +3880,9 @@ export function buildProjectGraphRenderPrompt({
       interior_3d:
         "Photoreal interior perspective — main living/kitchen space. Use the SAME materials and palette as the exterior. Match the reference interior volume.",
     }[panelType] || "Photoreal architectural render.";
+  const intent = cutawayActive
+    ? buildAxonometricCutawayIntent({ sheetDesignContext, brief })
+    : baseIntent;
   const buildingType = brief?.building_type || "building";
   const projectName = brief?.project_name || "project";
   // Phase D: every visual-panel prompt is prefixed with the visual identity
@@ -3867,7 +3921,23 @@ async function buildVisual3DPanelArtifacts({
   programmeSummary = null,
   region = null,
   visualManifest = null,
+  // Phase 4 — optional SheetDesignContext for cutaway programme injection
+  // and identity metadata propagation.
+  sheetDesignContext = null,
 }) {
+  // Phase 4 — feature flag gate. Default off; production behaviour
+  // unchanged. Server-side env override is `PROJECT_GRAPH_AXONOMETRIC_CUTAWAY_ENABLED=true`.
+  const cutawayEnvOverride = String(
+    (typeof process !== "undefined" &&
+      process.env?.PROJECT_GRAPH_AXONOMETRIC_CUTAWAY_ENABLED) ||
+      "",
+  )
+    .toLowerCase()
+    .trim();
+  const axonometricCutawayEnabled =
+    cutawayEnvOverride === "true" ||
+    cutawayEnvOverride === "1" ||
+    isFeatureEnabled("axonometricCutawayEnabled");
   const renderInputs = ensureCompiledProjectRenderInputs(compiledProject, {
     geometryHash,
     views: REQUIRED_3D_A1_PANEL_TYPES,
@@ -3902,6 +3972,8 @@ async function buildVisual3DPanelArtifacts({
           programmeSummary,
           region,
           visualManifest,
+          sheetDesignContext,
+          axonometricCutawayEnabled,
         });
         try {
           renderResult = await renderProjectGraphPanelImage({
@@ -4022,6 +4094,17 @@ async function buildVisual3DPanelArtifacts({
             visualManifestId: visualManifest?.manifestId || null,
             visualManifestHash: visualManifest?.manifestHash || null,
             visualIdentityLocked: Boolean(visualManifest?.manifestHash),
+            // Phase 4 — extended identity metadata. Surfaces the
+            // SheetDesignContext hash + cutaway flag + render prompt
+            // identity version on every visual panel so QA, validators,
+            // and downstream readers can prove the four panels share the
+            // same source of truth and detect any drift quickly.
+            sheetDesignContextHash: sheetDesignContext?.contextHash || null,
+            axonometricCutawayEnabled:
+              panelType === "axonometric"
+                ? axonometricCutawayEnabled === true
+                : false,
+            renderPromptIdentityVersion: RENDER_PROMPT_IDENTITY_VERSION,
           },
         },
       ];
@@ -4095,6 +4178,7 @@ async function buildSheetPanelArtifacts({
     programmeSummary,
     region,
     visualManifest,
+    sheetDesignContext,
   });
   return {
     [siteContext.asset_id]: siteContext,


### PR DESCRIPTION
## Summary

Phase 4 of the A1 goal-parity plan. Adds a feature-flagged axonometric cutaway prompt and strengthens cross-view identity metadata across `hero_3d` / `exterior_render` / `axonometric` / `interior_3d`. **Default behaviour is unchanged** — the cutaway prompt only activates when both `axonometricCutawayEnabled=true` AND `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true`.

### Feature flag (default OFF)
- New `axonometricCutawayEnabled` in `FEATURE_FLAGS` (default `false`).
- Server-side env override: `PROJECT_GRAPH_AXONOMETRIC_CUTAWAY_ENABLED=true`.
- `isFeatureEnabled` / `setFeatureFlag` continue to work the same way.

### Axonometric cutaway prompt (when flag is on)
- `buildProjectGraphRenderPrompt` now accepts `sheetDesignContext` + `axonometricCutawayEnabled`.
- When `panelType === "axonometric"` AND the flag is on, the intent line is replaced with a **CUTAWAY axonometric** request: roof + upper portion partially removed, interior rooms / walls / doors / furniture visible from above.
- Rooms are summarised from `sheetDesignContext.programSpaces` grouped by level (e.g. `"Ground: Living Room, Kitchen with Island | First: Master Bedroom, Bedroom 2"`).
- Same VISUAL IDENTITY LOCK + VISUAL CONTINUITY CONSTRAINTS still pin storey count, roof form, materials, window rhythm, and entrance position to the visualManifest. The cutaway only replaces the intent line.
- `hero_3d` / `exterior_render` / `interior_3d` prompts are byte-for-byte unchanged regardless of the flag.

### Cross-view identity metadata
Every visual panel now carries a consistent identity surface:

| field | source |
|---|---|
| `visualManifestId` | Phase D visualManifest |
| `visualManifestHash` | Phase D visualManifest |
| `visualIdentityLocked` | `Boolean(visualManifest?.manifestHash)` |
| `sheetDesignContextHash` | Phase 1 SheetDesignContext |
| `axonometricCutawayEnabled` | `true` only on the axonometric panel when the flag is on |
| `renderPromptIdentityVersion` | `"phase4-render-prompt-identity-v1"` |

All four visual panels for the same project share the same `visualManifestHash` and the same `sheetDesignContextHash`.

### Cross-view validator
`crossViewImageValidator` already includes `axonometric` in `VISUAL_COMPARISON_GROUP` and is unchanged — the deterministic-fallback path remains the same so QA does not start failing because of this PR.

## Forbidden / not in this PR
- No OpenAI provider/env changes
- No technical drawing renderer changes (Phase 3 territory)
- No data-panel / material palette / key notes / title block changes (Phase 2 territory)
- No site-boundary / map snapshot changes
- No export-gate broad policy changes
- No programme/floor authority changes
- No presentation-v3 layout coordinate changes
- No geometry mutation (verified)
- No old experiment-branch cherry-picks
- No generated outputs committed

## Files changed (3 files, +404 / -1)

- `src/config/featureFlags.js` — new `axonometricCutawayEnabled: false` entry with full doc block.
- `src/services/project/projectGraphVerticalSliceService.js` — adds `summariseProgramSpacesForCutaway`, `buildAxonometricCutawayIntent`, `RENDER_PROMPT_IDENTITY_VERSION`, threads `sheetDesignContext` + `axonometricCutawayEnabled` through `buildProjectGraphRenderPrompt` + `buildVisual3DPanelArtifacts`, and surfaces the new identity metadata on every visual panel artifact.
- `src/__tests__/services/axonometricCutawayPhase4.test.js` (NEW) — 12 specs covering flag wiring, prompt cutaway gating, programme injection, identity-constraint preservation, hero/exterior/interior unchanged when flag flips, and defensive behaviour with sparse inputs.

## Validation

| Check | Result |
| --- | --- |
| `npm run check:env` | pass |
| `npm run check:contracts` | pass |
| `npm run lint` | pass |
| `npm run build:active` | compiled |
| `npm run test:a1:tofu` | pass |
| `npm run test:compose:routing` | 22/22 |
| `node scripts/tests/test-a1-layout-regression.mjs` | 27/27 |
| Focused jest (`axonometricCutawayPhase4` + `visualManifestService` + `sheetDesignContextContract` + `crossViewImageValidator.hash` + `projectGraphImageRenderer`) | **53 passed / 1 failed**; the 1 failure is the documented pre-existing `projectGraphImageRenderer` test that already failed on `main` post-#66, unrelated to Phase 4 (see "Risks" below) |

The Phase-4 test file alone: **12/12 in 1.5s**.

## Fresh A1 generation report (flag OFF, deterministic path)

End-to-end vertical slice on the same Birmingham 2-storey detached fixture as Phase 3:

- **PDF**: `tmp/pdfs/phase4-fresh-a1-1777709097594.pdf` (7,124,388 bytes ~ 7.12 MB) — gitignored.
- **`exportGate.allowed`**: `true`, **`status`**: `warning`, **`blockers`**: `[]`
- **`sheetDesignContextHash`**: `c83181787d76f5e1` (Phase 1 contract still wired)
- **`geometryHash`**: `dda497018d81aace` (deterministic)
- **`qa.status`**: `fail` — same pre-existing baseline (missing OpenAI keys locally), not introduced by Phase 4.

### Identity hash coherence (critical Phase 4 invariant)

| panel | visualManifestHash | sheetDesignContextHash | axoCutawayEnabled | renderPromptIdentityVersion |
|---|---|---|---|---|
| hero_3d | `0fcb5c87ae03188a` | `c83181787d76f5e1` | false | `phase4-render-prompt-identity-v1` |
| exterior_render | `0fcb5c87ae03188a` | `c83181787d76f5e1` | false | `phase4-render-prompt-identity-v1` |
| axonometric | `0fcb5c87ae03188a` | `c83181787d76f5e1` | false | `phase4-render-prompt-identity-v1` |
| interior_3d | `0fcb5c87ae03188a` | `c83181787d76f5e1` | false | `phase4-render-prompt-identity-v1` |

- `allFourPanelsShareVisualManifest`: **true**
- `allFourPanelsShareSheetDesignContext`: **true**
- `axonometricCutawayEnabledOnAxoOnly`: **true** (flag default off; nothing flipped)
- `visualRenderMode`: `deterministic_fallback` for all four (no OpenAI keys in local env, so the cutaway intent is computed but not rendered into a photoreal image — exactly as documented)

### Photoreal flag-on smoke
Skipped in this run because the local environment has no OpenAI image keys; the deterministic fallback PDF is identical to flag-OFF (the prompt change is computed but not rendered without `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true`). The cutaway prompt itself is fully exercised by the unit tests on both the flag-on and flag-off paths.

## Risks

1. **Cutaway prompt only activates when both flags are on**: `axonometricCutawayEnabled=true` AND `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true`. With either off the deterministic axonometric SVG fallback is identical to before this PR. This is intentional per the brief ("Feature flag default must be false unless tests prove stable").
2. **Pre-existing failures**: `projectGraphVerticalSliceService.test.js` still has the `reference-match QA` test that fails on plain `main` post-#66 (verified earlier in the Phase 1 rebase round). Phase 4 does not change this.
3. **Cross-view validator**: unchanged. `axonometric` was already in `VISUAL_COMPARISON_GROUP` before this PR; the validator runs the same way for both flag states.
4. **Identity-version stamp**: `RENDER_PROMPT_IDENTITY_VERSION = "phase4-render-prompt-identity-v1"`. Bump when the prompt structure or identity surface changes so QA can detect drift.

## Out of scope (deferred)

- Photoreal flag-on smoke against an OpenAI key — not run locally because no keys present; CI will exercise it once.
- Tighter cross-view validator threshold for the cutaway image (could happen in a follow-up if cutaway photoreal proves inconsistent).
- Updating the legacy `panelPromptBuilders.buildAxonometricPrompt` in the same way — that path is used by `ConditionedImagePipeline` (legacy multi-panel), not the production vertical slice. Left untouched to keep this PR scoped.

## Test plan

- [x] `npm run check:env`
- [x] `npm run check:contracts`
- [x] `npm run lint`
- [x] `npm run build:active`
- [x] `npm run test:a1:tofu`
- [x] `npm run test:compose:routing`
- [x] `node scripts/tests/test-a1-layout-regression.mjs`
- [x] Focused jest: 5 suites / 53 passed (the 1 failure is documented pre-existing on main)
- [x] Fresh A1 PDF (flag OFF) generated locally — `tmp/pdfs/phase4-fresh-a1-1777709097594.pdf`
- [x] Identity hash coherence verified across all 4 visual panels

**Do not merge. Awaiting approval.** This is the final phase of the A1 goal-parity plan.

Generated with [Claude Code](https://claude.com/claude-code)
