### PR TITLE
[codex] Store A1 history assets as artifact URLs

### DIFF
--- a/src/__tests__/services/designHistoryRepository.storage.test.js
+++ b/src/__tests__/services/designHistoryRepository.storage.test.js
@@ -1,4 +1,7 @@
 import designHistoryRepository from "../../services/designHistoryRepository.js";
+import designHistoryArtifactStore, {
+  isDesignHistoryArtifactUrl,
+} from "../../services/designHistoryArtifactStore.js";
 import { StorageManager } from "../../utils/storageManager.js";
 
 jest.mock("../../utils/logger.js", () => ({
@@ -164,6 +167,7 @@ describe("design history storage hardening", () => {
   beforeEach(async () => {
     installStorageMock(320_000);
     await designHistoryRepository.clearAllDesigns();
+    await designHistoryArtifactStore.clearAllArtifacts();
     jest.clearAllMocks();
   });
 
@@ -220,5 +224,109 @@ describe("design history storage hardening", () => {
       window.localStorage.getItem("archiAI_design_history"),
     );
     expect(stored.payload).toHaveLength(1_100);
+  });
+
+  it("stores A1 data URLs as artifact URLs and keeps history lightweight", async () => {
+    const sheetDataUrl = buildLargeDataUrl(48);
+    const pdfDataUrl = `data:application/pdf;base64,${"J".repeat(32 * 1024)}`;
+    const panelSvg =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="50"/></svg>';
+
+    await expect(
+      designHistoryRepository.saveDesign({
+        designId: "artifact_design",
+        dna: {
+          dimensions: { length: 13, width: 9, height: 6, floors: 2 },
+          materials: [{ name: "Brick", hexColor: "#aa5533" }],
+          rooms: [{ name: "Room", dimensions: "4m x 4m", floor: "ground" }],
+        },
+        resultUrl: sheetDataUrl,
+        composedSheetUrl: sheetDataUrl,
+        pdfUrl: pdfDataUrl,
+        panelMap: {
+          plan: {
+            panelType: "floor_plan_ground",
+            imageUrl: sheetDataUrl,
+            svgString: panelSvg,
+            width: 100,
+            height: 50,
+            metadata: { geometryHash: "geometry-hash-1" },
+          },
+        },
+        sheetMetadata: {
+          width: 1792,
+          height: 1269,
+          geometryHash: "geometry-hash-1",
+          exportGate: { allowed: true },
+        },
+        a1Sheet: {
+          sheetId: "default",
+          url: sheetDataUrl,
+          composedSheetUrl: sheetDataUrl,
+          pdfUrl: pdfDataUrl,
+          metadata: {
+            width: 1792,
+            height: 1269,
+            geometryHash: "geometry-hash-1",
+            exportGate: { allowed: true },
+          },
+          panelMap: {
+            plan: {
+              panelType: "floor_plan_ground",
+              imageUrl: sheetDataUrl,
+              svgString: panelSvg,
+              width: 100,
+              height: 50,
+            },
+          },
+          compiledProject: {
+            huge: "compiled payload should not be in history",
+          },
+        },
+      }),
+    ).resolves.toBe("artifact_design");
+
+    const rawHistory = window.localStorage.getItem("archiAI_design_history");
+    const storedDesign =
+      await designHistoryRepository.getDesignById("artifact_design");
+    const storedJson = JSON.stringify(storedDesign);
+
+    expect(rawHistory).toBeTruthy();
+    expect(rawHistory).not.toContain("data:image");
+    expect(rawHistory).not.toContain("data:application/pdf");
+    expect(rawHistory).not.toContain("[DATA_URL_REMOVED");
+    expect(rawHistory).not.toContain(panelSvg);
+    expect(isDesignHistoryArtifactUrl(storedDesign.resultUrl)).toBe(true);
+    expect(isDesignHistoryArtifactUrl(storedDesign.pdfUrl)).toBe(true);
+    expect(isDesignHistoryArtifactUrl(storedDesign.a1Sheet.pdfUrl)).toBe(true);
+    expect(
+      isDesignHistoryArtifactUrl(storedDesign.panelMap.plan.imageUrl),
+    ).toBe(true);
+    expect(
+      isDesignHistoryArtifactUrl(storedDesign.panelMap.plan.svgArtifactUrl),
+    ).toBe(true);
+    expect(storedDesign.panelMap.plan.dataUrl).toBeUndefined();
+    expect(storedDesign.panelMap.plan.svgString).toBeUndefined();
+    expect(storedDesign.a1Sheet.compiledProject).toBeUndefined();
+    expect(storedDesign.a1ArtifactManifest).toEqual(
+      expect.objectContaining({
+        schema_version: "a1-artifact-url-manifest-v1",
+        designId: "artifact_design",
+      }),
+    );
+    expect(storedJson).toContain("artifactManifest");
+    expect(storedJson).not.toContain(
+      "compiled payload should not be in history",
+    );
+
+    const sheetRecord = await designHistoryArtifactStore.getRecord(
+      storedDesign.resultUrl,
+    );
+    const pdfRecord = await designHistoryArtifactStore.getRecord(
+      storedDesign.pdfUrl,
+    );
+
+    expect(sheetRecord.payload).toBe(sheetDataUrl);
+    expect(pdfRecord.payload).toBe(pdfDataUrl);
   });
 });

--- a/src/__tests__/services/designHistoryResultHydrator.test.js
+++ b/src/__tests__/services/designHistoryResultHydrator.test.js
@@ -1,0 +1,130 @@
+import designHistoryRepository from "../../services/designHistoryRepository.js";
+import designHistoryArtifactStore, {
+  isDesignHistoryArtifactUrl,
+  resolveDesignHistoryArtifactUrlToObjectUrl,
+} from "../../services/designHistoryArtifactStore.js";
+import { buildSheetResultFromDesignHistoryEntry } from "../../services/designHistoryResultHydrator.js";
+
+jest.mock("../../utils/logger.js", () => ({
+  info: jest.fn(),
+  success: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const pngDataUrl = `data:image/png;base64,${Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]).toString("base64")}`;
+const pdfDataUrl = `data:application/pdf;base64,${Buffer.from(
+  "%PDF-1.7\n",
+  "utf8",
+).toString("base64")}`;
+const panelSvg =
+  '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="50"/></svg>';
+
+describe("design history result hydration", () => {
+  const createdBlobs = [];
+
+  beforeEach(async () => {
+    createdBlobs.length = 0;
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      writable: true,
+      value: jest.fn((blob) => {
+        createdBlobs.push(blob);
+        return `blob:history-artifact-${createdBlobs.length}`;
+      }),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+
+    window.localStorage.clear();
+    await designHistoryRepository.clearAllDesigns();
+    await designHistoryArtifactStore.clearAllArtifacts();
+  });
+
+  it("rehydrates a saved A1 result and resolves artifact URLs from a fresh history read", async () => {
+    await designHistoryRepository.saveDesign({
+      designId: "restore_design",
+      resultUrl: pngDataUrl,
+      composedSheetUrl: pngDataUrl,
+      pdfUrl: pdfDataUrl,
+      sheetMetadata: {
+        width: 1792,
+        height: 1269,
+        exportGate: { allowed: true },
+        geometryHash: "geometry-hash-restore",
+      },
+      panelMap: {
+        site_context: {
+          label: "Site Context",
+          imageUrl: pngDataUrl,
+          svgString: panelSvg,
+          width: 100,
+          height: 50,
+          metadata: { geometryHash: "geometry-hash-restore" },
+        },
+      },
+      a1Sheet: {
+        sheetId: "default",
+        url: pngDataUrl,
+        composedSheetUrl: pngDataUrl,
+        pdfUrl: pdfDataUrl,
+        metadata: {
+          width: 1792,
+          height: 1269,
+          exportGate: { allowed: true },
+          geometryHash: "geometry-hash-restore",
+        },
+        panelMap: {
+          site_context: {
+            label: "Site Context",
+            imageUrl: pngDataUrl,
+            width: 100,
+            height: 50,
+          },
+        },
+      },
+    });
+
+    const rawHistory = window.localStorage.getItem("archiAI_design_history");
+    const storedDesign =
+      await designHistoryRepository.getDesignById("restore_design");
+    const restoredResult = buildSheetResultFromDesignHistoryEntry(storedDesign);
+
+    expect(rawHistory).toBeTruthy();
+    expect(rawHistory).not.toContain("data:image");
+    expect(rawHistory).not.toContain("data:application/pdf");
+    expect(restoredResult.restoredFromHistory).toBe(true);
+    expect(isDesignHistoryArtifactUrl(restoredResult.a1Sheet.url)).toBe(true);
+    expect(isDesignHistoryArtifactUrl(restoredResult.pdfUrl)).toBe(true);
+    expect(
+      isDesignHistoryArtifactUrl(restoredResult.panelMap.site_context.imageUrl),
+    ).toBe(true);
+    expect(restoredResult.panelsByKey.site_context.label).toBe("Site Context");
+    expect(restoredResult.panels).toHaveLength(1);
+    expect(restoredResult.metadata.exportGate.allowed).toBe(true);
+
+    await expect(
+      resolveDesignHistoryArtifactUrlToObjectUrl(restoredResult.a1Sheet.url),
+    ).resolves.toBe("blob:history-artifact-1");
+    await expect(
+      resolveDesignHistoryArtifactUrlToObjectUrl(
+        restoredResult.panelMap.site_context.imageUrl,
+      ),
+    ).resolves.toBe("blob:history-artifact-2");
+    await expect(
+      resolveDesignHistoryArtifactUrlToObjectUrl(restoredResult.pdfUrl),
+    ).resolves.toBe("blob:history-artifact-3");
+
+    expect(createdBlobs.map((blob) => blob.type)).toEqual([
+      "image/png",
+      "image/png",
+      "application/pdf",
+    ]);
+  });
+});

--- a/src/components/A1PanelGallery.jsx
+++ b/src/components/A1PanelGallery.jsx
@@ -13,6 +13,10 @@ import {
   sanitizeSvgDataUrl,
   svgToSanitizedDataUrl,
 } from "../utils/svgPathSanitizer.js";
+import {
+  isDesignHistoryArtifactUrl,
+  resolveDesignHistoryArtifactUrlToObjectUrl,
+} from "../services/designHistoryArtifactStore.js";
 
 function svgToDataUrl(svgString = "") {
   return svgToSanitizedDataUrl(svgString);
@@ -81,7 +85,13 @@ function extractPanels(result) {
 }
 
 const A1PanelGallery = ({ result }) => {
-  const panels = extractPanels(result);
+  const panels = React.useMemo(() => extractPanels(result), [result]);
+  const artifactPanelUrls = React.useMemo(
+    () =>
+      panels.map((panel) => panel.imageUrl).filter(isDesignHistoryArtifactUrl),
+    [panels],
+  );
+  const [artifactObjectUrlMap, setArtifactObjectUrlMap] = useState({});
   const [selectedIndex, setSelectedIndex] = useState(null);
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
@@ -90,7 +100,72 @@ const A1PanelGallery = ({ result }) => {
   const [isDownloading, setIsDownloading] = useState(false);
   const imageContainerRef = useRef(null);
 
-  const selectedPanel = selectedIndex !== null ? panels[selectedIndex] : null;
+  useEffect(() => {
+    let isCancelled = false;
+    const objectUrls = [];
+
+    async function resolvePanelArtifacts() {
+      if (artifactPanelUrls.length === 0) {
+        setArtifactObjectUrlMap({});
+        return;
+      }
+
+      const entries = await Promise.all(
+        artifactPanelUrls.map(async (artifactUrl) => {
+          try {
+            const objectUrl =
+              await resolveDesignHistoryArtifactUrlToObjectUrl(artifactUrl);
+            if (objectUrl) {
+              objectUrls.push(objectUrl);
+              return [artifactUrl, objectUrl];
+            }
+          } catch {
+            // Keep the unresolved artifact URL; the viewer will simply skip it.
+          }
+          return [artifactUrl, null];
+        }),
+      );
+
+      if (!isCancelled) {
+        setArtifactObjectUrlMap(
+          Object.fromEntries(
+            entries.filter(([, objectUrl]) => Boolean(objectUrl)),
+          ),
+        );
+      }
+    }
+
+    resolvePanelArtifacts();
+
+    return () => {
+      isCancelled = true;
+      objectUrls.forEach((objectUrl) => {
+        try {
+          URL.revokeObjectURL(objectUrl);
+        } catch {
+          // Ignore revoke failures for already-released object URLs.
+        }
+      });
+    };
+  }, [artifactPanelUrls]);
+
+  const displayPanels = React.useMemo(
+    () =>
+      panels
+        .map((panel) => ({
+          ...panel,
+          imageUrl:
+            artifactObjectUrlMap[panel.imageUrl] ||
+            (isDesignHistoryArtifactUrl(panel.imageUrl)
+              ? null
+              : panel.imageUrl),
+        }))
+        .filter((panel) => panel.imageUrl),
+    [artifactObjectUrlMap, panels],
+  );
+
+  const selectedPanel =
+    selectedIndex !== null ? displayPanels[selectedIndex] : null;
 
   const resetView = useCallback(() => {
     setZoom(1);
@@ -111,18 +186,20 @@ const A1PanelGallery = ({ result }) => {
   }, [resetView]);
 
   const goToPrev = useCallback(() => {
-    if (selectedIndex === null || panels.length === 0) return;
-    const prev = selectedIndex === 0 ? panels.length - 1 : selectedIndex - 1;
+    if (selectedIndex === null || displayPanels.length === 0) return;
+    const prev =
+      selectedIndex === 0 ? displayPanels.length - 1 : selectedIndex - 1;
     setSelectedIndex(prev);
     resetView();
-  }, [selectedIndex, panels.length, resetView]);
+  }, [selectedIndex, displayPanels.length, resetView]);
 
   const goToNext = useCallback(() => {
-    if (selectedIndex === null || panels.length === 0) return;
-    const next = selectedIndex === panels.length - 1 ? 0 : selectedIndex + 1;
+    if (selectedIndex === null || displayPanels.length === 0) return;
+    const next =
+      selectedIndex === displayPanels.length - 1 ? 0 : selectedIndex + 1;
     setSelectedIndex(next);
     resetView();
-  }, [selectedIndex, panels.length, resetView]);
+  }, [selectedIndex, displayPanels.length, resetView]);
 
   const handleZoomIn = useCallback(() => {
     setZoom((z) => Math.min(z + 0.5, 4));
@@ -239,7 +316,7 @@ const A1PanelGallery = ({ result }) => {
     };
   }, [selectedIndex]);
 
-  if (!panels.length) {
+  if (!displayPanels.length) {
     return (
       <Card variant="glass" padding="lg" className="text-center">
         <p className="text-gray-400">No individual panels available.</p>
@@ -256,13 +333,13 @@ const A1PanelGallery = ({ result }) => {
               A1 Panel Gallery
             </h3>
             <p className="text-sm text-gray-400">
-              {panels.length} panels — click to zoom
+              {displayPanels.length} panels — click to zoom
             </p>
           </div>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {panels.map((panel, index) => (
+          {displayPanels.map((panel, index) => (
             <div
               key={panel.key}
               onClick={() => openPanel(index)}
@@ -322,7 +399,7 @@ const A1PanelGallery = ({ result }) => {
                 {selectedPanel.label}
               </span>
               <span className="text-gray-400 text-sm whitespace-nowrap">
-                {selectedIndex + 1} / {panels.length}
+                {selectedIndex + 1} / {displayPanels.length}
               </span>
             </div>
 
@@ -384,7 +461,7 @@ const A1PanelGallery = ({ result }) => {
             }}
           >
             {/* Prev button */}
-            {panels.length > 1 && (
+            {displayPanels.length > 1 && (
               <button
                 onClick={goToPrev}
                 className="absolute left-3 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-black/50 hover:bg-black/70 text-white/80 hover:text-white transition-colors"
@@ -395,7 +472,7 @@ const A1PanelGallery = ({ result }) => {
             )}
 
             {/* Next button */}
-            {panels.length > 1 && (
+            {displayPanels.length > 1 && (
               <button
                 onClick={goToNext}
                 className="absolute right-3 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-black/50 hover:bg-black/70 text-white/80 hover:text-white transition-colors"

--- a/src/components/A1SheetViewer.jsx
+++ b/src/components/A1SheetViewer.jsx
@@ -18,6 +18,10 @@ import {
 
 // Removed html-to-image - using direct fetch download instead
 import logger from "../services/core/logger.js";
+import {
+  isDesignHistoryArtifactUrl,
+  resolveDesignHistoryArtifactUrlToObjectUrl,
+} from "../services/designHistoryArtifactStore.js";
 import { fadeInUp } from "../styles/animations.js";
 import { normalizeSheetMetadata } from "../types/schemas.js";
 import { sanitizeSvgDataUrl } from "../utils/svgPathSanitizer.js";
@@ -172,6 +176,86 @@ const A1SheetViewer = ({
       }))
       .filter((entry) => entry.pdfUrl);
   }, [result]);
+  const artifactSourceUrls = React.useMemo(
+    () =>
+      [
+        rawSheetUrl,
+        pdfDownloadUrl,
+        ...sheetSeries.map((entry) => entry.pdfUrl),
+      ].filter(isDesignHistoryArtifactUrl),
+    [pdfDownloadUrl, rawSheetUrl, sheetSeries],
+  );
+  const [artifactObjectUrlMap, setArtifactObjectUrlMap] = useState({});
+
+  useEffect(() => {
+    let isCancelled = false;
+    const objectUrls = [];
+
+    async function resolveArtifacts() {
+      if (artifactSourceUrls.length === 0) {
+        setArtifactObjectUrlMap({});
+        return;
+      }
+
+      const resolvedEntries = await Promise.all(
+        artifactSourceUrls.map(async (artifactUrl) => {
+          try {
+            const objectUrl =
+              await resolveDesignHistoryArtifactUrlToObjectUrl(artifactUrl);
+            if (objectUrl) {
+              objectUrls.push(objectUrl);
+              return [artifactUrl, objectUrl];
+            }
+          } catch (error) {
+            logger.warn("Failed to resolve A1 artifact URL", {
+              artifactUrl,
+              error: error?.message || String(error),
+            });
+          }
+          return [artifactUrl, null];
+        }),
+      );
+
+      if (!isCancelled) {
+        setArtifactObjectUrlMap(
+          Object.fromEntries(
+            resolvedEntries.filter(([, objectUrl]) => Boolean(objectUrl)),
+          ),
+        );
+      }
+    }
+
+    resolveArtifacts();
+
+    return () => {
+      isCancelled = true;
+      objectUrls.forEach((objectUrl) => {
+        try {
+          URL.revokeObjectURL(objectUrl);
+        } catch {
+          // Ignore revoke failures for already-released object URLs.
+        }
+      });
+    };
+  }, [artifactSourceUrls]);
+  const effectiveRawSheetUrl =
+    artifactObjectUrlMap[rawSheetUrl] ||
+    (isDesignHistoryArtifactUrl(rawSheetUrl) ? null : rawSheetUrl);
+  const effectivePdfDownloadUrl =
+    artifactObjectUrlMap[pdfDownloadUrl] ||
+    (isDesignHistoryArtifactUrl(pdfDownloadUrl) ? null : pdfDownloadUrl);
+  const resolvedSheetSeries = React.useMemo(
+    () =>
+      sheetSeries
+        .map((entry) => ({
+          ...entry,
+          pdfUrl:
+            artifactObjectUrlMap[entry.pdfUrl] ||
+            (isDesignHistoryArtifactUrl(entry.pdfUrl) ? null : entry.pdfUrl),
+        }))
+        .filter((entry) => entry.pdfUrl),
+    [artifactObjectUrlMap, sheetSeries],
+  );
 
   // Determine proxy base (dev uses localhost:3001, prod uses same origin)
   const proxyBase = React.useMemo(() => {
@@ -196,11 +280,11 @@ const A1SheetViewer = ({
 
   // Proxy Together AI URLs through our backend to avoid CORS, but fall back to raw URL if needed
   const sheetUrlCandidates = React.useMemo(() => {
-    if (!rawSheetUrl) {
+    if (!effectiveRawSheetUrl) {
       return [];
     }
 
-    const cleanedUrl = sanitizeSheetUrl(rawSheetUrl);
+    const cleanedUrl = sanitizeSheetUrl(effectiveRawSheetUrl);
     if (!cleanedUrl) {
       return [];
     }
@@ -287,7 +371,7 @@ const A1SheetViewer = ({
     }
 
     return Array.from(new Set(candidates));
-  }, [proxyBase, rawSheetUrl]);
+  }, [effectiveRawSheetUrl, proxyBase]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -440,7 +524,7 @@ const A1SheetViewer = ({
     // Plan §6.11 / §9: the canonical RIBA A1 deliverable is the vector PDF.
     // Try it first when present, then fall back to the SVG/PNG candidates.
     const downloadSources = [
-      pdfDownloadUrl,
+      effectivePdfDownloadUrl,
       resolvedSheetUrl,
       ...sheetUrlCandidates,
     ].filter((url, index, arr) => Boolean(url) && arr.indexOf(url) === index);
@@ -625,12 +709,12 @@ const A1SheetViewer = ({
             </Button>
           </div>
         </div>
-        {sheetSeries.length > 1 && (
+        {resolvedSheetSeries.length > 1 && (
           <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-white/10 pt-3">
             <span className="text-xs font-semibold uppercase text-white/45">
               PDF set
             </span>
-            {sheetSeries.map((entry) => (
+            {resolvedSheetSeries.map((entry) => (
               <a
                 key={`${entry.sheetNumber}-${entry.label}`}
                 href={entry.pdfUrl}

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -58,6 +58,7 @@ import {
 } from "../services/project/floorCountAuthority.js";
 import { normalizeProgramSpaces } from "../services/project/levelUtils.js";
 import PricingPage from "./PricingPage.jsx";
+import DesignHistoryMenu from "./DesignHistoryMenu.jsx";
 
 // Step Components
 import LocationStep from "./steps/LocationStep.jsx";
@@ -255,6 +256,8 @@ const ArchitectAIWizardContainer = () => {
     generateSheet,
     modifySheetWorkflow,
     exportSheetWorkflow,
+    loadDesign,
+    listDesigns,
     clearError,
     loadDemoResult,
   } = useArchitectAIWorkflow();
@@ -2174,6 +2177,34 @@ const ArchitectAIWizardContainer = () => {
     [result],
   );
 
+  const handleLoadDesignFromHistory = useCallback(
+    async (designId) => {
+      const restoredResult = await loadDesign(designId);
+      const restoredDesignId =
+        restoredResult?.designId || restoredResult?.id || designId;
+      setGeneratedDesignId(restoredDesignId);
+      setGenerationStartAtMs(null);
+      setGenerationElapsedSeconds(0);
+      setIsGenerationTimerRunning(false);
+      setView("wizard");
+      setCurrentStep(6);
+
+      logger.success("Design restored from history", {
+        designId: restoredDesignId,
+      });
+
+      return restoredResult;
+    },
+    [
+      loadDesign,
+      setCurrentStep,
+      setGeneratedDesignId,
+      setGenerationElapsedSeconds,
+      setGenerationStartAtMs,
+      setIsGenerationTimerRunning,
+    ],
+  );
+
   /**
    * Navigation handlers
    */
@@ -2231,6 +2262,13 @@ const ArchitectAIWizardContainer = () => {
     setSitePolygon,
   ]);
 
+  const historyControl = (
+    <DesignHistoryMenu
+      listDesigns={listDesigns}
+      onLoadDesign={handleLoadDesignFromHistory}
+    />
+  );
+
   /**
    * Render current step
    */
@@ -2243,6 +2281,7 @@ const ArchitectAIWizardContainer = () => {
             onDemo={() => {
               window.location.search = "?demo=true";
             }}
+            historyControl={historyControl}
           />
         );
 
@@ -2353,7 +2392,12 @@ const ArchitectAIWizardContainer = () => {
         );
 
       default:
-        return <LandingPage onStart={() => setCurrentStep(1)} />;
+        return (
+          <LandingPage
+            onStart={() => setCurrentStep(1)}
+            historyControl={historyControl}
+          />
+        );
     }
   };
 
@@ -2383,6 +2427,7 @@ const ArchitectAIWizardContainer = () => {
       navProps={{
         onNewDesign: handleStartNew,
         onPricing: () => setView("pricing"),
+        historyControl,
         showNewDesign: currentStep > 0,
       }}
       background={currentStep === 0 ? "default" : "gradient"}

--- a/src/components/DesignHistoryMenu.jsx
+++ b/src/components/DesignHistoryMenu.jsx
@@ -1,0 +1,222 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { ChevronDown, FileImage, History, Loader2, RefreshCw } from "lucide-react";
+import Button from "./ui/Button.jsx";
+
+function formatUpdatedAt(value) {
+  if (!value) {
+    return "Saved design";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Saved design";
+  }
+
+  return `Updated ${date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })}`;
+}
+
+function designLabel(design = {}) {
+  return (
+    design.projectName ||
+    design.name ||
+    design.projectId ||
+    design.designId ||
+    design.id ||
+    "Saved design"
+  );
+}
+
+const DesignHistoryMenu = ({ listDesigns, onLoadDesign, className = "" }) => {
+  const [open, setOpen] = useState(false);
+  const [designs, setDesigns] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingDesignId, setLoadingDesignId] = useState(null);
+  const [error, setError] = useState(null);
+  const menuRef = useRef(null);
+
+  const refreshDesigns = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const entries = await listDesigns();
+      const sortedEntries = [...(entries || [])].sort(
+        (a, b) =>
+          new Date(b.updatedAt || b.createdAt || 0).getTime() -
+          new Date(a.updatedAt || a.createdAt || 0).getTime(),
+      );
+      setDesigns(sortedEntries);
+    } catch (err) {
+      setError(err?.message || "Recent designs could not be loaded.");
+      setDesigns([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [listDesigns]);
+
+  useEffect(() => {
+    if (open) {
+      refreshDesigns();
+    }
+  }, [open, refreshDesigns]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const handleLoad = async (designId) => {
+    if (!designId || loadingDesignId) {
+      return;
+    }
+
+    setLoadingDesignId(designId);
+    setError(null);
+    try {
+      await onLoadDesign(designId);
+      setOpen(false);
+    } catch (err) {
+      setError(err?.message || "Saved design could not be reopened.");
+    } finally {
+      setLoadingDesignId(null);
+    }
+  };
+
+  return (
+    <div ref={menuRef} className={`relative ${className}`}>
+      <Button
+        type="button"
+        variant="glass"
+        size="sm"
+        onClick={() => setOpen((value) => !value)}
+        icon={<History className="h-4 w-4" />}
+        iconPosition="left"
+        data-testid="recent-designs-button"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        <span className="hidden sm:inline">Recent Designs</span>
+        <ChevronDown className="ml-2 h-3.5 w-3.5" />
+      </Button>
+
+      {open && (
+        <div
+          className="absolute right-0 z-[70] mt-2 w-[min(22rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-white/10 bg-navy-950/95 shadow-2xl backdrop-blur-xl"
+          role="menu"
+          aria-label="Recent designs"
+        >
+          <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-white">Recent Designs</p>
+              <p className="text-xs text-white/45">
+                Reopen from local history
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={refreshDesigns}
+              disabled={loading}
+              className="rounded-md p-2 text-white/60 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-50"
+              aria-label="Refresh recent designs"
+            >
+              {loading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+
+          {error && (
+            <div className="border-b border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+              {error}
+            </div>
+          )}
+
+          <div className="max-h-80 overflow-y-auto py-2">
+            {loading && designs.length === 0 ? (
+              <div className="flex items-center gap-2 px-4 py-4 text-sm text-white/60">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading recent designs...
+              </div>
+            ) : designs.length === 0 ? (
+              <div className="px-4 py-5 text-sm text-white/55">
+                No saved designs yet.
+              </div>
+            ) : (
+              designs.map((design) => {
+                const designId = design.designId || design.id;
+                const isLoadingDesign = loadingDesignId === designId;
+                return (
+                  <button
+                    key={designId}
+                    type="button"
+                    className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-white/8 focus:bg-white/8 focus:outline-none"
+                    onClick={() => handleLoad(designId)}
+                    disabled={Boolean(loadingDesignId)}
+                    role="menuitem"
+                    data-testid="recent-designs-item"
+                  >
+                    <span className="mt-0.5 rounded-md border border-white/10 bg-white/5 p-2 text-royal-200">
+                      {isLoadingDesign ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <FileImage className="h-4 w-4" />
+                      )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-white">
+                        {designLabel(design)}
+                      </span>
+                      <span className="mt-0.5 block text-xs text-white/45">
+                        {formatUpdatedAt(design.updatedAt || design.createdAt)}
+                      </span>
+                      {design.hasA1Sheet && (
+                        <span className="mt-1 inline-flex rounded-md border border-success-500/20 bg-success-500/10 px-1.5 py-0.5 text-[11px] text-success-200">
+                          A1 saved
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+DesignHistoryMenu.propTypes = {
+  listDesigns: PropTypes.func.isRequired,
+  onLoadDesign: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
+
+export default DesignHistoryMenu;

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -123,7 +123,7 @@ const NavLink = ({ href, children }) => (
   </a>
 );
 
-const LandingPage = ({ onStart, onDemo }) => {
+const LandingPage = ({ onStart, onDemo, historyControl = null }) => {
   return (
     <div className="relative min-h-screen bg-navy-950 text-white">
       {/* Subtle blueprint grid — single layer, low contrast */}
@@ -169,6 +169,7 @@ const LandingPage = ({ onStart, onDemo }) => {
           </div>
 
           <div className="flex items-center gap-3">
+            {historyControl}
             <button
               type="button"
               onClick={onDemo}

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -16,6 +16,7 @@ import {
 const NavBar = ({
   onNewDesign,
   onPricing,
+  historyControl = null,
   showNewDesign = true,
   transparent = false,
   className = "",
@@ -141,6 +142,7 @@ const NavBar = ({
 
           {/* CTA / Auth area */}
           <div className="flex items-center gap-3">
+            {historyControl}
             {showNewDesign && (
               <Button
                 variant="gradient"
@@ -204,6 +206,7 @@ NavLink.propTypes = {
 NavBar.propTypes = {
   onNewDesign: PropTypes.func,
   onPricing: PropTypes.func,
+  historyControl: PropTypes.node,
   showNewDesign: PropTypes.bool,
   transparent: PropTypes.bool,
   className: PropTypes.string,

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -16,6 +16,7 @@ import * as generationGate from "../services/generationGate.js";
 import { modifySheet } from "../services/pureModificationService.js";
 import exportService from "../services/exportService.js";
 import designHistoryRepository from "../services/designHistoryRepository.js";
+import { buildSheetResultFromDesignHistoryEntry } from "../services/designHistoryResultHydrator.js";
 import dnaWorkflowOrchestrator from "../services/dnaWorkflowOrchestrator.js";
 import logger from "../utils/logger.js";
 import { normalizeMultiPanelResult } from "../types/schemas.js";
@@ -1523,7 +1524,17 @@ export function useArchitectAIWorkflow() {
         throw new Error(`Design ${designId} not found`);
       }
 
-      return design;
+      const restoredResult = buildSheetResultFromDesignHistoryEntry(design);
+      setResult(restoredResult);
+      setProgress({
+        step: 5,
+        total: 5,
+        message: "Design restored",
+        stage: "finalizing",
+        percentage: 100,
+      });
+
+      return restoredResult;
     } catch (err) {
       logger.error("Failed to load design", err);
       setError(err.message);

--- a/src/services/designHistoryArtifactStore.js
+++ b/src/services/designHistoryArtifactStore.js
@@ -1,0 +1,348 @@
+import logger from "../utils/logger.js";
+import { computeCDSHashSync } from "./validation/cdsHash.js";
+
+export const DESIGN_HISTORY_ARTIFACT_URL_PREFIX = "archiai-artifact://";
+
+const DB_NAME = "archiAI_design_history_artifacts";
+const STORE_NAME = "artifacts";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function sanitizeIdPart(value = "") {
+  return String(value || "artifact")
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 96);
+}
+
+function mimeFromDataUrl(dataUrl = "") {
+  const match = String(dataUrl).match(/^data:([^;,]+)[;,]/i);
+  return match ? match[1] : "application/octet-stream";
+}
+
+function extensionForMime(mimeType = "") {
+  switch (mimeType) {
+    case "application/pdf":
+      return "pdf";
+    case "image/svg+xml":
+      return "svg";
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+    case "image/jpg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    default:
+      return "bin";
+  }
+}
+
+function decodeBase64ToUint8Array(base64 = "") {
+  const clean = String(base64 || "").replace(/\s/g, "");
+  if (typeof atob === "function") {
+    const binary = atob(clean);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  if (typeof Buffer !== "undefined" && typeof Buffer.from === "function") {
+    return new Uint8Array(Buffer.from(clean, "base64"));
+  }
+
+  throw new Error("Base64 decoder unavailable");
+}
+
+function dataUrlToBlob(dataUrl = "") {
+  const commaIndex = dataUrl.indexOf(",");
+  if (commaIndex < 0) {
+    throw new Error("Invalid data URL: missing payload separator");
+  }
+
+  const meta = dataUrl.slice(5, commaIndex);
+  const payload = dataUrl.slice(commaIndex + 1);
+  const mimeType = (meta.split(";")[0] || "application/octet-stream").trim();
+
+  if (/;base64\b/i.test(meta)) {
+    return new Blob([decodeBase64ToUint8Array(payload)], { type: mimeType });
+  }
+
+  return new Blob([decodeURIComponent(payload)], { type: mimeType });
+}
+
+export function isDesignHistoryArtifactUrl(value) {
+  return (
+    typeof value === "string" &&
+    value.startsWith(DESIGN_HISTORY_ARTIFACT_URL_PREFIX)
+  );
+}
+
+export function isStorableDataUrl(value) {
+  return typeof value === "string" && value.startsWith("data:");
+}
+
+export function artifactIdFromUrl(value = "") {
+  if (!isDesignHistoryArtifactUrl(value)) {
+    return String(value || "");
+  }
+  return decodeURIComponent(
+    value.slice(DESIGN_HISTORY_ARTIFACT_URL_PREFIX.length),
+  );
+}
+
+export function artifactUrlForId(artifactId) {
+  return `${DESIGN_HISTORY_ARTIFACT_URL_PREFIX}${encodeURIComponent(
+    artifactId,
+  )}`;
+}
+
+class DesignHistoryArtifactStore {
+  constructor() {
+    this.memoryStore = new Map();
+    this.dbPromise = null;
+    this.backend = "indexedDB";
+  }
+
+  async ensureDb() {
+    if (typeof indexedDB === "undefined") {
+      this.backend = "memory";
+      return null;
+    }
+
+    if (this.dbPromise) {
+      return this.dbPromise;
+    }
+
+    this.dbPromise = new Promise((resolve) => {
+      const request = indexedDB.open(DB_NAME, 1);
+
+      request.onerror = () => {
+        logger.warn(
+          "Design history artifact IndexedDB unavailable; using memory store",
+          {
+            error: request.error?.message || String(request.error || ""),
+          },
+        );
+        this.backend = "memory";
+        resolve(null);
+      };
+
+      request.onsuccess = () => {
+        this.backend = "indexedDB";
+        resolve(request.result);
+      };
+
+      request.onupgradeneeded = (event) => {
+        const db = event.target.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+    });
+
+    return this.dbPromise;
+  }
+
+  async putRecord(record) {
+    const db = await this.ensureDb();
+    if (!db) {
+      this.memoryStore.set(record.artifactId, record);
+      return true;
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([STORE_NAME], "readwrite");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.put(record, record.artifactId);
+      request.onsuccess = () => resolve(true);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async getRecord(artifactUrlOrId) {
+    const artifactId = artifactIdFromUrl(artifactUrlOrId);
+    if (!artifactId) {
+      return null;
+    }
+
+    const db = await this.ensureDb();
+    if (!db) {
+      return this.memoryStore.get(artifactId) || null;
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([STORE_NAME], "readonly");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.get(artifactId);
+      request.onsuccess = () => resolve(request.result || null);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async deleteRecord(artifactUrlOrId) {
+    const artifactId = artifactIdFromUrl(artifactUrlOrId);
+    if (!artifactId) return false;
+
+    const db = await this.ensureDb();
+    if (!db) {
+      return this.memoryStore.delete(artifactId);
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([STORE_NAME], "readwrite");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.delete(artifactId);
+      request.onsuccess = () => resolve(true);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async saveArtifact({
+    designId,
+    artifactType = "artifact",
+    payload,
+    payloadKind = "data_url",
+    mimeType = null,
+    metadata = {},
+  } = {}) {
+    if (typeof payload !== "string" || payload.length === 0) {
+      return null;
+    }
+
+    const resolvedMime =
+      mimeType ||
+      (payloadKind === "data_url"
+        ? mimeFromDataUrl(payload)
+        : "application/octet-stream");
+    const contentHash = computeCDSHashSync({
+      artifactType,
+      mimeType: resolvedMime,
+      payload,
+    });
+    const artifactId = sanitizeIdPart(
+      `${artifactType}-${designId || "design"}-${contentHash}`,
+    );
+    const artifactUrl = artifactUrlForId(artifactId);
+    const byteLength =
+      typeof Blob !== "undefined"
+        ? new Blob([payload]).size
+        : String(payload).length;
+    const record = {
+      schema_version: "design-history-artifact-v1",
+      artifactId,
+      artifactUrl,
+      designId: designId || null,
+      artifactType,
+      payloadKind,
+      payload,
+      mimeType: resolvedMime,
+      extension: extensionForMime(resolvedMime),
+      byteLength,
+      contentHash,
+      metadata: metadata || {},
+      createdAt: nowIso(),
+    };
+
+    await this.putRecord(record);
+
+    return {
+      artifactId,
+      artifactUrl,
+      artifactType,
+      mimeType: resolvedMime,
+      extension: record.extension,
+      byteLength,
+      contentHash,
+      storage: this.backend,
+      metadata: record.metadata,
+    };
+  }
+
+  async loadArtifactBlob(artifactUrlOrId) {
+    const record = await this.getRecord(artifactUrlOrId);
+    if (!record) {
+      return null;
+    }
+
+    if (record.payloadKind === "data_url") {
+      return dataUrlToBlob(record.payload);
+    }
+
+    return new Blob([record.payload || ""], {
+      type: record.mimeType || "application/octet-stream",
+    });
+  }
+
+  async resolveArtifactUrlToObjectUrl(artifactUrl) {
+    if (!isDesignHistoryArtifactUrl(artifactUrl)) {
+      return artifactUrl || null;
+    }
+
+    const blob = await this.loadArtifactBlob(artifactUrl);
+    if (!blob || typeof URL === "undefined" || !URL.createObjectURL) {
+      return null;
+    }
+
+    return URL.createObjectURL(blob);
+  }
+
+  async deleteArtifactsForDesign(designId) {
+    if (!designId) return false;
+
+    const db = await this.ensureDb();
+    if (!db) {
+      for (const [artifactId, record] of this.memoryStore.entries()) {
+        if (record?.designId === designId) {
+          this.memoryStore.delete(artifactId);
+        }
+      }
+      return true;
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([STORE_NAME], "readwrite");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.openCursor();
+
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          resolve(true);
+          return;
+        }
+        if (cursor.value?.designId === designId) {
+          cursor.delete();
+        }
+        cursor.continue();
+      };
+    });
+  }
+
+  async clearAllArtifacts() {
+    this.memoryStore.clear();
+    const db = await this.ensureDb();
+    if (!db) return true;
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([STORE_NAME], "readwrite");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.clear();
+      request.onsuccess = () => resolve(true);
+      request.onerror = () => reject(request.error);
+    });
+  }
+}
+
+const designHistoryArtifactStore = new DesignHistoryArtifactStore();
+
+export async function resolveDesignHistoryArtifactUrlToObjectUrl(artifactUrl) {
+  return designHistoryArtifactStore.resolveArtifactUrlToObjectUrl(artifactUrl);
+}
+
+export default designHistoryArtifactStore;

--- a/src/services/designHistoryRepository.js
+++ b/src/services/designHistoryRepository.js
@@ -24,6 +24,10 @@ import {
   stripDataUrlsDeep,
 } from "../utils/designHistorySanitizer.js";
 import baselineArtifactStore from "./baselineArtifactStore.js";
+import designHistoryArtifactStore, {
+  isDesignHistoryArtifactUrl,
+  isStorableDataUrl,
+} from "./designHistoryArtifactStore.js";
 
 const MAX_DESIGNS = 2;
 const MAX_VERSIONS_PER_DESIGN = 3;
@@ -312,6 +316,436 @@ function compactSiteSnapshotMetadata(metadata = {}) {
   };
 }
 
+function createA1ArtifactManifest(designId) {
+  return {
+    schema_version: "a1-artifact-url-manifest-v1",
+    designId,
+    storage: "design_history_artifact_store",
+    artifacts: {
+      sheet: null,
+      pdf: null,
+      panels: {},
+    },
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function addArtifactManifestEntry(manifest, slot, entry, panelKey = null) {
+  if (!manifest || !entry) {
+    return;
+  }
+
+  const lightweight = {
+    artifactId: entry.artifactId,
+    artifactUrl: entry.artifactUrl,
+    artifactType: entry.artifactType,
+    mimeType: entry.mimeType,
+    extension: entry.extension,
+    byteLength: entry.byteLength,
+    contentHash: entry.contentHash,
+    storage: entry.storage,
+    metadata: entry.metadata || {},
+  };
+
+  if (slot === "panels" && panelKey) {
+    manifest.artifacts.panels[panelKey] = {
+      ...(manifest.artifacts.panels[panelKey] || {}),
+      [entry.artifactType]: lightweight,
+    };
+    return;
+  }
+
+  manifest.artifacts[slot] = lightweight;
+}
+
+function manifestHasArtifacts(manifest) {
+  return Boolean(
+    manifest?.artifacts?.sheet ||
+    manifest?.artifacts?.pdf ||
+    Object.keys(manifest?.artifacts?.panels || {}).length > 0,
+  );
+}
+
+function attachA1ArtifactManifest(design, manifest) {
+  if (!manifestHasArtifacts(manifest)) {
+    return design;
+  }
+
+  design.a1ArtifactManifest = manifest;
+  design.artifactManifest = manifest;
+  design.sheetMetadata = {
+    ...(design.sheetMetadata || design.a1Sheet?.metadata || {}),
+    artifactManifest: manifest,
+  };
+  design.a1Sheet = {
+    ...(design.a1Sheet || {}),
+    artifactManifest: manifest,
+    metadata: {
+      ...(design.a1Sheet?.metadata || design.sheetMetadata || {}),
+      artifactManifest: manifest,
+    },
+  };
+  return design;
+}
+
+function deleteStoredArtifactsForDesign(designId) {
+  if (!designId) {
+    return;
+  }
+
+  designHistoryArtifactStore
+    .deleteArtifactsForDesign(designId)
+    .catch((error) => {
+      logger.warn("Failed to delete design history artifacts", {
+        designId,
+        error: error?.message || String(error),
+      });
+    });
+}
+
+function compactA1SheetForHistory(sheet = {}) {
+  if (!sheet || typeof sheet !== "object") {
+    return {};
+  }
+
+  const compacted = cloneData(sheet) || {};
+  delete compacted.dataUrl;
+  delete compacted.svgString;
+  delete compacted.svg;
+  delete compacted.pdfDataUrl;
+  delete compacted.compiledProject;
+  delete compacted.projectGraph;
+  delete compacted.projectGeometry;
+  delete compacted.projectQuantityTakeoff;
+  delete compacted.artifacts;
+  delete compacted.trace;
+  delete compacted.reasoningChain;
+
+  return compacted;
+}
+
+async function persistArtifactPayload({
+  designId,
+  artifactType,
+  payload,
+  payloadKind,
+  mimeType,
+  metadata,
+  manifest,
+  manifestSlot,
+  panelKey,
+  cache,
+}) {
+  if (isDesignHistoryArtifactUrl(payload)) {
+    return payload;
+  }
+
+  if (typeof payload !== "string" || payload.length === 0) {
+    return payload;
+  }
+
+  const cacheKey = `${artifactType}:${payloadKind}:${payload}`;
+  if (cache.has(cacheKey)) {
+    const cached = cache.get(cacheKey);
+    addArtifactManifestEntry(manifest, manifestSlot, cached, panelKey);
+    return cached.artifactUrl;
+  }
+
+  try {
+    const artifact = await designHistoryArtifactStore.saveArtifact({
+      designId,
+      artifactType,
+      payload,
+      payloadKind,
+      mimeType,
+      metadata,
+    });
+    if (!artifact) {
+      return payload;
+    }
+    cache.set(cacheKey, artifact);
+    addArtifactManifestEntry(manifest, manifestSlot, artifact, panelKey);
+    return artifact.artifactUrl;
+  } catch (error) {
+    logger.warn("Failed to persist design history artifact", {
+      designId,
+      artifactType,
+      error: error?.message || String(error),
+    });
+    return payload;
+  }
+}
+
+async function materializeUrlField({
+  target,
+  key,
+  designId,
+  artifactType,
+  manifest,
+  manifestSlot,
+  panelKey = null,
+  metadata = {},
+  cache,
+}) {
+  if (!target || typeof target !== "object") {
+    return;
+  }
+
+  const value = target[key];
+  if (!isStorableDataUrl(value)) {
+    return;
+  }
+
+  target[key] = await persistArtifactPayload({
+    designId,
+    artifactType,
+    payload: value,
+    payloadKind: "data_url",
+    metadata,
+    manifest,
+    manifestSlot,
+    panelKey,
+    cache,
+  });
+}
+
+async function materializePanelArtifacts({
+  panel,
+  panelKey,
+  designId,
+  manifest,
+  cache,
+}) {
+  if (!panel || typeof panel !== "object") {
+    return null;
+  }
+
+  const metadata = {
+    panelKey,
+    panelType: panel.panelType || panel.panel_type || panel.type || panelKey,
+    width: panel.width || panel.metadata?.width || null,
+    height: panel.height || panel.metadata?.height || null,
+    geometryHash: panel.geometryHash || panel.metadata?.geometryHash || null,
+    sourceModelHash:
+      panel.source_model_hash || panel.metadata?.sourceModelHash || null,
+    svgHash: panel.svgHash || panel.metadata?.svgHash || null,
+  };
+
+  for (const key of ["imageUrl", "url", "previewUrl", "dataUrl"]) {
+    await materializeUrlField({
+      target: panel,
+      key,
+      designId,
+      artifactType: "a1_panel_raster_or_svg",
+      manifest,
+      manifestSlot: "panels",
+      panelKey,
+      metadata,
+      cache,
+    });
+  }
+
+  if (isDesignHistoryArtifactUrl(panel.dataUrl)) {
+    panel.artifactUrl = panel.dataUrl;
+  }
+
+  if (!panel.url && panel.artifactUrl) {
+    panel.url = panel.artifactUrl;
+  }
+
+  if (typeof panel.svgString === "string" && panel.svgString.trim()) {
+    const svgArtifactUrl = await persistArtifactPayload({
+      designId,
+      artifactType: "a1_panel_svg",
+      payload: panel.svgString,
+      payloadKind: "text",
+      mimeType: "image/svg+xml",
+      metadata,
+      manifest,
+      manifestSlot: "panels",
+      panelKey,
+      cache,
+    });
+    panel.svgArtifactUrl = svgArtifactUrl;
+    panel.svgHash = panel.svgHash || computeStringHash(panel.svgString);
+    if (!panel.url && isDesignHistoryArtifactUrl(svgArtifactUrl)) {
+      panel.url = svgArtifactUrl;
+    }
+    delete panel.svgString;
+  }
+
+  if (typeof panel.svg === "string" && panel.svg.trim()) {
+    const svgArtifactUrl = await persistArtifactPayload({
+      designId,
+      artifactType: "a1_panel_svg",
+      payload: panel.svg,
+      payloadKind: "text",
+      mimeType: "image/svg+xml",
+      metadata,
+      manifest,
+      manifestSlot: "panels",
+      panelKey,
+      cache,
+    });
+    panel.svgArtifactUrl = panel.svgArtifactUrl || svgArtifactUrl;
+    if (!panel.url && isDesignHistoryArtifactUrl(svgArtifactUrl)) {
+      panel.url = svgArtifactUrl;
+    }
+    delete panel.svg;
+  }
+
+  delete panel.dataUrl;
+  return panel;
+}
+
+function computeStringHash(value = "") {
+  let hash = 0x811c9dc5;
+  const input = String(value || "");
+  for (let i = 0; i < input.length; i += 1) {
+    hash = Math.imul(hash ^ input.charCodeAt(i), 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+async function materializePanelMapArtifacts(panelMap, options) {
+  if (!panelMap || typeof panelMap !== "object") {
+    return panelMap || null;
+  }
+
+  if (Array.isArray(panelMap)) {
+    for (let index = 0; index < panelMap.length; index += 1) {
+      await materializePanelArtifacts({
+        panel: panelMap[index],
+        panelKey:
+          panelMap[index]?.panelType || panelMap[index]?.type || `${index}`,
+        ...options,
+      });
+    }
+    return panelMap;
+  }
+
+  const entries = Object.entries(panelMap);
+  for (const [panelKey, panel] of entries) {
+    await materializePanelArtifacts({
+      panel,
+      panelKey,
+      ...options,
+    });
+  }
+  return panelMap;
+}
+
+async function prepareDesignArtifactsForHistory(design, designId) {
+  const prepared = cloneData(design) || {};
+  const manifest = createA1ArtifactManifest(designId);
+  const cache = new Map();
+  const sheetMetadata = {
+    ...(prepared.sheetMetadata || prepared.a1Sheet?.metadata || {}),
+  };
+  const sheetArtifactMetadata = {
+    sheetId: prepared.sheetId || prepared.a1Sheet?.sheetId || "default",
+    width: sheetMetadata.width || prepared.a1Sheet?.width || null,
+    height: sheetMetadata.height || prepared.a1Sheet?.height || null,
+    sheetSizeMm:
+      sheetMetadata.sheetSizeMm || prepared.a1Sheet?.sheet_size_mm || null,
+    geometryHash:
+      sheetMetadata.geometryHash ||
+      prepared.geometryHash ||
+      prepared.a1Sheet?.metadata?.geometryHash ||
+      null,
+    exportGate:
+      sheetMetadata.exportGate ||
+      sheetMetadata.sheetArtifactManifest?.exportGate ||
+      null,
+  };
+
+  for (const target of [prepared, prepared.a1Sheet].filter(Boolean)) {
+    await materializeUrlField({
+      target,
+      key: "resultUrl",
+      designId,
+      artifactType: "a1_sheet",
+      manifest,
+      manifestSlot: "sheet",
+      metadata: sheetArtifactMetadata,
+      cache,
+    });
+    await materializeUrlField({
+      target,
+      key: "composedSheetUrl",
+      designId,
+      artifactType: "a1_sheet",
+      manifest,
+      manifestSlot: "sheet",
+      metadata: sheetArtifactMetadata,
+      cache,
+    });
+    await materializeUrlField({
+      target,
+      key: "url",
+      designId,
+      artifactType: "a1_sheet",
+      manifest,
+      manifestSlot: "sheet",
+      metadata: sheetArtifactMetadata,
+      cache,
+    });
+    await materializeUrlField({
+      target,
+      key: "a1SheetUrl",
+      designId,
+      artifactType: "a1_sheet",
+      manifest,
+      manifestSlot: "sheet",
+      metadata: sheetArtifactMetadata,
+      cache,
+    });
+    await materializeUrlField({
+      target,
+      key: "pdfUrl",
+      designId,
+      artifactType: "a1_pdf",
+      manifest,
+      manifestSlot: "pdf",
+      metadata: sheetArtifactMetadata,
+      cache,
+    });
+  }
+
+  await materializePanelMapArtifacts(prepared.panelMap, {
+    designId,
+    manifest,
+    cache,
+  });
+  await materializePanelMapArtifacts(prepared.panels, {
+    designId,
+    manifest,
+    cache,
+  });
+  await materializePanelMapArtifacts(prepared.a1Sheet?.panelMap, {
+    designId,
+    manifest,
+    cache,
+  });
+  await materializePanelMapArtifacts(prepared.a1Sheet?.panels, {
+    designId,
+    manifest,
+    cache,
+  });
+  await materializePanelMapArtifacts(prepared.sheetMetadata?.panelMap, {
+    designId,
+    manifest,
+    cache,
+  });
+  await materializePanelMapArtifacts(prepared.a1Sheet?.metadata?.panelMap, {
+    designId,
+    manifest,
+    cache,
+  });
+
+  return attachA1ArtifactManifest(prepared, manifest);
+}
+
 const VERSION_METADATA_KEYS = [
   "width",
   "height",
@@ -444,6 +878,16 @@ function buildDesignPayload(design, existingDesign = null) {
       design.composedSheetUrl ||
       null,
   );
+  const pdfUrl = stripDataUrl(
+    design.pdfUrl || design.a1Sheet?.pdfUrl || existingDesign?.a1Sheet?.pdfUrl,
+  );
+  const artifactManifest =
+    design.a1ArtifactManifest ||
+    design.artifactManifest ||
+    design.a1Sheet?.artifactManifest ||
+    design.sheetMetadata?.artifactManifest ||
+    existingDesign?.a1ArtifactManifest ||
+    null;
   const panelMapInput =
     design.panelMap ||
     design.panels ||
@@ -506,7 +950,7 @@ function buildDesignPayload(design, existingDesign = null) {
   const sanitizedBlendedStyle = cloneData(design.blendedStyle) || null;
   stripDataUrlsDeep(sanitizedBlendedStyle);
 
-  const clonedA1Sheet = design.a1Sheet ? cloneData(design.a1Sheet) || {} : {};
+  const clonedA1Sheet = compactA1SheetForHistory(design.a1Sheet);
   stripDataUrlsDeep(clonedA1Sheet);
   if (
     clonedA1Sheet &&
@@ -547,11 +991,16 @@ function buildDesignPayload(design, existingDesign = null) {
     blendedStyle: sanitizedBlendedStyle,
     composedSheetUrl: sheetUrl,
     resultUrl: sheetUrl,
+    pdfUrl,
+    a1ArtifactManifest: artifactManifest,
+    artifactManifest,
     a1Sheet: {
       ...(clonedA1Sheet || {}),
       sheetId: design.sheetId || clonedA1Sheet?.sheetId || "default",
       url: sheetUrl,
       composedSheetUrl: sheetUrl,
+      pdfUrl,
+      artifactManifest,
       metadata: sheetMetadata,
       panelMap: resolvedPanelMap || null,
       panels: resolvedPanelMap || null,
@@ -653,6 +1102,7 @@ function enforceHistoryCap(designs = []) {
     if (entry?.siteSnapshot?.key) {
       deleteSiteSnapshot(entry.siteSnapshot.key);
     }
+    deleteStoredArtifactsForDesign(entry?.designId || entry?.id);
   });
 
   logger.warn(`History exceeds ${MAX_DESIGNS} designs, removing oldest...`);
@@ -824,6 +1274,7 @@ function trimHistoryForStorage(history, maxBytes = MAX_HISTORY_BYTES) {
         if (entry?.siteSnapshot?.key) {
           deleteSiteSnapshot(entry.siteSnapshot.key);
         }
+        deleteStoredArtifactsForDesign(entry?.designId || entry?.id);
       });
 
       candidate = candidate.filter(
@@ -925,8 +1376,12 @@ class DesignHistoryRepository {
     const existingDesign =
       existingIndex >= 0 ? allDesigns[existingIndex] : null;
 
+    const storagePreparedDesign = await prepareDesignArtifactsForHistory(
+      { ...design, designId },
+      designId,
+    );
     const sanitizedDesign = enforceDesignSize(
-      buildDesignPayload({ ...design, designId }, existingDesign),
+      buildDesignPayload(storagePreparedDesign, existingDesign),
     );
 
     const updatedDesigns = [...allDesigns];
@@ -961,9 +1416,9 @@ class DesignHistoryRepository {
           designId,
           sheetId: design.sheetId || design.a1Sheet?.sheetId || "default",
           baselineImageUrl:
-            design.resultUrl ||
-            design.composedSheetUrl ||
-            design.a1Sheet?.url ||
+            storagePreparedDesign.resultUrl ||
+            storagePreparedDesign.composedSheetUrl ||
+            storagePreparedDesign.a1Sheet?.url ||
             "",
           baselineDNA: design.masterDNA || design.dna || {},
           geometryBaseline: {
@@ -1028,8 +1483,16 @@ class DesignHistoryRepository {
     const design = allDesigns[index];
 
     const versionId = `v${(design.versions?.length || 0) + 1}`;
+    const storagePreparedVersion = await prepareDesignArtifactsForHistory(
+      {
+        ...versionData,
+        designId,
+      },
+      designId,
+    );
     const sanitizedVersion = sanitizeVersionEntry({
       ...versionData,
+      ...storagePreparedVersion,
       versionId,
       createdAt: new Date().toISOString(),
     });
@@ -1108,11 +1571,13 @@ class DesignHistoryRepository {
     if (removed?.siteSnapshot?.key) {
       await deleteSiteSnapshot(removed.siteSnapshot.key);
     }
+    await designHistoryArtifactStore.deleteArtifactsForDesign(designId);
 
     return this.persistDesigns(filtered);
   }
 
   async clearAllDesigns() {
+    await designHistoryArtifactStore.clearAllArtifacts();
     if (typeof this.backend.setAll === "function") {
       await this.backend.setAll([]);
       return true;

--- a/src/services/designHistoryResultHydrator.js
+++ b/src/services/designHistoryResultHydrator.js
@@ -1,0 +1,138 @@
+function firstDefined(...values) {
+  return values.find((value) => value !== undefined && value !== null);
+}
+
+function normalizePanelMap(value) {
+  if (!value) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return Object.fromEntries(
+      value
+        .map((panel, index) => {
+          if (!panel || typeof panel !== "object") {
+            return null;
+          }
+          const key =
+            panel.key ||
+            panel.id ||
+            panel.type ||
+            panel.panelType ||
+            panel.panel_type ||
+            `panel_${index}`;
+          return [key, panel];
+        })
+        .filter(Boolean),
+    );
+  }
+
+  if (typeof value === "object") {
+    return value;
+  }
+
+  return null;
+}
+
+function normalizePanels(value) {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === "object") {
+    return Object.entries(value).map(([key, panel]) => ({
+      key,
+      type: panel?.type || panel?.panelType || panel?.panel_type || key,
+      label: panel?.label || panel?.name || key,
+      ...(panel || {}),
+    }));
+  }
+
+  return [];
+}
+
+export function buildSheetResultFromDesignHistoryEntry(design = {}) {
+  if (!design || typeof design !== "object") {
+    return null;
+  }
+
+  const designId = design.designId || design.id || null;
+  const sheet = design.a1Sheet || {};
+  const metadata = {
+    ...(sheet.metadata || {}),
+    ...(design.sheetMetadata || {}),
+    ...(design.metadata || {}),
+    designId,
+    restoredFromHistory: true,
+  };
+  const sheetUrl = firstDefined(
+    design.composedSheetUrl,
+    design.resultUrl,
+    design.url,
+    design.a1SheetUrl,
+    sheet.composedSheetUrl,
+    sheet.url,
+  );
+  const pdfUrl = firstDefined(design.pdfUrl, sheet.pdfUrl);
+  const panelMap = normalizePanelMap(
+    firstDefined(
+      design.panelMap,
+      design.panelsByKey,
+      design.panels,
+      sheet.panelMap,
+      sheet.panels,
+      metadata.panelMap,
+      metadata.panels,
+    ),
+  );
+  const panels = normalizePanels(firstDefined(design.panels, panelMap));
+  const coordinates = firstDefined(
+    design.panelCoordinates,
+    design.coordinates,
+    sheet.coordinates,
+    metadata.panelCoordinates,
+    metadata.coordinates,
+  );
+  const artifactManifest = firstDefined(
+    design.a1ArtifactManifest,
+    design.artifactManifest,
+    sheet.artifactManifest,
+    metadata.artifactManifest,
+  );
+
+  return {
+    ...design,
+    designId,
+    id: design.id || designId,
+    restoredFromHistory: true,
+    composedSheetUrl: sheetUrl,
+    resultUrl: sheetUrl,
+    url: sheetUrl,
+    pdfUrl,
+    metadata,
+    sheetMetadata: metadata,
+    panelMap,
+    panels,
+    panelsByKey: panelMap,
+    panelCoordinates: coordinates,
+    coordinates,
+    a1ArtifactManifest: artifactManifest,
+    artifactManifest,
+    a1Sheet: {
+      ...sheet,
+      sheetId: sheet.sheetId || design.sheetId || "default",
+      url: firstDefined(sheet.url, sheetUrl),
+      composedSheetUrl: firstDefined(sheet.composedSheetUrl, sheetUrl),
+      pdfUrl: firstDefined(sheet.pdfUrl, pdfUrl),
+      metadata,
+      panelMap,
+      panels: panelMap || panels,
+      coordinates,
+      artifactManifest,
+    },
+  };
+}

--- a/src/utils/designHistorySanitizer.js
+++ b/src/utils/designHistorySanitizer.js
@@ -146,6 +146,9 @@ export function sanitizeSheetMetadata(metadata = {}) {
     delete sanitized.dataUrl;
   }
 
+  delete sanitized.svgString;
+  delete sanitized.svg;
+
   if (sanitized.imageUrl) {
     sanitized.imageUrl = stripDataUrl(sanitized.imageUrl);
   }
@@ -221,13 +224,70 @@ export function sanitizePanelLayout(panels) {
         delete panel.dataUrl;
       }
 
+      delete panel.svgString;
+      delete panel.svg;
+
       if (panel.attachment && typeof panel.attachment === "string") {
         panel.attachment = stripDataUrl(panel.attachment);
       }
 
-      return panel;
+      return compactPanelForHistory(panel);
     })
     .filter(Boolean);
+}
+
+function compactPanelMetadata(metadata = {}) {
+  if (!metadata || typeof metadata !== "object") {
+    return metadata || {};
+  }
+
+  const allowedKeys = [
+    "panelType",
+    "panel_type",
+    "authoritySource",
+    "authorityUsed",
+    "sourceType",
+    "geometryHash",
+    "sourceModelHash",
+    "source_model_hash",
+    "svgHash",
+    "contentHash",
+    "width",
+    "height",
+    "sheetNumber",
+    "drawingNumber",
+    "exportGate",
+    "dimensions",
+    "bounds",
+  ];
+  const compacted = {};
+  allowedKeys.forEach((key) => {
+    if (metadata[key] !== undefined) {
+      compacted[key] = metadata[key];
+    }
+  });
+  return compacted;
+}
+
+function compactPanelForHistory(panel = {}) {
+  if (!panel || typeof panel !== "object") {
+    return panel;
+  }
+
+  delete panel.prompt;
+  delete panel.negativePrompt;
+  delete panel.fullPrompt;
+  delete panel.reasoning;
+  delete panel.trace;
+  delete panel.svgString;
+  delete panel.svg;
+  delete panel.dataUrl;
+
+  if (panel.metadata && typeof panel.metadata === "object") {
+    panel.metadata = compactPanelMetadata(panel.metadata);
+  }
+
+  return panel;
 }
 
 export function sanitizePanelMap(panelMap) {
@@ -272,7 +332,7 @@ export function sanitizePanelMap(panelMap) {
       delete sanitizedPanel.dataUrl;
     }
 
-    cloned[key] = sanitizedPanel;
+    cloned[key] = compactPanelForHistory(sanitizedPanel);
   });
 
   return cloned;


### PR DESCRIPTION
## Summary
- Add an IndexedDB-backed A1 design-history artifact store with lightweight `archiai-artifact://` manifest URLs.
- Persist large A1 sheet, PDF, panel raster/data URL, and raw panel SVG payloads outside localStorage history.
- Keep design history lightweight by storing artifact metadata, hashes, dimensions, export gate details, and artifact URLs while compacting heavy sheet/panel payloads.
- Resolve artifact URLs back to object URLs in the A1 sheet viewer and panel gallery.

## Scope notes
- No changes to ProjectGraph generation quality or A1 visual output.
- No changes to OpenAI/provider/env logic.
- No changes to project-type support.
- No Vercel Blob integration in this branch; the abstraction is ready for artifact URL persistence.

## Validation
- `npx react-scripts test --watchAll=false --runInBand --runTestsByPath src/__tests__/services/designHistoryRepository.storage.test.js src/__tests__/components/a1SheetDownload.test.js`
- `npm run lint`
- `npm run build:active`