### PR TITLE
feat(a1): Phase 5C — server-side site-boundary proxy (/api/site/boundary)

### DIFF
--- a/api/site/_lib/boundaryNormalize.js
+++ b/api/site/_lib/boundaryNormalize.js
@@ -1,0 +1,299 @@
+/**
+ * Phase 5C — Site boundary response shaping.
+ *
+ * Pure helpers that turn raw OSM/Overpass elements into the canonical
+ * `{ polygon, source, confidence, areaM2, ... }` shape that
+ * `propertyBoundaryService.js` already understands. Keeping this in a
+ * separate module so the endpoint and tests can import the same
+ * normalisation without pulling in fetch/timeout machinery.
+ *
+ * IMPORTANT — safety contract preserved from PR #60/#62/#63:
+ *   - low-confidence results never claim `boundaryAuthoritative: true`
+ *   - the existing Intelligent Fallback path stays as the FINAL safety
+ *     net (this module only deals with proxy results upstream of that)
+ *   - confidence values mirror the bands used by
+ *     `assessSiteBoundaryAuthority()` so downstream gating is unchanged
+ */
+
+export const PROXY_RESPONSE_SCHEMA_VERSION = "site-boundary-proxy-v1";
+
+export const BOUNDARY_SOURCE = Object.freeze({
+  OVERPASS_BUILDING_CONTAINS: "openstreetmap-overpass-building-contains-point",
+  OVERPASS_BUILDING_NEAREST: "openstreetmap-overpass-building-nearest",
+  OVERPASS_PARCEL_CONTAINS: "openstreetmap-overpass-parcel-contains-point",
+  NONE: null,
+});
+
+const CONFIDENCE_BY_SOURCE = Object.freeze({
+  [BOUNDARY_SOURCE.OVERPASS_PARCEL_CONTAINS]: 0.95,
+  [BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS]: 0.92,
+  [BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST]: 0.7,
+});
+
+const AUTHORITATIVE_BY_SOURCE = Object.freeze({
+  [BOUNDARY_SOURCE.OVERPASS_PARCEL_CONTAINS]: true,
+  [BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS]: true,
+  [BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST]: false,
+});
+
+/**
+ * Convert a raw Overpass `way` element with embedded `geometry` into
+ * the canonical polygon shape `[{ lat, lng }, …]`.
+ */
+export function extractPolygonFromOverpassWay(element) {
+  if (!element || element.type !== "way" || !Array.isArray(element.geometry)) {
+    return [];
+  }
+  const polygon = [];
+  for (const node of element.geometry) {
+    if (
+      Number.isFinite(Number(node?.lat)) &&
+      Number.isFinite(Number(node?.lon))
+    ) {
+      polygon.push({ lat: Number(node.lat), lng: Number(node.lon) });
+    }
+  }
+  return polygon;
+}
+
+/**
+ * Compute polygon area in square metres using the spherical excess /
+ * shoelace approximation good enough for parcel-scale polygons.
+ */
+export function polygonAreaM2(polygon) {
+  if (!Array.isArray(polygon) || polygon.length < 3) return 0;
+  const earthRadiusM = 6_371_008.8;
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  let sum = 0;
+  for (let i = 0; i < polygon.length; i++) {
+    const a = polygon[i];
+    const b = polygon[(i + 1) % polygon.length];
+    if (!a || !b) continue;
+    sum +=
+      toRad(b.lng - a.lng) *
+      (2 + Math.sin(toRad(a.lat)) + Math.sin(toRad(b.lat)));
+  }
+  return Math.abs((sum * earthRadiusM * earthRadiusM) / 2);
+}
+
+/**
+ * Return true when the polygon contains the given point. Uses the ray-
+ * casting algorithm; treats the polygon as closed (does NOT require the
+ * caller to repeat the first vertex at the end).
+ */
+export function polygonContainsPoint(polygon, point) {
+  if (
+    !Array.isArray(polygon) ||
+    polygon.length < 3 ||
+    !point ||
+    !Number.isFinite(Number(point.lat)) ||
+    !Number.isFinite(Number(point.lng))
+  ) {
+    return false;
+  }
+  const x = Number(point.lng);
+  const y = Number(point.lat);
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = Number(polygon[i].lng);
+    const yi = Number(polygon[i].lat);
+    const xj = Number(polygon[j].lng);
+    const yj = Number(polygon[j].lat);
+    const intersect =
+      yi > y !== yj > y &&
+      x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function polygonCentroid(polygon) {
+  if (!Array.isArray(polygon) || polygon.length === 0) return null;
+  let lat = 0;
+  let lng = 0;
+  for (const p of polygon) {
+    lat += Number(p.lat);
+    lng += Number(p.lng);
+  }
+  return { lat: lat / polygon.length, lng: lng / polygon.length };
+}
+
+/**
+ * Approximate haversine distance in metres for two `{lat,lng}` points.
+ */
+export function distanceM(a, b) {
+  if (!a || !b) return Infinity;
+  const earthRadiusM = 6_371_008.8;
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const lat1 = toRad(Number(a.lat));
+  const lat2 = toRad(Number(b.lat));
+  const dLat = lat2 - lat1;
+  const dLng = toRad(Number(b.lng) - Number(a.lng));
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+  const h =
+    sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng;
+  return 2 * earthRadiusM * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * Choose the best Overpass `way` element for the given point.
+ *
+ * Preference order:
+ *   1. parcel polygon that contains the point (rare in OSM but highest)
+ *   2. building polygon that contains the point
+ *   3. nearest building polygon (within 25 m of the point) — flagged
+ *      non-authoritative so downstream gating treats it as estimated
+ *
+ * Returns `{ element, polygon, source }` or null when nothing usable.
+ */
+export function selectBestOverpassWay({
+  buildingElements = [],
+  parcelElements = [],
+  point,
+}) {
+  const checkPoint = point;
+  // 1. parcel containing the point
+  for (const el of parcelElements) {
+    const polygon = extractPolygonFromOverpassWay(el);
+    if (polygon.length >= 3 && polygonContainsPoint(polygon, checkPoint)) {
+      return {
+        element: el,
+        polygon,
+        source: BOUNDARY_SOURCE.OVERPASS_PARCEL_CONTAINS,
+      };
+    }
+  }
+  // 2. building containing the point
+  for (const el of buildingElements) {
+    const polygon = extractPolygonFromOverpassWay(el);
+    if (polygon.length >= 3 && polygonContainsPoint(polygon, checkPoint)) {
+      return {
+        element: el,
+        polygon,
+        source: BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS,
+      };
+    }
+  }
+  // 3. nearest building within 25 m
+  let nearest = null;
+  let nearestDistance = Infinity;
+  for (const el of buildingElements) {
+    const polygon = extractPolygonFromOverpassWay(el);
+    if (polygon.length < 3) continue;
+    const centroid = polygonCentroid(polygon);
+    const d = distanceM(centroid, checkPoint);
+    if (d < nearestDistance && d <= 25) {
+      nearest = { element: el, polygon };
+      nearestDistance = d;
+    }
+  }
+  if (nearest) {
+    return {
+      element: nearest.element,
+      polygon: nearest.polygon,
+      source: BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST,
+    };
+  }
+  return null;
+}
+
+/**
+ * Cheap deterministic hash for cache keys — not crypto. Produces a
+ * stable hex string for a polygon + source so identical results compare
+ * equal across requests.
+ */
+export function hashBoundaryShape({ polygon, source }) {
+  const input = JSON.stringify({
+    source,
+    polygon: (polygon || []).map((p) => [
+      Number(p.lat).toFixed(6),
+      Number(p.lng).toFixed(6),
+    ]),
+  });
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash = Math.imul(hash ^ input.charCodeAt(i), 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Build the canonical proxy response body. Deterministic for a given
+ * input — used by both the live endpoint and the test fixtures.
+ *
+ * @param {object} params
+ * @param {Array}  params.polygon      - canonical polygon, may be empty
+ * @param {string|null} params.source  - one of BOUNDARY_SOURCE
+ * @param {object} [params.osmElement] - the raw way element (for metadata)
+ * @param {number} [params.queryRadiusM]
+ * @param {boolean} [params.cached]
+ * @param {string} [params.now]        - ISO timestamp; defaults to Date.now()
+ */
+export function buildBoundaryResponse({
+  polygon = [],
+  source = BOUNDARY_SOURCE.NONE,
+  osmElement = null,
+  queryRadiusM = 30,
+  cached = false,
+  now = null,
+} = {}) {
+  const hasShape = Array.isArray(polygon) && polygon.length >= 3;
+  const resolvedSource = hasShape ? source : BOUNDARY_SOURCE.NONE;
+  const confidence = hasShape ? CONFIDENCE_BY_SOURCE[resolvedSource] || 0 : 0;
+  const boundaryAuthoritative = hasShape
+    ? AUTHORITATIVE_BY_SOURCE[resolvedSource] === true
+    : false;
+  const areaM2 = hasShape ? polygonAreaM2(polygon) : 0;
+  const hash = hashBoundaryShape({ polygon, source: resolvedSource });
+
+  return {
+    schemaVersion: PROXY_RESPONSE_SCHEMA_VERSION,
+    polygon: hasShape ? polygon : null,
+    source: resolvedSource,
+    confidence,
+    boundaryAuthoritative,
+    areaM2: Math.round(areaM2),
+    hash,
+    cached: Boolean(cached),
+    timestamp: now || new Date().toISOString(),
+    metadata: {
+      osmId: osmElement?.id || null,
+      osmType: osmElement?.type || null,
+      buildingTag: osmElement?.tags?.building || null,
+      landuseTag: osmElement?.tags?.landuse || null,
+      addrHousenumber: osmElement?.tags?.["addr:housenumber"] || null,
+      addrStreet: osmElement?.tags?.["addr:street"] || null,
+      overpassQueryRadiusM: queryRadiusM,
+    },
+  };
+}
+
+/**
+ * Build a "no polygon found" response. Same shape as a successful
+ * response so the client never has to branch on `null` vs. object —
+ * just on `polygon` being null. Returns a 200 from the endpoint, NOT a
+ * 404, because "no boundary" is a valid (negative) result, not an error.
+ */
+export function buildEmptyResponse({
+  reason = "no_polygon_found",
+  cached = false,
+  now = null,
+  queryRadiusM = 30,
+} = {}) {
+  return {
+    schemaVersion: PROXY_RESPONSE_SCHEMA_VERSION,
+    polygon: null,
+    source: BOUNDARY_SOURCE.NONE,
+    confidence: 0,
+    boundaryAuthoritative: false,
+    areaM2: 0,
+    hash: hashBoundaryShape({ polygon: [], source: null }),
+    cached: Boolean(cached),
+    timestamp: now || new Date().toISOString(),
+    metadata: {
+      reason,
+      overpassQueryRadiusM: queryRadiusM,
+    },
+  };
+}

--- a/api/site/_lib/overpassClient.js
+++ b/api/site/_lib/overpassClient.js
@@ -1,0 +1,244 @@
+/**
+ * Phase 5C — Overpass client (server-side only).
+ *
+ * Thin wrapper around the public Overpass instance. Server-only: this
+ * module is imported by `api/site/boundary.js` and runs in Vercel
+ * Functions, where there is no CORS to worry about. The browser must
+ * NOT import this directly — it talks to `/api/site/boundary` instead.
+ *
+ * Behaviour:
+ *   - 8 s timeout per request (well below Vercel's default 300 s)
+ *   - 1 retry on 5xx with 500 ms backoff
+ *   - 429 returns immediately (no retry); upstream caller should fall
+ *     through to the existing estimated-boundary path
+ *   - parses JSON, returns `data.elements` or empty array
+ *   - throws on network error, timeout, malformed JSON, or persistent
+ *     5xx — caller wraps in try/catch and falls through to fallback
+ *
+ * The `fetchImpl` parameter exists so tests can inject a mocked fetch.
+ */
+
+const DEFAULT_OVERPASS_URL = "https://overpass-api.de/api/interpreter";
+const DEFAULT_TIMEOUT_MS = 8000;
+const DEFAULT_USER_AGENT =
+  "architect-ai-platform/site-boundary-proxy (https://archiaisolution.pro)";
+
+export class OverpassRateLimitError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "OverpassRateLimitError";
+    this.rateLimited = true;
+  }
+}
+
+export class OverpassTimeoutError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "OverpassTimeoutError";
+    this.timedOut = true;
+  }
+}
+
+/**
+ * Build the Overpass query for a building near `(lat, lng)` within
+ * `radiusM` metres. Mirrors the existing in-tree query in
+ * `propertyBoundaryService.detectFromOSMBuilding` so behaviour parity
+ * is preserved when the proxy lights up.
+ */
+export function buildBuildingQuery({ lat, lng, radiusM = 30 }) {
+  return `[out:json][timeout:25];
+(
+  way["building"](around:${radiusM},${lat},${lng});
+);
+out geom;
+`;
+}
+
+/**
+ * Build the Overpass query for landuse / parcel polygons near
+ * `(lat, lng)`. Mirrors `detectFromOSMParcel`.
+ */
+export function buildParcelQuery({ lat, lng, radiusM = 50 }) {
+  return `[out:json][timeout:25];
+(
+  way["landuse"](around:${radiusM},${lat},${lng});
+  way["boundary"="administrative"](around:${radiusM},${lat},${lng});
+);
+out geom;
+`;
+}
+
+async function postOverpass({ url, query, timeoutMs, fetchImpl, signal }) {
+  const controller = new AbortController();
+  const aborted = signal
+    ? () => controller.abort(signal.reason || "caller_signal")
+    : null;
+  if (signal) {
+    if (signal.aborted) controller.abort(signal.reason || "caller_signal");
+    else signal.addEventListener("abort", aborted);
+  }
+  const timer = setTimeout(() => {
+    controller.abort("overpass_timeout");
+  }, timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      body: query,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "User-Agent": DEFAULT_USER_AGENT,
+      },
+      signal: controller.signal,
+    });
+    return response;
+  } finally {
+    clearTimeout(timer);
+    if (signal && aborted) signal.removeEventListener("abort", aborted);
+  }
+}
+
+/**
+ * Run an Overpass query with timeout + 1 retry on 5xx.
+ *
+ * @param {object} params
+ * @param {string} params.query     - Overpass QL text
+ * @param {string} [params.url]     - override Overpass endpoint (tests)
+ * @param {number} [params.timeoutMs]
+ * @param {function} [params.fetchImpl] - injected fetch (tests)
+ * @param {AbortSignal} [params.signal] - upstream cancellation
+ * @returns {Promise<{ elements: Array }>}
+ */
+export async function runOverpassQuery({
+  query,
+  url = process.env.OVERPASS_URL || DEFAULT_OVERPASS_URL,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  fetchImpl,
+  signal = undefined,
+} = {}) {
+  const resolvedFetch =
+    fetchImpl || (typeof fetch === "function" ? fetch : null);
+  if (typeof resolvedFetch !== "function") {
+    throw new Error("runOverpassQuery: fetch is not available in this runtime");
+  }
+  const attempt = async (isRetry) => {
+    let response;
+    try {
+      response = await postOverpass({
+        url,
+        query,
+        timeoutMs,
+        fetchImpl: resolvedFetch,
+        signal,
+      });
+    } catch (err) {
+      if (err?.name === "AbortError") {
+        throw new OverpassTimeoutError(
+          `Overpass request timed out after ${timeoutMs}ms`,
+        );
+      }
+      throw err;
+    }
+    if (response.status === 429) {
+      throw new OverpassRateLimitError(
+        "Overpass rate limit (429); falling through to estimated boundary",
+      );
+    }
+    if (!response.ok) {
+      const text = await safeText(response);
+      const err = new Error(
+        `Overpass ${response.status} ${response.statusText || ""}: ${text.slice(0, 200)}`,
+      );
+      err.status = response.status;
+      err.retryable = response.status >= 500 && !isRetry;
+      throw err;
+    }
+    let data;
+    try {
+      data = await response.json();
+    } catch (err) {
+      throw new Error(`Overpass returned malformed JSON: ${err?.message}`);
+    }
+    if (!data || !Array.isArray(data.elements)) {
+      return { elements: [] };
+    }
+    return { elements: data.elements };
+  };
+
+  try {
+    return await attempt(false);
+  } catch (err) {
+    if (err?.retryable) {
+      await new Promise((r) => setTimeout(r, 500));
+      return await attempt(true);
+    }
+    throw err;
+  }
+}
+
+async function safeText(response) {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Convenience wrapper: run building + parcel queries in parallel.
+ * Either query failing independently does NOT throw — the caller can
+ * still attempt to use whichever set of elements came back. Only when
+ * both fail does the wrapper rethrow.
+ */
+export async function fetchBuildingAndParcel({
+  lat,
+  lng,
+  buildingRadiusM = 30,
+  parcelRadiusM = 50,
+  url,
+  timeoutMs,
+  fetchImpl,
+  signal,
+}) {
+  const buildingPromise = runOverpassQuery({
+    query: buildBuildingQuery({ lat, lng, radiusM: buildingRadiusM }),
+    url,
+    timeoutMs,
+    fetchImpl,
+    signal,
+  }).catch((err) => ({ error: err }));
+  const parcelPromise = runOverpassQuery({
+    query: buildParcelQuery({ lat, lng, radiusM: parcelRadiusM }),
+    url,
+    timeoutMs,
+    fetchImpl,
+    signal,
+  }).catch((err) => ({ error: err }));
+
+  const [buildingResult, parcelResult] = await Promise.all([
+    buildingPromise,
+    parcelPromise,
+  ]);
+
+  const buildingElements = buildingResult?.elements || [];
+  const parcelElements = parcelResult?.elements || [];
+  const buildingError = buildingResult?.error || null;
+  const parcelError = parcelResult?.error || null;
+
+  // If both errored out, rethrow the building error (the more important
+  // of the two for our use case). Caller catches and falls through.
+  if (buildingError && parcelError) {
+    if (buildingError.rateLimited || parcelError.rateLimited) {
+      throw new OverpassRateLimitError(
+        "Both Overpass building and parcel queries were rate-limited",
+      );
+    }
+    throw buildingError;
+  }
+
+  return {
+    buildingElements,
+    parcelElements,
+    buildingError,
+    parcelError,
+  };
+}

--- a/api/site/boundary.js
+++ b/api/site/boundary.js
@@ -1,0 +1,272 @@
+/**
+ * Phase 5C — `/api/site/boundary` server proxy.
+ *
+ * Browser code cannot call Overpass directly because OSM does not send
+ * CORS headers. This Vercel Function runs the same Overpass query
+ * server-side, normalises the response, and returns a stable JSON
+ * shape that `propertyBoundaryService.js` can consume from the browser.
+ *
+ * Request:
+ *   GET  /api/site/boundary?lat=52.4&lng=-1.9
+ *   POST /api/site/boundary  with JSON { lat, lng, buildingRadiusM?, parcelRadiusM? }
+ *
+ * Response (200 always when the request is well-formed):
+ *   {
+ *     schemaVersion: "site-boundary-proxy-v1",
+ *     polygon: [{lat,lng}, …] | null,
+ *     source:  "openstreetmap-overpass-building-contains-point" | … | null,
+ *     confidence: 0.0–0.95,
+ *     boundaryAuthoritative: bool,
+ *     areaM2: integer,
+ *     hash: hex string,
+ *     cached: bool,
+ *     timestamp: ISO,
+ *     metadata: { osmId, buildingTag, … }
+ *   }
+ *
+ * The endpoint NEVER returns the legacy "Intelligent Fallback" estimated
+ * polygon. When Overpass returns nothing, the response carries
+ * `polygon: null` and `boundaryAuthoritative: false`; the browser
+ * client (`propertyBoundaryService.js`) is responsible for falling
+ * through to the existing fallback chain. This keeps the proxy purely
+ * about authoritative evidence.
+ *
+ * Caching: per-instance LRU keyed on `${lat},${lng}` rounded to 6 dp.
+ * Hits are served without an Overpass call. We deliberately do NOT use
+ * Vercel Runtime Cache (KV) in Phase 5C to keep the diff small and
+ * avoid a marketplace dep; Lambda warmth on Vercel covers most cases
+ * within the 10-minute idle window. A KV upgrade is a follow-up.
+ */
+
+import { setCorsHeaders, handlePreflight } from "../_shared/cors.js";
+import {
+  fetchBuildingAndParcel,
+  OverpassRateLimitError,
+  OverpassTimeoutError,
+} from "./_lib/overpassClient.js";
+import {
+  buildBoundaryResponse,
+  buildEmptyResponse,
+  selectBestOverpassWay,
+} from "./_lib/boundaryNormalize.js";
+
+const CACHE_MAX_ENTRIES = 256;
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days for found
+const CACHE_NEGATIVE_TTL_MS = 60 * 60 * 1000; // 1 hour for negatives
+
+const cache = new Map();
+
+function cacheKey({ lat, lng, buildingRadiusM, parcelRadiusM }) {
+  return [
+    Number(lat).toFixed(6),
+    Number(lng).toFixed(6),
+    Number(buildingRadiusM),
+    Number(parcelRadiusM),
+  ].join("|");
+}
+
+function cacheGet(key) {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  // Refresh LRU position
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.value;
+}
+
+function cacheSet(key, value) {
+  while (cache.size >= CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey === undefined) break;
+    cache.delete(oldestKey);
+  }
+  const ttl = value?.polygon ? CACHE_TTL_MS : CACHE_NEGATIVE_TTL_MS;
+  cache.set(key, {
+    expiresAt: Date.now() + ttl,
+    value,
+  });
+}
+
+function parseLatLng(req) {
+  if (req.method === "GET") {
+    const lat = Number(req.query?.lat);
+    const lng = Number(req.query?.lng);
+    return {
+      lat,
+      lng,
+      buildingRadiusM: Number(req.query?.buildingRadiusM) || 30,
+      parcelRadiusM: Number(req.query?.parcelRadiusM) || 50,
+    };
+  }
+  const body = req.body || {};
+  return {
+    lat: Number(body.lat),
+    lng: Number(body.lng),
+    buildingRadiusM: Number(body.buildingRadiusM) || 30,
+    parcelRadiusM: Number(body.parcelRadiusM) || 50,
+  };
+}
+
+function isValidPoint(lat, lng) {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+/**
+ * Pure handler used by Jest. The default export wraps this with
+ * Vercel-style req/res. Tests can call this directly with already-
+ * parsed inputs and an injected `fetchImpl`.
+ *
+ * @param {object} params
+ * @param {number} params.lat
+ * @param {number} params.lng
+ * @param {number} [params.buildingRadiusM]
+ * @param {number} [params.parcelRadiusM]
+ * @param {function} [params.fetchImpl]
+ * @param {boolean} [params.useCache=true]
+ * @returns {Promise<{ status: number, body: object }>}
+ */
+export async function resolveBoundaryRequest({
+  lat,
+  lng,
+  buildingRadiusM = 30,
+  parcelRadiusM = 50,
+  fetchImpl,
+  useCache = true,
+} = {}) {
+  if (!isValidPoint(lat, lng)) {
+    return {
+      status: 400,
+      body: {
+        error: "invalid_lat_lng",
+        message: "Both lat and lng must be finite numbers in valid ranges.",
+      },
+    };
+  }
+
+  const key = cacheKey({ lat, lng, buildingRadiusM, parcelRadiusM });
+  if (useCache) {
+    const cached = cacheGet(key);
+    if (cached) {
+      return {
+        status: 200,
+        body: { ...cached, cached: true },
+      };
+    }
+  }
+
+  let buildingElements;
+  let parcelElements;
+  let overpassError;
+  try {
+    const result = await fetchBuildingAndParcel({
+      lat,
+      lng,
+      buildingRadiusM,
+      parcelRadiusM,
+      fetchImpl,
+    });
+    buildingElements = result.buildingElements;
+    parcelElements = result.parcelElements;
+  } catch (err) {
+    overpassError = err;
+    buildingElements = [];
+    parcelElements = [];
+  }
+
+  let body;
+  if (overpassError) {
+    const reason = overpassError.rateLimited
+      ? "overpass_rate_limited"
+      : overpassError.timedOut
+        ? "overpass_timeout"
+        : "overpass_unavailable";
+    body = buildEmptyResponse({
+      reason,
+      cached: false,
+      queryRadiusM: buildingRadiusM,
+    });
+    body.metadata = {
+      ...body.metadata,
+      overpassError: overpassError?.message || String(overpassError),
+    };
+    if (useCache) cacheSet(key, body);
+    return { status: 200, body };
+  }
+
+  const best = selectBestOverpassWay({
+    buildingElements,
+    parcelElements,
+    point: { lat, lng },
+  });
+
+  if (!best) {
+    body = buildEmptyResponse({
+      reason: "no_polygon_found",
+      cached: false,
+      queryRadiusM: buildingRadiusM,
+    });
+  } else {
+    body = buildBoundaryResponse({
+      polygon: best.polygon,
+      source: best.source,
+      osmElement: best.element,
+      queryRadiusM: buildingRadiusM,
+      cached: false,
+    });
+  }
+  if (useCache) cacheSet(key, body);
+  return { status: 200, body };
+}
+
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "GET, POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, POST, OPTIONS" });
+  if (req.method !== "GET" && req.method !== "POST") {
+    res.status(405).json({ error: "method_not_allowed" });
+    return;
+  }
+
+  const params = parseLatLng(req);
+  try {
+    const { status, body } = await resolveBoundaryRequest(params);
+    res.status(status).json(body);
+  } catch (err) {
+    // Defensive: pure handler shouldn't throw on its own, but if a
+    // surprise happens (e.g. fetch missing in runtime), degrade to
+    // empty response so the browser falls through to fallback rather
+    // than seeing a 500.
+    console.warn("[/api/site/boundary] handler error:", err?.message || err);
+    const body = buildEmptyResponse({
+      reason: "proxy_handler_error",
+      cached: false,
+      queryRadiusM: params?.buildingRadiusM || 30,
+    });
+    body.metadata = {
+      ...body.metadata,
+      handlerError: err?.message || String(err),
+    };
+    res.status(200).json(body);
+  }
+}
+
+export const __testing = Object.freeze({
+  cache,
+  cacheKey,
+  cacheGet,
+  cacheSet,
+  parseLatLng,
+  isValidPoint,
+  OverpassRateLimitError,
+  OverpassTimeoutError,
+});

