### PR TITLE
feat(a1): Phase 5B — post-render visual identity validation report

### DIFF
--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -496,6 +496,33 @@ describe("projectGraphVerticalSliceService", () => {
         imageProviderUsed: "deterministic",
       }),
     );
+    // Phase 5B — visual identity validation report attached to artifacts
+    // and to sheet metadata. Deterministic-fallback path must not fail.
+    // The validator is report-only; it never modifies the export gate
+    // (the gate's decision is driven by its own evidence chain at
+    // src/services/project/projectGraphVerticalSliceService.js Phase F
+    // and is unchanged by this PR).
+    expect(result.artifacts.visualIdentityValidation).toEqual(
+      expect.objectContaining({
+        version: "visual-manifest-validator-v1",
+        strictMode: false,
+      }),
+    );
+    expect(result.artifacts.visualIdentityValidation.status).not.toBe("fail");
+    expect(result.artifacts.visualIdentityValidation.summary).toEqual(
+      expect.objectContaining({ totalPanels: 4 }),
+    );
+    expect(
+      Object.keys(result.artifacts.visualIdentityValidation.panels).sort(),
+    ).toEqual(
+      ["axonometric", "exterior_render", "hero_3d", "interior_3d"].sort(),
+    );
+    expect(
+      result.artifacts.a1Sheet.metadata.visualIdentityValidation,
+    ).toBeTruthy();
+    expect(
+      result.artifacts.a1Sheet.metadata.visualIdentityValidation.version,
+    ).toBe("visual-manifest-validator-v1");
     expect(result.artifacts.a1Pdf.asset_type).toBe("a1_sheet_pdf");
     expect(result.artifacts.a1Pdf.sheet_size_mm).toEqual({
       width: 841,

--- a/src/__tests__/services/render/visualManifestValidator.test.js
+++ b/src/__tests__/services/render/visualManifestValidator.test.js
@@ -1,0 +1,379 @@
+/**
+ * Phase 5B — visualManifestValidator focused tests.
+ *
+ * Locks the validator's behaviour for the four required scenarios in the
+ * Phase 5B brief:
+ *   1. matching panel metadata → status "pass"
+ *   2. mismatched visualManifestHash → status "warning"
+ *   3. mismatched sheetDesignContextHash → status "warning"
+ *   4. missing/blank panel image → status "warning" (or "fail" for missing)
+ *   5. deterministic fallback path passes
+ *   6. output attaches to artifacts metadata (covered by separate
+ *      projectGraphVerticalSliceService integration test)
+ *   7. exportGate stays allowed in non-strict mode (covered by
+ *      projectGraphVerticalSliceService integration test)
+ */
+
+import {
+  evaluateVisualIdentity,
+  validateVisualPanelArtifact,
+  REQUIRED_VISUAL_PANEL_TYPES,
+  VISUAL_MANIFEST_VALIDATOR_VERSION,
+} from "../../../services/render/visualManifestValidator.js";
+
+const MANIFEST_HASH = "manifest-hash-abc";
+const MANIFEST_ID = "visual-manifest-pg001";
+const CONTEXT_HASH = "context-hash-xyz";
+
+const MOCK_MANIFEST = Object.freeze({
+  manifestHash: MANIFEST_HASH,
+  manifestId: MANIFEST_ID,
+});
+
+const MOCK_SHEET_DESIGN_CONTEXT = Object.freeze({
+  contextHash: CONTEXT_HASH,
+});
+
+function makeDeterministicPanel(panelType, overrides = {}) {
+  return {
+    asset_id: `asset-${panelType}`,
+    asset_type: "compiled_3d_control_svg",
+    panel_type: panelType,
+    panelType,
+    width: 1500,
+    height: 1050,
+    svgString:
+      `<svg xmlns="http://www.w3.org/2000/svg" width="1500" height="1050"><path d="M10 10 L1490 10 L1490 1040 L10 1040 Z" fill="#cccccc"/><polygon points="100,100 200,100 200,200 100,200"/><rect x="500" y="500" width="100" height="100"/><circle cx="800" cy="500" r="40"/></svg>`.padEnd(
+        400,
+        " ",
+      ),
+    metadata: {
+      visualManifestId: MANIFEST_ID,
+      visualManifestHash: MANIFEST_HASH,
+      visualIdentityLocked: true,
+      visualRenderMode: "deterministic_fallback",
+      visualFidelityStatus: "degraded_control_render",
+      imageRenderFallback: true,
+      imageRenderFallbackReason: "gate_disabled",
+      imageRenderByteLength: null,
+      ...((overrides && overrides.metadata) || {}),
+    },
+    ...overrides,
+  };
+}
+
+function makePhotorealPanel(panelType, overrides = {}) {
+  return {
+    ...makeDeterministicPanel(panelType, overrides),
+    asset_type: "geometry_locked_presentation_svg",
+    metadata: {
+      visualManifestId: MANIFEST_ID,
+      visualManifestHash: MANIFEST_HASH,
+      visualIdentityLocked: true,
+      visualRenderMode: "photoreal_image_gen",
+      visualFidelityStatus: "photoreal_geometry_locked",
+      imageRenderFallback: false,
+      imageRenderByteLength: 256_000,
+      imageProviderUsed: "openai",
+      ...((overrides && overrides.metadata) || {}),
+    },
+  };
+}
+
+function makeFourDeterministicPanels(overrides = {}) {
+  return {
+    hero_3d: makeDeterministicPanel("hero_3d", overrides.hero_3d),
+    exterior_render: makeDeterministicPanel(
+      "exterior_render",
+      overrides.exterior_render,
+    ),
+    axonometric: makeDeterministicPanel("axonometric", overrides.axonometric),
+    interior_3d: makeDeterministicPanel("interior_3d", overrides.interior_3d),
+  };
+}
+
+describe("visualManifestValidator — Phase 5B", () => {
+  test("reports the validator version and required panel types", () => {
+    expect(VISUAL_MANIFEST_VALIDATOR_VERSION).toBe(
+      "visual-manifest-validator-v1",
+    );
+    expect(REQUIRED_VISUAL_PANEL_TYPES).toEqual([
+      "hero_3d",
+      "exterior_render",
+      "axonometric",
+      "interior_3d",
+    ]);
+  });
+
+  test("matching panel metadata → status pass", () => {
+    const panels = makeFourDeterministicPanels();
+    const report = evaluateVisualIdentity({
+      visualManifest: MOCK_MANIFEST,
+      sheetDesignContext: MOCK_SHEET_DESIGN_CONTEXT,
+      panelArtifacts: panels,
+      sheetMetadata: { sheetDesignContextHash: CONTEXT_HASH },
+    });
+
+    expect(report.status).toBe("pass");
+    expect(report.severity).toBe("info");
+    expect(report.summary.passedPanels).toBe(4);
+    expect(report.summary.warningPanels).toBe(0);
+    expect(report.summary.missingPanels).toBe(0);
+    expect(report.summary.distinctManifestHashes).toBe(1);
+    expect(report.warnings).toEqual([]);
+    expect(report.sheetWarnings).toEqual([]);
+    expect(report.expectedManifestHash).toBe(MANIFEST_HASH);
+    expect(report.expectedSheetDesignContextHash).toBe(CONTEXT_HASH);
+    for (const panelType of REQUIRED_VISUAL_PANEL_TYPES) {
+      expect(report.panels[panelType].status).toBe("pass");
+      expect(report.panels[panelType].checks.manifestHashMatches).toBe(true);
+      expect(report.panels[panelType].checks.manifestIdMatches).toBe(true);
+      expect(report.panels[panelType].checks.visualIdentityLocked).toBe(true);
+      expect(report.panels[panelType].checks.dimensionsValid).toBe(true);
+      expect(report.panels[panelType].checks.nonBlankContent).toBe(true);
+    }
+  });
+
+  test("mismatched visualManifestHash on one panel → status warning", () => {
+    const panels = makeFourDeterministicPanels({
+      axonometric: {
+        metadata: {
+          visualManifestId: MANIFEST_ID,
+          visualManifestHash: "different-hash-xxx",
+          visualIdentityLocked: true,
+          visualRenderMode: "deterministic_fallback",
+          visualFidelityStatus: "degraded_control_render",
+          imageRenderFallback: true,
+        },
+      },
+    });
+
+    const report = evaluateVisualIdentity({
+      visualManifest: MOCK_MANIFEST,
+      sheetDesignContext: MOCK_SHEET_DESIGN_CONTEXT,
+      panelArtifacts: panels,
+      sheetMetadata: { sheetDesignContextHash: CONTEXT_HASH },
+    });
+
+    expect(report.status).toBe("warning");
+    expect(report.severity).toBe("warning");
+    expect(report.summary.warningPanels).toBe(1);
+    expect(report.summary.passedPanels).toBe(3);
+    expect(report.summary.distinctManifestHashes).toBe(2);
+    expect(report.panels.axonometric.status).toBe("warning");
+    expect(report.panels.axonometric.checks.manifestHashMatches).toBe(false);
+    expect(report.sheetChecks.crossPanelManifestHashUnique).toBe(false);
+    expect(report.warnings.some((w) => w.includes("axonometric"))).toBe(true);
+    expect(
+      report.warnings.some((w) => w.includes("visualManifestHash mismatch")),
+    ).toBe(true);
+    expect(
+      report.sheetWarnings.some((w) =>
+        w.includes("All four panels must share one identity"),
+      ),
+    ).toBe(true);
+  });
+
+  test("mismatched sheetDesignContextHash → status warning", () => {
+    const panels = makeFourDeterministicPanels();
+
+    const report = evaluateVisualIdentity({
+      visualManifest: MOCK_MANIFEST,
+      sheetDesignContext: MOCK_SHEET_DESIGN_CONTEXT,
+      panelArtifacts: panels,
+      sheetMetadata: { sheetDesignContextHash: "different-context-hash" },
+    });
+
+    expect(report.status).toBe("warning");
+    expect(report.severity).toBe("warning");
+    expect(report.sheetChecks.sheetDesignContextHashMatches).toBe(false);
+    expect(
+      report.sheetWarnings.some((w) =>
+        w.includes("sheetDesignContextHash mismatch"),
+      ),
+    ).toBe(true);
+    // Per-panel checks still pass
+    for (const panelType of REQUIRED_VISUAL_PANEL_TYPES) {
+      expect(report.panels[panelType].status).toBe("pass");
+    }
+  });
+
+  test("blank/missing panel image → blank warns, missing fails", () => {
+    const panels = makeFourDeterministicPanels({
+      // Blank panel: empty svgString
+      hero_3d: {
+        svgString: "",
+      },
+    });
+    // Drop interior_3d entirely
+    delete panels.interior_3d;
+
+    const report = evaluateVisualIdentity({
+      visualManifest: MOCK_MANIFEST,
+      sheetDesignContext: MOCK_SHEET_DESIGN_CONTEXT,
+      panelArtifacts: panels,
+      sheetMetadata: { sheetDesignContextHash: CONTEXT_HASH },
+    });
+
+    expect(report.status).toBe("fail");
+    expect(report.severity).toBe("error");
+    expect(report.summary.missingPanels).toBe(1);
+    expect(report.summary.warningPanels).toBe(1);
+    expect(report.panels.hero_3d.status).toBe("warning");
+    expect(report.panels.hero_3d.checks.nonBlankContent).toBe(false);
+    expect(report.panels.interior_3d.status).toBe("fail");
+    expect(report.panels.interior_3d.checks.panelExists).toBe(false);
+    expect(report.warnings.some((w) => w.includes("svgString is empty"))).toBe(
+      true,
+    );
+    expect(
+      report.warnings.some((w) => w.includes("Panel artifact missing")),
+    ).toBe(true);
+  });
+
+  test("deterministic fallback path passes (no photoreal metadata required)", () => {
+    const panels = makeFourDeterministicPanels();
+    // Belt and braces: explicitly null out PNG-specific fields
+    for (const panelType of REQUIRED_VISUAL_PANEL_TYPES) {
+      panels[panelType].metadata.imageRenderByteLength = null;
+      panels[panelType].metadata.imageProviderUsed = "deterministic";
+      panels[panelType].metadata.openaiImageUsed = false;
+    }
+
+    const report = evaluateVisualIdentity({
+      visualManifest: MOCK_MANIFEST,
+      sheetDesignContext: MOCK_SHEET_DESIGN_CONTEXT,
+      panelArtifacts: panels,
+      sheetMetadata: { sheetDesignContextHash: CONTEXT_HASH },
+    });
+
+    expect(report.status).toBe("pass");
+    for (const panelType of REQUIRED_VISUAL_PANEL_TYPES) {
+      expect(report.panels[panelType].deterministicFallback).toBe(true);
+      expect(report.panels[panelType].photoreal).toBe(false);
+      expect(report.panels[panelType].checks.nonBlankContent).toBe(true);
+    }
+  });
+
+  test("photoreal panel below PNG byte floor warns", () => {
+    const panels = {
+      hero_3d: makePhotorealPanel("hero_3d", {
+        metadata: {
+          visualManifestId: MANIFEST_ID,
+          visualManifestHash: MANIFEST_HASH,
+          visualIdentityLocked: true,
+          visualRenderMode: "photoreal_image_gen",
+          visualFidelityStatus: "photoreal_geometry_locked",
+          imageRenderFallback: false,
+          imageRenderByteLength: 64, // below floor
+          imageProviderUsed: "openai",
+        },
+      }),
+      exterior_render: makePhotorealPanel("exterior_render"),
+      axonometric: makePhotorealPanel("axonometric"),
+      interior_3d: makePhotorealPanel("interior_3d"),
+    };
+
+    const report = evaluateVisualIdentity({
+      visualManifest: MOCK_MANIFEST,
+      sheetDesignContext: MOCK_SHEET_DESIGN_CONTEXT,
+      panelArtifacts: panels,
+      sheetMetadata: { sheetDesignContextHash: CONTEXT_HASH },
+    });
+
+    expect(report.panels.hero_3d.status).toBe("warning");
+    expect(report.panels.hero_3d.checks.nonBlankContent).toBe(false);
+    expect(
+      report.panels.hero_3d.warnings.some((w) =>
+        w.includes("PNG byte length below floor"),
+      ),
+    ).toBe(true);
+  });
+
+  test("strict mode promotes warnings to error severity but does not throw", () => {
+    const panels = makeFourDeterministicPanels({
+      axonometric: {
+        metadata: {
+          visualManifestId: MANIFEST_ID,
+          visualManifestHash: "different-hash-xxx",
+          visualIdentityLocked: true,
+          visualRenderMode: "deterministic_fallback",
+          imageRenderFallback: true,
+        },
+      },
+    });
+
+    const report = evaluateVisualIdentity({
+      visualManifest: MOCK_MANIFEST,
+      sheetDesignContext: MOCK_SHEET_DESIGN_CONTEXT,
+      panelArtifacts: panels,
+      sheetMetadata: { sheetDesignContextHash: CONTEXT_HASH },
+      options: { strictMode: true },
+    });
+
+    expect(report.strictMode).toBe(true);
+    expect(report.status).toBe("fail");
+    expect(report.severity).toBe("error");
+    // warnings still surface as warnings on the panel level — only the
+    // top-level severity is promoted, so the gate can choose to demote.
+    expect(report.panels.axonometric.severity).toBe("warning");
+  });
+
+  test("validator never throws when called with empty input (degenerate case)", () => {
+    const report = evaluateVisualIdentity({});
+    expect(report.version).toBe(VISUAL_MANIFEST_VALIDATOR_VERSION);
+    // Empty input = all 4 panels missing (per-panel severity "error") +
+    // missing manifest (sheet warning). Top severity rolls up to "error".
+    expect(report.status).toBe("fail");
+    expect(report.severity).toBe("error");
+    expect(report.summary.missingPanels).toBe(4);
+    expect(report.sheetChecks.manifestPresent).toBe(false);
+    expect(report.warnings.length).toBeGreaterThan(0);
+  });
+
+  test("validateVisualPanelArtifact passes for a complete panel", () => {
+    const panel = makeDeterministicPanel("hero_3d");
+    const report = validateVisualPanelArtifact({
+      panelType: "hero_3d",
+      panel,
+      expectedManifestHash: MANIFEST_HASH,
+      expectedManifestId: MANIFEST_ID,
+    });
+    expect(report.status).toBe("pass");
+    expect(report.warnings).toEqual([]);
+  });
+
+  test("validateVisualPanelArtifact warns when visualIdentityLocked is false", () => {
+    const panel = makeDeterministicPanel("hero_3d");
+    panel.metadata.visualIdentityLocked = false;
+    const report = validateVisualPanelArtifact({
+      panelType: "hero_3d",
+      panel,
+      expectedManifestHash: MANIFEST_HASH,
+      expectedManifestId: MANIFEST_ID,
+    });
+    expect(report.status).toBe("warning");
+    expect(
+      report.warnings.some((w) =>
+        w.includes("visualIdentityLocked is not true"),
+      ),
+    ).toBe(true);
+  });
+
+  test("validateVisualPanelArtifact warns on dimension regression", () => {
+    const panel = makeDeterministicPanel("hero_3d");
+    panel.width = 0;
+    panel.height = -10;
+    const report = validateVisualPanelArtifact({
+      panelType: "hero_3d",
+      panel,
+      expectedManifestHash: MANIFEST_HASH,
+      expectedManifestId: MANIFEST_ID,
+    });
+    expect(report.status).toBe("warning");
+    expect(report.checks.dimensionsValid).toBe(false);
+    expect(report.warnings.some((w) => w.includes("invalid dimensions"))).toBe(
+      true,
+    );
+  });
+});

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -27,6 +27,10 @@ import {
   buildVisualIdentityLockBlock,
 } from "../render/visualManifestService.js";
 import {
+  evaluateVisualIdentity,
+  VISUAL_MANIFEST_VALIDATOR_VERSION,
+} from "../render/visualManifestValidator.js";
+import {
   buildSheetDesignContext,
   assertSheetDesignContext,
   SHEET_DESIGN_CONTEXT_VERSION,
@@ -10037,6 +10041,55 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       )
       .map((artifact) => [artifact.panel_type, artifact]),
   );
+  // Phase 5B: post-render visual identity validation. Reports only — does
+  // NOT block the export gate by default. Strict mode (opt-in via
+  // PROJECT_GRAPH_VISUAL_IDENTITY_STRICT=true) promotes warnings to error
+  // severity so a downstream gate can choose to demote, but this
+  // validator never throws and never decides for the gate. The report is
+  // stamped onto sheetArtifact.metadata.visualIdentityValidation and
+  // surfaced at artifacts.visualIdentityValidation for QA / API consumers.
+  const visualIdentityStrictMode =
+    String(
+      (typeof process !== "undefined" &&
+        process.env?.PROJECT_GRAPH_VISUAL_IDENTITY_STRICT) ||
+        "",
+    )
+      .toLowerCase()
+      .trim() === "true";
+  let visualIdentityValidation;
+  try {
+    visualIdentityValidation = evaluateVisualIdentity({
+      visualManifest,
+      sheetDesignContext,
+      sheetDesignContextHash: sheetDesignContext?.contextHash || null,
+      panelArtifacts: visuals3d,
+      sheetMetadata: sheetArtifact?.metadata || null,
+      options: { strictMode: visualIdentityStrictMode },
+    });
+  } catch (validationError) {
+    visualIdentityValidation = {
+      version: VISUAL_MANIFEST_VALIDATOR_VERSION,
+      status: "warning",
+      severity: "warning",
+      strictMode: visualIdentityStrictMode,
+      summary: { totalPanels: 4, error: true },
+      warnings: [
+        `Visual identity validator threw: ${validationError?.message || "unknown"}.`,
+      ],
+      panels: {},
+      sheetChecks: {},
+      sheetWarnings: [],
+    };
+  }
+  sheetArtifact.metadata = {
+    ...(sheetArtifact.metadata || {}),
+    visualIdentityValidation,
+  };
+  __vsMark = __vsLog(
+    "visual_identity_validation",
+    __vsMark,
+    `status=${visualIdentityValidation.status} warnings=${visualIdentityValidation.summary?.totalWarnings ?? 0}`,
+  );
   const openaiReasoningExecution =
     input.openaiReasoningExecution ||
     input.providerExecution?.openaiReasoning ||
@@ -10303,6 +10356,13 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     sheetDesignContext,
     sheetDesignContextHash: sheetDesignContext.contextHash,
     sheetDesignContextReport,
+    // Phase 5B — post-render visual identity validation report. Warning-
+    // only by default; opt-in strict mode lets a downstream export gate
+    // demote on visual-identity drift. The validator reads what panel
+    // artifacts already stamp (visualManifestHash / Id / locked) plus the
+    // sheet-level sheetDesignContextHash and emits a structured per-panel
+    // report. See src/services/render/visualManifestValidator.js.
+    visualIdentityValidation,
     technicalBuild: {
       ok: technicalBuild.ok,
       technicalPanelTypes: technicalBuild.technicalPanelTypes,

--- a/src/services/render/visualManifestValidator.js
+++ b/src/services/render/visualManifestValidator.js
@@ -1,0 +1,401 @@
+/**
+ * Phase 5B — Visual Identity Validator (post-render).
+ *
+ * The visual identity manifest (Phase D) and the SheetDesignContext
+ * (Phase 1) are injected into every visual-panel prompt. That guarantees
+ * the *intent* shared across hero_3d / exterior_render / axonometric /
+ * interior_3d, but it does not guarantee the rendered PNGs/SVGs actually
+ * preserve that identity. Phase 5B adds a deterministic, cheap, post-
+ * render validator that reads what panel artifacts now carry and produces
+ * a `visualIdentityValidation` report.
+ *
+ * Scope (intentionally narrow for this phase):
+ *   - panel exists and has the expected `panel_type`
+ *   - panel dimensions are positive numbers
+ *   - panel content is non-blank (`svgString` contains at least one
+ *     drawing primitive: <path>, <polygon>, <rect>, <polyline>, <circle>,
+ *     or <image>; image-render panels also must report a non-trivial
+ *     `imageRenderByteLength`)
+ *   - panel `metadata.visualManifestHash` matches the build-time manifest
+ *     and is identical across all four panels
+ *   - panel `metadata.visualManifestId` is set
+ *   - panel `metadata.visualIdentityLocked === true`
+ *   - sheet `metadata.sheetDesignContextHash` matches the build-time
+ *     SheetDesignContext (sheet-level, not per-panel — only the sheet
+ *     artifact stamps the context hash today)
+ *
+ * Out of scope here (called out so the next phase has a clear hook):
+ *   - decoding rendered PNGs to sample dominant colours
+ *   - perceptual edge-density / storey-count proofs
+ *   - regenerating non-conforming panels
+ *   - blocking the export gate (warning-only by default; strict mode is a
+ *     separate, opt-in flag described in `evaluateVisualIdentity()`)
+ *
+ * The validator is pure and synchronous. It returns a structured report
+ * that the slice service attaches to `sheetArtifact.metadata` and to the
+ * top-level `artifacts.visualIdentityValidation` slot.
+ */
+
+export const VISUAL_MANIFEST_VALIDATOR_VERSION = "visual-manifest-validator-v1";
+
+export const REQUIRED_VISUAL_PANEL_TYPES = Object.freeze([
+  "hero_3d",
+  "exterior_render",
+  "axonometric",
+  "interior_3d",
+]);
+
+const MIN_NON_BLANK_SVG_LENGTH = 200;
+const MIN_PHOTOREAL_PNG_BYTES = 1024;
+
+const DRAWING_PRIMITIVE_PATTERN =
+  /<(?:path|polygon|polyline|rect|circle|image|line|ellipse)\b/i;
+
+const SEVERITY_INFO = "info";
+const SEVERITY_WARNING = "warning";
+const SEVERITY_ERROR = "error";
+
+const SEVERITY_RANK = Object.freeze({
+  [SEVERITY_INFO]: 0,
+  [SEVERITY_WARNING]: 1,
+  [SEVERITY_ERROR]: 2,
+});
+
+function bumpSeverity(current, candidate) {
+  return SEVERITY_RANK[candidate] > SEVERITY_RANK[current]
+    ? candidate
+    : current;
+}
+
+function isPositiveNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0;
+}
+
+function looksLikePhotorealRender(panel) {
+  const meta = panel?.metadata || {};
+  if (meta.visualRenderMode === "photoreal_image_gen") return true;
+  if (meta.imageProviderUsed === "openai") return true;
+  if (Number(meta.imageRenderByteLength || 0) > 0) return true;
+  return false;
+}
+
+function isDeterministicFallback(panel) {
+  const meta = panel?.metadata || {};
+  if (meta.visualRenderMode === "deterministic_fallback") return true;
+  if (meta.imageRenderFallback === true) return true;
+  return false;
+}
+
+function panelKey(panel, fallback) {
+  return panel?.panel_type || panel?.panelType || fallback || "unknown_panel";
+}
+
+/**
+ * Validate a single visual-panel artifact against the manifest.
+ * Pure: returns a per-panel report with structured checks and severity.
+ *
+ * @param {object} params
+ * @param {string} params.panelType - one of REQUIRED_VISUAL_PANEL_TYPES
+ * @param {object|null} params.panel - panel artifact (or null when missing)
+ * @param {string} params.expectedManifestHash
+ * @param {string|null} params.expectedManifestId
+ * @returns {{ panelType: string, status: "pass"|"warning"|"fail", severity: string, checks: object, warnings: string[] }}
+ */
+export function validateVisualPanelArtifact({
+  panelType,
+  panel,
+  expectedManifestHash,
+  expectedManifestId,
+}) {
+  const checks = {
+    panelExists: false,
+    panelTypeMatches: false,
+    dimensionsValid: false,
+    nonBlankContent: false,
+    manifestHashMatches: false,
+    manifestIdMatches: false,
+    visualIdentityLocked: false,
+  };
+  const warnings = [];
+  let severity = SEVERITY_INFO;
+
+  if (!panel || typeof panel !== "object") {
+    warnings.push(`Panel artifact missing for ${panelType}.`);
+    return {
+      panelType,
+      status: "fail",
+      severity: SEVERITY_ERROR,
+      checks,
+      warnings,
+    };
+  }
+
+  checks.panelExists = true;
+  const actualType = panelKey(panel, panelType);
+  checks.panelTypeMatches = actualType === panelType;
+  if (!checks.panelTypeMatches) {
+    warnings.push(
+      `Panel ${panelType} reports panel_type="${actualType}" — does not match expected slot.`,
+    );
+    severity = bumpSeverity(severity, SEVERITY_WARNING);
+  }
+
+  const width = Number(panel.width || panel.metadata?.width || 0);
+  const height = Number(panel.height || panel.metadata?.height || 0);
+  checks.dimensionsValid = isPositiveNumber(width) && isPositiveNumber(height);
+  if (!checks.dimensionsValid) {
+    warnings.push(
+      `Panel ${panelType} has invalid dimensions: ${width}x${height}.`,
+    );
+    severity = bumpSeverity(severity, SEVERITY_WARNING);
+  }
+
+  const svgString = String(panel.svgString || "");
+  const hasPrimitive = DRAWING_PRIMITIVE_PATTERN.test(svgString);
+  const meetsLengthFloor = svgString.length >= MIN_NON_BLANK_SVG_LENGTH;
+  const photorealByteFloorOk =
+    !looksLikePhotorealRender(panel) ||
+    Number(panel.metadata?.imageRenderByteLength || 0) >=
+      MIN_PHOTOREAL_PNG_BYTES;
+  checks.nonBlankContent =
+    Boolean(svgString) &&
+    hasPrimitive &&
+    meetsLengthFloor &&
+    photorealByteFloorOk;
+  if (!checks.nonBlankContent) {
+    if (!svgString) {
+      warnings.push(`Panel ${panelType} svgString is empty.`);
+    } else if (!hasPrimitive) {
+      warnings.push(
+        `Panel ${panelType} svgString contains no drawing primitives.`,
+      );
+    } else if (!meetsLengthFloor) {
+      warnings.push(
+        `Panel ${panelType} svgString below non-blank floor (${svgString.length} < ${MIN_NON_BLANK_SVG_LENGTH}).`,
+      );
+    } else if (!photorealByteFloorOk) {
+      warnings.push(
+        `Panel ${panelType} reports photoreal render but PNG byte length below floor (${panel.metadata?.imageRenderByteLength || 0} < ${MIN_PHOTOREAL_PNG_BYTES}).`,
+      );
+    }
+    severity = bumpSeverity(severity, SEVERITY_WARNING);
+  }
+
+  const manifestHash = panel.metadata?.visualManifestHash || null;
+  checks.manifestHashMatches = Boolean(
+    manifestHash &&
+    expectedManifestHash &&
+    manifestHash === expectedManifestHash,
+  );
+  if (!checks.manifestHashMatches) {
+    if (!manifestHash) {
+      warnings.push(
+        `Panel ${panelType} is missing metadata.visualManifestHash.`,
+      );
+    } else if (!expectedManifestHash) {
+      warnings.push(
+        `Panel ${panelType} carries metadata.visualManifestHash="${manifestHash}" but no manifest hash was provided to the validator.`,
+      );
+    } else {
+      warnings.push(
+        `Panel ${panelType} metadata.visualManifestHash mismatch (got "${manifestHash}", expected "${expectedManifestHash}").`,
+      );
+    }
+    severity = bumpSeverity(severity, SEVERITY_WARNING);
+  }
+
+  const manifestId = panel.metadata?.visualManifestId || null;
+  checks.manifestIdMatches = Boolean(
+    manifestId && expectedManifestId && manifestId === expectedManifestId,
+  );
+  if (!checks.manifestIdMatches && expectedManifestId) {
+    if (!manifestId) {
+      warnings.push(`Panel ${panelType} is missing metadata.visualManifestId.`);
+    } else {
+      warnings.push(
+        `Panel ${panelType} metadata.visualManifestId mismatch (got "${manifestId}", expected "${expectedManifestId}").`,
+      );
+    }
+    severity = bumpSeverity(severity, SEVERITY_WARNING);
+  }
+
+  checks.visualIdentityLocked = panel.metadata?.visualIdentityLocked === true;
+  if (!checks.visualIdentityLocked) {
+    warnings.push(
+      `Panel ${panelType} metadata.visualIdentityLocked is not true.`,
+    );
+    severity = bumpSeverity(severity, SEVERITY_WARNING);
+  }
+
+  let status = "pass";
+  if (severity === SEVERITY_ERROR) status = "fail";
+  else if (severity === SEVERITY_WARNING) status = "warning";
+
+  return {
+    panelType,
+    status,
+    severity,
+    checks,
+    warnings,
+    visualRenderMode: panel.metadata?.visualRenderMode || null,
+    visualFidelityStatus: panel.metadata?.visualFidelityStatus || null,
+    deterministicFallback: isDeterministicFallback(panel),
+    photoreal: looksLikePhotorealRender(panel),
+  };
+}
+
+/**
+ * Top-level validator: takes the build-time manifest + sheetDesignContext
+ * + the four rendered visual panels and returns a structured report that
+ * the slice service can stamp onto sheet/artifacts metadata.
+ *
+ * The validator is **report-only** by default. The optional `strictMode`
+ * flag (typically wired to `process.env.PROJECT_GRAPH_VISUAL_IDENTITY_STRICT`)
+ * promotes warnings to error severity so an external export gate can
+ * choose to demote — but this validator never throws and never decides
+ * for the gate. It only reports.
+ *
+ * @param {object} params
+ * @param {object|null} params.visualManifest - manifest from buildVisualManifest()
+ * @param {object|null} params.sheetDesignContext - context from buildSheetDesignContext()
+ * @param {string|null} params.sheetDesignContextHash - optional explicit hash
+ *        if the slice service has it readily available; falls back to
+ *        sheetDesignContext?.contextHash.
+ * @param {object} params.panelArtifacts - { hero_3d, exterior_render, axonometric, interior_3d }
+ * @param {object|null} params.sheetMetadata - sheet artifact metadata; used to
+ *        verify sheetDesignContextHash on the sheet (per-panel hash is not
+ *        currently stamped, only the sheet stamps it).
+ * @param {object} [params.options]
+ * @param {boolean} [params.options.strictMode=false]
+ * @returns {object} report
+ */
+export function evaluateVisualIdentity({
+  visualManifest = null,
+  sheetDesignContext = null,
+  sheetDesignContextHash = null,
+  panelArtifacts = {},
+  sheetMetadata = null,
+  options = {},
+} = {}) {
+  const strictMode = options.strictMode === true;
+  const expectedManifestHash = visualManifest?.manifestHash || null;
+  const expectedManifestId = visualManifest?.manifestId || null;
+  const expectedSheetDesignContextHash =
+    sheetDesignContextHash || sheetDesignContext?.contextHash || null;
+
+  const panels = {};
+  let totalWarnings = 0;
+  let topSeverity = SEVERITY_INFO;
+  let missingPanels = 0;
+  let warningPanels = 0;
+  let passedPanels = 0;
+  const allManifestHashes = new Set();
+
+  for (const panelType of REQUIRED_VISUAL_PANEL_TYPES) {
+    const panel = panelArtifacts ? panelArtifacts[panelType] : null;
+    const report = validateVisualPanelArtifact({
+      panelType,
+      panel,
+      expectedManifestHash,
+      expectedManifestId,
+    });
+    panels[panelType] = report;
+    totalWarnings += report.warnings.length;
+    topSeverity = bumpSeverity(topSeverity, report.severity);
+    if (!report.checks.panelExists) missingPanels += 1;
+    else if (report.status === "warning") warningPanels += 1;
+    else if (report.status === "pass") passedPanels += 1;
+    if (panel?.metadata?.visualManifestHash) {
+      allManifestHashes.add(panel.metadata.visualManifestHash);
+    }
+  }
+
+  const sheetWarnings = [];
+  const sheetChecks = {
+    manifestPresent: Boolean(visualManifest && expectedManifestHash),
+    sheetDesignContextHashMatches: false,
+    crossPanelManifestHashUnique: allManifestHashes.size <= 1,
+  };
+  if (!sheetChecks.manifestPresent) {
+    sheetWarnings.push(
+      "visualManifest is missing or has no manifestHash; cannot validate identity.",
+    );
+    topSeverity = bumpSeverity(topSeverity, SEVERITY_WARNING);
+  }
+
+  const sheetActualContextHash = sheetMetadata?.sheetDesignContextHash || null;
+  sheetChecks.sheetDesignContextHashMatches = Boolean(
+    expectedSheetDesignContextHash &&
+    sheetActualContextHash &&
+    sheetActualContextHash === expectedSheetDesignContextHash,
+  );
+  if (!sheetChecks.sheetDesignContextHashMatches) {
+    if (!expectedSheetDesignContextHash) {
+      sheetWarnings.push(
+        "No SheetDesignContext hash was provided; cannot assert sheet-level identity hash.",
+      );
+    } else if (!sheetActualContextHash) {
+      sheetWarnings.push("Sheet metadata is missing sheetDesignContextHash.");
+    } else {
+      sheetWarnings.push(
+        `Sheet metadata.sheetDesignContextHash mismatch (got "${sheetActualContextHash}", expected "${expectedSheetDesignContextHash}").`,
+      );
+    }
+    topSeverity = bumpSeverity(topSeverity, SEVERITY_WARNING);
+  }
+
+  if (!sheetChecks.crossPanelManifestHashUnique) {
+    sheetWarnings.push(
+      `Visual panels carry ${allManifestHashes.size} distinct visualManifestHash values: [${Array.from(allManifestHashes).join(", ")}]. All four panels must share one identity.`,
+    );
+    topSeverity = bumpSeverity(topSeverity, SEVERITY_WARNING);
+  }
+
+  const flatWarnings = [];
+  for (const panelType of REQUIRED_VISUAL_PANEL_TYPES) {
+    panels[panelType].warnings.forEach((w) =>
+      flatWarnings.push(`[${panelType}] ${w}`),
+    );
+  }
+  sheetWarnings.forEach((w) => flatWarnings.push(`[sheet] ${w}`));
+
+  let finalSeverity = topSeverity;
+  if (strictMode && finalSeverity === SEVERITY_WARNING) {
+    finalSeverity = SEVERITY_ERROR;
+  }
+
+  let status = "pass";
+  if (finalSeverity === SEVERITY_ERROR) status = "fail";
+  else if (finalSeverity === SEVERITY_WARNING) status = "warning";
+
+  return {
+    version: VISUAL_MANIFEST_VALIDATOR_VERSION,
+    status,
+    severity: finalSeverity,
+    strictMode,
+    expectedManifestHash,
+    expectedManifestId,
+    expectedSheetDesignContextHash,
+    sheetActualContextHash,
+    summary: {
+      totalPanels: REQUIRED_VISUAL_PANEL_TYPES.length,
+      passedPanels,
+      warningPanels,
+      missingPanels,
+      totalWarnings,
+      distinctManifestHashes: allManifestHashes.size,
+    },
+    sheetChecks,
+    sheetWarnings,
+    panels,
+    warnings: flatWarnings,
+  };
+}
+
+export default {
+  VISUAL_MANIFEST_VALIDATOR_VERSION,
+  REQUIRED_VISUAL_PANEL_TYPES,
+  evaluateVisualIdentity,
+  validateVisualPanelArtifact,
+};


### PR DESCRIPTION
## Summary

Adds a deterministic, cheap, post-render validator that confirms the four visual panels (`hero_3d`, `exterior_render`, `axonometric`, `interior_3d`) remain consistent with the `visualManifest` and `SheetDesignContext` that were injected into their prompts. Report-only by default; an opt-in `PROJECT_GRAPH_VISUAL_IDENTITY_STRICT=true` env flag promotes warnings to error severity so a downstream gate can choose to demote, but the validator never throws and never decides for the gate.

## Per-panel checks (cheap, structural)

- panel exists with the expected `panel_type`
- dimensions are positive numbers
- `svgString` contains a drawing primitive (`<path>` / `<polygon>` / `<rect>` / `<polyline>` / `<circle>` / `<image>` / `<line>` / `<ellipse>`) and meets a minimum length floor; photoreal panels also need `metadata.imageRenderByteLength >= 1024`
- `metadata.visualManifestHash` matches the build-time `manifestHash` and is identical across all four panels
- `metadata.visualManifestId` matches
- `metadata.visualIdentityLocked === true`

## Sheet-level check

- `sheetMetadata.sheetDesignContextHash` matches the build-time `SheetDesignContext.contextHash`

## Wiring

The report is stamped onto:
- `result.artifacts.a1Sheet.metadata.visualIdentityValidation`
- `result.artifacts.visualIdentityValidation` (top-level for QA / API consumers)

The validator runs immediately after `visuals3d` is assembled in [`projectGraphVerticalSliceService.js`](src/services/project/projectGraphVerticalSliceService.js), before the existing Phase F upstream-partial export gate, but does **not** participate in the gate's evidence chain. The existing gate logic is byte-identical.

## Out of scope (called out so the next phase has a clear hook)

- decoding rendered PNGs to sample dominant colours
- perceptual edge-density / storey-count proofs
- regenerating non-conforming panels
- blocking the export gate (warning-only by default; strict mode is opt-in)

## Files

- `src/services/render/visualManifestValidator.js` (NEW, 411 lines)
- `src/services/project/projectGraphVerticalSliceService.js` (+60 lines: import + wiring + artifact slot)
- `src/__tests__/services/render/visualManifestValidator.test.js` (NEW, 381 lines, 12 focused tests)
- `src/__tests__/services/projectGraphVerticalSliceService.test.js` (+27 lines: integration assertions on the canonical brief→QA test)

## Validation

All baseline checks green on `main` (`70303a0`) and after Phase 5B:

- ` npm run check:env`
- ` npm run check:contracts`
- ` npm run lint`
- ` npm run build:active`
- ` npm run test:a1:tofu`
- ` npm run test:compose:routing`
- ` node scripts/tests/test-a1-layout-regression.mjs` — 27/27
- ` jest visualManifestValidator + visualManifestService + projectGraphImageRenderer` — 38/38
- ` jest projectGraphVerticalSliceService.test.js -t "brief to QA vertical slice"` — pass

## Local deterministic A1 smoke (tmp/phase5b-fresh-a1.mjs, not committed)

\`\`\`json
{
  "qaStatus": "fail",                     // unchanged: existing QA fails for deterministic mode
  "geometryHash": "474711f16559534a",
  "pdfBytes": 7164948,
  "sheetDesignContextHash": "b902161944c3eec6",
  "visualManifestHash": "3a3f67dca1443bf7",
  "openaiImageUsed": false,
  "visualPanelsRenderMode": "all_deterministic",
  "visualIdentityValidation": {
    "version": "visual-manifest-validator-v1",
    "status": "pass",
    "severity": "info",
    "strictMode": false,
    "summary": {
      "totalPanels": 4,
      "passedPanels": 4,
      "warningPanels": 0,
      "missingPanels": 0,
      "totalWarnings": 0,
      "distinctManifestHashes": 1
    },
    "sheetChecks": {
      "manifestPresent": true,
      "sheetDesignContextHashMatches": true,
      "crossPanelManifestHashUnique": true
    }
  },
  "exportGate": {
    "scope": "upstream_partial",
    "allowed": true,
    "status": "warning",
    "blockers": []
  }
}
\`\`\`

Confirms:
- Validator status \`"pass"\` on the deterministic-fallback baseline (does not regress non-photoreal flow).
- All four panels share the same \`visualManifestHash\` and \`sheetDesignContextHash\` matches.
- \`exportGate.allowed: true\` in non-strict mode — validator did not block the gate.

Photoreal smoke not run in this session (no Preview env set up for it). The validator's behaviour for photoreal panels is locked by the \`photoreal panel below PNG byte floor warns\` unit test.

## Test plan

- [x] Unit: matching panel metadata → status pass
- [x] Unit: mismatched \`visualManifestHash\` → status warning
- [x] Unit: mismatched \`sheetDesignContextHash\` → status warning
- [x] Unit: missing/blank panel image → blank warns, missing fails
- [x] Unit: deterministic fallback path passes
- [x] Unit: photoreal panel below PNG byte floor warns
- [x] Unit: strict mode promotes warnings to error severity but does not throw
- [x] Unit: validator never throws on empty/degenerate input
- [x] Integration: report attaches to \`artifacts.visualIdentityValidation\` and to \`a1Sheet.metadata.visualIdentityValidation\`
- [x] Local deterministic A1: status \"pass\", exportGate \`allowed: true\`

## Stop and wait

Per the Phase 5 plan, this is **stop-and-report between phases**. Do not start Phase 5C (site boundary accuracy) until this PR is reviewed and merged.