### PR TITLE
Add project type support registry

### DIFF
--- a/src/__tests__/components/ArchitectAIWizardContainer.projectTypeSupport.test.js
+++ b/src/__tests__/components/ArchitectAIWizardContainer.projectTypeSupport.test.js
@@ -1,0 +1,57 @@
+jest.mock("../../utils/pdfToImages.js", () => ({
+  convertPdfFileToImageFile: jest.fn(),
+}));
+
+import {
+  assertProjectTypeSupportedForGeneration,
+  resolveWizardProjectTypeSupport,
+  shouldUseResidentialV2Route,
+} from "../../components/ArchitectAIWizardContainer.jsx";
+
+describe("ArchitectAIWizardContainer project type routing", () => {
+  test("generation guard allows supported registry entries", () => {
+    for (const projectDetails of [
+      { category: "commercial", subType: "office" },
+      { category: "education", subType: "school" },
+      { category: "healthcare", subType: "clinic" },
+      { category: "healthcare", subType: "hospital" },
+    ]) {
+      expect(assertProjectTypeSupportedForGeneration(projectDetails)).toEqual(
+        expect.objectContaining({
+          enabledInUi: true,
+          route: "project_graph",
+        }),
+      );
+    }
+  });
+
+  test("generation guard still blocks disabled entries", () => {
+    expect(() =>
+      assertProjectTypeSupportedForGeneration({
+        category: "commercial",
+        subType: "retail",
+      }),
+    ).toThrow(/not enabled|Experimental\/off/i);
+  });
+
+  test("residential still resolves to Residential V2", () => {
+    const projectDetails = {
+      category: "residential",
+      subType: "detached-house",
+    };
+
+    expect(resolveWizardProjectTypeSupport(projectDetails)).toEqual(
+      expect.objectContaining({
+        canonicalBuildingType: "dwelling",
+        route: "residential_v2",
+        supportStatus: "production",
+      }),
+    );
+    expect(shouldUseResidentialV2Route(projectDetails)).toBe(true);
+    expect(
+      shouldUseResidentialV2Route(projectDetails, {
+        residentialV2Enabled: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/components/BuildingTypeSelector.support.test.js
+++ b/src/__tests__/components/BuildingTypeSelector.support.test.js
@@ -1,0 +1,133 @@
+import {
+  getBuildingTypeSelectorCategoryState,
+  getBuildingTypeSelectorSubTypeState,
+} from "../../components/specs/BuildingTypeSelector.jsx";
+import { getCategoryById } from "../../data/buildingTypes.js";
+
+describe("BuildingTypeSelector project type support", () => {
+  test("keeps residential supported subtypes enabled", () => {
+    const residential = getCategoryById("residential");
+    const detached = residential.subTypes.find(
+      (entry) => entry.id === "detached-house",
+    );
+    const mansion = residential.subTypes.find(
+      (entry) => entry.id === "mansion",
+    );
+
+    expect(getBuildingTypeSelectorCategoryState(residential).isEnabled).toBe(
+      true,
+    );
+    expect(
+      getBuildingTypeSelectorSubTypeState("residential", detached).isEnabled,
+    ).toBe(true);
+    expect(
+      getBuildingTypeSelectorSubTypeState("residential", detached).support,
+    ).toEqual(
+      expect.objectContaining({
+        badgeLabel: "Residential V2",
+        route: "residential_v2",
+      }),
+    );
+    expect(
+      getBuildingTypeSelectorSubTypeState("residential", mansion).isEnabled,
+    ).toBe(false);
+  });
+
+  test("enables only the first non-residential ProjectGraph set", () => {
+    const commercial = getCategoryById("commercial");
+    const education = getCategoryById("education");
+    const healthcare = getCategoryById("healthcare");
+    const office = commercial.subTypes.find((entry) => entry.id === "office");
+    const retail = commercial.subTypes.find((entry) => entry.id === "retail");
+    const school = education.subTypes.find((entry) => entry.id === "school");
+    const clinic = healthcare.subTypes.find((entry) => entry.id === "clinic");
+    const hospital = healthcare.subTypes.find(
+      (entry) => entry.id === "hospital",
+    );
+
+    expect(getBuildingTypeSelectorCategoryState(commercial).isEnabled).toBe(
+      true,
+    );
+    expect(getBuildingTypeSelectorCategoryState(education).isEnabled).toBe(
+      true,
+    );
+    expect(getBuildingTypeSelectorCategoryState(healthcare).isEnabled).toBe(
+      true,
+    );
+    expect(getBuildingTypeSelectorSubTypeState("commercial", office)).toEqual(
+      expect.objectContaining({
+        isEnabled: true,
+        support: expect.objectContaining({
+          canonicalBuildingType: "office_studio",
+          badgeLabel: "ProjectGraph",
+        }),
+      }),
+    );
+    expect(getBuildingTypeSelectorSubTypeState("education", school)).toEqual(
+      expect.objectContaining({
+        isEnabled: true,
+        support: expect.objectContaining({
+          canonicalBuildingType: "education_studio",
+          badgeLabel: "Beta ProjectGraph",
+          supportStatus: "beta",
+        }),
+      }),
+    );
+    expect(getBuildingTypeSelectorSubTypeState("healthcare", clinic)).toEqual(
+      expect.objectContaining({
+        isEnabled: true,
+        support: expect.objectContaining({
+          canonicalBuildingType: "clinic",
+          badgeLabel: "ProjectGraph",
+        }),
+      }),
+    );
+    expect(getBuildingTypeSelectorSubTypeState("healthcare", hospital)).toEqual(
+      expect.objectContaining({
+        isEnabled: true,
+        support: expect.objectContaining({
+          canonicalBuildingType: "hospital",
+          badgeLabel: "Beta ProjectGraph",
+          supportStatus: "beta",
+        }),
+      }),
+    );
+    expect(getBuildingTypeSelectorSubTypeState("commercial", retail)).toEqual(
+      expect.objectContaining({
+        isEnabled: false,
+        support: expect.objectContaining({
+          badgeLabel: "Experimental/off",
+          supportStatus: "disabled",
+        }),
+      }),
+    );
+  });
+
+  test("unsupported categories stay visible but disabled", () => {
+    const industrial = getCategoryById("industrial");
+    const manufacturing = industrial.subTypes.find(
+      (entry) => entry.id === "manufacturing",
+    );
+
+    expect(getBuildingTypeSelectorCategoryState(industrial)).toEqual(
+      expect.objectContaining({
+        isEnabled: false,
+        supportSummary: expect.objectContaining({
+          enabledInUi: false,
+          enabledCount: 0,
+        }),
+      }),
+    );
+    expect(
+      getBuildingTypeSelectorSubTypeState("industrial", manufacturing),
+    ).toEqual(
+      expect.objectContaining({
+        isEnabled: false,
+        support: expect.objectContaining({
+          supportStatus: "disabled",
+          badgeLabel: "Experimental/off",
+        }),
+      }),
+    );
+  });
+});

--- a/src/__tests__/components/SpecsStep.projectTypeSupport.test.js
+++ b/src/__tests__/components/SpecsStep.projectTypeSupport.test.js
@@ -1,0 +1,49 @@
+import { canProceedWithProjectType } from "../../components/steps/SpecsStep.jsx";
+
+describe("SpecsStep project type support", () => {
+  test.each([
+    ["detached house", "residential", "detached-house"],
+    ["office", "commercial", "office"],
+    ["school", "education", "school"],
+    ["clinic", "healthcare", "clinic"],
+    ["hospital", "healthcare", "hospital"],
+  ])("canProceed is true for supported %s", (_label, category, subType) => {
+    expect(
+      canProceedWithProjectType({
+        area: 250,
+        category,
+        subType,
+      }),
+    ).toBe(true);
+  });
+
+  test.each([
+    ["retail", "commercial", "retail"],
+    ["hotel", "hospitality", "hotel"],
+    ["manufacturing", "industrial", "manufacturing"],
+    ["mansion", "residential", "mansion"],
+  ])("canProceed is false for disabled %s", (_label, category, subType) => {
+    expect(
+      canProceedWithProjectType({
+        area: 250,
+        category,
+        subType,
+      }),
+    ).toBe(false);
+  });
+
+  test("canProceed is false until area and subtype are present", () => {
+    expect(
+      canProceedWithProjectType({
+        category: "commercial",
+        subType: "office",
+      }),
+    ).toBe(false);
+    expect(
+      canProceedWithProjectType({
+        area: 250,
+        category: "commercial",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
+++ b/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
@@ -128,6 +128,44 @@ describe("buildProjectGraphVerticalSliceRequest", () => {
     expect(request.brief.targetStoreys).toBe(2);
   });
 
+  test.each([
+    ["office", "commercial", "office", "office_studio", "production"],
+    ["school", "education", "school", "education_studio", "beta"],
+    ["clinic", "healthcare", "clinic", "clinic", "production"],
+    ["hospital", "healthcare", "hospital", "hospital", "beta"],
+  ])(
+    "preserves %s selection and posts canonical ProjectGraph building_type",
+    (_label, category, subType, canonicalBuildingType, supportStatus) => {
+      const request = buildProjectGraphVerticalSliceRequest({
+        designSpec: {
+          buildingCategory: category,
+          buildingSubType: subType,
+          area: 480,
+          floorCount: 2,
+          floorCountLocked: true,
+        },
+      });
+
+      expect(request.projectDetails.category).toBe(category);
+      expect(request.projectDetails.subType).toBe(subType);
+      expect(request.projectDetails.canonicalBuildingType).toBe(
+        canonicalBuildingType,
+      );
+      expect(request.projectDetails.buildingType).toBe(canonicalBuildingType);
+      expect(request.projectDetails.projectTypeRoute).toBe("project_graph");
+      expect(request.projectDetails.supportStatus).toBe(supportStatus);
+      expect(request.projectDetails.programmeTemplateKey).toBe(
+        canonicalBuildingType,
+      );
+      expect(request.brief.building_type).toBe(canonicalBuildingType);
+      expect(request.brief.canonical_building_type).toBe(canonicalBuildingType);
+      expect(request.brief.original_category).toBe(category);
+      expect(request.brief.original_subtype).toBe(subType);
+      expect(request.brief.project_type_route).toBe("project_graph");
+      expect(request.brief.support_status).toBe(supportStatus);
+    },
+  );
+
   test("preserves a compact provided site map data URL for ProjectGraph site context", () => {
     const mapDataUrl =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFklEQVR42mNk+M9Qz0AEYBxVSFIAAAeSAi8BTyQ1AAAAAElFTkSuQmCC";

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -2,6 +2,7 @@ import {
   buildArchitectureProjectVerticalSlice,
   validateProjectGraphVerticalSlice,
   KNOWN_BUILDING_TYPES,
+  __projectGraphVerticalSliceInternals,
 } from "../../services/project/projectGraphVerticalSliceService.js";
 
 jest.setTimeout(420000);
@@ -1058,6 +1059,10 @@ describe("projectGraphVerticalSliceService", () => {
       expect(
         result.projectGraph.programme.template_provenance.resolved_template,
       ).toBe(buildingType);
+      expect(
+        result.projectGraph.programme.template_provenance
+          .programme_template_key,
+      ).toBe(buildingType);
       const totalArea = result.projectGraph.programme.spaces.reduce(
         (sum, space) => sum + Number(space.target_area_m2 || 0),
         0,
@@ -1065,6 +1070,123 @@ describe("projectGraphVerticalSliceService", () => {
       const targetGia = briefInput.brief.target_gia_m2;
       expect(totalArea).toBeGreaterThan(targetGia * 0.9);
       expect(totalArea).toBeLessThan(targetGia * 1.1);
+    },
+  );
+
+  test.each([
+    ["office", "commercial", "office", "office_studio", "production"],
+    ["school", "education", "school", "education_studio", "beta"],
+    ["clinic", "healthcare", "clinic", "clinic", "production"],
+    ["hospital", "healthcare", "hospital", "hospital", "beta"],
+  ])(
+    "maps %s category/subtype to ProjectGraph programme metadata",
+    async (_label, category, subType, canonicalBuildingType, supportStatus) => {
+      const briefInput = createReadingRoomBrief();
+      delete briefInput.brief.building_type;
+      briefInput.brief.project_name = `Registry Smoke ${canonicalBuildingType}`;
+      briefInput.brief.target_gia_m2 = 520;
+      briefInput.projectDetails = {
+        category,
+        subType,
+        area: 520,
+        floorCount: 2,
+        floorCountLocked: true,
+      };
+
+      const brief =
+        __projectGraphVerticalSliceInternals.normalizeBrief(briefInput);
+      const programme = __projectGraphVerticalSliceInternals.buildProgramme({
+        brief,
+      });
+      const site = __projectGraphVerticalSliceInternals.buildSiteContext({
+        brief,
+        sitePolygon: briefInput.sitePolygon,
+        siteMetrics: briefInput.siteMetrics,
+      });
+      const climate = __projectGraphVerticalSliceInternals.buildClimatePack(
+        brief,
+        site,
+      );
+      const localStyle =
+        __projectGraphVerticalSliceInternals.buildLocalStylePack(
+          brief,
+          site,
+          climate,
+        );
+      const projectGeometry =
+        __projectGraphVerticalSliceInternals.buildProjectGeometryFromProgramme({
+          brief,
+          site,
+          programme,
+          localStyle,
+          climate,
+        });
+      const placedProgramme =
+        __projectGraphVerticalSliceInternals.syncProgrammeActuals(
+          programme,
+          projectGeometry,
+        );
+      const compiledProject =
+        __projectGraphVerticalSliceInternals.compileProject({
+          projectGeometry,
+          masterDNA: {
+            projectName: brief.project_name,
+            projectID: projectGeometry.project_id,
+            styleDNA: projectGeometry.metadata.style_dna,
+            rooms: placedProgramme.spaces,
+          },
+          locationData: {
+            address: brief.site_input.address,
+            coordinates: { lat: site.lat, lng: site.lon },
+            climate: { type: climate.weather_source },
+            localMaterials: localStyle.material_palette,
+          },
+        });
+      const spaces = programme.spaces;
+      const levelIndexes = new Set(
+        spaces.map((space) => Number(space.target_level_index)),
+      );
+
+      expect(KNOWN_BUILDING_TYPES).toContain(canonicalBuildingType);
+      expect(brief).toEqual(
+        expect.objectContaining({
+          building_type: canonicalBuildingType,
+          canonical_building_type: canonicalBuildingType,
+          original_category: category,
+          original_subtype: subType,
+          support_status: supportStatus,
+          programme_template_key: canonicalBuildingType,
+          project_type_route: "project_graph",
+        }),
+      );
+      expect(brief.project_type_support).toEqual(
+        expect.objectContaining({
+          categoryId: category,
+          subtypeId: subType,
+          canonicalBuildingType,
+          route: "project_graph",
+          supportStatus,
+        }),
+      );
+      expect(spaces.length).toBeGreaterThanOrEqual(6);
+      expect(levelIndexes.has(0)).toBe(true);
+      expect(Math.max(...levelIndexes)).toBeGreaterThanOrEqual(1);
+      expect(projectGeometry.levels.length).toBeGreaterThan(0);
+      expect(projectGeometry.rooms.length).toBeGreaterThan(0);
+      expect(compiledProject.geometryHash).toEqual(expect.any(String));
+      expect(programme.template_provenance).toEqual(
+        expect.objectContaining({
+          source: "matched_template",
+          resolved_template: canonicalBuildingType,
+          programme_template_key: canonicalBuildingType,
+          support_status: supportStatus,
+        }),
+      );
+      expect(brief.building_type).not.toBe("dwelling");
+      expect(brief.building_type).not.toBe("detached-house");
+      expect(spaces.map((space) => space.name).join(" ")).not.toMatch(
+        /bedroom|living room|kitchen\/dining/i,
+      );
     },
   );
 

--- a/src/__tests__/services/projectTypeSupportRegistry.test.js
+++ b/src/__tests__/services/projectTypeSupportRegistry.test.js
@@ -1,0 +1,125 @@
+import { BUILDING_CATEGORIES } from "../../data/buildingTypes.js";
+import {
+  PROJECT_TYPE_ROUTES,
+  PROJECT_TYPE_SUPPORT_REGISTRY,
+  PROJECT_TYPE_SUPPORT_STATUS,
+  getProjectTypeSupport,
+} from "../../services/project/projectTypeSupportRegistry.js";
+import { SUPPORTED_RESIDENTIAL_V2_SUBTYPES } from "../../services/project/v2ProjectContracts.js";
+
+const enabledNonResidentialKeys = () =>
+  PROJECT_TYPE_SUPPORT_REGISTRY.filter(
+    (entry) => entry.categoryId !== "residential" && entry.enabledInUi,
+  )
+    .map((entry) => `${entry.categoryId}:${entry.subtypeId}`)
+    .sort();
+
+describe("projectTypeSupportRegistry", () => {
+  test("keeps the Residential V2 supported subtype set unchanged", () => {
+    const residentialSubtypes = BUILDING_CATEGORIES.RESIDENTIAL.subTypes.map(
+      (entry) => entry.id,
+    );
+
+    const enabledResidential = PROJECT_TYPE_SUPPORT_REGISTRY.filter(
+      (entry) => entry.categoryId === "residential" && entry.enabledInUi,
+    )
+      .map((entry) => entry.subtypeId)
+      .sort();
+
+    expect(enabledResidential).toEqual(
+      [...SUPPORTED_RESIDENTIAL_V2_SUBTYPES].sort(),
+    );
+
+    for (const subtypeId of residentialSubtypes) {
+      const support = getProjectTypeSupport("residential", subtypeId);
+      if (SUPPORTED_RESIDENTIAL_V2_SUBTYPES.includes(subtypeId)) {
+        expect(support).toEqual(
+          expect.objectContaining({
+            enabledInUi: true,
+            route: PROJECT_TYPE_ROUTES.RESIDENTIAL_V2,
+            supportStatus: PROJECT_TYPE_SUPPORT_STATUS.PRODUCTION,
+          }),
+        );
+      } else {
+        expect(support).toEqual(
+          expect.objectContaining({
+            enabledInUi: false,
+            route: null,
+            supportStatus: PROJECT_TYPE_SUPPORT_STATUS.DISABLED,
+          }),
+        );
+      }
+    }
+  });
+
+  test("enables only supported non-residential ProjectGraph templates", () => {
+    expect(enabledNonResidentialKeys()).toEqual([
+      "commercial:office",
+      "education:school",
+      "healthcare:clinic",
+      "healthcare:hospital",
+    ]);
+
+    expect(getProjectTypeSupport("commercial", "office")).toEqual(
+      expect.objectContaining({
+        canonicalBuildingType: "office_studio",
+        programmeTemplateKey: "office_studio",
+        route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+      }),
+    );
+    expect(getProjectTypeSupport("education", "school")).toEqual(
+      expect.objectContaining({
+        canonicalBuildingType: "education_studio",
+        programmeTemplateKey: "education_studio",
+        route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+      }),
+    );
+    expect(getProjectTypeSupport("healthcare", "clinic")).toEqual(
+      expect.objectContaining({
+        canonicalBuildingType: "clinic",
+        programmeTemplateKey: "clinic",
+        route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+      }),
+    );
+    expect(getProjectTypeSupport("healthcare", "hospital")).toEqual(
+      expect.objectContaining({
+        canonicalBuildingType: "hospital",
+        programmeTemplateKey: "hospital",
+        route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+      }),
+    );
+  });
+
+  test("unsupported categories and subtypes remain disabled with a clear status", () => {
+    const supportedNonResidential = new Set(enabledNonResidentialKeys());
+
+    for (const entry of PROJECT_TYPE_SUPPORT_REGISTRY) {
+      if (
+        entry.categoryId === "residential" ||
+        supportedNonResidential.has(`${entry.categoryId}:${entry.subtypeId}`)
+      ) {
+        continue;
+      }
+
+      expect(entry).toEqual(
+        expect.objectContaining({
+          enabledInUi: false,
+          supportStatus: PROJECT_TYPE_SUPPORT_STATUS.DISABLED,
+          route: null,
+          canonicalBuildingType: null,
+          badgeLabel: "Experimental/off",
+        }),
+      );
+    }
+
+    expect(getProjectTypeSupport("civic", "museum")).toEqual(
+      expect.objectContaining({
+        enabledInUi: false,
+        supportStatus: PROJECT_TYPE_SUPPORT_STATUS.DISABLED,
+        route: null,
+        canonicalBuildingType: null,
+        badgeLabel: "Experimental/off",
+      }),
+    );
+  });
+});

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -44,10 +44,13 @@ import {
   generateResidentialProgramBrief,
   normalizeResidentialProgramSpaces,
 } from "../services/project/residentialProgramEngine.js";
+import { UK_RESIDENTIAL_V2_PIPELINE_VERSION } from "../services/project/v2ProjectContracts.js";
 import {
-  isSupportedResidentialV2SubType,
-  UK_RESIDENTIAL_V2_PIPELINE_VERSION,
-} from "../services/project/v2ProjectContracts.js";
+  buildProjectTypeSupportMetadata,
+  getProjectTypeSupportForDetails,
+  PROJECT_GRAPH_PROJECT_TYPE_PIPELINE_VERSION,
+  PROJECT_TYPE_ROUTES,
+} from "../services/project/projectTypeSupportRegistry.js";
 import { runProgramPreflight } from "../services/project/programPreflight.js";
 import {
   resolveAuthoritativeFloorCount,
@@ -210,6 +213,35 @@ const normalizeSitePolygonForUi = (polygon = []) => {
   return normalized.length >= 3 ? normalized : [];
 };
 
+export function resolveWizardProjectTypeSupport(projectDetails = {}) {
+  return getProjectTypeSupportForDetails(projectDetails);
+}
+
+export function assertProjectTypeSupportedForGeneration(projectDetails = {}) {
+  const support = resolveWizardProjectTypeSupport(projectDetails);
+  if (!projectDetails.category || !projectDetails.subType) {
+    throw new Error("Choose a supported project type before generation.");
+  }
+  if (support.enabledInUi !== true || !support.route) {
+    throw new Error(
+      support.message ||
+        "This project type is not enabled for production generation.",
+    );
+  }
+  return support;
+}
+
+export function shouldUseResidentialV2Route(
+  projectDetails = {},
+  { residentialV2Enabled = true } = {},
+) {
+  const support = resolveWizardProjectTypeSupport(projectDetails);
+  return (
+    residentialV2Enabled === true &&
+    support.route === PROJECT_TYPE_ROUTES.RESIDENTIAL_V2
+  );
+}
+
 const ArchitectAIWizardContainer = () => {
   // Top-level view: 'wizard' | 'pricing'
   const [view, setView] = useState("wizard");
@@ -287,9 +319,6 @@ const ArchitectAIWizardContainer = () => {
   // Surfaces PDF conversion failures via Modal instead of native alert().
   const [pdfErrorState, setPdfErrorState] = useState(null);
   const residentialV2Enabled = isFeatureEnabled("ukResidentialV2");
-  const restrictToResidentialV2 = isFeatureEnabled(
-    "hideExperimentalBuildingTypes",
-  );
 
   const hasA1Output = Boolean(
     result?.a1Sheet?.url ||
@@ -1050,17 +1079,22 @@ const ArchitectAIWizardContainer = () => {
     setProgramWarnings([]);
 
     try {
+      const projectTypeSupport =
+        resolveWizardProjectTypeSupport(projectDetails);
       const subType = projectDetails.subType || projectDetails.program;
-      const isSupportedResidentialV2 =
-        residentialV2Enabled &&
-        projectDetails.category === "residential" &&
-        isSupportedResidentialV2SubType(subType);
-      const sanitizedProgram = sanitizePromptInput(
-        projectDetails.program ||
-          projectDetails.subType ||
-          projectDetails.category,
-        { maxLength: 120, allowNewlines: false },
+      const isSupportedResidentialV2 = shouldUseResidentialV2Route(
+        projectDetails,
+        { residentialV2Enabled },
       );
+      const canonicalProgram =
+        projectTypeSupport.canonicalBuildingType ||
+        projectDetails.program ||
+        projectDetails.subType ||
+        projectDetails.category;
+      const sanitizedProgram = sanitizePromptInput(canonicalProgram, {
+        maxLength: 120,
+        allowNewlines: false,
+      });
       const sanitizedArea = sanitizeDimensionInput(projectDetails.area);
       const siteArea = siteMetrics?.areaM2 || 0;
       // Single source of truth for floor count. Every downstream call -
@@ -1097,9 +1131,13 @@ const ArchitectAIWizardContainer = () => {
         return;
       }
 
-      if (restrictToResidentialV2 && !isSupportedResidentialV2) {
+      if (
+        projectTypeSupport.enabledInUi !== true ||
+        !projectTypeSupport.route
+      ) {
         setProgramWarnings([
-          "UK Residential V2 currently supports low-rise residential types only.",
+          projectTypeSupport.message ||
+            "This project type is not enabled for production generation.",
         ]);
         setProgramSpaces([]);
         return [];
@@ -1219,6 +1257,12 @@ const ArchitectAIWizardContainer = () => {
             qualityTier: prev.qualityTier || "mid",
             program: subType,
             pipelineVersion: UK_RESIDENTIAL_V2_PIPELINE_VERSION,
+            canonicalBuildingType: projectTypeSupport.canonicalBuildingType,
+            projectTypeRoute: projectTypeSupport.route,
+            supportStatus: projectTypeSupport.supportStatus,
+            programmeTemplateKey: projectTypeSupport.programmeTemplateKey,
+            projectTypeSupport:
+              buildProjectTypeSupportMetadata(projectTypeSupport),
           };
           // Only overwrite floorCount when the resolver pulled it from the
           // auto-detected source. Locked / manual values are the user's
@@ -1293,7 +1337,20 @@ const ArchitectAIWizardContainer = () => {
         return levels;
       })();
 
-      const prompt = `You are an architectural programming expert. Generate a JSON array of spaces for a ${sanitizedProgram} totaling ~${sanitizedArea} m². Ensure the total area (area×count sum) is within ±5% of ${sanitizedArea}. Assign each space to ONE of these level names only: ${levelNames.join(", ")}. Public/amenity spaces on Ground; private/sleeping spaces on upper levels. Return ONLY the JSON array, no commentary.`;
+      const programmeGuidanceByType = {
+        clinic:
+          "Include reception, waiting, consult/treatment rooms, clinical support, staff/admin, storage, clean/dirty utility, toilets, plant, and circulation.",
+        hospital:
+          "Include reception/admissions, outpatient or emergency care, diagnostics, wards, clinical support, staff/admin, logistics, plant, toilets, and circulation.",
+        office_studio:
+          "Include reception, open office, meeting rooms, focus rooms, shared support, staff amenities, storage, plant, toilets, and circulation.",
+        education_studio:
+          "Include classrooms, admin, staff areas, library or resource space, assembly or multipurpose space, dining/support, toilets, storage, plant, and circulation.",
+      };
+      const programmeGuidance =
+        programmeGuidanceByType[projectTypeSupport.canonicalBuildingType] ||
+        "Put public and high-footfall spaces on Ground, with support, staff, teaching, workplace, or clinical spaces distributed logically across the remaining levels.";
+      const prompt = `You are an architectural programming expert. Generate a JSON array of spaces for a ${projectTypeSupport.label || sanitizedProgram} totaling ~${sanitizedArea} m². Ensure the total area (area×count sum) is within ±5% of ${sanitizedArea}. Assign each space to ONE of these level names only: ${levelNames.join(", ")}. ${programmeGuidance} Return ONLY the JSON array, no commentary.`;
 
       const response = await togetherAIReasoningService.chatCompletion(
         [
@@ -1408,6 +1465,16 @@ const ArchitectAIWizardContainer = () => {
         if (floorMetrics) {
           next.floorMetrics = floorMetrics;
         }
+        next.canonicalBuildingType = projectTypeSupport.canonicalBuildingType;
+        next.projectTypeRoute = projectTypeSupport.route;
+        next.supportStatus = projectTypeSupport.supportStatus;
+        next.programmeTemplateKey = projectTypeSupport.programmeTemplateKey;
+        next.projectTypeSupport =
+          buildProjectTypeSupportMetadata(projectTypeSupport);
+        next.pipelineVersion =
+          projectTypeSupport.route === PROJECT_TYPE_ROUTES.PROJECT_GRAPH
+            ? PROJECT_GRAPH_PROJECT_TYPE_PIPELINE_VERSION
+            : prev.pipelineVersion;
         // Only auto-source overwrites floorCount; locked/manual are the
         // user's authority and must not be stomped.
         if (
@@ -1459,7 +1526,6 @@ const ArchitectAIWizardContainer = () => {
     setProjectDetails,
     siteMetrics,
     residentialV2Enabled,
-    restrictToResidentialV2,
   ]);
 
   const handleProgramSpacesChange = useCallback(
@@ -1675,14 +1741,30 @@ const ArchitectAIWizardContainer = () => {
     setIsGenerationTimerRunning(true);
 
     try {
+      const projectTypeSupport =
+        assertProjectTypeSupportedForGeneration(projectDetails);
+      const projectTypeSupportMetadata =
+        buildProjectTypeSupportMetadata(projectTypeSupport);
+      const selectedSubType = projectDetails.subType || projectDetails.program;
+      const canUseResidentialV2 = shouldUseResidentialV2Route(projectDetails, {
+        residentialV2Enabled,
+      });
+      const projectTypePipelineVersion =
+        projectTypeSupport.route === PROJECT_TYPE_ROUTES.PROJECT_GRAPH
+          ? PROJECT_GRAPH_PROJECT_TYPE_PIPELINE_VERSION
+          : UK_RESIDENTIAL_V2_PIPELINE_VERSION;
+
       // Auto-generate program spaces if user skipped "Generate Program" button.
       // The ProgramComplianceGate requires programSpaces to build ProgramLock + CDS.
+      // ProjectGraph project types may intentionally rely on service-side
+      // deterministic programme templates, so do not synthesize UI spaces first.
       // React setState is async so we capture the returned array for immediate use.
       let effectiveProgramSpaces = programSpaces;
       if (
         programSpaces.length === 0 &&
         projectDetails.category &&
-        projectDetails.area
+        projectDetails.area &&
+        projectTypeSupport.route !== PROJECT_TYPE_ROUTES.PROJECT_GRAPH
       ) {
         logger.info(
           "Auto-generating program spaces before generation...",
@@ -1829,15 +1911,12 @@ const ArchitectAIWizardContainer = () => {
       });
 
       let v2Bundle = null;
-      const selectedSubType = projectDetails.subType || projectDetails.program;
-      const canUseResidentialV2 =
-        residentialV2Enabled &&
-        projectDetails.category === "residential" &&
-        isSupportedResidentialV2SubType(selectedSubType);
-
-      if (restrictToResidentialV2 && !canUseResidentialV2) {
+      if (
+        projectTypeSupport.route === PROJECT_TYPE_ROUTES.RESIDENTIAL_V2 &&
+        !canUseResidentialV2
+      ) {
         throw new Error(
-          "UK Residential V2 currently supports detached, semi-detached, terraced, villa, cottage, duplex, and small apartment residential projects only.",
+          "Residential V2 generation is disabled by feature flag.",
         );
       }
 
@@ -1902,9 +1981,20 @@ const ArchitectAIWizardContainer = () => {
       const designFloorCount = designFloorAuth.floorCount;
 
       const designSpec = {
-        buildingProgram: selectedSubType || projectDetails.category,
+        buildingProgram:
+          projectTypeSupport.label ||
+          selectedSubType ||
+          projectDetails.category,
         buildingCategory: projectDetails.category,
         buildingSubType: projectDetails.subType,
+        originalCategory: projectDetails.category,
+        originalSubtype: projectDetails.subType,
+        buildingType: projectTypeSupport.canonicalBuildingType,
+        canonicalBuildingType: projectTypeSupport.canonicalBuildingType,
+        projectTypeRoute: projectTypeSupport.route,
+        supportStatus: projectTypeSupport.supportStatus,
+        programmeTemplateKey: projectTypeSupport.programmeTemplateKey,
+        projectTypeSupport: projectTypeSupportMetadata,
         buildingNotes: projectDetails.customNotes,
         floorArea: parseFloat(projectDetails.area),
         area: parseFloat(projectDetails.area), // Alias for services expecting `area`
@@ -1921,13 +2011,13 @@ const ArchitectAIWizardContainer = () => {
           confidence: projectDetails.entranceConfidence,
           warnings: programWarnings,
           pipelineVersion:
-            v2Bundle?.pipelineVersion || UK_RESIDENTIAL_V2_PIPELINE_VERSION,
+            v2Bundle?.pipelineVersion || projectTypePipelineVersion,
         },
         sitePolygon,
         siteMetrics, // Alias for downstream generators expecting `siteMetrics`
         sitePolygonMetrics: siteMetrics,
         pipelineVersion:
-          v2Bundle?.pipelineVersion || UK_RESIDENTIAL_V2_PIPELINE_VERSION,
+          v2Bundle?.pipelineVersion || projectTypePipelineVersion,
         portfolioBlend: {
           materialWeight,
           characteristicWeight,
@@ -2002,7 +2092,6 @@ const ArchitectAIWizardContainer = () => {
     programWarnings,
     projectDetails,
     residentialV2Enabled,
-    restrictToResidentialV2,
     setCurrentStep,
     setGeneratedDesignId,
     setProgramSpaces,

--- a/src/components/specs/BuildingTypeSelector.jsx
+++ b/src/components/specs/BuildingTypeSelector.jsx
@@ -7,10 +7,28 @@
 import React, { useState } from "react";
 import { motion } from "framer-motion";
 import * as LucideIcons from "lucide-react";
-import { isFeatureEnabled } from "../../config/featureFlags.js";
 import { getAllCategories, getCategoryById } from "../../data/buildingTypes.js";
-import { isSupportedResidentialV2SubType } from "../../services/project/v2ProjectContracts.js";
+import {
+  getCategorySupportSummary,
+  getProjectTypeSupport,
+} from "../../services/project/projectTypeSupportRegistry.js";
 import Card from "../ui/Card.jsx";
+
+export function getBuildingTypeSelectorCategoryState(category) {
+  const summary = getCategorySupportSummary(category?.id);
+  return {
+    supportSummary: summary,
+    isEnabled: summary.enabledInUi === true,
+  };
+}
+
+export function getBuildingTypeSelectorSubTypeState(categoryId, subType) {
+  const support = getProjectTypeSupport(categoryId, subType?.id);
+  return {
+    support,
+    isEnabled: support.enabledInUi === true,
+  };
+}
 
 const BuildingTypeSelector = ({
   selectedCategory,
@@ -22,17 +40,12 @@ const BuildingTypeSelector = ({
     selectedCategory || null,
   );
   const categories = getAllCategories();
-  const restrictToResidentialV2 =
-    isFeatureEnabled("ukResidentialV2") &&
-    isFeatureEnabled("hideExperimentalBuildingTypes");
 
   const isCategoryEnabled = (category) =>
-    !restrictToResidentialV2 || category?.id === "residential";
+    getBuildingTypeSelectorCategoryState(category).isEnabled;
 
   const isSubTypeEnabled = (categoryId, subType) =>
-    !restrictToResidentialV2 ||
-    (categoryId === "residential" &&
-      isSupportedResidentialV2SubType(subType?.id));
+    getBuildingTypeSelectorSubTypeState(categoryId, subType).isEnabled;
 
   const handleCategoryClick = (categoryId) => {
     const category = getCategoryById(categoryId);
@@ -75,7 +88,8 @@ const BuildingTypeSelector = ({
         {categories.map((category) => {
           const isSelected = selectedCategory === category.id;
           const isExpanded = expandedCategory === category.id;
-          const isEnabled = isCategoryEnabled(category);
+          const { supportSummary, isEnabled } =
+            getBuildingTypeSelectorCategoryState(category);
 
           return (
             <motion.button
@@ -103,9 +117,14 @@ const BuildingTypeSelector = ({
                   <p className="text-sm text-gray-400 mt-1">
                     {category.subTypes.length} types
                   </p>
+                  {isEnabled && (
+                    <p className="text-xs text-emerald-300 mt-2">
+                      {supportSummary.message}
+                    </p>
+                  )}
                   {!isEnabled && (
                     <p className="text-xs text-amber-300 mt-2">
-                      Experimental/off in UK Residential V2
+                      {supportSummary.message}
                     </p>
                   )}
                 </div>
@@ -150,7 +169,17 @@ const BuildingTypeSelector = ({
                 const isSelected =
                   selectedSubType === subType.id &&
                   selectedCategory === expandedCategory;
-                const isEnabled = isSubTypeEnabled(expandedCategory, subType);
+                const { support, isEnabled } =
+                  getBuildingTypeSelectorSubTypeState(
+                    expandedCategory,
+                    subType,
+                  );
+                const badgeClass =
+                  support.supportStatus === "production"
+                    ? "text-emerald-300"
+                    : support.supportStatus === "beta"
+                      ? "text-sky-300"
+                      : "text-amber-300";
 
                 return (
                   <motion.button
@@ -180,12 +209,18 @@ const BuildingTypeSelector = ({
                       </div>
                       <span
                         className={`text-[10px] uppercase tracking-wide ${
-                          isEnabled ? "text-emerald-300" : "text-amber-300"
+                          isEnabled ? badgeClass : "text-amber-300"
                         }`}
                       >
-                        {isEnabled ? "Supported" : "Experimental/Off"}
+                        {support.badgeLabel ||
+                          (isEnabled ? "Supported" : "Experimental/Off")}
                       </span>
                     </div>
+                    {!isEnabled && support.message && (
+                      <p className="mt-2 text-xs text-amber-200/80">
+                        {support.message}
+                      </p>
+                    )}
                   </motion.button>
                 );
               })}

--- a/src/components/steps/SpecsStep.jsx
+++ b/src/components/steps/SpecsStep.jsx
@@ -28,8 +28,10 @@ import BuildingProgramTable from "../specs/BuildingProgramTable.jsx";
 import ProgramReviewCards from "../specs/ProgramReviewCards.jsx";
 import StepContainer from "../layout/StepContainer.jsx";
 import { fadeInUp, staggerChildren } from "../../styles/animations.js";
-import { isFeatureEnabled } from "../../config/featureFlags.js";
-import { isSupportedResidentialV2SubType } from "../../services/project/v2ProjectContracts.js";
+import {
+  getProjectTypeSupportForDetails,
+  PROJECT_TYPE_ROUTES,
+} from "../../services/project/projectTypeSupportRegistry.js";
 import {
   levelIndexFromLabel,
   levelName,
@@ -89,6 +91,16 @@ export function applyProgramRowChangeForFloorAuthority({
   return stampProgramFloorAuthorityMetadata(updated, floorCount, floorMetrics);
 }
 
+export function canProceedWithProjectType(projectDetails = {}) {
+  const support = getProjectTypeSupportForDetails(projectDetails);
+  return Boolean(
+    projectDetails.area &&
+    projectDetails.category &&
+    projectDetails.subType &&
+    support.enabledInUi,
+  );
+}
+
 const SpecsStep = ({
   projectDetails,
   programSpaces,
@@ -107,18 +119,13 @@ const SpecsStep = ({
   validationState,
 }) => {
   const [showProgramReview, setShowProgramReview] = useState(false);
-  const restrictToResidentialV2 =
-    isFeatureEnabled("ukResidentialV2") &&
-    isFeatureEnabled("hideExperimentalBuildingTypes");
-  const supportedResidentialSubtype =
-    projectDetails.category === "residential" &&
-    isSupportedResidentialV2SubType(projectDetails.subType);
-
-  const canProceed =
-    projectDetails.area &&
-    projectDetails.category &&
-    projectDetails.subType &&
-    (!restrictToResidentialV2 || supportedResidentialSubtype);
+  const projectTypeSupport = useMemo(
+    () => getProjectTypeSupportForDetails(projectDetails),
+    [projectDetails],
+  );
+  const canProceed = canProceedWithProjectType(projectDetails);
+  const usesResidentialV2 =
+    projectTypeSupport.route === PROJECT_TYPE_ROUTES.RESIDENTIAL_V2;
 
   const handleBuildingTypeChange = useCallback(
     ({ category, subType }) => {
@@ -316,27 +323,29 @@ const SpecsStep = ({
             <h3 className="mb-4 text-lg font-semibold tracking-tight text-white">
               Building type
             </h3>
-            {restrictToResidentialV2 && (
-              <div className="mb-4 rounded-xl border border-success-500/30 bg-success-500/10 px-4 py-3 text-sm text-success-200">
-                UK Residential V2 is live. Production generation is restricted
-                to supported low-rise residential types, and unsupported types
-                are intentionally marked experimental/off.
-              </div>
-            )}
+            <div className="mb-4 rounded-xl border border-success-500/30 bg-success-500/10 px-4 py-3 text-sm text-success-200">
+              Production generation is controlled by the project type support
+              registry. Residential V2 remains the production residential route;
+              selected ProjectGraph beta types are enabled explicitly.
+            </div>
             <BuildingTypeSelector
               selectedCategory={projectDetails.category}
               selectedSubType={projectDetails.subType}
               onSelectionChange={handleBuildingTypeChange}
               validationErrors={validationState?.buildingType || []}
             />
-            {restrictToResidentialV2 &&
-              projectDetails.category &&
+            {projectDetails.category &&
               projectDetails.subType &&
-              !supportedResidentialSubtype && (
+              !projectTypeSupport.enabledInUi && (
                 <p className="mt-4 text-sm text-warning-300">
-                  This subtype is outside the supported UK Residential V2
-                  production scope. Choose a supported residential subtype to
-                  continue.
+                  {projectTypeSupport.message ||
+                    "This subtype is not enabled for production generation."}
+                </p>
+              )}
+            {projectTypeSupport.enabledInUi &&
+              projectTypeSupport.supportStatus === "beta" && (
+                <p className="mt-4 text-sm text-sky-300">
+                  {projectTypeSupport.message}
                 </p>
               )}
           </Card>
@@ -559,7 +568,7 @@ const SpecsStep = ({
                 >
                   {isGeneratingSpaces
                     ? "Compiling..."
-                    : restrictToResidentialV2 && supportedResidentialSubtype
+                    : usesResidentialV2
                       ? "Compile Program"
                       : "Generate Program"}
                 </Button>

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -28,6 +28,10 @@ import {
 import { PIPELINE_MODE } from "../config/pipelineMode.js";
 import { createSheetArtifactManifest } from "../services/project/v2ProjectContracts.js";
 import {
+  buildProjectTypeSupportMetadata,
+  getProjectTypeSupport,
+} from "../services/project/projectTypeSupportRegistry.js";
+import {
   levelIndexFromLabel,
   levelName,
   normalizeLevelIndex,
@@ -408,6 +412,61 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
     designSpec.program?.spaces ||
     designSpec.rooms ||
     [];
+  const originalCategory =
+    projectDetails.category ||
+    projectDetails.buildingCategory ||
+    designSpec.originalCategory ||
+    designSpec.buildingCategory ||
+    designSpec.projectTypeSupport?.categoryId ||
+    null;
+  const originalSubtype =
+    projectDetails.subType ||
+    projectDetails.buildingSubType ||
+    designSpec.originalSubtype ||
+    designSpec.buildingSubType ||
+    designSpec.projectTypeSupport?.subtypeId ||
+    null;
+  const registrySupport = getProjectTypeSupport(
+    originalCategory,
+    originalSubtype,
+  );
+  const incomingSupport =
+    projectDetails.projectTypeSupport || designSpec.projectTypeSupport || {};
+  const projectTypeSupport = {
+    ...registrySupport,
+    ...incomingSupport,
+    categoryId: incomingSupport.categoryId || originalCategory,
+    subtypeId: incomingSupport.subtypeId || originalSubtype,
+    supportStatus:
+      incomingSupport.supportStatus ||
+      projectDetails.supportStatus ||
+      designSpec.supportStatus ||
+      registrySupport.supportStatus,
+    canonicalBuildingType:
+      incomingSupport.canonicalBuildingType ||
+      projectDetails.canonicalBuildingType ||
+      designSpec.canonicalBuildingType ||
+      registrySupport.canonicalBuildingType,
+    route:
+      incomingSupport.route ||
+      projectDetails.projectTypeRoute ||
+      designSpec.projectTypeRoute ||
+      registrySupport.route,
+    programmeTemplateKey:
+      incomingSupport.programmeTemplateKey ||
+      projectDetails.programmeTemplateKey ||
+      designSpec.programmeTemplateKey ||
+      registrySupport.programmeTemplateKey,
+  };
+  const projectTypeSupportMetadata =
+    buildProjectTypeSupportMetadata(projectTypeSupport);
+  const canonicalBuildingType =
+    projectTypeSupportMetadata.canonicalBuildingType ||
+    projectDetails.canonicalBuildingType ||
+    designSpec.canonicalBuildingType ||
+    projectDetails.buildingType ||
+    designSpec.buildingType ||
+    null;
 
   // Single resolver across the workflow: ensures floorCountLocked /
   // autoDetectedFloorCount semantics are honoured even on replay/import paths
@@ -432,10 +491,11 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
         projectDetails.area ??
         designSpec.area,
       buildingType:
+        canonicalBuildingType ||
         projectDetails.buildingType ||
-        projectDetails.subType ||
         designSpec.buildingType ||
         designSpec.buildingSubType ||
+        projectDetails.subType ||
         designSpec.buildingProgram ||
         projectDetails.category,
       subType:
@@ -478,6 +538,35 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
   const resolvedBrief = sourceProjectBrief
     ? {
         ...sourceProjectBrief,
+        building_type:
+          canonicalBuildingType ||
+          sourceProjectBrief.building_type ||
+          "dwelling",
+        canonical_building_type:
+          canonicalBuildingType ||
+          sourceProjectBrief.canonical_building_type ||
+          sourceProjectBrief.building_type ||
+          "dwelling",
+        original_category:
+          originalCategory || sourceProjectBrief.original_category || null,
+        original_subtype:
+          originalSubtype || sourceProjectBrief.original_subtype || null,
+        support_status:
+          projectTypeSupportMetadata.supportStatus ||
+          sourceProjectBrief.support_status ||
+          null,
+        programme_template_key:
+          projectTypeSupportMetadata.programmeTemplateKey ||
+          sourceProjectBrief.programme_template_key ||
+          null,
+        project_type_route:
+          projectTypeSupportMetadata.route ||
+          sourceProjectBrief.project_type_route ||
+          null,
+        project_type_support:
+          projectTypeSupportMetadata ||
+          sourceProjectBrief.project_type_support ||
+          null,
         target_storeys: resolvedFloorCount,
         targetStoreys: resolvedFloorCount,
         referenceMatch,
@@ -500,11 +589,14 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
           180,
         target_storeys: resolvedFloorCount,
         targetStoreys: resolvedFloorCount,
-        building_type:
-          projectDetails.buildingType ||
-          projectDetails.subType ||
-          designSpec.buildingType ||
-          "dwelling",
+        building_type: canonicalBuildingType || "dwelling",
+        canonical_building_type: canonicalBuildingType || "dwelling",
+        original_category: originalCategory,
+        original_subtype: originalSubtype,
+        support_status: projectTypeSupportMetadata.supportStatus,
+        programme_template_key: projectTypeSupportMetadata.programmeTemplateKey,
+        project_type_route: projectTypeSupportMetadata.route,
+        project_type_support: projectTypeSupportMetadata,
         required_spaces_text:
           projectDetails.requiredSpacesText ||
           designSpec.requiredSpacesText ||
@@ -547,13 +639,19 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
       ? "reference_match"
       : params.qualityTarget || designSpec.qualityTarget || null,
     projectDetails: {
-      category: projectDetails.category || designSpec.buildingCategory || null,
-      subType: projectDetails.subType || designSpec.buildingSubType || null,
+      category: originalCategory,
+      subType: originalSubtype,
       program:
         projectDetails.program ||
         designSpec.buildingProgram ||
         designSpec.buildingSubType ||
         null,
+      canonicalBuildingType,
+      buildingType: canonicalBuildingType,
+      projectTypeRoute: projectTypeSupportMetadata.route,
+      supportStatus: projectTypeSupportMetadata.supportStatus,
+      programmeTemplateKey: projectTypeSupportMetadata.programmeTemplateKey,
+      projectTypeSupport: projectTypeSupportMetadata,
       area: projectDetails.area ?? designSpec.area ?? designSpec.floorArea,
       floorCount: resolvedFloorCount,
       autoDetectedFloorCount:

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -88,6 +88,10 @@ import {
 } from "./levelUtils.js";
 import { runProgramPreflight } from "./programPreflight.js";
 import { resolveAuthoritativeFloorCount } from "./floorCountAuthority.js";
+import {
+  buildProjectTypeSupportMetadata,
+  getProjectTypeSupport,
+} from "./projectTypeSupportRegistry.js";
 
 export const PROJECT_GRAPH_SCHEMA_VERSION = "project-graph-v1";
 export const PROJECT_GRAPH_VERTICAL_SLICE_VERSION =
@@ -273,6 +277,8 @@ export const KNOWN_BUILDING_TYPES = Object.freeze([
   "community",
   "office_studio",
   "education_studio",
+  "clinic",
+  "hospital",
 ]);
 
 const DWELLING_SYNONYMS = [
@@ -288,12 +294,17 @@ const DWELLING_SYNONYMS = [
 
 function normalizeBuildingType(input = {}) {
   const raw = String(
-    input.building_type ||
+    input.canonical_building_type ||
+      input.canonicalBuildingType ||
+      input.project_type_support?.canonicalBuildingType ||
+      input.projectTypeSupport?.canonicalBuildingType ||
+      input.building_type ||
       input.buildingType ||
-      input.category ||
-      input.projectType ||
-      input.program ||
       input.subType ||
+      input.buildingSubType ||
+      input.program ||
+      input.projectType ||
+      input.category ||
       "dwelling",
   )
     .trim()
@@ -322,6 +333,22 @@ function normalizeBuildingType(input = {}) {
     raw === "tenement"
   ) {
     return "multi_residential";
+  }
+  if (
+    raw.includes("hospital") ||
+    raw.includes("inpatient") ||
+    raw.includes("ward")
+  ) {
+    return "hospital";
+  }
+  if (
+    raw.includes("clinic") ||
+    raw.includes("medical") ||
+    raw.includes("healthcare") ||
+    raw.includes("health-center") ||
+    raw.includes("health-centre")
+  ) {
+    return "clinic";
   }
   if (
     raw.includes("community") ||
@@ -593,9 +620,73 @@ function normalizeBrief(input = {}) {
     Number.isFinite(Number(siteInput.lon))
       ? { lat: Number(siteInput.lat), lng: Number(siteInput.lon) }
       : null);
+  const originalCategory =
+    projectDetails.category ||
+    projectDetails.buildingCategory ||
+    sourceBrief.original_category ||
+    sourceBrief.originalCategory ||
+    input.originalCategory ||
+    input.category ||
+    null;
+  const originalSubtype =
+    projectDetails.subType ||
+    projectDetails.buildingSubType ||
+    sourceBrief.original_subtype ||
+    sourceBrief.originalSubtype ||
+    input.originalSubtype ||
+    input.subType ||
+    null;
+  const registrySupport = getProjectTypeSupport(
+    originalCategory,
+    originalSubtype,
+  );
+  const incomingSupport =
+    projectDetails.projectTypeSupport ||
+    sourceBrief.project_type_support ||
+    sourceBrief.projectTypeSupport ||
+    input.projectTypeSupport ||
+    {};
+  const projectTypeSupport = {
+    ...registrySupport,
+    ...incomingSupport,
+    categoryId: incomingSupport.categoryId || originalCategory,
+    subtypeId: incomingSupport.subtypeId || originalSubtype,
+    supportStatus:
+      incomingSupport.supportStatus ||
+      projectDetails.supportStatus ||
+      sourceBrief.support_status ||
+      sourceBrief.supportStatus ||
+      input.supportStatus ||
+      registrySupport.supportStatus,
+    canonicalBuildingType:
+      incomingSupport.canonicalBuildingType ||
+      projectDetails.canonicalBuildingType ||
+      sourceBrief.canonical_building_type ||
+      sourceBrief.canonicalBuildingType ||
+      input.canonicalBuildingType ||
+      registrySupport.canonicalBuildingType,
+    route:
+      incomingSupport.route ||
+      projectDetails.projectTypeRoute ||
+      sourceBrief.project_type_route ||
+      sourceBrief.projectTypeRoute ||
+      input.projectTypeRoute ||
+      registrySupport.route,
+    programmeTemplateKey:
+      incomingSupport.programmeTemplateKey ||
+      projectDetails.programmeTemplateKey ||
+      sourceBrief.programme_template_key ||
+      sourceBrief.programmeTemplateKey ||
+      input.programmeTemplateKey ||
+      registrySupport.programmeTemplateKey,
+  };
+  const projectTypeSupportMetadata =
+    buildProjectTypeSupportMetadata(projectTypeSupport);
   const buildingType = normalizeBuildingType({
     ...projectDetails,
     ...sourceBrief,
+    canonicalBuildingType: projectTypeSupportMetadata.canonicalBuildingType,
+    projectTypeSupport: projectTypeSupportMetadata,
   });
   const targetGiaM2 = Math.max(
     40,
@@ -692,6 +783,11 @@ function normalizeBrief(input = {}) {
     source: "active_generation_input",
     project_name: projectName,
     building_type: buildingType,
+    original_category: originalCategory,
+    original_subtype: originalSubtype,
+    support_status: projectTypeSupportMetadata.supportStatus,
+    programme_template_key: projectTypeSupportMetadata.programmeTemplateKey,
+    project_type_route: projectTypeSupportMetadata.route,
     address: activeAddress,
     postcode: siteInput.postcode || locationData.postcode || null,
     target_gia_m2: round(targetGiaM2, 2),
@@ -704,6 +800,13 @@ function normalizeBrief(input = {}) {
   return {
     project_name: projectName,
     building_type: buildingType,
+    canonical_building_type: buildingType,
+    original_category: originalCategory,
+    original_subtype: originalSubtype,
+    support_status: projectTypeSupportMetadata.supportStatus,
+    programme_template_key: projectTypeSupportMetadata.programmeTemplateKey,
+    project_type_route: projectTypeSupportMetadata.route,
+    project_type_support: projectTypeSupportMetadata,
     client_goals: toArray(
       sourceBrief.client_goals ||
         sourceBrief.clientGoals ||
@@ -1078,75 +1181,83 @@ function mixedUseProgrammeTemplate(upperLevel) {
 function officeStudioProgrammeTemplate(upperLevel) {
   return [
     [
-      "Reception and breakout",
-      "client arrival and informal meeting",
+      "Reception and client lounge",
+      "visitor arrival and front-of-house waiting",
       "public",
+      0.08,
+      0,
+      "medium",
+    ],
+    [
+      "Open office floorplate (ground)",
+      "primary desk workspace",
+      "semi_public",
+      0.22,
+      0,
+      "high",
+    ],
+    [
+      "Meeting suite",
+      "bookable meeting and collaboration rooms",
+      "semi_public",
       0.1,
       0,
       "medium",
     ],
     [
-      "Open studio (ground)",
-      "primary collaborative workspace",
+      "Collaboration and breakout",
+      "informal work and team breakout",
       "semi_public",
-      0.3,
-      0,
-      "high",
-    ],
-    [
-      "Meeting room",
-      "enclosed client meeting",
-      "semi_public",
-      0.07,
+      0.08,
       0,
       "medium",
     ],
     ["WC and accessible WC", "inclusive WCs", "service", 0.05, 0, "low"],
     [
-      "Tea point and store",
-      "kitchenette and storage",
-      "service",
-      0.05,
-      0,
-      "low",
-    ],
-    [
       "Ground circulation",
-      "stair, corridor and store",
+      "stair, corridor and reception support",
       "semi_public",
-      0.06,
+      0.07,
       0,
       "medium",
     ],
     [
-      "Open studio (upper)",
-      "additional desk space",
+      "Open office floorplate (upper)",
+      "additional desk workspace",
       "semi_public",
       0.2,
       upperLevel,
       "high",
     ],
     [
-      "Workshop or model room",
-      "physical making and prototyping",
+      "Focus and phone rooms",
+      "quiet focus booths and calls",
       "private",
-      0.08,
+      0.06,
       upperLevel,
       "medium",
     ],
     [
-      "Quiet focus room",
-      "phone and focus booths",
+      "Staff kitchen and welfare",
+      "staff kitchen, lockers and rest area",
       "private",
       0.05,
       upperLevel,
       "medium",
     ],
     [
-      "Upper circulation and store",
-      "landing and storage",
-      "semi_public",
+      "IT, storage and plant",
+      "server, storage and MEP plant",
+      "service",
       0.04,
+      upperLevel,
+      "low",
+    ],
+    [
+      "Upper circulation",
+      "landing, corridor and refuge",
+      "semi_public",
+      0.05,
       upperLevel,
       "medium",
     ],
@@ -1156,75 +1267,292 @@ function officeStudioProgrammeTemplate(upperLevel) {
 function educationStudioProgrammeTemplate(upperLevel) {
   return [
     [
-      "Entrance and showcase",
-      "public arrival and pupil work display",
+      "Entrance, reception and admin",
+      "secure arrival, administration and waiting",
       "public",
+      0.08,
+      0,
+      "high",
+    ],
+    [
+      "Classrooms (ground)",
+      "general teaching rooms",
+      "semi_public",
+      0.2,
+      0,
+      "high",
+    ],
+    [
+      "Assembly and multipurpose hall",
+      "assembly, indoor activity and community use",
+      "semi_public",
       0.1,
       0,
-      "high",
+      "medium",
     ],
     [
-      "Workshop (messy)",
-      "primary making space",
-      "semi_public",
-      0.22,
-      0,
-      "high",
-    ],
-    [
-      "Workshop store and prep",
-      "tool and material store",
+      "Pupil and accessible WCs",
+      "inclusive pupil WCs",
       "service",
-      0.07,
+      0.05,
       0,
       "low",
     ],
-    ["Accessible WC", "inclusive pupil WC", "service", 0.04, 0, "low"],
     [
-      "Plant and cleaner store",
-      "MEP plant and cleaner store",
+      "Dining and kitchen support",
+      "dining support, servery and back-of-house",
+      "service",
+      0.06,
+      0,
+      "medium",
+    ],
+    [
+      "Ground circulation",
+      "secure stair, corridor and cloak support",
+      "semi_public",
+      0.07,
+      0,
+      "medium",
+    ],
+    [
+      "Classrooms (upper)",
+      "additional general teaching rooms",
+      "semi_public",
+      0.22,
+      upperLevel,
+      "high",
+    ],
+    [
+      "Library and resource centre",
+      "reading, resources and small group learning",
+      "semi_public",
+      0.08,
+      upperLevel,
+      "medium",
+    ],
+    [
+      "Staff, prep and SEN support",
+      "staff base, prep and specialist support",
+      "private",
+      0.06,
+      upperLevel,
+      "high",
+    ],
+    [
+      "Plant and stores",
+      "MEP plant, curriculum storage and cleaner store",
+      "service",
+      0.03,
+      upperLevel,
+      "low",
+    ],
+    [
+      "Upper circulation",
+      "landing, corridor and refuge",
+      "semi_public",
+      0.05,
+      upperLevel,
+      "medium",
+    ],
+  ];
+}
+
+function clinicProgrammeTemplate(upperLevel) {
+  return [
+    [
+      "Reception and waiting",
+      "patient arrival and waiting",
+      "public",
+      0.12,
+      0,
+      "medium",
+    ],
+    [
+      "Consult rooms (ground)",
+      "primary consultation and triage rooms",
+      "semi_public",
+      0.16,
+      0,
+      "high",
+    ],
+    [
+      "Treatment suite",
+      "minor procedures and treatment",
+      "semi_public",
+      0.12,
+      0,
+      "medium",
+    ],
+    [
+      "Patient and accessible WCs",
+      "public clinical WCs",
       "service",
       0.04,
       0,
       "low",
     ],
     [
-      "Ground circulation",
-      "stair and corridor",
+      "Clean and dirty utility",
+      "clinical support and disposal",
+      "service",
+      0.06,
+      0,
+      "low",
+    ],
+    [
+      "Ground clinical circulation",
+      "patient corridor, stair and refuge",
       "semi_public",
-      0.07,
+      0.08,
       0,
       "medium",
     ],
     [
-      "Studio (clean)",
-      "drawing and design studio",
+      "Consult rooms (upper)",
+      "additional clinical consultation rooms",
       "semi_public",
-      0.2,
+      0.16,
       upperLevel,
       "high",
     ],
     [
-      "Seminar room",
-      "small group teaching",
-      "semi_public",
-      0.1,
+      "Staff and administration",
+      "clinical administration and staff base",
+      "private",
+      0.08,
       upperLevel,
       "medium",
     ],
     [
-      "Quiet study",
-      "focused individual work",
-      "private",
-      0.1,
+      "Records and clinical store",
+      "secure records and consumables store",
+      "service",
+      0.04,
       upperLevel,
-      "high",
+      "low",
     ],
     [
-      "Upper circulation",
-      "landing and storage",
+      "Staff welfare",
+      "staff rest, lockers and kitchenette",
+      "private",
+      0.04,
+      upperLevel,
+      "medium",
+    ],
+    [
+      "Plant and services",
+      "MEP plant and service riser",
+      "service",
+      0.04,
+      upperLevel,
+      "low",
+    ],
+    [
+      "Upper clinical circulation",
+      "clinical corridor, landing and refuge",
       "semi_public",
       0.06,
+      upperLevel,
+      "medium",
+    ],
+  ];
+}
+
+function hospitalProgrammeTemplate(upperLevel) {
+  return [
+    [
+      "Main reception and admissions",
+      "public arrival, admissions and waiting",
+      "public",
+      0.08,
+      0,
+      "medium",
+    ],
+    [
+      "Emergency and outpatient assessment",
+      "triage, outpatient and urgent assessment",
+      "semi_public",
+      0.12,
+      0,
+      "medium",
+    ],
+    [
+      "Diagnostics",
+      "imaging, diagnostics and testing",
+      "semi_public",
+      0.1,
+      0,
+      "low",
+    ],
+    [
+      "Clinical support and utility",
+      "clean utility, dirty utility and treatment support",
+      "service",
+      0.07,
+      0,
+      "low",
+    ],
+    [
+      "Public WCs and cafe support",
+      "public WCs and refreshment support",
+      "public",
+      0.05,
+      0,
+      "medium",
+    ],
+    [
+      "Ground hospital circulation",
+      "public concourse, clinical corridor and stair",
+      "semi_public",
+      0.08,
+      0,
+      "medium",
+    ],
+    [
+      "Ward and day rooms",
+      "patient rooms, bay wards and day space",
+      "private",
+      0.18,
+      upperLevel,
+      "medium",
+    ],
+    [
+      "Treatment and consult suites",
+      "clinical treatment and consultation rooms",
+      "semi_public",
+      0.09,
+      upperLevel,
+      "medium",
+    ],
+    [
+      "Staff and administration base",
+      "staff base, changing and administration",
+      "private",
+      0.07,
+      upperLevel,
+      "medium",
+    ],
+    [
+      "Pharmacy, stores and logistics",
+      "medicines, supplies and FM logistics",
+      "service",
+      0.05,
+      upperLevel,
+      "low",
+    ],
+    [
+      "Plant and services",
+      "MEP plant and service risers",
+      "service",
+      0.04,
+      upperLevel,
+      "low",
+    ],
+    [
+      "Upper hospital circulation",
+      "clinical corridor, lift lobby and refuge",
+      "semi_public",
+      0.07,
       upperLevel,
       "medium",
     ],
@@ -1261,6 +1589,16 @@ function getProgrammeTemplate(buildingType, upperLevel) {
     case "education_studio":
       return {
         template: educationStudioProgrammeTemplate(upperLevel),
+        fallback: false,
+      };
+    case "clinic":
+      return {
+        template: clinicProgrammeTemplate(upperLevel),
+        fallback: false,
+      };
+    case "hospital":
+      return {
+        template: hospitalProgrammeTemplate(upperLevel),
         fallback: false,
       };
     default:
@@ -1337,12 +1675,18 @@ function buildTemplateProgramSpaces(brief) {
           source: "fallback_template",
           requested_building_type: fallbackFrom,
           resolved_template: "community",
+          programme_template_key:
+            brief.programme_template_key || brief.building_type,
+          support_status: brief.support_status || null,
           severity: "warning",
           message: `building_type "${fallbackFrom}" not in KNOWN_BUILDING_TYPES; using community template as deterministic fallback.`,
         }
       : {
           source: "matched_template",
           resolved_template: brief.building_type,
+          programme_template_key:
+            brief.programme_template_key || brief.building_type,
+          support_status: brief.support_status || null,
           severity: "info",
         },
   };
@@ -1357,6 +1701,8 @@ function buildProgramme({ brief, programSpaces = [] } = {}) {
     templateProvenance = {
       source: "user_supplied",
       resolved_template: null,
+      programme_template_key: brief.programme_template_key || null,
+      support_status: brief.support_status || null,
       severity: "info",
     };
   } else {
@@ -3611,6 +3957,19 @@ function todayIsoDate() {
   }
 }
 
+function resolveProgrammeDisplayLabel(brief = {}) {
+  return String(
+    brief?.project_type_support?.label ||
+      brief?.projectTypeSupport?.label ||
+      brief?.programme_label ||
+      brief?.programmeLabel ||
+      brief?.building_type ||
+      "architecture",
+  )
+    .replace(/[_-]+/g, " ")
+    .trim();
+}
+
 export function buildTitleBlockPanelArtifact({
   projectGraphId,
   brief,
@@ -3634,9 +3993,7 @@ export function buildTitleBlockPanelArtifact({
     .trim()
     .toUpperCase();
   const titleLines = splitNoteLines(projectTitle, 22, 2);
-  const programmeLabel = String(brief?.building_type || "architecture")
-    .replace(/[_-]+/g, " ")
-    .trim();
+  const programmeLabel = resolveProgrammeDisplayLabel(brief);
   const ribaStageLabel = resolveRibaStageLabel(brief, sheetPlan);
   const status = String(
     brief?.status ||
@@ -3708,7 +4065,7 @@ export function buildTitleBlockPanelArtifact({
   <rect width="${width}" height="${height}" fill="#ffffff"/>
   <rect x="18" y="18" width="584" height="864" fill="none" stroke="#111111" stroke-width="3"/>
   ${titleSvg}
-  <text x="34" y="170" font-family="Arial, sans-serif" font-size="20" fill="#333333">${escapeXml((brief?.building_type || "architecture").replace(/_/g, " ").toUpperCase())}</text>
+  <text x="34" y="170" font-family="Arial, sans-serif" font-size="20" fill="#333333">${escapeXml(programmeLabel.toUpperCase())}</text>
   <line x1="34" y1="206" x2="586" y2="206" stroke="#111111" stroke-width="2"/>
   ${rowSvg}
   <line x1="34" y1="780" x2="586" y2="780" stroke="#111111" stroke-width="1"/>
@@ -3752,6 +4109,10 @@ export function buildTitleBlockPanelArtifact({
       targetGiaM2: Number(brief?.target_gia_m2 || 0),
       targetStoreys: Number(brief?.target_storeys || 1),
       buildingType: brief?.building_type || null,
+      programmeLabel,
+      supportStatus: brief?.support_status || null,
+      programmeTemplateKey: brief?.programme_template_key || null,
+      projectTypeRoute: brief?.project_type_route || null,
       drawingNumber,
       sheetLabel,
       // Phase 2 — RIBA-style metadata fields
@@ -7644,6 +8005,7 @@ function buildProjectGraph({
     jurisdiction: regulations?.jurisdiction || "england",
     brief,
     user_intent: brief.user_intent,
+    project_type_support: brief.project_type_support || null,
     site,
     climate,
     regulations,
@@ -8370,6 +8732,12 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     brief: {
       project_name: brief?.project_name || null,
       building_type: brief?.building_type || null,
+      original_category: brief?.original_category || null,
+      original_subtype: brief?.original_subtype || null,
+      canonical_building_type: brief?.canonical_building_type || null,
+      support_status: brief?.support_status || null,
+      programme_template_key: brief?.programme_template_key || null,
+      project_type_route: brief?.project_type_route || null,
       target_gia_m2: brief?.target_gia_m2 || null,
       target_storeys: brief?.target_storeys || null,
       floorCountLocked:
@@ -8434,6 +8802,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     success: qa.status === "pass",
     pipelineVersion: PROJECT_GRAPH_VERTICAL_SLICE_VERSION,
     geometryHash: compiledProject.geometryHash,
+    projectTypeSupport: brief.project_type_support || null,
     projectGraph: finalGraph,
     artifacts: {
       ...artifacts,
@@ -8474,6 +8843,17 @@ export async function buildArchitectureProjectVerticalSliceWithRepair(
     maxAttempts,
   });
 }
+
+export const __projectGraphVerticalSliceInternals = Object.freeze({
+  normalizeBrief,
+  buildProgramme,
+  buildSiteContext,
+  buildClimatePack,
+  buildLocalStylePack,
+  buildProjectGeometryFromProgramme,
+  syncProgrammeActuals,
+  compileProject,
+});
 
 export default {
   PROJECT_GRAPH_SCHEMA_VERSION,

--- a/src/services/project/projectTypeSupportRegistry.js
+++ b/src/services/project/projectTypeSupportRegistry.js
@@ -1,0 +1,257 @@
+import {
+  BUILDING_CATEGORIES,
+  getSubTypeById,
+} from "../../data/buildingTypes.js";
+import { isSupportedResidentialV2SubType } from "./v2ProjectContracts.js";
+
+export const PROJECT_TYPE_SUPPORT_STATUS = Object.freeze({
+  PRODUCTION: "production",
+  BETA: "beta",
+  EXPERIMENTAL: "experimental",
+  DISABLED: "disabled",
+});
+
+export const PROJECT_TYPE_ROUTES = Object.freeze({
+  RESIDENTIAL_V2: "residential_v2",
+  PROJECT_GRAPH: "project_graph",
+});
+
+export const PROJECT_GRAPH_PROJECT_TYPE_PIPELINE_VERSION =
+  "project-graph-project-types-v1";
+
+const DEFAULT_DISABLED_MESSAGE =
+  "Experimental/off in the current production ProjectGraph rollout.";
+
+const RESIDENTIAL_CANONICAL_BY_SUBTYPE = Object.freeze({
+  "detached-house": "dwelling",
+  "semi-detached-house": "dwelling",
+  "terraced-house": "dwelling",
+  villa: "dwelling",
+  cottage: "dwelling",
+  "apartment-building": "multi_residential",
+  "multi-family": "multi_residential",
+  duplex: "dwelling",
+});
+
+const ENABLED_OVERRIDES = Object.freeze({
+  "commercial:office": {
+    supportStatus: PROJECT_TYPE_SUPPORT_STATUS.PRODUCTION,
+    canonicalBuildingType: "office_studio",
+    route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+    enabledInUi: true,
+    message: "ProjectGraph office support is enabled.",
+    reason: "Office is backed by the ProjectGraph office programme template.",
+    programmeTemplateKey: "office_studio",
+    badgeLabel: "ProjectGraph",
+  },
+  "education:school": {
+    supportStatus: PROJECT_TYPE_SUPPORT_STATUS.BETA,
+    canonicalBuildingType: "education_studio",
+    route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+    enabledInUi: true,
+    message: "Beta ProjectGraph school support is enabled.",
+    reason:
+      "School is available as a beta ProjectGraph route with a deterministic education template.",
+    programmeTemplateKey: "education_studio",
+    badgeLabel: "Beta ProjectGraph",
+  },
+  "healthcare:clinic": {
+    supportStatus: PROJECT_TYPE_SUPPORT_STATUS.PRODUCTION,
+    canonicalBuildingType: "clinic",
+    route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+    enabledInUi: true,
+    message: "ProjectGraph clinic support is enabled.",
+    reason: "Clinic is backed by the ProjectGraph clinic programme template.",
+    programmeTemplateKey: "clinic",
+    badgeLabel: "ProjectGraph",
+  },
+  "healthcare:hospital": {
+    supportStatus: PROJECT_TYPE_SUPPORT_STATUS.BETA,
+    canonicalBuildingType: "hospital",
+    route: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+    enabledInUi: true,
+    message: "Beta ProjectGraph hospital support is enabled.",
+    reason:
+      "Hospital is available as a beta ProjectGraph route with a deterministic hospital template.",
+    programmeTemplateKey: "hospital",
+    badgeLabel: "Beta ProjectGraph",
+  },
+});
+
+function registryKey(categoryId, subtypeId) {
+  return `${String(categoryId || "").trim()}:${String(subtypeId || "").trim()}`;
+}
+
+function labelFor(categoryId, subtypeId) {
+  const subType = getSubTypeById(categoryId, subtypeId);
+  return subType?.label || subtypeId || categoryId || "Project type";
+}
+
+function createDisabledEntry(category, subType) {
+  return {
+    categoryId: category.id,
+    subtypeId: subType.id,
+    label: subType.label,
+    supportStatus: PROJECT_TYPE_SUPPORT_STATUS.DISABLED,
+    canonicalBuildingType: null,
+    route: null,
+    enabledInUi: false,
+    reason: DEFAULT_DISABLED_MESSAGE,
+    message: DEFAULT_DISABLED_MESSAGE,
+    programmeTemplateKey: null,
+    badgeLabel: "Experimental/off",
+  };
+}
+
+function createResidentialEntry(category, subType) {
+  const supported = isSupportedResidentialV2SubType(subType.id);
+  if (!supported) {
+    return {
+      ...createDisabledEntry(category, subType),
+      reason: "Outside the supported UK Residential V2 production subtype set.",
+      message:
+        "UK Residential V2 currently supports selected low-rise residential subtypes only.",
+    };
+  }
+
+  return {
+    categoryId: category.id,
+    subtypeId: subType.id,
+    label: subType.label,
+    supportStatus: PROJECT_TYPE_SUPPORT_STATUS.PRODUCTION,
+    canonicalBuildingType:
+      RESIDENTIAL_CANONICAL_BY_SUBTYPE[subType.id] || "dwelling",
+    route: PROJECT_TYPE_ROUTES.RESIDENTIAL_V2,
+    enabledInUi: true,
+    reason: "Supported by the production UK Residential V2 route.",
+    message: "Production Residential V2 support is enabled.",
+    programmeTemplateKey: subType.id,
+    badgeLabel: "Residential V2",
+  };
+}
+
+function buildRegistry() {
+  const entries = [];
+  Object.values(BUILDING_CATEGORIES).forEach((category) => {
+    category.subTypes.forEach((subType) => {
+      const key = registryKey(category.id, subType.id);
+      if (category.id === "residential") {
+        entries.push(createResidentialEntry(category, subType));
+        return;
+      }
+      const override = ENABLED_OVERRIDES[key];
+      if (override) {
+        entries.push({
+          categoryId: category.id,
+          subtypeId: subType.id,
+          label: subType.label,
+          ...override,
+        });
+        return;
+      }
+      entries.push(createDisabledEntry(category, subType));
+    });
+  });
+  return entries;
+}
+
+export const PROJECT_TYPE_SUPPORT_REGISTRY = Object.freeze(buildRegistry());
+
+const PROJECT_TYPE_SUPPORT_BY_KEY = Object.freeze(
+  Object.fromEntries(
+    PROJECT_TYPE_SUPPORT_REGISTRY.map((entry) => [
+      registryKey(entry.categoryId, entry.subtypeId),
+      Object.freeze({ ...entry }),
+    ]),
+  ),
+);
+
+export function getProjectTypeSupport(categoryId, subtypeId) {
+  const key = registryKey(categoryId, subtypeId);
+  const entry = PROJECT_TYPE_SUPPORT_BY_KEY[key];
+  if (entry) return entry;
+
+  return {
+    categoryId: categoryId || null,
+    subtypeId: subtypeId || null,
+    label: labelFor(categoryId, subtypeId),
+    supportStatus: PROJECT_TYPE_SUPPORT_STATUS.DISABLED,
+    canonicalBuildingType: null,
+    route: null,
+    enabledInUi: false,
+    reason: DEFAULT_DISABLED_MESSAGE,
+    message: DEFAULT_DISABLED_MESSAGE,
+    programmeTemplateKey: null,
+    badgeLabel: "Experimental/off",
+  };
+}
+
+export function getProjectTypeSupportForDetails(projectDetails = {}) {
+  return getProjectTypeSupport(
+    projectDetails.category || projectDetails.buildingCategory,
+    projectDetails.subType ||
+      projectDetails.buildingSubType ||
+      projectDetails.program,
+  );
+}
+
+export function isProjectTypeEnabled(categoryId, subtypeId) {
+  const support = getProjectTypeSupport(categoryId, subtypeId);
+  return support.enabledInUi === true && Boolean(support.route);
+}
+
+export function isResidentialV2ProjectType(categoryId, subtypeId) {
+  return (
+    getProjectTypeSupport(categoryId, subtypeId).route ===
+    PROJECT_TYPE_ROUTES.RESIDENTIAL_V2
+  );
+}
+
+export function getCategorySupportSummary(categoryId) {
+  const entries = PROJECT_TYPE_SUPPORT_REGISTRY.filter(
+    (entry) => entry.categoryId === categoryId,
+  );
+  const enabledEntries = entries.filter((entry) => entry.enabledInUi === true);
+  return {
+    categoryId,
+    entries,
+    enabledEntries,
+    enabledCount: enabledEntries.length,
+    totalCount: entries.length,
+    enabledInUi: enabledEntries.length > 0,
+    supportStatuses: [...new Set(entries.map((entry) => entry.supportStatus))],
+    message:
+      enabledEntries.length > 0
+        ? `${enabledEntries.length} supported project type${enabledEntries.length === 1 ? "" : "s"} available.`
+        : DEFAULT_DISABLED_MESSAGE,
+  };
+}
+
+export function buildProjectTypeSupportMetadata(support) {
+  const resolved = support || getProjectTypeSupport(null, null);
+  return {
+    categoryId: resolved.categoryId,
+    subtypeId: resolved.subtypeId,
+    label: resolved.label,
+    supportStatus: resolved.supportStatus,
+    canonicalBuildingType: resolved.canonicalBuildingType,
+    route: resolved.route,
+    enabledInUi: resolved.enabledInUi,
+    reason: resolved.reason,
+    message: resolved.message,
+    programmeTemplateKey: resolved.programmeTemplateKey,
+  };
+}
+
+export default {
+  PROJECT_TYPE_SUPPORT_STATUS,
+  PROJECT_TYPE_ROUTES,
+  PROJECT_GRAPH_PROJECT_TYPE_PIPELINE_VERSION,
+  PROJECT_TYPE_SUPPORT_REGISTRY,
+  getProjectTypeSupport,
+  getProjectTypeSupportForDetails,
+  getCategorySupportSummary,
+  isProjectTypeEnabled,
+  isResidentialV2ProjectType,
+  buildProjectTypeSupportMetadata,
+};


### PR DESCRIPTION
## Summary
- Added a central `projectTypeSupportRegistry` for production/beta/disabled project-type support.
- Kept Residential V2 on the existing `residential_v2` route and enabled only Office, School, Clinic, and Hospital on `project_graph`.
- Updated selector, specs proceed logic, wizard generation guards, ProjectGraph payload metadata, canonical building type normalization, and non-residential programme templates.
- Preserved original category/subtype and support metadata through ProjectGraph output, and adjusted title/key-note language away from residential-only wording for non-residential types.

## Enabled project types
- Residential supported V2 subtypes: production, `residential_v2`.
- Commercial / Office: production, `office_studio`, `project_graph`.
- Education / School: beta, `education_studio`, `project_graph`.
- Healthcare / Clinic: production, `clinic`, `project_graph`.
- Healthcare / Hospital: beta, `hospital`, `project_graph`.
- Other categories/subtypes remain visible but disabled with Experimental/off status.

## Validation
Passed:
- `npm run check:env`
- `npm run check:contracts`
- `npm run lint`
- `npm run build:active`
- `npm run test:a1:tofu`
- `npm run test:compose:routing`
- `node scripts/tests/test-a1-layout-regression.mjs`
- `npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/components/BuildingTypeSelector.support.test.js src/__tests__/components/SpecsStep.projectTypeSupport.test.js src/__tests__/components/ArchitectAIWizardContainer.projectTypeSupport.test.js src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js`
- `npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/projectTypeSupportRegistry.test.js`
- `npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/projectPipelineV2Service.test.js`
- Focused ProjectGraph service test: `--testNamePattern="maps .* ProjectGraph programme metadata|known building_type (office_studio|education_studio)"`

Attempted but not completed cleanly:
- Exact combined requested command with hook + full `projectGraphVerticalSliceService.test.js` + `projectPipelineV2Service.test.js`; the ProjectGraph worker stayed CPU-active for the long A1/PDF suite window, then the tool session exited without a Jest summary. Orphaned `react-scripts test` processes were stopped. Focused service coverage above was rerun afterward.

## Smoke results
- Detached house: PASS direct deterministic ProjectGraph/A1 smoke. QA `pass`, `building_type=dwelling`, original `residential/detached-house`, 10 programme spaces, 2 levels, geometry hash `70c0cfe71080ca66`, A1 sheet and PDF present, title programme `Detached House`.
- Office: PASS targeted ProjectGraph/A1 service smoke; reached ProjectGraph, generated A1/PDF, QA pass.
- School: PASS targeted ProjectGraph/A1 service smoke; reached ProjectGraph, generated A1/PDF, QA pass.
- Clinic: PASS targeted ProjectGraph/A1 service smoke; reached ProjectGraph, generated A1/PDF, QA pass.
- Hospital: PASS targeted ProjectGraph/A1 service smoke; reached ProjectGraph, generated A1/PDF, QA pass.

No generated outputs are staged or committed.