--- a/src/__tests__/api/site-boundary.test.js
+++ b/src/__tests__/api/site-boundary.test.js
@@ -1,0 +1,441 @@
+/**
+ * Phase 5C — `/api/site/boundary` proxy tests.
+ *
+ * All tests use mocked Overpass responses. NO live external calls. The
+ * fixtures are deliberately small and fictional — they prove the
+ * normalisation, fallback, and cache logic without depending on real
+ * OSM data or current Cherish House polygon shape (manual smoke only).
+ */
+
+import {
+  resolveBoundaryRequest,
+  __testing,
+} from "../../../api/site/boundary.js";
+import {
+  buildBoundaryResponse,
+  buildEmptyResponse,
+  selectBestOverpassWay,
+  polygonAreaM2,
+  polygonContainsPoint,
+  hashBoundaryShape,
+  BOUNDARY_SOURCE,
+  PROXY_RESPONSE_SCHEMA_VERSION,
+} from "../../../api/site/_lib/boundaryNormalize.js";
+import {
+  buildBuildingQuery,
+  buildParcelQuery,
+  runOverpassQuery,
+  fetchBuildingAndParcel,
+  OverpassRateLimitError,
+  OverpassTimeoutError,
+} from "../../../api/site/_lib/overpassClient.js";
+
+const POINT = { lat: 52.4722, lng: -1.8839 }; // Bradford St area, but fictional polygon
+
+function makeBuildingWay(id, points, tags = {}) {
+  return {
+    type: "way",
+    id,
+    geometry: points.map(([lat, lng]) => ({ lat, lon: lng })),
+    tags: { building: "yes", ...tags },
+  };
+}
+
+function makeOverpassResponse(elements) {
+  return new Response(JSON.stringify({ version: 0.6, elements }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function clearProxyCache() {
+  __testing.cache.clear();
+}
+
+beforeEach(() => {
+  clearProxyCache();
+});
+
+describe("api/site/boundary — request validation", () => {
+  test("rejects invalid lat/lng", async () => {
+    const r = await resolveBoundaryRequest({ lat: "abc", lng: -1.88 });
+    expect(r.status).toBe(400);
+    expect(r.body.error).toBe("invalid_lat_lng");
+  });
+
+  test("rejects out-of-range lat/lng", async () => {
+    const r = await resolveBoundaryRequest({ lat: 100, lng: 0 });
+    expect(r.status).toBe(400);
+  });
+});
+
+describe("api/site/boundary — Overpass success path", () => {
+  test("returns authoritative polygon when building contains the point", async () => {
+    const containingBuilding = makeBuildingWay(
+      111,
+      [
+        [52.4721, -1.884],
+        [52.4721, -1.8838],
+        [52.4723, -1.8838],
+        [52.4723, -1.884],
+      ],
+      { "addr:housenumber": "97", "addr:street": "Bradford St" },
+    );
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeOverpassResponse([containingBuilding]))
+      .mockResolvedValueOnce(makeOverpassResponse([])); // parcel query empty
+
+    const r = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+
+    expect(r.status).toBe(200);
+    expect(r.body.schemaVersion).toBe(PROXY_RESPONSE_SCHEMA_VERSION);
+    expect(r.body.polygon).toBeTruthy();
+    expect(r.body.polygon).toHaveLength(4);
+    expect(r.body.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS);
+    expect(r.body.confidence).toBeGreaterThan(0.9);
+    expect(r.body.boundaryAuthoritative).toBe(true);
+    expect(r.body.areaM2).toBeGreaterThan(0);
+    expect(r.body.metadata.osmId).toBe(111);
+    expect(r.body.metadata.addrHousenumber).toBe("97");
+    expect(r.body.metadata.addrStreet).toBe("Bradford St");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test("nearest building (≤ 25 m) is returned as non-authoritative", async () => {
+    // Building offset ~11 m N of the query point (centroid distance),
+    // not containing it. Polygon spans 52.47227 → 52.47233 latitude.
+    const nearbyBuilding = makeBuildingWay(222, [
+      [52.47227, -1.884],
+      [52.47227, -1.8838],
+      [52.47233, -1.8838],
+      [52.47233, -1.884],
+    ]);
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeOverpassResponse([nearbyBuilding]))
+      .mockResolvedValueOnce(makeOverpassResponse([]));
+
+    const r = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.polygon).toBeTruthy();
+    expect(r.body.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST);
+    expect(r.body.confidence).toBeGreaterThan(0.5);
+    expect(r.body.confidence).toBeLessThan(0.9);
+    expect(r.body.boundaryAuthoritative).toBe(false);
+  });
+});
+
+describe("api/site/boundary — empty / fallback paths", () => {
+  test("returns polygon=null when Overpass returns no elements", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeOverpassResponse([]))
+      .mockResolvedValueOnce(makeOverpassResponse([]));
+
+    const r = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.polygon).toBeNull();
+    expect(r.body.source).toBeNull();
+    expect(r.body.boundaryAuthoritative).toBe(false);
+    expect(r.body.areaM2).toBe(0);
+    expect(r.body.metadata.reason).toBe("no_polygon_found");
+  });
+
+  test("returns polygon=null when Overpass times out (AbortError)", async () => {
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+    const fetchImpl = jest.fn().mockRejectedValue(abortErr);
+
+    const r = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.polygon).toBeNull();
+    expect(r.body.boundaryAuthoritative).toBe(false);
+    expect(r.body.metadata.reason).toBe("overpass_timeout");
+  });
+
+  test("returns polygon=null when Overpass rate-limits (429)", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response("Too Many Requests", {
+        status: 429,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+    const r = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.polygon).toBeNull();
+    expect(r.body.metadata.reason).toBe("overpass_rate_limited");
+  });
+
+  test("returns polygon=null on malformed Overpass JSON", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response("<html>not json</html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+    const r = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.polygon).toBeNull();
+    expect(r.body.metadata.reason).toBe("overpass_unavailable");
+  });
+
+  test("never claims authoritative for empty / errored responses", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(new Response("", { status: 503 }));
+    const r = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+    expect(r.body.polygon).toBeNull();
+    expect(r.body.boundaryAuthoritative).toBe(false);
+    expect(r.body.confidence).toBe(0);
+  });
+});
+
+describe("api/site/boundary — caching", () => {
+  test("second identical request is served from in-memory cache", async () => {
+    const containingBuilding = makeBuildingWay(333, [
+      [52.4721, -1.884],
+      [52.4721, -1.8838],
+      [52.4723, -1.8838],
+      [52.4723, -1.884],
+    ]);
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeOverpassResponse([containingBuilding]))
+      .mockResolvedValueOnce(makeOverpassResponse([]));
+
+    const first = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: true,
+    });
+    expect(first.body.cached).toBe(false);
+    expect(first.body.polygon).toBeTruthy();
+
+    // Cached call: no further fetch invocations
+    const second = await resolveBoundaryRequest({
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: true,
+    });
+    expect(second.body.cached).toBe(true);
+    expect(second.body.hash).toBe(first.body.hash);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  test("cache key changes with rounded lat/lng", () => {
+    const k1 = __testing.cacheKey({
+      lat: 52.4722,
+      lng: -1.8839,
+      buildingRadiusM: 30,
+      parcelRadiusM: 50,
+    });
+    const k2 = __testing.cacheKey({
+      lat: 52.4723,
+      lng: -1.8839,
+      buildingRadiusM: 30,
+      parcelRadiusM: 50,
+    });
+    expect(k1).not.toBe(k2);
+  });
+});
+
+describe("api/site/boundary — pure helpers", () => {
+  test("polygonContainsPoint detects containment", () => {
+    const square = [
+      { lat: 52.0, lng: -1.0 },
+      { lat: 52.0, lng: -0.99 },
+      { lat: 52.01, lng: -0.99 },
+      { lat: 52.01, lng: -1.0 },
+    ];
+    expect(polygonContainsPoint(square, { lat: 52.005, lng: -0.995 })).toBe(
+      true,
+    );
+    expect(polygonContainsPoint(square, { lat: 52.05, lng: -0.5 })).toBe(false);
+  });
+
+  test("polygonAreaM2 returns positive area for a small UK plot", () => {
+    const square = [
+      { lat: 52.0, lng: -1.0 },
+      { lat: 52.0, lng: -0.99 },
+      { lat: 52.01, lng: -0.99 },
+      { lat: 52.01, lng: -1.0 },
+    ];
+    const a = polygonAreaM2(square);
+    expect(a).toBeGreaterThan(100_000);
+    expect(a).toBeLessThan(2_000_000);
+  });
+
+  test("hashBoundaryShape is deterministic and source-sensitive", () => {
+    const polygon = [
+      { lat: 52, lng: -1 },
+      { lat: 52, lng: -0.99 },
+      { lat: 52.01, lng: -0.99 },
+    ];
+    const h1 = hashBoundaryShape({
+      polygon,
+      source: BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS,
+    });
+    const h2 = hashBoundaryShape({
+      polygon,
+      source: BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS,
+    });
+    const h3 = hashBoundaryShape({
+      polygon,
+      source: BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST,
+    });
+    expect(h1).toBe(h2);
+    expect(h1).not.toBe(h3);
+    expect(typeof h1).toBe("string");
+    expect(h1).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  test("buildBoundaryResponse returns empty shape when polygon is short", () => {
+    const r = buildBoundaryResponse({
+      polygon: [
+        { lat: 0, lng: 0 },
+        { lat: 1, lng: 1 },
+      ],
+      source: BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS,
+    });
+    expect(r.polygon).toBeNull();
+    expect(r.source).toBeNull();
+    expect(r.boundaryAuthoritative).toBe(false);
+  });
+
+  test("selectBestOverpassWay prefers a containing building over a nearby one", () => {
+    const containingBuilding = makeBuildingWay(1, [
+      [52.4721, -1.884],
+      [52.4721, -1.8838],
+      [52.4723, -1.8838],
+      [52.4723, -1.884],
+    ]);
+    const farBuilding = makeBuildingWay(2, [
+      [52.5, -1.0],
+      [52.5, -0.99],
+      [52.51, -0.99],
+    ]);
+    const best = selectBestOverpassWay({
+      buildingElements: [farBuilding, containingBuilding],
+      parcelElements: [],
+      point: POINT,
+    });
+    expect(best?.element?.id).toBe(1);
+    expect(best?.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS);
+  });
+});
+
+describe("api/site/boundary — Overpass query construction", () => {
+  test("buildBuildingQuery embeds lat/lng and radius", () => {
+    const q = buildBuildingQuery({ lat: 52, lng: -1, radiusM: 25 });
+    expect(q).toContain("around:25,52,-1");
+    expect(q).toContain('way["building"]');
+  });
+
+  test("buildParcelQuery embeds lat/lng and radius", () => {
+    const q = buildParcelQuery({ lat: 52, lng: -1, radiusM: 60 });
+    expect(q).toContain("around:60,52,-1");
+    expect(q).toContain('way["landuse"]');
+  });
+});
+
+describe("api/site/boundary — runOverpassQuery low-level", () => {
+  test("retries once on 5xx and succeeds on second attempt", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 503 }))
+      .mockResolvedValueOnce(makeOverpassResponse([]));
+
+    const result = await runOverpassQuery({
+      query: "[out:json];out;",
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.elements).toEqual([]);
+  });
+
+  test("throws OverpassRateLimitError on 429 (no retry)", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(new Response("", { status: 429 }));
+    await expect(
+      runOverpassQuery({ query: "[out:json];out;", fetchImpl }),
+    ).rejects.toBeInstanceOf(OverpassRateLimitError);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws OverpassTimeoutError when fetch aborts", async () => {
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+    const fetchImpl = jest.fn().mockRejectedValue(abortErr);
+    await expect(
+      runOverpassQuery({ query: "[out:json];out;", fetchImpl }),
+    ).rejects.toBeInstanceOf(OverpassTimeoutError);
+  });
+
+  test("fetchBuildingAndParcel returns both error fields without throwing when one query fails", async () => {
+    const fetchImpl = jest
+      .fn()
+      // building OK
+      .mockResolvedValueOnce(makeOverpassResponse([{ type: "way", id: 1 }]))
+      // parcel 503 then 503 again (retry exhausted; throws)
+      .mockResolvedValue(new Response("", { status: 503 }));
+
+    const result = await fetchBuildingAndParcel({
+      lat: 52,
+      lng: -1,
+      fetchImpl,
+    });
+    expect(result.buildingElements).toHaveLength(1);
+    expect(result.parcelError).toBeTruthy();
+  });
+});
+
+describe("api/site/boundary — buildEmptyResponse shape", () => {
+  test("documents the no-polygon shape callers depend on", () => {
+    const r = buildEmptyResponse({ reason: "no_polygon_found" });
+    expect(r.polygon).toBeNull();
+    expect(r.source).toBeNull();
+    expect(r.boundaryAuthoritative).toBe(false);
+    expect(r.confidence).toBe(0);
+    expect(r.areaM2).toBe(0);
+    expect(r.schemaVersion).toBe(PROXY_RESPONSE_SCHEMA_VERSION);
+  });
+});

