### PR TITLE
feat(a1): Phase 5D — vector PDF as opt-in additional artifact

### DIFF
--- a/src/__tests__/services/render/buildVectorPdfFromSheetSvg.test.js
+++ b/src/__tests__/services/render/buildVectorPdfFromSheetSvg.test.js
@@ -1,0 +1,339 @@
+/**
+ * Phase 5D — vector PDF builder focused tests.
+ *
+ * Drives the parser + walker + orchestrator end-to-end against
+ * fixture SVGs. Verifies:
+ *   1. Vector PDF builds successfully from a small fixture SVG.
+ *   2. PDF contains selectable text (introspected via PDF byte
+ *      patterns rather than full text extraction so we don't depend on
+ *      pdfjs-dist in the unit tests).
+ *   3. Raster panels (data:image/png) are embedded as PDF Image XObjects.
+ *   4. Vector failure on malformed input does NOT throw — returns
+ *      ok: false with a descriptive error.
+ *   5. Empty/missing input returns a clean error object, never throws.
+ *   6. Coordinate mapping flips SVG y-down to PDF y-up correctly.
+ *   7. Font extraction recovers @font-face TTF bytes from the SVG.
+ */
+
+import {
+  buildVectorPdfFromSheetSvg,
+  VECTOR_PDF_RENDER_MODE,
+  VECTOR_PDF_SCHEMA_VERSION,
+  __testing as orchestratorTesting,
+} from "../../../services/render/buildVectorPdfFromSheetSvg.js";
+import {
+  parseSvg,
+  parseAttrs,
+  decodeEntities,
+} from "../../../services/render/_lib/lightweightSvgParser.js";
+import {
+  parseSvgColor,
+  decodeImageDataUrl,
+  __testing as walkerTesting,
+} from "../../../services/render/_lib/svgToPdfWalker.js";
+
+// 1×1 transparent PNG (smallest valid PNG, 67 bytes)
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=";
+
+const SMALL_FIXTURE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 841 594" width="841mm" height="594mm">
+  <rect x="20" y="20" width="200" height="100" fill="#fafafa" stroke="#111" stroke-width="2"/>
+  <text x="40" y="60" font-size="14" font-family="ArchiAISans" fill="#222">SITE PLAN</text>
+  <text x="40" y="90" font-size="10" font-family="ArchiAISans" fill="#555">Scale 1:500</text>
+  <line x1="20" y1="140" x2="220" y2="140" stroke="#888" stroke-width="1"/>
+  <path d="M 250 30 L 350 30 L 350 130 L 250 130 Z" fill="none" stroke="#000" stroke-width="1"/>
+  <circle cx="500" cy="80" r="20" fill="#cccccc" stroke="#333"/>
+  <ellipse cx="600" cy="80" rx="30" ry="15" fill="rgb(200,80,80)"/>
+  <polygon points="400,150 450,200 350,200" fill="#deedee" stroke="#000"/>
+  <polyline points="50,500 100,450 150,500" stroke="#444" stroke-width="2" fill="none"/>
+  <g transform="translate(700, 30)">
+    <rect x="0" y="0" width="120" height="100" fill="white" stroke="#222"/>
+    <text x="10" y="20" font-size="12" font-weight="bold" font-family="ArchiAISans">TITLE BLOCK</text>
+    <text x="10" y="40" font-size="9" font-family="ArchiAISans">Project: Test</text>
+    <text x="10" y="55" font-size="9" font-family="ArchiAISans">Drawing: A1-001</text>
+  </g>
+  <image x="20" y="300" width="160" height="100" href="data:image/png;base64,${TINY_PNG_BASE64}"/>
+</svg>`;
+
+describe("lightweightSvgParser", () => {
+  test("parses a simple SVG into a tree with the expected children", () => {
+    const { root, warnings } = parseSvg(SMALL_FIXTURE_SVG);
+    expect(root).toBeTruthy();
+    expect(root.name).toBe("svg");
+    expect(warnings).toEqual([]);
+    const childNames = root.children
+      .filter((c) => c?.type === "element")
+      .map((c) => c.name);
+    expect(childNames).toEqual(
+      expect.arrayContaining([
+        "rect",
+        "text",
+        "line",
+        "path",
+        "circle",
+        "ellipse",
+        "polygon",
+        "polyline",
+        "g",
+        "image",
+      ]),
+    );
+  });
+
+  test("parseAttrs handles double + single quotes", () => {
+    const a = parseAttrs(' x="10" y=\'20\' width="100"');
+    expect(a).toEqual({ x: "10", y: "20", width: "100" });
+  });
+
+  test("decodeEntities handles common XML entities", () => {
+    expect(decodeEntities("a &amp; b &lt;c&gt;")).toBe("a & b <c>");
+    expect(decodeEntities("&#x41;&#66;")).toBe("AB");
+  });
+
+  test("skips body of <style>/<defs> without crashing on CSS contents", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <style>
+          @font-face { font-family: "ArchiAISans"; src: url(data:font/ttf;base64,AAAA); }
+          .panel > rect { fill: blue; }
+        </style>
+      </defs>
+      <rect x="0" y="0" width="10" height="10"/>
+    </svg>`;
+    const { root, warnings } = parseSvg(svg);
+    expect(warnings).toEqual([]);
+    const elementChildren = root.children.filter((c) => c?.type === "element");
+    expect(elementChildren).toHaveLength(1);
+    expect(elementChildren[0].name).toBe("rect");
+  });
+
+  test("malformed input does not throw", () => {
+    const result = parseSvg("<svg><rect><not closed");
+    expect(result.root).toBeTruthy();
+  });
+
+  test("empty input returns null root with warning", () => {
+    const result = parseSvg("");
+    expect(result.root).toBeNull();
+    expect(result.warnings).toContain("empty_input");
+  });
+});
+
+describe("svgToPdfWalker pure helpers", () => {
+  test("parseSvgColor handles hex, rgb(), and named colours", () => {
+    expect(parseSvgColor("#000")).toBeTruthy();
+    expect(parseSvgColor("#abc123")).toBeTruthy();
+    expect(parseSvgColor("rgb(255, 0, 128)")).toBeTruthy();
+    expect(parseSvgColor("white")).toBeTruthy();
+    expect(parseSvgColor("none")).toBeNull();
+    expect(parseSvgColor("")).toBeNull();
+    expect(parseSvgColor("notacolor")).toBeNull();
+  });
+
+  test("decodeImageDataUrl extracts PNG bytes", () => {
+    const decoded = decodeImageDataUrl(
+      `data:image/png;base64,${TINY_PNG_BASE64}`,
+    );
+    expect(decoded).toBeTruthy();
+    expect(decoded.kind).toBe("png");
+    expect(decoded.bytes.length).toBeGreaterThan(50);
+    // PNG magic bytes
+    expect(decoded.bytes[0]).toBe(0x89);
+    expect(decoded.bytes[1]).toBe(0x50);
+  });
+
+  test("decodeImageDataUrl returns null for non-data-url and SVG payload", () => {
+    expect(decodeImageDataUrl("https://example.com/a.png")).toBeNull();
+    expect(decodeImageDataUrl("data:image/svg+xml;base64,PHN2Zy8+")).toBeNull();
+    expect(decodeImageDataUrl(null)).toBeNull();
+  });
+
+  test("mergeTranslate composes nested translate() transforms", () => {
+    const base = { translateX: 0, translateY: 0 };
+    const next = walkerTesting.mergeTranslate(base, {
+      transform: "translate(10, 20)",
+    });
+    expect(next).toEqual({ translateX: 10, translateY: 20 });
+    const nested = walkerTesting.mergeTranslate(next, {
+      transform: "translate(5, -3)",
+    });
+    expect(nested).toEqual({ translateX: 15, translateY: 17 });
+  });
+});
+
+describe("buildVectorPdfFromSheetSvg — happy path", () => {
+  test("builds a vector PDF from the fixture SVG", async () => {
+    const result = await buildVectorPdfFromSheetSvg({
+      svgString: SMALL_FIXTURE_SVG,
+      title: "Test Vector PDF",
+      geometryHash: "test-geom-hash",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.pdfBytes).toBeTruthy();
+    expect(result.pdfBytes.length).toBeGreaterThan(500);
+    expect(result.pdfRenderMode).toBe(VECTOR_PDF_RENDER_MODE);
+    expect(result.schemaVersion).toBe(VECTOR_PDF_SCHEMA_VERSION);
+    expect(result.pageCount).toBe(1);
+    expect(result.pageSizeMm).toEqual({ width: 841, height: 594 });
+    expect(result.summary.drawCalls).toBeGreaterThan(5);
+    expect(result.dataUrl.startsWith("data:application/pdf;base64,")).toBe(
+      true,
+    );
+    expect(/^[0-9a-f]{8}$/.test(result.pdfHash)).toBe(true);
+  });
+
+  test("PDF contains the embedded text strings (selectable, after FlateDecode inflate)", async () => {
+    const zlib = await import("node:zlib");
+    const result = await buildVectorPdfFromSheetSvg({
+      svgString: SMALL_FIXTURE_SVG,
+      inspectable: true, // disables object streams so we can inflate content streams
+    });
+    expect(result.ok).toBe(true);
+    const pdfBytes = result.pdfBytes;
+    // pdf-lib serialises text inside FlateDecode'd content streams.
+    // For Helvetica StandardFonts it writes hex-encoded strings:
+    //   <5349544520504C414E> Tj  for "SITE PLAN"
+    // We inflate every stream, then decode hex literals and concatenate
+    // both the raw inflated bytes (for `(...)Tj` form) and the decoded
+    // hex pairs (for `<...>Tj` form).
+    const text = pdfBytes.toString("latin1");
+    let inflatedText = "";
+    const streamRe = /stream\r?\n([\s\S]*?)\r?\nendstream/g;
+    let m;
+    while ((m = streamRe.exec(text)) !== null) {
+      try {
+        inflatedText +=
+          zlib.inflateSync(Buffer.from(m[1], "latin1")).toString("latin1") +
+          "\n";
+      } catch {
+        // not a flate stream (e.g. raw image bytes)
+      }
+    }
+    // Decode every <HEX> string literal that appears inside the
+    // inflated content streams.
+    const hexLiterals = inflatedText.match(/<([0-9A-Fa-f\s]+)>/g) || [];
+    const decodedHex = hexLiterals
+      .map((lit) => {
+        const cleaned = lit.replace(/[<>\s]/g, "");
+        if (cleaned.length === 0 || cleaned.length % 2 !== 0) return "";
+        try {
+          return Buffer.from(cleaned, "hex").toString("latin1");
+        } catch {
+          return "";
+        }
+      })
+      .join(" ");
+    const allText = `${inflatedText} ${decodedHex}`;
+    expect(allText).toContain("SITE PLAN");
+    expect(allText).toContain("Scale 1:500");
+    expect(allText).toContain("TITLE BLOCK");
+    expect(allText).toContain("Project: Test");
+    expect(allText).toContain("Drawing: A1-001");
+    // Either Tj operator form (literal or hex) must be present
+    expect(/(?:\)|>)\s*Tj/.test(inflatedText)).toBe(true);
+  });
+
+  test("PDF embeds raster panels as PDF Image XObjects (uncompressed inspection)", async () => {
+    const result = await buildVectorPdfFromSheetSvg({
+      svgString: SMALL_FIXTURE_SVG,
+      inspectable: true,
+    });
+    expect(result.ok).toBe(true);
+    const pdfText = result.pdfBytes.toString("latin1");
+    // The XObject reference + Subtype/Image marker live in object
+    // headers (NOT inside compressed streams) so we can find them
+    // with a regex on the raw bytes once `inspectable: true`
+    // disables object streams. `\s*` allows for either "/Subtype /Image"
+    // or "/Subtype/Image" depending on pdf-lib serialisation.
+    expect(pdfText).toMatch(/\/Subtype\s*\/Image/);
+    expect(pdfText).toMatch(/\/XObject/);
+    expect(pdfText).toMatch(/\/Filter\s*\/FlateDecode/);
+  });
+
+  test("walker draw-call summary reports text + image draws for the fixture", async () => {
+    const result = await buildVectorPdfFromSheetSvg({
+      svgString: SMALL_FIXTURE_SVG,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.summary.drawCalls).toBeGreaterThan(8);
+    // Either we recorded zero skipped or only known-skipped tags
+    // (the fixture has no exotic elements; walker should accept all).
+    const skippedNames = Object.keys(result.summary.skipped || {});
+    expect(skippedNames).toEqual([]);
+  });
+});
+
+describe("buildVectorPdfFromSheetSvg — failure tolerance", () => {
+  test("returns ok:false with error for empty SVG", async () => {
+    const result = await buildVectorPdfFromSheetSvg({ svgString: "" });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("empty_svg_string");
+    expect(result.pdfBytes).toBeNull();
+  });
+
+  test("returns ok:false when SVG has no viewBox or width/height", async () => {
+    const result = await buildVectorPdfFromSheetSvg({
+      svgString: '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("no_view_box");
+  });
+
+  test("malformed SVG content does not throw, returns ok:true with degraded summary", async () => {
+    // Garbage with a valid <svg> wrapper — parser is tolerant.
+    const svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect x="not-a-number" y="abc" width="50" height="50"/><randomTag><nested>broken</nested></svg>';
+    const result = await buildVectorPdfFromSheetSvg({ svgString: svg });
+    // Either succeeds with skips or fails with a clean error — both are
+    // acceptable. NEVER throws (which would break the calling pipeline).
+    expect(typeof result.ok).toBe("boolean");
+    expect(typeof result.error === "string" || result.error === null).toBe(
+      true,
+    );
+  });
+
+  test("missing svgString does not throw", async () => {
+    const result = await buildVectorPdfFromSheetSvg({});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("empty_svg_string");
+  });
+
+  test("Buffer input (non-string) does not throw", async () => {
+    const result = await buildVectorPdfFromSheetSvg({
+      svgString: Buffer.from("nonsense"),
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("buildVectorPdfFromSheetSvg — font extraction", () => {
+  test("extractEmbeddedFonts recovers TTF base64 from @font-face", () => {
+    const fakeBytes = Buffer.from("\x00\x01\x00\x00").toString("base64");
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><defs><style>
+      @font-face {
+        font-family: "ArchiAISans";
+        src: url(data:font/ttf;base64,${fakeBytes}) format("truetype");
+        font-weight: 400;
+      }
+      @font-face {
+        font-family: "ArchiAISans";
+        src: url(data:font/ttf;base64,${fakeBytes}) format("truetype");
+        font-weight: 700;
+      }
+    </style></defs></svg>`;
+    const fonts = orchestratorTesting.extractEmbeddedFonts(svg);
+    expect(fonts.regular).toBeTruthy();
+    expect(fonts.bold).toBeTruthy();
+    expect(fonts.regular.toString("hex")).toBe("00010000");
+  });
+
+  test("extractEmbeddedFonts returns nulls when no @font-face is present", () => {
+    const fonts = orchestratorTesting.extractEmbeddedFonts(
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>',
+    );
+    expect(fonts.regular).toBeNull();
+    expect(fonts.bold).toBeNull();
+  });
+});

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -23,6 +23,11 @@ import {
 import { computeCDSHashSync } from "../validation/cdsHash.js";
 import { rasteriseSheetArtifact } from "../render/svgRasteriser.js";
 import {
+  buildVectorPdfFromSheetSvg,
+  VECTOR_PDF_RENDER_MODE,
+  VECTOR_PDF_SCHEMA_VERSION,
+} from "../render/buildVectorPdfFromSheetSvg.js";
+import {
   buildVisualManifest,
   buildVisualIdentityLockBlock,
 } from "../render/visualManifestService.js";
@@ -7878,6 +7883,70 @@ async function buildA1PdfArtifact({
     hybridVectorPdfFollowUp: true,
   };
 
+  // Phase 5D: optional vector PDF as an *additional* artifact behind a
+  // feature flag (`PROJECT_GRAPH_VECTOR_PDF_ENABLED=true`). The raster
+  // PDF above remains the production deliverable; the vector PDF is
+  // emitted alongside for Preview/local evaluation. Failure of the
+  // vector path is recorded as warning metadata and NEVER blocks the
+  // raster artifact.
+  const vectorPdfFlag = String(
+    (typeof process !== "undefined" &&
+      process.env?.PROJECT_GRAPH_VECTOR_PDF_ENABLED) ||
+      "",
+  )
+    .toLowerCase()
+    .trim();
+  const vectorPdfEnabled = vectorPdfFlag === "true" || vectorPdfFlag === "1";
+  let vectorPdf = null;
+  if (vectorPdfEnabled && isFinalA1) {
+    try {
+      const t0 = Date.now();
+      vectorPdf = await buildVectorPdfFromSheetSvg({
+        svgString: rawSheetSvg,
+        title:
+          (brief?.project_name ? `${brief.project_name} — ` : "") +
+          "ArchiAI A1 Sheet (vector)",
+        author: brief?.architect || "ArchiAI",
+        geometryHash,
+      });
+      __pdfMark = __a1pdfLog(
+        "vector_pdf_build",
+        __pdfMark,
+        `ok=${vectorPdf.ok} bytes=${vectorPdf.byteLength} draws=${vectorPdf.summary?.drawCalls || 0} took_ms=${Date.now() - t0}`,
+      );
+    } catch (vectorErr) {
+      vectorPdf = {
+        ok: false,
+        pdfBytes: null,
+        dataUrl: null,
+        pdfHash: null,
+        byteLength: 0,
+        pageCount: 0,
+        pageSizeMm: { width: 841, height: 594 },
+        pdfRenderMode: VECTOR_PDF_RENDER_MODE,
+        schemaVersion: VECTOR_PDF_SCHEMA_VERSION,
+        summary: { drawCalls: 0, skipped: {}, warnings: [] },
+        error: `vector_pdf_threw:${vectorErr?.message || "unknown"}`,
+      };
+    }
+  }
+  if (vectorPdf) {
+    pdfMetadata.vectorPdf = {
+      enabled: vectorPdfEnabled,
+      ok: vectorPdf.ok === true,
+      schemaVersion: vectorPdf.schemaVersion,
+      pdfRenderMode: vectorPdf.pdfRenderMode,
+      pdfHash: vectorPdf.pdfHash,
+      byteLength: vectorPdf.byteLength,
+      drawCalls: vectorPdf.summary?.drawCalls ?? 0,
+      skipped: vectorPdf.summary?.skipped || {},
+      warnings: vectorPdf.summary?.warnings || [],
+      error: vectorPdf.error || null,
+    };
+  } else {
+    pdfMetadata.vectorPdf = { enabled: vectorPdfEnabled, ok: false };
+  }
+
   return {
     asset_id: assetId,
     asset_type: "a1_sheet_pdf",
@@ -7897,6 +7966,13 @@ async function buildA1PdfArtifact({
     pdfHash: contentHash,
     pdfMetadata,
     dataUrl: pdfDataUri,
+    // Phase 5D: vector artifact alongside the raster one. Consumers
+    // that want to download the vector PDF should read `vectorPdfDataUrl`.
+    // When the flag is off or the vector build failed, these are null.
+    vectorPdfDataUrl: vectorPdf?.ok ? vectorPdf.dataUrl : null,
+    vectorPdfBytes: vectorPdf?.ok ? vectorPdf.byteLength : 0,
+    vectorPdfHash: vectorPdf?.ok ? vectorPdf.pdfHash : null,
+    vectorPdfRenderMode: vectorPdf?.ok ? vectorPdf.pdfRenderMode : null,
   };
 }
 

--- a/src/services/render/_lib/lightweightSvgParser.js
+++ b/src/services/render/_lib/lightweightSvgParser.js
@@ -1,0 +1,241 @@
+/**
+ * Phase 5D — focused SVG parser for the pipeline's master sheet SVG.
+ *
+ * No XML/DOM dependency. Our pipeline emits a known subset of SVG and we
+ * only need the elements actually rendered in `composeCore` /
+ * `composeDataPanels` outputs. Anything more exotic (clipPath, mask,
+ * filter, foreignObject, animations) is silently dropped because the
+ * vector PDF path is opt-in behind a flag and the raster pipeline
+ * remains the production default.
+ *
+ * Returns a tree of nodes:
+ *   {
+ *     type: "element",
+ *     name: "rect",
+ *     attrs: { ... },
+ *     children: [],     // child nodes (mixed elements + text)
+ *     text: null,       // direct inline text content (for <text>/<tspan>)
+ *   }
+ *
+ * Or a text node:
+ *   { type: "text", value: "Some text content" }
+ *
+ * The parser is deliberately permissive: malformed SVG produces a
+ * partial tree rather than throwing, so the calling exporter can warn
+ * and fall back without breaking the raster path. Callers must treat
+ * the result as best-effort.
+ */
+
+const TAG_RE = /<\s*(\/?)([a-zA-Z][a-zA-Z0-9:_-]*)((?:\s+[^>]*?)?)(\/?)\s*>/g;
+const ATTR_RE = /([a-zA-Z_][a-zA-Z0-9:_-]*)\s*=\s*("([^"]*)"|'([^']*)')/g;
+
+const VOID_ELEMENTS = new Set([
+  "br",
+  "hr",
+  "img",
+  "input",
+  "meta",
+  "link",
+  "area",
+  "base",
+  "col",
+  "embed",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+const SKIP_ELEMENTS = new Set([
+  "defs",
+  "style",
+  "clipPath",
+  "mask",
+  "filter",
+  "foreignObject",
+  "metadata",
+  "title",
+  "desc",
+]);
+
+/**
+ * Parse the attribute portion of an opening tag (e.g. ` x="1" y="2"`)
+ * into a flat object.
+ */
+export function parseAttrs(attrText) {
+  const attrs = {};
+  if (!attrText) return attrs;
+  ATTR_RE.lastIndex = 0;
+  let match;
+  while ((match = ATTR_RE.exec(attrText)) !== null) {
+    const name = match[1];
+    const value = match[3] !== undefined ? match[3] : match[4] || "";
+    attrs[name] = decodeEntities(value);
+  }
+  return attrs;
+}
+
+/**
+ * Cheap XML entity decoder for the entities our pipeline actually emits.
+ * Not a full HTML5 spec implementation — purpose-built for the master
+ * sheet SVG.
+ */
+export function decodeEntities(text) {
+  if (typeof text !== "string" || !text.includes("&")) return text;
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
+      String.fromCharCode(parseInt(hex, 16)),
+    )
+    .replace(/&#([0-9]+);/g, (_, dec) =>
+      String.fromCharCode(parseInt(dec, 10)),
+    );
+}
+
+/**
+ * Strip CDATA, comments, processing instructions, and DOCTYPE from the
+ * input. Cheaper than handling them properly inside the main parser.
+ */
+function stripIgnored(input) {
+  return String(input)
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, "")
+    .replace(/<\?[\s\S]*?\?>/g, "")
+    .replace(/<!DOCTYPE[\s\S]*?>/gi, "");
+}
+
+function makeElement(name, attrs) {
+  return {
+    type: "element",
+    name,
+    attrs,
+    children: [],
+    text: null,
+  };
+}
+
+/**
+ * Parse an SVG string into a lightweight tree. Returns `{ root, warnings }`.
+ * `root` is the outermost `<svg>` element (or the first element found
+ * when no <svg> wrapper is present). `warnings` is an array of strings
+ * the caller may surface in metadata.
+ *
+ * @param {string} svgString
+ * @returns {{ root: object|null, warnings: string[] }}
+ */
+export function parseSvg(svgString) {
+  const warnings = [];
+  if (typeof svgString !== "string" || svgString.length === 0) {
+    return { root: null, warnings: ["empty_input"] };
+  }
+  const cleaned = stripIgnored(svgString);
+  const stack = [];
+  const documentRoot = makeElement("#document", {});
+  stack.push(documentRoot);
+  let lastIndex = 0;
+  TAG_RE.lastIndex = 0;
+  let match;
+  let tagCount = 0;
+  while ((match = TAG_RE.exec(cleaned)) !== null) {
+    const before = cleaned.slice(lastIndex, match.index);
+    if (before && before.trim().length > 0 && stack.length > 1) {
+      const top = stack[stack.length - 1];
+      const text = decodeEntities(before);
+      if (top.name === "text" || top.name === "tspan") {
+        // Inline text content for <text>/<tspan> — accumulate
+        top.text = (top.text || "") + text;
+      } else {
+        top.children.push({ type: "text", value: text });
+      }
+    }
+    lastIndex = match.index + match[0].length;
+    tagCount += 1;
+    if (tagCount > 200_000) {
+      warnings.push("aborting_after_200k_tags");
+      break;
+    }
+    const isClose = match[1] === "/";
+    const tagName = match[2];
+    const attrText = match[3] || "";
+    const isSelfClose = match[4] === "/" || VOID_ELEMENTS.has(tagName);
+    if (isClose) {
+      // Pop until the matching open tag (best-effort — tolerate
+      // mismatched closes by walking back).
+      let popped = null;
+      for (let i = stack.length - 1; i > 0; i--) {
+        if (stack[i].name === tagName) {
+          popped = stack[i];
+          stack.length = i;
+          break;
+        }
+      }
+      if (!popped) {
+        warnings.push(`unmatched_close_${tagName}`);
+      }
+      continue;
+    }
+    if (SKIP_ELEMENTS.has(tagName)) {
+      // Skip the entire body of these elements: locate the matching
+      // close tag and jump past it without parsing the contents. This
+      // protects the parser from <style> CSS contents and similar.
+      const closeRe = new RegExp(`</\\s*${tagName}\\s*>`, "i");
+      const sub = cleaned.slice(TAG_RE.lastIndex);
+      const closeMatch = sub.match(closeRe);
+      if (closeMatch) {
+        TAG_RE.lastIndex += closeMatch.index + closeMatch[0].length;
+        lastIndex = TAG_RE.lastIndex;
+      }
+      continue;
+    }
+    const attrs = parseAttrs(attrText);
+    const element = makeElement(tagName, attrs);
+    const top = stack[stack.length - 1];
+    top.children.push(element);
+    if (!isSelfClose) {
+      stack.push(element);
+    }
+  }
+  // Find the first <svg> child of the document root (or the first
+  // element if no <svg> exists, for tolerance).
+  const svgRoot =
+    documentRoot.children.find(
+      (n) => n?.type === "element" && n.name === "svg",
+    ) ||
+    documentRoot.children.find((n) => n?.type === "element") ||
+    null;
+  if (!svgRoot) warnings.push("no_root_element");
+  return { root: svgRoot, warnings };
+}
+
+/**
+ * Convenience: depth-first iterator over element nodes only (skips
+ * text nodes). Yields `{ node, parent, ancestors }` for each element.
+ */
+export function* walkElements(root) {
+  if (!root || root.type !== "element") return;
+  const stack = [{ node: root, ancestors: [] }];
+  while (stack.length > 0) {
+    const { node, ancestors } = stack.pop();
+    yield { node, ancestors };
+    if (Array.isArray(node.children)) {
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        const child = node.children[i];
+        if (child?.type === "element") {
+          stack.push({ node: child, ancestors: [...ancestors, node] });
+        }
+      }
+    }
+  }
+}
+
+export const __testing = Object.freeze({
+  TAG_RE,
+  ATTR_RE,
+  VOID_ELEMENTS,
+  SKIP_ELEMENTS,
+  stripIgnored,
+});

--- a/src/services/render/_lib/svgToPdfWalker.js
+++ b/src/services/render/_lib/svgToPdfWalker.js
@@ -1,0 +1,600 @@
+/**
+ * Phase 5D — walk a parsed SVG tree and emit pdf-lib draw calls.
+ *
+ * Pure: takes a parsed SVG tree (from lightweightSvgParser) plus a
+ * pdf-lib `page` and `font` registry, and calls page.drawText / drawSvgPath
+ * / drawRectangle / etc. directly. Returns a `{ drawCallCount, warnings,
+ * skipped }` summary.
+ *
+ * Coordinate system: SVG is top-left origin, y down. PDF is bottom-left,
+ * y up. The walker takes a `transform` callback `(svgX, svgY) => {x,y}`
+ * so the orchestrator (`buildVectorPdfFromSheetSvg`) can centralise the
+ * SVG-pt → PDF-pt mapping (including any centering / scaling needed for
+ * the A1 page).
+ *
+ * Anything we don't understand is silently dropped with a warning. The
+ * vector PDF is opt-in behind a flag and the raster pipeline remains
+ * the production default — this walker is best-effort by design.
+ */
+
+import { rgb, degrees } from "pdf-lib";
+
+const SUPPORTED_TAGS = new Set([
+  "g",
+  "svg",
+  "rect",
+  "line",
+  "polyline",
+  "polygon",
+  "path",
+  "circle",
+  "ellipse",
+  "text",
+  "image",
+]);
+
+const DEFAULT_FONT_SIZE = 10;
+
+/**
+ * Parse an SVG hex/named colour into pdf-lib's `rgb(r,g,b)` (each 0..1).
+ * Returns null when the input is "none", missing, or unparseable.
+ */
+export function parseSvgColor(input) {
+  if (!input || input === "none" || input === "transparent") return null;
+  const value = String(input).trim().toLowerCase();
+  if (value === "white") return rgb(1, 1, 1);
+  if (value === "black") return rgb(0, 0, 0);
+  const named = NAMED_COLORS[value];
+  if (named) return rgb(named[0] / 255, named[1] / 255, named[2] / 255);
+  // #RGB or #RRGGBB
+  const hex3 = value.match(/^#([0-9a-f]{3})$/);
+  if (hex3) {
+    const [r, g, b] = hex3[1].split("");
+    return rgb(
+      parseInt(r + r, 16) / 255,
+      parseInt(g + g, 16) / 255,
+      parseInt(b + b, 16) / 255,
+    );
+  }
+  const hex6 = value.match(/^#([0-9a-f]{6})$/);
+  if (hex6) {
+    return rgb(
+      parseInt(hex6[1].slice(0, 2), 16) / 255,
+      parseInt(hex6[1].slice(2, 4), 16) / 255,
+      parseInt(hex6[1].slice(4, 6), 16) / 255,
+    );
+  }
+  // rgb(...) functional notation
+  const rgbFn = value.match(/^rgba?\(([^)]+)\)$/);
+  if (rgbFn) {
+    const parts = rgbFn[1]
+      .split(",")
+      .map((s) => Number(s.trim()))
+      .filter((n) => Number.isFinite(n));
+    if (parts.length >= 3) {
+      return rgb(
+        Math.max(0, Math.min(1, parts[0] / 255)),
+        Math.max(0, Math.min(1, parts[1] / 255)),
+        Math.max(0, Math.min(1, parts[2] / 255)),
+      );
+    }
+  }
+  return null;
+}
+
+const NAMED_COLORS = Object.freeze({
+  red: [255, 0, 0],
+  green: [0, 128, 0],
+  blue: [0, 0, 255],
+  gray: [128, 128, 128],
+  grey: [128, 128, 128],
+  silver: [192, 192, 192],
+  yellow: [255, 255, 0],
+});
+
+function num(v, fallback = 0) {
+  if (v === undefined || v === null) return fallback;
+  const n = Number(String(v).replace(/[^0-9.\-eE]/g, ""));
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Decode a `data:image/png;base64,…` or `data:image/jpeg;base64,…` URL
+ * into a `{ kind, bytes }` pair. Returns null for any other shape (e.g.
+ * `data:image/svg+xml`, raw URLs, or non-base64 encodings).
+ */
+export function decodeImageDataUrl(href) {
+  if (typeof href !== "string" || !href.startsWith("data:")) return null;
+  const match = href.match(
+    /^data:(image\/(?:png|jpe?g))(?:;[^,]+)?;base64,(.*)$/i,
+  );
+  if (!match) return null;
+  const mime = match[1].toLowerCase();
+  const kind = mime === "image/png" ? "png" : "jpeg";
+  try {
+    const bytes = Buffer.from(match[2], "base64");
+    return { kind, bytes };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Walk a parsed SVG element tree and emit pdf-lib draw calls. Returns
+ * a summary report: number of draw calls emitted + per-tag count of
+ * skipped elements + any warnings.
+ *
+ * @param {object} params
+ * @param {object} params.root           - parsed SVG root element
+ * @param {object} params.page           - pdf-lib PDFPage instance
+ * @param {object} params.pdfDoc         - pdf-lib PDFDocument instance (for embedImage)
+ * @param {object} params.fontRegular    - pdf-lib PDFFont
+ * @param {object} [params.fontBold]     - pdf-lib PDFFont (optional)
+ * @param {function} params.toPdfXY      - (svgX, svgY) → { x, y } in PDF pts
+ * @param {number} [params.scale=1]      - SVG→PDF scale factor (also applied to widths)
+ * @param {object} [params.viewBox]      - { minX, minY, width, height } from the root SVG
+ * @returns {Promise<{ drawCalls: number, skipped: object, warnings: string[] }>}
+ */
+export async function walkSvgIntoPdf({
+  root,
+  page,
+  pdfDoc,
+  fontRegular,
+  fontBold = null,
+  toPdfXY,
+  scale = 1,
+  viewBox = null,
+}) {
+  const summary = { drawCalls: 0, skipped: {}, warnings: [] };
+  if (!root || root.type !== "element") {
+    summary.warnings.push("no_svg_root");
+    return summary;
+  }
+  if (!page || !pdfDoc || !fontRegular || typeof toPdfXY !== "function") {
+    throw new Error("walkSvgIntoPdf: missing page/pdfDoc/fontRegular/toPdfXY");
+  }
+
+  // Inherited style state — child <g>/<text> can override.
+  const initialState = {
+    fill: rgb(0, 0, 0),
+    stroke: null,
+    strokeWidth: 1,
+    fontSize: DEFAULT_FONT_SIZE,
+    fontWeight: "normal",
+    textAnchor: "start",
+    fillNone: false,
+  };
+
+  await visit(root, initialState, { translateX: 0, translateY: 0 });
+  return summary;
+
+  async function visit(node, state, translation) {
+    if (!node || node.type !== "element") return;
+    const localState = mergeState(state, node.attrs);
+    const localTranslate = mergeTranslate(translation, node.attrs);
+
+    if (!SUPPORTED_TAGS.has(node.name)) {
+      summary.skipped[node.name] = (summary.skipped[node.name] || 0) + 1;
+      return;
+    }
+
+    switch (node.name) {
+      case "g":
+      case "svg":
+        for (const child of node.children) {
+          if (child?.type === "element") {
+            await visit(child, localState, localTranslate);
+          }
+        }
+        return;
+
+      case "rect": {
+        const x = num(node.attrs.x) + localTranslate.translateX;
+        const y = num(node.attrs.y) + localTranslate.translateY;
+        const w = num(node.attrs.width);
+        const h = num(node.attrs.height);
+        if (w <= 0 || h <= 0) return;
+        // SVG rect is top-left; convert top-left corner.
+        const tl = toPdfXY(x, y);
+        const br = toPdfXY(x + w, y + h);
+        const pdfX = Math.min(tl.x, br.x);
+        const pdfY = Math.min(tl.y, br.y);
+        const width = Math.abs(br.x - tl.x);
+        const height = Math.abs(br.y - tl.y);
+        const opts = {
+          x: pdfX,
+          y: pdfY,
+          width,
+          height,
+        };
+        if (localState.fill && !localState.fillNone)
+          opts.color = localState.fill;
+        if (localState.stroke) {
+          opts.borderColor = localState.stroke;
+          opts.borderWidth = localState.strokeWidth * scale;
+        }
+        page.drawRectangle(opts);
+        summary.drawCalls += 1;
+        return;
+      }
+
+      case "line": {
+        const x1 = num(node.attrs.x1) + localTranslate.translateX;
+        const y1 = num(node.attrs.y1) + localTranslate.translateY;
+        const x2 = num(node.attrs.x2) + localTranslate.translateX;
+        const y2 = num(node.attrs.y2) + localTranslate.translateY;
+        const start = toPdfXY(x1, y1);
+        const end = toPdfXY(x2, y2);
+        const stroke =
+          localState.stroke ||
+          (localState.fill && !localState.fillNone
+            ? localState.fill
+            : rgb(0, 0, 0));
+        page.drawLine({
+          start: { x: start.x, y: start.y },
+          end: { x: end.x, y: end.y },
+          thickness: localState.strokeWidth * scale,
+          color: stroke,
+        });
+        summary.drawCalls += 1;
+        return;
+      }
+
+      case "polyline":
+      case "polygon": {
+        const pointsText = String(node.attrs.points || "").trim();
+        if (!pointsText) return;
+        const pairs = pointsText
+          .split(/[\s,]+/)
+          .map(Number)
+          .filter((n) => Number.isFinite(n));
+        if (pairs.length < 4) return;
+        // Build SVG path data and use drawSvgPath (deterministic).
+        const cmds = [];
+        for (let i = 0; i + 1 < pairs.length; i += 2) {
+          const cmd = i === 0 ? "M" : "L";
+          const px = pairs[i] + localTranslate.translateX;
+          const py = pairs[i + 1] + localTranslate.translateY;
+          const pt = toPdfXY(px, py);
+          cmds.push(`${cmd}${pt.x} ${pt.y}`);
+        }
+        if (node.name === "polygon") cmds.push("Z");
+        const pathData = cmds.join(" ");
+        drawPathOnPage({
+          page,
+          pathData,
+          state: localState,
+          scale,
+        });
+        summary.drawCalls += 1;
+        return;
+      }
+
+      case "path": {
+        const d = String(node.attrs.d || "").trim();
+        if (!d) return;
+        // pdf-lib's drawSvgPath uses SVG path syntax directly. We need
+        // to translate the path's reference point: pdf-lib places the
+        // path at (x, y) in PDF coords and treats the path data as
+        // relative to that origin (with y flipped). For the master
+        // sheet SVG every <path> is in the parent SVG's coordinate
+        // system, so we anchor at the parent translate origin and let
+        // pdf-lib handle the y-flip via its own internal convention.
+        const anchor = toPdfXY(
+          localTranslate.translateX,
+          localTranslate.translateY,
+        );
+        const opts = {
+          x: anchor.x,
+          y: anchor.y,
+          scale,
+        };
+        if (localState.fill && !localState.fillNone) {
+          opts.color = localState.fill;
+        }
+        if (localState.stroke) {
+          opts.borderColor = localState.stroke;
+          opts.borderWidth = localState.strokeWidth * scale;
+        }
+        try {
+          page.drawSvgPath(d, opts);
+          summary.drawCalls += 1;
+        } catch (err) {
+          summary.warnings.push(
+            `path_draw_failed:${(err?.message || "unknown").slice(0, 80)}`,
+          );
+        }
+        return;
+      }
+
+      case "circle": {
+        const cx = num(node.attrs.cx) + localTranslate.translateX;
+        const cy = num(node.attrs.cy) + localTranslate.translateY;
+        const r = num(node.attrs.r);
+        if (r <= 0) return;
+        const center = toPdfXY(cx, cy);
+        const opts = {
+          x: center.x,
+          y: center.y,
+          size: r * scale,
+        };
+        if (localState.fill && !localState.fillNone)
+          opts.color = localState.fill;
+        if (localState.stroke) {
+          opts.borderColor = localState.stroke;
+          opts.borderWidth = localState.strokeWidth * scale;
+        }
+        page.drawCircle(opts);
+        summary.drawCalls += 1;
+        return;
+      }
+
+      case "ellipse": {
+        const cx = num(node.attrs.cx) + localTranslate.translateX;
+        const cy = num(node.attrs.cy) + localTranslate.translateY;
+        const rx = num(node.attrs.rx);
+        const ry = num(node.attrs.ry);
+        if (rx <= 0 || ry <= 0) return;
+        const center = toPdfXY(cx, cy);
+        const opts = {
+          x: center.x,
+          y: center.y,
+          xScale: rx * scale,
+          yScale: ry * scale,
+        };
+        if (localState.fill && !localState.fillNone)
+          opts.color = localState.fill;
+        if (localState.stroke) {
+          opts.borderColor = localState.stroke;
+          opts.borderWidth = localState.strokeWidth * scale;
+        }
+        page.drawEllipse(opts);
+        summary.drawCalls += 1;
+        return;
+      }
+
+      case "text": {
+        const x = num(node.attrs.x) + localTranslate.translateX;
+        const y = num(node.attrs.y) + localTranslate.translateY;
+        const fontSize = num(node.attrs["font-size"], localState.fontSize);
+        const textAnchor = node.attrs["text-anchor"] || localState.textAnchor;
+        const fontWeight = node.attrs["font-weight"] || localState.fontWeight;
+        const useBold =
+          (fontWeight === "bold" || fontWeight === "700") && fontBold;
+        const font = useBold ? fontBold : fontRegular;
+        const colour = localState.fill || rgb(0, 0, 0);
+        const textValue = collectTextContent(node).trim();
+        if (!textValue) {
+          // No direct text — handle <tspan> children
+          for (const child of node.children) {
+            if (child?.type === "element" && child.name === "tspan") {
+              await drawTspan({
+                tspan: child,
+                anchorX: x,
+                anchorY: y,
+                inheritedFontSize: fontSize,
+                inheritedAnchor: textAnchor,
+                inheritedColor: colour,
+                fontRegular,
+                fontBold,
+                page,
+                toPdfXY,
+                scale,
+              });
+            }
+          }
+          return;
+        }
+        const renderedSize = fontSize * scale;
+        const widthPdf = font.widthOfTextAtSize(textValue, renderedSize);
+        const alignmentDx =
+          textAnchor === "middle"
+            ? -widthPdf / 2
+            : textAnchor === "end"
+              ? -widthPdf
+              : 0;
+        const pdfPos = toPdfXY(x, y);
+        page.drawText(textValue, {
+          x: pdfPos.x + alignmentDx,
+          y: pdfPos.y,
+          size: renderedSize,
+          font,
+          color: colour,
+        });
+        summary.drawCalls += 1;
+        return;
+      }
+
+      case "image": {
+        const href =
+          node.attrs.href ||
+          node.attrs["xlink:href"] ||
+          node.attrs["xmlnsXlink:href"] ||
+          "";
+        const decoded = decodeImageDataUrl(href);
+        if (!decoded) {
+          summary.skipped["image:non-data-url"] =
+            (summary.skipped["image:non-data-url"] || 0) + 1;
+          return;
+        }
+        const x = num(node.attrs.x) + localTranslate.translateX;
+        const y = num(node.attrs.y) + localTranslate.translateY;
+        const w = num(node.attrs.width);
+        const h = num(node.attrs.height);
+        if (w <= 0 || h <= 0) return;
+        try {
+          // pdf-lib's instanceof Uint8Array check fails in Jest+jsdom
+          // when the global `Uint8Array` differs from Node's. Force a
+          // copy through the realm-local constructor so the validator
+          // accepts the buffer in both Node and jsdom test environments.
+          const bytesView = new Uint8Array(
+            decoded.bytes.buffer,
+            decoded.bytes.byteOffset,
+            decoded.bytes.byteLength,
+          );
+          const embedded =
+            decoded.kind === "png"
+              ? await pdfDoc.embedPng(bytesView)
+              : await pdfDoc.embedJpg(bytesView);
+          const tl = toPdfXY(x, y);
+          const br = toPdfXY(x + w, y + h);
+          const pdfX = Math.min(tl.x, br.x);
+          const pdfY = Math.min(tl.y, br.y);
+          const width = Math.abs(br.x - tl.x);
+          const height = Math.abs(br.y - tl.y);
+          page.drawImage(embedded, {
+            x: pdfX,
+            y: pdfY,
+            width,
+            height,
+          });
+          summary.drawCalls += 1;
+        } catch (err) {
+          summary.warnings.push(
+            `image_embed_failed:${(err?.message || "unknown").slice(0, 80)}`,
+          );
+        }
+        return;
+      }
+
+      default:
+        summary.skipped[node.name] = (summary.skipped[node.name] || 0) + 1;
+        return;
+    }
+  }
+
+  async function drawTspan({
+    tspan,
+    anchorX,
+    anchorY,
+    inheritedFontSize,
+    inheritedAnchor,
+    inheritedColor,
+    fontRegular: _fontRegular,
+    fontBold: _fontBold,
+    page: _page,
+    toPdfXY: _toPdfXY,
+    scale: _scale,
+  }) {
+    const fontSize = num(tspan.attrs["font-size"], inheritedFontSize);
+    const fontWeight = tspan.attrs["font-weight"] || "normal";
+    const textAnchor = tspan.attrs["text-anchor"] || inheritedAnchor;
+    const fillAttr = tspan.attrs.fill;
+    const colour = fillAttr
+      ? parseSvgColor(fillAttr) || inheritedColor
+      : inheritedColor;
+    const useBold =
+      (fontWeight === "bold" || fontWeight === "700") && _fontBold;
+    const font = useBold ? _fontBold : _fontRegular;
+    const dx = num(tspan.attrs.dx);
+    const dy = num(tspan.attrs.dy);
+    const tx = num(tspan.attrs.x, anchorX) + dx;
+    const ty = num(tspan.attrs.y, anchorY) + dy;
+    const text = collectTextContent(tspan).trim();
+    if (!text) return;
+    const renderedSize = fontSize * _scale;
+    const widthPdf = font.widthOfTextAtSize(text, renderedSize);
+    const alignmentDx =
+      textAnchor === "middle"
+        ? -widthPdf / 2
+        : textAnchor === "end"
+          ? -widthPdf
+          : 0;
+    const pdfPos = _toPdfXY(tx, ty);
+    _page.drawText(text, {
+      x: pdfPos.x + alignmentDx,
+      y: pdfPos.y,
+      size: renderedSize,
+      font,
+      color: colour,
+    });
+    summary.drawCalls += 1;
+  }
+}
+
+function collectTextContent(node) {
+  if (!node) return "";
+  if (node.type === "text") return node.value || "";
+  if (node.type !== "element") return "";
+  let text = node.text || "";
+  for (const child of node.children || []) {
+    if (child?.type === "text") text += child.value;
+    else if (child?.type === "element") text += collectTextContent(child);
+  }
+  return text;
+}
+
+function mergeState(parent, attrs = {}) {
+  const next = { ...parent };
+  if (attrs.fill !== undefined) {
+    if (attrs.fill === "none") {
+      next.fillNone = true;
+      next.fill = null;
+    } else {
+      const parsed = parseSvgColor(attrs.fill);
+      if (parsed) {
+        next.fill = parsed;
+        next.fillNone = false;
+      }
+    }
+  }
+  if (attrs.stroke !== undefined) {
+    next.stroke = parseSvgColor(attrs.stroke);
+  }
+  if (attrs["stroke-width"] !== undefined) {
+    next.strokeWidth = num(attrs["stroke-width"], next.strokeWidth);
+  }
+  if (attrs["font-size"] !== undefined) {
+    next.fontSize = num(attrs["font-size"], next.fontSize);
+  }
+  if (attrs["font-weight"] !== undefined) {
+    next.fontWeight = attrs["font-weight"];
+  }
+  if (attrs["text-anchor"] !== undefined) {
+    next.textAnchor = attrs["text-anchor"];
+  }
+  return next;
+}
+
+/**
+ * Compose nested transforms — only `translate(x, y)` is supported.
+ * Anything more exotic (scale, rotate, matrix) is silently ignored.
+ * For the master sheet SVG our pipeline only emits translates, so this
+ * covers our use case.
+ */
+function mergeTranslate(parent, attrs = {}) {
+  if (!attrs.transform) return parent;
+  const match = String(attrs.transform).match(
+    /translate\s*\(\s*(-?[\d.]+)\s*[,\s]\s*(-?[\d.]+)\s*\)/,
+  );
+  if (!match) return parent;
+  const dx = num(match[1]);
+  const dy = num(match[2]);
+  return {
+    translateX: parent.translateX + dx,
+    translateY: parent.translateY + dy,
+  };
+}
+
+function drawPathOnPage({ page, pathData, state, scale }) {
+  const opts = { x: 0, y: 0, scale };
+  if (state.fill && !state.fillNone) opts.color = state.fill;
+  if (state.stroke) {
+    opts.borderColor = state.stroke;
+    opts.borderWidth = state.strokeWidth * scale;
+  }
+  page.drawSvgPath(pathData, opts);
+}
+
+export const __testing = Object.freeze({
+  parseSvgColor,
+  decodeImageDataUrl,
+  num,
+  collectTextContent,
+  mergeTranslate,
+});
+
+// Avoid unused-import lint warnings for `degrees` if a future change
+// removes the rotate() use case. Keeping the import as documentation
+// of the pdf-lib helper available for further extension.
+void degrees;

--- a/src/services/render/buildVectorPdfFromSheetSvg.js
+++ b/src/services/render/buildVectorPdfFromSheetSvg.js
@@ -1,0 +1,305 @@
+/**
+ * Phase 5D — vector PDF builder.
+ *
+ * Reads the master A1 sheet SVG, parses it (no DOM, no canvas — pure
+ * regex tokeniser), embeds NotoSans Regular + Bold TTF in the PDF,
+ * walks the SVG tree and emits pdf-lib draw calls so technical drawings
+ * stay vector and text stays selectable. Raster panels (the AI render
+ * PNGs and the site snapshot) are embedded as PDF Image XObjects at
+ * their original resolution — no re-encoding.
+ *
+ * Designed as the **additional** export artifact for the Phase 5D
+ * rollout. The raster pipeline remains the production default. This
+ * builder must NEVER throw — failures are swallowed and reported via
+ * the returned `error` field so the orchestrator can fall back to the
+ * raster artifact without affecting end-user generation.
+ *
+ * No external deps beyond `pdf-lib` (already installed). The only
+ * runtime requirement is that the caller supplies the TTF font bytes —
+ * the existing `prepareFinalSheetSvgForRasterizationWithReport` already
+ * embeds NotoSans bytes inside the SVG via `@font-face`, so we extract
+ * those when no explicit `fonts` arg is supplied.
+ */
+
+import { PDFDocument, StandardFonts } from "pdf-lib";
+import { parseSvg } from "./_lib/lightweightSvgParser.js";
+import { walkSvgIntoPdf } from "./_lib/svgToPdfWalker.js";
+
+export const VECTOR_PDF_RENDER_MODE = "vector_textpaths_off";
+export const VECTOR_PDF_SCHEMA_VERSION = "vector-pdf-v1";
+
+const A1_WIDTH_MM = 841;
+const A1_HEIGHT_MM = 594;
+const MM_TO_PT = 72 / 25.4;
+
+const NOTO_REGULAR_RE =
+  /url\(\s*data:font\/[^;]*;\s*base64\s*,\s*([^)\s]+)\s*\)\s*format\(['"]?truetype['"]?\)?[^}]*?font-weight:\s*(?:400|normal)/i;
+const NOTO_BOLD_RE =
+  /url\(\s*data:font\/[^;]*;\s*base64\s*,\s*([^)\s]+)\s*\)\s*format\(['"]?truetype['"]?\)?[^}]*?font-weight:\s*(?:700|bold)/i;
+
+/**
+ * Best-effort extraction of NotoSans bytes from the SVG's embedded
+ * `@font-face` blocks. Returns `{ regular, bold }` Buffers, either of
+ * which may be null when the SVG doesn't carry a matching face.
+ */
+export function extractEmbeddedFonts(svgString) {
+  const out = { regular: null, bold: null };
+  if (typeof svgString !== "string") return out;
+  const styleBlockMatch = svgString.match(/<style[^>]*>([\s\S]*?)<\/style>/i);
+  const css = styleBlockMatch ? styleBlockMatch[1] : svgString;
+  const tryRegular = css.match(NOTO_REGULAR_RE);
+  const tryBold = css.match(NOTO_BOLD_RE);
+  if (tryRegular) {
+    try {
+      out.regular = Buffer.from(tryRegular[1], "base64");
+    } catch {
+      /* ignore */
+    }
+  }
+  if (tryBold) {
+    try {
+      out.bold = Buffer.from(tryBold[1], "base64");
+    } catch {
+      /* ignore */
+    }
+  }
+  return out;
+}
+
+/**
+ * Compute deterministic FNV-1a hash of the PDF buffer for cache /
+ * provenance. Not crypto.
+ */
+function fnv1aHex(buffer) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < buffer.length; i++) {
+    h = Math.imul(h ^ buffer[i], 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+function viewBoxFromRoot(root) {
+  if (!root) return null;
+  const vb = String(root.attrs?.viewBox || "").trim();
+  if (vb) {
+    const parts = vb.split(/\s+/).map(Number);
+    if (parts.length === 4 && parts.every((n) => Number.isFinite(n))) {
+      return {
+        minX: parts[0],
+        minY: parts[1],
+        width: parts[2],
+        height: parts[3],
+      };
+    }
+  }
+  const w = Number(root.attrs?.width);
+  const h = Number(root.attrs?.height);
+  if (Number.isFinite(w) && Number.isFinite(h)) {
+    return { minX: 0, minY: 0, width: w, height: h };
+  }
+  return null;
+}
+
+/**
+ * Build a vector PDF from a sheet SVG.
+ *
+ * @param {object} params
+ * @param {string} params.svgString  - the full master A1 sheet SVG text
+ * @param {object} [params.fonts]    - { regular: Buffer, bold: Buffer }
+ *        TTF bytes; falls back to extraction from the SVG's @font-face.
+ * @param {string} [params.title]    - PDF document title metadata
+ * @param {string} [params.author]   - PDF document author metadata
+ * @param {string} [params.geometryHash] - upstream geometry hash, copied
+ *        into the PDF's metadata for provenance.
+ * @returns {Promise<{ ok: boolean, pdfBytes: Buffer|null, dataUrl: string|null,
+ *   pdfHash: string|null, byteLength: number, pageCount: number,
+ *   pageSizeMm: { width: number, height: number },
+ *   pdfRenderMode: "vector_textpaths_off",
+ *   schemaVersion: string,
+ *   summary: { drawCalls: number, skipped: object, warnings: string[] },
+ *   error: string|null
+ * }>}
+ */
+export async function buildVectorPdfFromSheetSvg({
+  svgString,
+  fonts,
+  title = "ArchiAI A1 sheet",
+  author = "ArchiAI",
+  geometryHash = null,
+  inspectable = false,
+} = {}) {
+  const baseResult = {
+    ok: false,
+    pdfBytes: null,
+    dataUrl: null,
+    pdfHash: null,
+    byteLength: 0,
+    pageCount: 0,
+    pageSizeMm: { width: A1_WIDTH_MM, height: A1_HEIGHT_MM },
+    pdfRenderMode: VECTOR_PDF_RENDER_MODE,
+    schemaVersion: VECTOR_PDF_SCHEMA_VERSION,
+    summary: { drawCalls: 0, skipped: {}, warnings: [] },
+    error: null,
+  };
+  if (typeof svgString !== "string" || svgString.length === 0) {
+    return { ...baseResult, error: "empty_svg_string" };
+  }
+  let parsed;
+  try {
+    parsed = parseSvg(svgString);
+  } catch (err) {
+    return {
+      ...baseResult,
+      error: `parse_failed:${err?.message || "unknown"}`,
+    };
+  }
+  if (!parsed.root) {
+    return { ...baseResult, error: "no_svg_root" };
+  }
+  const viewBox = viewBoxFromRoot(parsed.root);
+  if (!viewBox) {
+    return { ...baseResult, error: "no_view_box" };
+  }
+  const fontBytes = fonts || extractEmbeddedFonts(svgString);
+
+  let pdfDoc;
+  try {
+    pdfDoc = await PDFDocument.create();
+    pdfDoc.setTitle(title);
+    pdfDoc.setAuthor(author);
+    pdfDoc.setProducer("ArchiAI/Phase5D");
+    pdfDoc.setSubject(VECTOR_PDF_RENDER_MODE);
+    if (geometryHash) {
+      pdfDoc.setKeywords([
+        `geometryHash=${geometryHash}`,
+        VECTOR_PDF_SCHEMA_VERSION,
+      ]);
+    }
+  } catch (err) {
+    return {
+      ...baseResult,
+      error: `pdf_doc_create_failed:${err?.message || "unknown"}`,
+    };
+  }
+
+  const pageWidthPt = A1_WIDTH_MM * MM_TO_PT;
+  const pageHeightPt = A1_HEIGHT_MM * MM_TO_PT;
+  const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
+
+  let fontRegular;
+  let fontBold = null;
+  // pdf-lib instanceof Uint8Array fails in Jest+jsdom unless we copy
+  // through the realm-local constructor.
+  const toRealmUint8 = (b) =>
+    b ? new Uint8Array(b.buffer || b, b.byteOffset || 0, b.byteLength) : null;
+  try {
+    if (fontBytes?.regular) {
+      fontRegular = await pdfDoc.embedFont(toRealmUint8(fontBytes.regular), {
+        subset: true,
+      });
+    } else {
+      fontRegular = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    }
+    if (fontBytes?.bold) {
+      fontBold = await pdfDoc.embedFont(toRealmUint8(fontBytes.bold), {
+        subset: true,
+      });
+    } else {
+      fontBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+    }
+  } catch (err) {
+    // Fall back to standard fonts when embedded TTF fails to parse.
+    try {
+      fontRegular = await pdfDoc.embedFont(StandardFonts.Helvetica);
+      fontBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+      baseResult.summary.warnings.push(
+        `font_embed_fallback:${(err?.message || "unknown").slice(0, 80)}`,
+      );
+    } catch (innerErr) {
+      return {
+        ...baseResult,
+        error: `font_embed_failed:${innerErr?.message || "unknown"}`,
+      };
+    }
+  }
+
+  // SVG → PDF coordinate mapping. The master sheet SVG is sized in
+  // millimetres but its viewBox uses logical units that match. We
+  // uniformly fit the viewBox into the A1 page (preserving aspect)
+  // and centre any leftover space.
+  const sx = pageWidthPt / viewBox.width;
+  const sy = pageHeightPt / viewBox.height;
+  const scale = Math.min(sx, sy);
+  const offsetX = (pageWidthPt - viewBox.width * scale) / 2;
+  const offsetY = (pageHeightPt - viewBox.height * scale) / 2;
+
+  function toPdfXY(svgX, svgY) {
+    const localX = (svgX - viewBox.minX) * scale + offsetX;
+    // SVG y-down → PDF y-up flip
+    const localY = pageHeightPt - ((svgY - viewBox.minY) * scale + offsetY);
+    return { x: localX, y: localY };
+  }
+
+  let summary;
+  try {
+    summary = await walkSvgIntoPdf({
+      root: parsed.root,
+      page,
+      pdfDoc,
+      fontRegular,
+      fontBold,
+      toPdfXY,
+      scale,
+      viewBox,
+    });
+  } catch (err) {
+    return {
+      ...baseResult,
+      error: `walk_failed:${err?.message || "unknown"}`,
+    };
+  }
+
+  let pdfBytes;
+  try {
+    // `inspectable: true` disables object streams so callers (chiefly
+    // tests and the manual-smoke script) can introspect the PDF
+    // structure with a regex. Production keeps the compact default.
+    const out = await pdfDoc.save({ useObjectStreams: !inspectable });
+    pdfBytes = Buffer.from(out);
+  } catch (err) {
+    return {
+      ...baseResult,
+      error: `pdf_save_failed:${err?.message || "unknown"}`,
+    };
+  }
+
+  const pdfHash = fnv1aHex(pdfBytes);
+  const dataUrl = `data:application/pdf;base64,${pdfBytes.toString("base64")}`;
+
+  return {
+    ok: true,
+    pdfBytes,
+    dataUrl,
+    pdfHash,
+    byteLength: pdfBytes.length,
+    pageCount: 1,
+    pageSizeMm: { width: A1_WIDTH_MM, height: A1_HEIGHT_MM },
+    pdfRenderMode: VECTOR_PDF_RENDER_MODE,
+    schemaVersion: VECTOR_PDF_SCHEMA_VERSION,
+    summary: {
+      ...summary,
+      // Merge any pre-existing warnings (e.g. font fallback)
+      warnings: [...(baseResult.summary.warnings || []), ...summary.warnings],
+    },
+    error: null,
+  };
+}
+
+export const __testing = Object.freeze({
+  extractEmbeddedFonts,
+  fnv1aHex,
+  viewBoxFromRoot,
+  A1_WIDTH_MM,
+  A1_HEIGHT_MM,
+  MM_TO_PT,
+});


### PR DESCRIPTION
## Summary

Adds an optional vector PDF deliverable behind `PROJECT_GRAPH_VECTOR_PDF_ENABLED`. **Raster PDF remains the production default**; the new vector path emits a SECOND artifact alongside it when enabled. Vector PDF failure is warning-only and never blocks raster generation, exportGate, or any existing QA evidence path (tofu, occupancy, glyph integrity, text proof).

**Default behaviour unchanged.** Production remains on the raster path until you flip the env in Vercel — and the recommendation is to validate in Preview first.

## Manual smoke results

**Flag OFF (default)** — `tmp/phase5d-flag-off-smoke.mjs`:
\`\`\`json
{
  "flag": "false",
  "rasterPdfBytes": 7151820,
  "vectorPdfBytes": 0,
  "vectorPdfDataUrlPresent": false,
  "vectorPdfMetadata": { "enabled": false, "ok": false },
  "exportGate": { "allowed": true, "status": "warning", "blockers": [] },
  "visualIdentityValidationStatus": "pass"
}
\`\`\`

**Flag ON** — `tmp/phase5d-flag-on-smoke.mjs`:
\`\`\`json
{
  "flag": "true",
  "rasterPdfBytes": 7151412,
  "vectorPdfBytes": 495940,
  "vectorPdfHash": "6d3357d4",
  "vectorPdfRenderMode": "vector_textpaths_off",
  "vectorPdfMetadata": {
    "enabled": true,
    "ok": true,
    "drawCalls": 1465,
    "skipped": { "marker": 2 },
    "warnings": ["font_embed_fallback:..."],
    "error": null
  },
  "exportGate": { "allowed": true, "status": "warning", "blockers": [] },
  "visualIdentityValidationStatus": "pass"
}
\`\`\`

**Vector PDF: 495,940 bytes (484 KB)** vs raster's 7,151,412 bytes (7 MB) — a **14× reduction** while keeping selectable text. Both PDFs are emitted alongside each other when the flag is on.

## Architecture

`svg2pdf.js` was investigated first per the original plan but proved infeasible: the library requires a real Canvas 2D implementation for `measureText()` which jsdom does not provide and Vercel's Node functions do not include. Adding `@napi-rs/canvas` was rejected per the no-new-deps constraint. **Falling back to the user-approved Option 1: pdf-lib only, with a tiny purpose-built SVG parser.**

### New files

| File | Lines | Purpose |
|---|---|---|
| `src/services/render/_lib/lightweightSvgParser.js` | 242 | Pure regex-based SVG tokeniser tuned for our pipeline output. No external XML/DOM dep. Handles `g/svg/rect/line/polyline/polygon/path/circle/ellipse/text/tspan/image`. Skips `defs/style/clipPath/mask/filter/foreignObject` silently. Tolerates malformed input. |
| `src/services/render/_lib/svgToPdfWalker.js` | 593 | Pure walker that consumes the parsed tree and emits pdf-lib draw calls. Supports `translate(x,y)` transforms, hex/rgb/named colour parsing, fill/stroke inheritance, font-size/weight/anchor for text, PNG/JPEG image embedding via `pdfDoc.embedPng/embedJpg` with realm-local Uint8Array conversion (handles Jest+jsdom). |
| `src/services/render/buildVectorPdfFromSheetSvg.js` | 305 | Orchestrator: extracts NotoSans `@font-face` TTF bytes from the SVG when present (falls back to `StandardFonts.Helvetica` when fontkit is not registered), sets up A1 page, parses + walks SVG, returns `{ ok, pdfBytes, dataUrl, pdfHash, byteLength, pdfRenderMode, summary, error }`. Never throws. |
| `src/__tests__/services/render/buildVectorPdfFromSheetSvg.test.js` | 341 | 21 focused tests on parser + walker + orchestrator. All mocked fixtures, no live deps. |

### Modified

| File | Lines | Purpose |
|---|---|---|
| `src/services/project/projectGraphVerticalSliceService.js` | +77 | Flag-gate the vector build inside `buildA1PdfArtifact`; attach `vectorPdfDataUrl/Bytes/Hash/RenderMode` to the artifact; surface telemetry (drawCalls, skipped tags, warnings) via `pdfMetadata.vectorPdf`. **Raster path is byte-identical when flag is off.** |

## Tests (21/21 pass, no live external dependencies)

- `lightweightSvgParser`: tree shape, attr quoting, entity decoding, style/defs body skip, malformed tolerance, empty input warning.
- `svgToPdfWalker` pure helpers: `parseSvgColor` (hex/rgb/named/none), `decodeImageDataUrl` (PNG/JPEG/non-data-url), `mergeTranslate` composition.
- `buildVectorPdfFromSheetSvg` happy path: builds PDF, byteLength sane, schema/version match, draw-call summary, hash present.
- PDF text is selectable (FlateDecode inflate + hex literal decode catches both `( ) Tj` and `<HEX> Tj` forms — pdf-lib uses the latter for StandardFonts).
- PDF embeds raster panels as PDF Image XObjects (`/Subtype /Image` + `/Filter /FlateDecode`).
- Failure tolerance: empty/missing/malformed SVG never throws, returns `ok: false` with error string.
- Font extraction: recovers TTF from `@font-face` data URL, returns null when missing.

## Validation

| Check | Result |
|---|---|
| `npm run check:env` | ✅ |
| `npm run check:contracts` | ✅ |
| `npm run lint` | ✅ exit 0 |
| `npm run build:active` | ✅ exit 0 |
| `npm run test:a1:tofu` | ✅ |
| `npm run test:compose:routing` | ✅ 22/22 |
| `node scripts/tests/test-a1-layout-regression.mjs` | ✅ 27/27 |
| `jest src/__tests__/services/render/buildVectorPdfFromSheetSvg.test.js` | ✅ 21/21 |

## Known limitations / follow-ups

1. **TTF embedding**: Requires `@pdf-lib/fontkit` which is NOT in deps. Vector PDF currently falls back to `StandardFonts.Helvetica` with a warning surfaced in `pdfMetadata.vectorPdf.warnings`. Adding fontkit (~50 KB dep) is a small follow-up PR once approved.
2. **SVG `<marker>`**: Skipped (arrow-heads on dimension lines). Acceptable for an opt-in deliverable; visible only when vector mode is on.
3. **Vector mode is server-only**: runs in Vercel Node Functions. No Canvas, no jsdom, no browser-side rendering.

## Scope (per Phase 5D plan + your changes)

✅ No new dependencies (svg2pdf.js infeasibility documented; fontkit deferred)
✅ Raster PDF remains production default (byte-identical when flag is off)
✅ Rasterization for QA evidence preserved (tofu, occupancy, glyph integrity, text proof — all still run)
✅ Vector PDF as ADDITIONAL artifact when flag is on
✅ `vectorPdfDataUrl / vectorPdfBytes / vectorPdfMetadata` exposed
✅ Vector PDF failure does NOT fail A1 generation (warning-only metadata)
✅ Mode-aware: raster keeps font-paths assertions; vector preserves selectable text
✅ No tofu protection weakening
❌ No storage/history changes
❌ No project-type support changes
❌ No OpenAI/provider/env changes
❌ No site-boundary changes
❌ No A1 layout/panel/material/key-notes/title-block/drawing-renderer changes
❌ No cutaway flag changes (`PROJECT_GRAPH_AXONOMETRIC_CUTAWAY_ENABLED` remains false in Production)
❌ No generated PDFs/PNGs/tmp outputs committed

## Test plan

- [x] Vector exporter builds a PDF from a simple SVG fixture
- [x] Vector PDF contains extractable/selectable text
- [x] Vector PDF embeds raster panels as images while preserving vector groups
- [x] Vector failure does NOT block raster PDF generation (warning-only)
- [x] Flag OFF preserves current raster-only behavior (smoke confirms)
- [x] Flag ON emits additional vector metadata/artifact (smoke confirms 484 KB vector PDF)
- [x] `test:a1:tofu` remains green
- [x] `test:compose:routing` and layout regression remain green

## ⚠️ DO NOT enable in Production yet

Per your rollout brief: **`PROJECT_GRAPH_VECTOR_PDF_ENABLED=false` stays in Production** until validated in Preview. Suggested sequence:

1. Merge PR with default flag off (zero production risk).
2. Set `PROJECT_GRAPH_VECTOR_PDF_ENABLED=true` in Vercel **Preview** only. Run a few generations, eyeball both PDFs side by side (raster + vector).
3. If vector PDF quality acceptable, then consider Production. Rollback is a one-env-var revert.