--- a/src/__tests__/services/propertyBoundaryService.proxy.test.js
+++ b/src/__tests__/services/propertyBoundaryService.proxy.test.js
@@ -1,0 +1,267 @@
+/**
+ * Phase 5C — propertyBoundaryService browser-proxy tests.
+ *
+ * Verifies that:
+ *   1. In browser runtime, `detectPropertyBoundary` calls
+ *      `/api/site/boundary` first.
+ *   2. A successful proxy response replaces the legacy estimated
+ *      fallback.
+ *   3. A failing proxy response (network error, non-OK, low-confidence,
+ *      polygon=null) cleanly falls through to the existing chain — the
+ *      Intelligent Fallback safety net is unchanged.
+ *   4. `bypassProxy: true` (test fixture isolation) skips the proxy.
+ *   5. Server runtime path is unchanged (no proxy call).
+ *
+ * NO live external calls. All `fetch` is injected.
+ */
+
+import {
+  detectPropertyBoundary,
+  fetchSiteBoundaryFromProxy,
+  isEstimatedBoundaryResult,
+  INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
+} from "../../services/propertyBoundaryService.js";
+
+const POINT = { lat: 52.4722, lng: -1.8839 };
+const ADDRESS = "97 Bradford St, Birmingham B12 0PW";
+
+function makeProxyResponse(body, init = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function authoritativeProxyBody() {
+  return {
+    schemaVersion: "site-boundary-proxy-v1",
+    polygon: [
+      { lat: 52.4721, lng: -1.884 },
+      { lat: 52.4721, lng: -1.8838 },
+      { lat: 52.4723, lng: -1.8838 },
+      { lat: 52.4723, lng: -1.884 },
+    ],
+    source: "openstreetmap-overpass-building-contains-point",
+    confidence: 0.92,
+    boundaryAuthoritative: true,
+    areaM2: 240,
+    hash: "deadbeef",
+    cached: false,
+    timestamp: "2026-05-02T14:00:00.000Z",
+    metadata: {
+      osmId: 12345,
+      buildingTag: "house",
+      addrHousenumber: "97",
+      addrStreet: "Bradford St",
+      overpassQueryRadiusM: 30,
+    },
+  };
+}
+
+function lowConfidenceProxyBody() {
+  return {
+    ...authoritativeProxyBody(),
+    source: "openstreetmap-overpass-building-nearest",
+    confidence: 0.55, // < 0.6 → treated as estimated by isEstimatedBoundaryResult
+    boundaryAuthoritative: false,
+  };
+}
+
+function emptyProxyBody() {
+  return {
+    schemaVersion: "site-boundary-proxy-v1",
+    polygon: null,
+    source: null,
+    confidence: 0,
+    boundaryAuthoritative: false,
+    areaM2: 0,
+    hash: "00000000",
+    cached: false,
+    timestamp: "2026-05-02T14:00:00.000Z",
+    metadata: { reason: "no_polygon_found" },
+  };
+}
+
+const originalWindow = global.window;
+
+function installBrowserRuntime() {
+  Object.defineProperty(global, "window", {
+    value: { document: {} },
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreRuntime() {
+  if (originalWindow === undefined) {
+    delete global.window;
+  } else {
+    Object.defineProperty(global, "window", {
+      value: originalWindow,
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+describe("fetchSiteBoundaryFromProxy", () => {
+  beforeEach(() => {
+    installBrowserRuntime();
+  });
+  afterEach(() => {
+    restoreRuntime();
+  });
+
+  test("returns normalised boundary for an authoritative proxy response", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(makeProxyResponse(authoritativeProxyBody()));
+    const result = await fetchSiteBoundaryFromProxy({
+      coordinates: POINT,
+      address: ADDRESS,
+      fetchImpl,
+    });
+    expect(result).toBeTruthy();
+    expect(result.polygon).toHaveLength(4);
+    expect(result.source).toBe(
+      "openstreetmap-overpass-building-contains-point",
+    );
+    expect(result.confidence).toBeCloseTo(0.92, 2);
+    expect(result.boundaryAuthoritative).toBe(true);
+    expect(result.metadata.proxyHash).toBe("deadbeef");
+    expect(result.metadata.proxyCached).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0][0]).toBe("/api/site/boundary");
+  });
+
+  test("returns null when proxy responds with polygon: null", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(makeProxyResponse(emptyProxyBody()));
+    const result = await fetchSiteBoundaryFromProxy({
+      coordinates: POINT,
+      fetchImpl,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when proxy responds non-OK", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(new Response("", { status: 502 }));
+    const result = await fetchSiteBoundaryFromProxy({
+      coordinates: POINT,
+      fetchImpl,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when fetch rejects (network error / abort)", async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new Error("network down"));
+    const result = await fetchSiteBoundaryFromProxy({
+      coordinates: POINT,
+      fetchImpl,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when given invalid coordinates", async () => {
+    const fetchImpl = jest.fn();
+    const result = await fetchSiteBoundaryFromProxy({
+      coordinates: { lat: NaN, lng: 0 },
+      fetchImpl,
+    });
+    expect(result).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("detectPropertyBoundary — browser proxy wiring", () => {
+  beforeEach(() => {
+    installBrowserRuntime();
+  });
+  afterEach(() => {
+    restoreRuntime();
+  });
+
+  test("uses proxy result when authoritative and skips legacy chain", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(makeProxyResponse(authoritativeProxyBody()));
+    const result = await detectPropertyBoundary(POINT, ADDRESS, { fetchImpl });
+    expect(result.polygon).toHaveLength(4);
+    expect(result.boundaryAuthoritative).toBe(true);
+    expect(isEstimatedBoundaryResult(result)).toBe(false);
+    expect(result.source).toBe(
+      "openstreetmap-overpass-building-contains-point",
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls through to Intelligent Fallback when proxy returns low-confidence", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(makeProxyResponse(lowConfidenceProxyBody()));
+    const result = await detectPropertyBoundary(POINT, ADDRESS, { fetchImpl });
+    // Low-confidence proxy → not used; existing chain runs and ends in
+    // INTELLIGENT_FALLBACK_BOUNDARY_SOURCE because Google Maps returns null
+    // and the browser chain has no Overpass.
+    expect(result.source).toBe(INTELLIGENT_FALLBACK_BOUNDARY_SOURCE);
+    expect(isEstimatedBoundaryResult(result)).toBe(true);
+    expect(result.boundaryAuthoritative).toBe(false);
+  });
+
+  test("falls through to Intelligent Fallback when proxy returns no polygon", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(makeProxyResponse(emptyProxyBody()));
+    const result = await detectPropertyBoundary(POINT, ADDRESS, { fetchImpl });
+    expect(result.source).toBe(INTELLIGENT_FALLBACK_BOUNDARY_SOURCE);
+    expect(isEstimatedBoundaryResult(result)).toBe(true);
+  });
+
+  test("falls through to Intelligent Fallback when proxy fetch fails", async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new Error("network down"));
+    const result = await detectPropertyBoundary(POINT, ADDRESS, { fetchImpl });
+    expect(result.source).toBe(INTELLIGENT_FALLBACK_BOUNDARY_SOURCE);
+    expect(isEstimatedBoundaryResult(result)).toBe(true);
+  });
+
+  test("bypassProxy:true skips the proxy call entirely (test fixture isolation)", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(makeProxyResponse(authoritativeProxyBody()));
+    const result = await detectPropertyBoundary(POINT, ADDRESS, {
+      bypassProxy: true,
+      fetchImpl,
+    });
+    // Browser chain without proxy ends in Intelligent Fallback.
+    expect(result.source).toBe(INTELLIGENT_FALLBACK_BOUNDARY_SOURCE);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("detectPropertyBoundary — server runtime path is unchanged", () => {
+  beforeEach(() => {
+    restoreRuntime(); // ensure window is undefined
+    if (typeof global.window !== "undefined") {
+      delete global.window;
+    }
+  });
+
+  test("server runtime does NOT call the proxy", async () => {
+    // Sanity: when window is undefined, isBrowserRuntime() is false.
+    const fetchImpl = jest.fn();
+    const result = await detectPropertyBoundary(POINT, ADDRESS, { fetchImpl });
+    // The server-side chain attempts Overpass directly via global fetch
+    // (not our injected fetchImpl, since the proxy step is skipped).
+    // We only assert the proxy was NOT called via our injected fetch.
+    expect(fetchImpl).not.toHaveBeenCalled();
+    // The result is some boundary — could be Overpass-derived if global
+    // fetch is available, or Intelligent Fallback if not. Either way,
+    // it has a valid polygon.
+    expect(result.polygon).toBeTruthy();
+    expect(Array.isArray(result.polygon)).toBe(true);
+  });
+});

--- a/src/services/propertyBoundaryService.js
+++ b/src/services/propertyBoundaryService.js
@@ -9,6 +9,15 @@ const API_ENDPOINTS = {
   NOMINATIM: "https://nominatim.openstreetmap.org/search",
 };
 
+// Phase 5C: server-side proxy that runs the same Overpass queries but
+// without browser CORS restrictions. The browser path calls this URL
+// instead of skipping Overpass and going straight to the estimated
+// fallback. A fetch failure / non-OK response / null polygon causes the
+// caller to fall through to the existing Intelligent Fallback chain —
+// the proxy is purely additive evidence, never the safety net itself.
+export const SITE_BOUNDARY_PROXY_URL = "/api/site/boundary";
+export const SITE_BOUNDARY_PROXY_TIMEOUT_MS = 9000;
+
 export const INTELLIGENT_FALLBACK_BOUNDARY_SOURCE = "Intelligent Fallback";
 export const INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE = 0.4;
 
@@ -61,6 +70,102 @@ function isBrowserRuntime() {
   );
 }
 
+/**
+ * Phase 5C: call the server-side `/api/site/boundary` proxy from the
+ * browser. Returns a normalised `{ polygon, source, confidence,
+ * boundaryAuthoritative, ... }` object on success, or `null` on any
+ * failure (network error, timeout, non-OK status, empty result, or
+ * low-confidence response). A null return is the explicit signal for
+ * `detectPropertyBoundary` to continue down the existing chain into the
+ * Intelligent Fallback — the proxy is *additive* evidence and never a
+ * replacement for the existing safety net.
+ *
+ * Pure-ish: the only side effects are the fetch and a console.warn on
+ * failure. Accepts an injected `fetchImpl` so tests can mock without
+ * monkey-patching globals.
+ *
+ * @param {object} params
+ * @param {{lat:number,lng:number}} params.coordinates
+ * @param {string} [params.address]
+ * @param {string} [params.proxyUrl=SITE_BOUNDARY_PROXY_URL]
+ * @param {number} [params.timeoutMs=SITE_BOUNDARY_PROXY_TIMEOUT_MS]
+ * @param {function} [params.fetchImpl]
+ * @returns {Promise<Object|null>}
+ */
+export async function fetchSiteBoundaryFromProxy({
+  coordinates,
+  address = null,
+  proxyUrl = SITE_BOUNDARY_PROXY_URL,
+  timeoutMs = SITE_BOUNDARY_PROXY_TIMEOUT_MS,
+  fetchImpl = typeof fetch === "function" ? fetch : null,
+} = {}) {
+  if (typeof fetchImpl !== "function") return null;
+  if (
+    !coordinates ||
+    !Number.isFinite(Number(coordinates.lat)) ||
+    !Number.isFinite(Number(coordinates.lng))
+  ) {
+    return null;
+  }
+
+  const controller =
+    typeof AbortController === "function" ? new AbortController() : null;
+  const timer = controller
+    ? setTimeout(
+        () => controller.abort("site_boundary_proxy_timeout"),
+        timeoutMs,
+      )
+    : null;
+
+  try {
+    const response = await fetchImpl(proxyUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        lat: Number(coordinates.lat),
+        lng: Number(coordinates.lng),
+      }),
+      signal: controller?.signal,
+    });
+    if (!response.ok) {
+      console.warn(
+        `[site-boundary-proxy] non-OK response ${response.status}; falling through to existing chain`,
+      );
+      return null;
+    }
+    const json = await response.json();
+    if (!json || !Array.isArray(json.polygon) || json.polygon.length < 3) {
+      // No polygon found server-side. The browser chain falls through
+      // to the existing Intelligent Fallback path. We deliberately do
+      // NOT promote `polygon: null` from the proxy to anything else.
+      return null;
+    }
+    return {
+      polygon: json.polygon,
+      shapeType: analyzeShapeType(json.polygon),
+      source: json.source,
+      confidence: Number(json.confidence) || 0,
+      area: Number(json.areaM2) || 0,
+      boundaryAuthoritative: Boolean(json.boundaryAuthoritative),
+      boundaryConfidence: Number(json.confidence) || 0,
+      boundarySource: json.source,
+      metadata: {
+        ...(json.metadata || {}),
+        proxyHash: json.hash,
+        proxyCached: Boolean(json.cached),
+        proxySchemaVersion: json.schemaVersion,
+      },
+    };
+  } catch (error) {
+    console.warn(
+      `[site-boundary-proxy] fetch failed (${error?.name || "error"}: ${error?.message || error}); falling through to existing chain`,
+    );
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 function createSeededRandom(seedInput) {
   let seed = 2166136261;
   const input = String(seedInput || "");
@@ -80,16 +185,69 @@ function createSeededRandom(seedInput) {
 }
 
 /**
- * Detect property boundary shape from coordinates
+ * Detect property boundary shape from coordinates.
+ *
+ * Phase 5C: the browser path now starts by calling the
+ * `/api/site/boundary` server proxy so Overpass evidence is available
+ * without CORS. If the proxy returns no polygon, we fall through to
+ * the existing chain (which still ends in the Intelligent Fallback).
+ * The estimated-boundary safety net at the bottom of the chain is
+ * untouched — the proxy is purely additive evidence.
+ *
  * @param {Object} coordinates - { lat, lng }
  * @param {string} address - Full address string
+ * @param {Object} [options]
+ * @param {boolean} [options.bypassProxy=false] - skip the `/api/site/boundary`
+ *        proxy call. Used by Jest fixtures that stub the existing chain
+ *        directly so the proxy doesn't interfere with their assertions.
+ *        The corresponding env override is `BYPASS_SITE_BOUNDARY_PROXY=true`.
+ * @param {function} [options.fetchImpl] - injected fetch for the proxy
+ *        call (tests).
  * @returns {Promise<Object>} Boundary data with shape type
  */
-export async function detectPropertyBoundary(coordinates, address) {
+export async function detectPropertyBoundary(
+  coordinates,
+  address,
+  options = {},
+) {
   console.log("🔍 Detecting property boundary for:", address);
 
   try {
     const browserRuntime = isBrowserRuntime();
+    const bypassProxy =
+      options?.bypassProxy === true ||
+      (typeof process !== "undefined" &&
+        String(process.env?.BYPASS_SITE_BOUNDARY_PROXY || "")
+          .toLowerCase()
+          .trim() === "true");
+
+    // Phase 5C: server-side proxy call. Browser-only — server runtime
+    // already calls Overpass directly via the existing chain, so we
+    // skip the proxy hop there.
+    if (browserRuntime && !bypassProxy) {
+      const proxyResult = await fetchSiteBoundaryFromProxy({
+        coordinates,
+        address,
+        fetchImpl: options?.fetchImpl,
+      });
+      if (
+        proxyResult &&
+        Array.isArray(proxyResult.polygon) &&
+        proxyResult.polygon.length >= 3
+      ) {
+        const estimated = isEstimatedBoundaryResult(proxyResult);
+        if (estimated) {
+          console.warn(
+            `⚠️ Proxy returned a low-confidence boundary (source=${proxyResult.source}, confidence=${proxyResult.confidence}); falling through to existing chain.`,
+          );
+        } else {
+          console.log(
+            `✅ Boundary detected via /api/site/boundary: ${proxyResult.shapeType} (${proxyResult.polygon.length} pts, source=${proxyResult.source})`,
+          );
+          return proxyResult;
+        }
+      }
+    }
 
     // Try multiple detection methods in order of accuracy
     const methods = browserRuntime
@@ -107,7 +265,7 @@ export async function detectPropertyBoundary(coordinates, address) {
 
     if (browserRuntime) {
       console.info(
-        "Skipping direct Overpass boundary detection in browser runtime; using CORS-safe fallbacks.",
+        "Falling through to CORS-safe browser chain (proxy returned no authoritative polygon).",
       );
     }
 


### PR DESCRIPTION
## Summary

Adds `/api/site/boundary` so the browser can get authoritative OSM evidence for the site polygon **without hitting CORS**. Replaces the long-standing `Skipping direct Overpass boundary detection in browser runtime` short-circuit with a proxy call. If the proxy returns no polygon, a low-confidence shape, or fails for any reason, the **existing Intelligent Fallback chain runs unchanged**.

## Endpoint behaviour

- `GET /api/site/boundary?lat=…&lng=…` or `POST { lat, lng }`
- Server-side runs the same Overpass building + parcel queries that the in-tree code already issues, with an 8 s timeout and one retry on 5xx. 429 short-circuits to "rate-limited" and falls through to the legacy chain.
- Selects the best element in this order:
  1. **parcel polygon containing the point** → confidence `0.95`, `boundaryAuthoritative: true`
  2. **building polygon containing the point** → confidence `0.92`, `boundaryAuthoritative: true`
  3. **nearest building within 25 m of the point** → confidence `0.70`, `boundaryAuthoritative: false`
- "No polygon found" returns 200 with `polygon: null` (NOT a 404) so the client never has to branch on missing-vs-error — only on `polygon === null`.
- Per-instance LRU cache (max 256 entries) keyed on rounded lat/lng; 30-day TTL for hits, 1-hour TTL for negatives. Vercel Lambda warmth covers the 10-minute idle window without external KV.

## Safety contract preserved (PRs #60 / #62 / #63)

- Low-confidence boundaries remain non-authoritative.
- The existing **Intelligent Fallback** path stays the **final** safety net — the proxy is purely additive evidence upstream of it.
- No fallback area becomes authoritative.
- `boundaryAuthoritative === false` for any 429 / 5xx / timeout / malformed / no-polygon response.

## Browser wiring

- `propertyBoundaryService.detectPropertyBoundary` now starts the browser chain by calling `/api/site/boundary`. A successful authoritative response replaces the legacy estimated fallback. Any failure / low-confidence / `polygon: null` response falls through to the existing chain (which still ends in Intelligent Fallback).
- New options: `{ bypassProxy: true }` and env `BYPASS_SITE_BOUNDARY_PROXY=true` for Jest fixtures that stub the legacy chain directly.
- `siteAnalysisService.getPropertyBoundary` already delegates to `detectPropertyBoundary` — no separate wiring needed.

## Tests (all mocked, **no live external calls in CI**)

- `src/__tests__/api/site-boundary.test.js` (NEW, 23 tests):
  - request validation (invalid / out-of-range lat/lng)
  - Overpass success path: containing-point → authoritative; nearest building → non-authoritative
  - empty / timeout / rate-limit / malformed / 5xx responses → `polygon: null` + correct `metadata.reason`
  - cache: cold + cached round-trip, cache-key sensitivity to rounded lat/lng
  - pure helpers: `polygonContainsPoint`, `polygonAreaM2`, `hashBoundaryShape`, `selectBestOverpassWay`
  - low-level `runOverpassQuery`: 5xx-retry, 429-no-retry, abort-timeout
  - `fetchBuildingAndParcel` partial-failure tolerance
  - `buildEmptyResponse` shape contract
- `src/__tests__/services/propertyBoundaryService.proxy.test.js` (NEW, 11 tests):
  - authoritative proxy → used; legacy chain skipped
  - low-confidence proxy → falls through to Intelligent Fallback
  - `polygon: null` → falls through
  - fetch rejection → falls through
  - `bypassProxy: true` → proxy NOT called
  - server-runtime path does NOT call the proxy

## Validation

All baseline + new tests green on `feat/a1-phase5c-site-boundary-accuracy`:

| Check | Result |
|---|---|
| `npm run check:env` | ✅ |
| `npm run check:contracts` | ✅ |
| `npm run lint` | ✅ |
| `npm run build:active` | ✅ |
| `npm run test:a1:tofu` | ✅ |
| `npm run test:compose:routing` | ✅ 22/22 |
| `node scripts/tests/test-a1-layout-regression.mjs` | ✅ 27/27 |
| `jest src/__tests__/api/site-boundary.test.js src/__tests__/services/propertyBoundaryService.proxy.test.js` | ✅ 34/34 |

## Manual smoke results (NOT in CI)

**Deterministic A1 with brief-supplied sitePolygon** (`tmp/phase5c-cherish-house-smoke.mjs`):
- `qaStatus: "fail"` ← existing pipeline behaviour for deterministic mode, unchanged
- `visualIdentityValidation.status: "pass"` (Phase 5B unaffected)
- `exportGate.allowed: true`, `blockers: []`
- A1 PDF emitted

**Live proxy direct call** (`tmp/phase5c-proxy-direct-smoke.mjs`) for Cherish House (`52.4722, -1.8839`):
\`\`\`json
{
  "status": 200,
  "body": {
    "polygon": [/* 7-vertex residential parcel */],
    "source": "openstreetmap-overpass-parcel-contains-point",
    "confidence": 0.95,
    "boundaryAuthoritative": true,
    "areaM2": 18335,
    "hash": "d8319562",
    "cached": false,
    "metadata": {
      "osmId": 46250041,
      "osmType": "way",
      "landuseTag": "residential",
      "overpassQueryRadiusM": 30
    }
  },
  "elapsedMs": 692
}
\`\`\`

Cherish House previously resolved to a 6-point estimated fallback at 119,408 m² @ 40 % confidence with `boundaryAuthoritative: false`. The proxy now returns a real 18,335 m² OSM residential parcel @ 95 % confidence with `boundaryAuthoritative: true`, in 692 ms. Smoke is one-off / NOT in CI.

## Scope (per Phase 5C plan)

In:
- `api/site/boundary.js` Vercel Function + helpers
- `propertyBoundaryService.js` browser-path wiring
- focused mocked tests

Out (explicitly forbidden):
- ❌ Storage/history changes
- ❌ Project-type support changes
- ❌ OpenAI/provider/env changes
- ❌ Vector PDF work
- ❌ A1 layout/rendering changes
- ❌ `PROJECT_GRAPH_AXONOMETRIC_CUTAWAY_ENABLED` flag changes (remains `false` in Production)
- ❌ Paid services
- ❌ Manual override UX
- ❌ Old branch cherry-picks

**Microsoft Building Footprints fallback** intentionally deferred to a follow-up PR. Per-tile GeoJSON fetch + point-in-polygon over multi-MB tiles needs its own scope and mocked fixtures; Overpass + existing fallback are sufficient for Phase 5C's first PR.

## Test plan

- [x] Endpoint response shape, mocked Overpass success
- [x] Endpoint fallback when Overpass returns empty
- [x] Endpoint timeout / rate-limit / malformed-JSON fallback
- [x] `propertyBoundaryService` browser path calls proxy
- [x] Proxy failure / low-confidence / null → falls back to Intelligent Fallback
- [x] `bypassProxy: true` for fixture isolation
- [x] No live external API calls in Jest/CI
- [x] Manual smoke: Cherish House live Overpass returns real parcel polygon
- [x] Manual smoke: deterministic A1 still completes, `exportGate.allowed: true`

## Stop and wait

**Do not start Phase 5D.** Per the phased-execution policy, this PR stands alone and waits for review.