### PR TITLE
feat(a1): blue site boundary, autodetect type from brief, mansion + per-subtype messaging

### DIFF
--- a/api/site/_lib/__tests__/boundaryNormalize.test.js
+++ b/api/site/_lib/__tests__/boundaryNormalize.test.js
@@ -1,0 +1,160 @@
+import {
+  BOUNDARY_SOURCE,
+  ESTIMATE_REASON,
+  RESIDENTIAL_PARCEL_MAX_M2,
+  RESIDENTIAL_PARCEL_MAX_VERTICES,
+  buildBoundaryResponse,
+  classifyParcelCandidate,
+  polygonAreaM2,
+  selectBestOverpassWay,
+} from "../boundaryNormalize.js";
+
+// Build a square polygon centred on (lat, lng) whose half-edge in metres
+// is approximately the given size. Quick-and-dirty conversion using
+// degrees-per-metre at latitude — accurate enough for area sanity tests.
+function squarePolygonAround(lat, lng, halfEdgeM) {
+  const latPerM = 1 / 111_000;
+  const lngPerM = 1 / (111_000 * Math.cos((lat * Math.PI) / 180));
+  const dLat = halfEdgeM * latPerM;
+  const dLng = halfEdgeM * lngPerM;
+  return [
+    { lat: lat - dLat, lng: lng - dLng },
+    { lat: lat - dLat, lng: lng + dLng },
+    { lat: lat + dLat, lng: lng + dLng },
+    { lat: lat + dLat, lng: lng - dLng },
+  ];
+}
+
+function wayWithGeometry(polygon, tags = {}, id = 1) {
+  return {
+    id,
+    type: "way",
+    geometry: polygon.map(({ lat, lng }) => ({ lat, lon: lng })),
+    tags,
+  };
+}
+
+const POINT = { lat: 52.4898, lng: -1.8832 };
+
+describe("classifyParcelCandidate", () => {
+  test("accepts a small residential lot polygon", () => {
+    const polygon = squarePolygonAround(POINT.lat, POINT.lng, 15); // ~900 m²
+    const reason = classifyParcelCandidate({
+      polygon,
+      element: { tags: { boundary: "land_lot" } },
+    });
+    expect(reason).toBeNull();
+  });
+
+  test("rejects a polygon with landuse=residential as a district", () => {
+    const polygon = squarePolygonAround(POINT.lat, POINT.lng, 15);
+    const reason = classifyParcelCandidate({
+      polygon,
+      element: { tags: { landuse: "residential" } },
+    });
+    expect(reason).toBe(ESTIMATE_REASON.PARCEL_LANDUSE_DISTRICT);
+  });
+
+  test("rejects an oversized parcel even without landuse tag", () => {
+    // 250m half-edge → 500m × 500m → 250,000 m² — clearly a district
+    const polygon = squarePolygonAround(POINT.lat, POINT.lng, 250);
+    expect(polygonAreaM2(polygon)).toBeGreaterThan(RESIDENTIAL_PARCEL_MAX_M2);
+    const reason = classifyParcelCandidate({ polygon, element: {} });
+    expect(reason).toBe(ESTIMATE_REASON.PARCEL_OVERSIZED);
+  });
+
+  test("rejects a polygon with too many vertices", () => {
+    const polygon = [];
+    for (let i = 0; i < RESIDENTIAL_PARCEL_MAX_VERTICES + 5; i += 1) {
+      const angle = (i / (RESIDENTIAL_PARCEL_MAX_VERTICES + 5)) * 2 * Math.PI;
+      polygon.push({
+        lat: POINT.lat + Math.sin(angle) * 0.0001,
+        lng: POINT.lng + Math.cos(angle) * 0.0001,
+      });
+    }
+    const reason = classifyParcelCandidate({ polygon, element: {} });
+    expect(reason).toBe(ESTIMATE_REASON.PARCEL_TOO_COMPLEX);
+  });
+});
+
+describe("selectBestOverpassWay", () => {
+  test("returns a small parcel as authoritative when it contains the point", () => {
+    const parcel = squarePolygonAround(POINT.lat, POINT.lng, 12); // ~576 m²
+    const result = selectBestOverpassWay({
+      parcelElements: [wayWithGeometry(parcel, { boundary: "land_lot" })],
+      buildingElements: [],
+      point: POINT,
+    });
+    expect(result?.source).toBe(BOUNDARY_SOURCE.OVERPASS_PARCEL_CONTAINS);
+    expect(result?.estimateReason).toBeUndefined();
+  });
+
+  test("falls back to the building polygon when the parcel is a landuse district", () => {
+    const district = squarePolygonAround(POINT.lat, POINT.lng, 200); // ~160k m²
+    const building = squarePolygonAround(POINT.lat, POINT.lng, 6); // ~144 m²
+    const result = selectBestOverpassWay({
+      parcelElements: [
+        wayWithGeometry(district, { landuse: "residential" }, 1),
+      ],
+      buildingElements: [wayWithGeometry(building, { building: "yes" }, 2)],
+      point: POINT,
+    });
+    expect(result?.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS);
+    expect(result?.estimateReason).toBe(
+      ESTIMATE_REASON.PARCEL_LANDUSE_DISTRICT,
+    );
+    expect(result?.demotedParcel?.element?.tags?.landuse).toBe("residential");
+  });
+
+  test("falls back to the building polygon when the parcel is oversized", () => {
+    const oversized = squarePolygonAround(POINT.lat, POINT.lng, 100); // ~40k m²
+    const building = squarePolygonAround(POINT.lat, POINT.lng, 6);
+    const result = selectBestOverpassWay({
+      parcelElements: [wayWithGeometry(oversized, {}, 1)],
+      buildingElements: [wayWithGeometry(building, { building: "yes" }, 2)],
+      point: POINT,
+    });
+    expect(result?.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS);
+    expect(result?.estimateReason).toBe(ESTIMATE_REASON.PARCEL_OVERSIZED);
+  });
+
+  test("returns null when neither parcel nor building contains the point", () => {
+    const farAway = squarePolygonAround(POINT.lat + 1, POINT.lng + 1, 6);
+    const result = selectBestOverpassWay({
+      parcelElements: [],
+      buildingElements: [wayWithGeometry(farAway, { building: "yes" })],
+      point: POINT,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildBoundaryResponse", () => {
+  test("preserves authoritative semantics for a small parcel", () => {
+    const polygon = squarePolygonAround(POINT.lat, POINT.lng, 12);
+    const body = buildBoundaryResponse({
+      polygon,
+      source: BOUNDARY_SOURCE.OVERPASS_PARCEL_CONTAINS,
+    });
+    expect(body.boundaryAuthoritative).toBe(true);
+    expect(body.estimateReason).toBeNull();
+    expect(body.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test("demotes building-contains response when estimateReason is set", () => {
+    const polygon = squarePolygonAround(POINT.lat, POINT.lng, 6);
+    const body = buildBoundaryResponse({
+      polygon,
+      source: BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS,
+      estimateReason: ESTIMATE_REASON.PARCEL_LANDUSE_DISTRICT,
+      demotedParcel: {
+        element: { id: 99, tags: { landuse: "residential" } },
+        polygon: squarePolygonAround(POINT.lat, POINT.lng, 200),
+      },
+    });
+    expect(body.boundaryAuthoritative).toBe(false);
+    expect(body.estimateReason).toBe(ESTIMATE_REASON.PARCEL_LANDUSE_DISTRICT);
+    expect(body.confidence).toBeLessThanOrEqual(0.7);
+    expect(body.metadata.demotedParcel?.landuseTag).toBe("residential");
+  });
+});

--- a/api/site/_lib/boundaryNormalize.js
+++ b/api/site/_lib/boundaryNormalize.js
@@ -167,8 +167,10 @@ export function polygonContainsPoint(polygon, point) {
     const yi = Number(polygon[i].lat);
     const xj = Number(polygon[j].lng);
     const yj = Number(polygon[j].lat);
+    const yiAbove = yi > y;
+    const yjAbove = yj > y;
     const intersect =
-      yi > y !== yj > y &&
+      yiAbove !== yjAbove &&
       x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi;
     if (intersect) inside = !inside;
   }

--- a/api/site/_lib/boundaryNormalize.js
+++ b/api/site/_lib/boundaryNormalize.js
@@ -36,6 +36,74 @@ const AUTHORITATIVE_BY_SOURCE = Object.freeze({
   [BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST]: false,
 });
 
+// A residential / small-parcel polygon should not exceed this area. Anything
+// larger is almost certainly an OSM `landuse=*` district polygon (a whole
+// neighbourhood) rather than the legal parcel of the address. Demote those
+// candidates to "estimated" and prefer the building-contains polygon.
+export const RESIDENTIAL_PARCEL_MAX_M2 = 5000;
+
+// Vertex-count cap mirrors the same heuristic — district polygons frequently
+// have 50+ vertices, while typical lot polygons sit well under this.
+export const RESIDENTIAL_PARCEL_MAX_VERTICES = 30;
+
+// `landuse` tag values that almost always indicate zoning districts rather
+// than legal parcel boundaries. Treat any parcel candidate carrying one of
+// these tags as non-authoritative even when it geometrically contains the
+// query point.
+const DISTRICT_LANDUSE_TAGS = Object.freeze(
+  new Set([
+    "residential",
+    "commercial",
+    "industrial",
+    "retail",
+    "education",
+    "institutional",
+    "religious",
+    "recreation_ground",
+    "farmland",
+    "forest",
+    "meadow",
+    "village_green",
+  ]),
+);
+
+export const ESTIMATE_REASON = Object.freeze({
+  PARCEL_OVERSIZED: "parcel_oversized",
+  PARCEL_LANDUSE_DISTRICT: "parcel_landuse_district",
+  PARCEL_TOO_COMPLEX: "parcel_too_complex",
+  BUILDING_NEAREST_FALLBACK: "building_nearest_fallback",
+  NONE: null,
+});
+
+/**
+ * Inspect a candidate parcel polygon and decide whether it is plausibly the
+ * legal lot boundary or a much larger zoning/landuse district. District
+ * polygons routinely cover 20+ ha at a residential address point, which is
+ * authoritative *for the district*, not for the parcel — and using one as
+ * the site boundary produces wildly incorrect setbacks and areas downstream.
+ *
+ * Returns `null` when the candidate is plausible, otherwise an
+ * `ESTIMATE_REASON` describing the demotion cause.
+ */
+export function classifyParcelCandidate({ polygon, element }) {
+  if (!Array.isArray(polygon) || polygon.length < 3) {
+    return null;
+  }
+  const vertexCount = polygon.length;
+  const areaM2 = polygonAreaM2(polygon);
+  const landuseTag = element?.tags?.landuse;
+  if (landuseTag && DISTRICT_LANDUSE_TAGS.has(String(landuseTag))) {
+    return ESTIMATE_REASON.PARCEL_LANDUSE_DISTRICT;
+  }
+  if (Number.isFinite(areaM2) && areaM2 > RESIDENTIAL_PARCEL_MAX_M2) {
+    return ESTIMATE_REASON.PARCEL_OVERSIZED;
+  }
+  if (vertexCount > RESIDENTIAL_PARCEL_MAX_VERTICES) {
+    return ESTIMATE_REASON.PARCEL_TOO_COMPLEX;
+  }
+  return null;
+}
+
 /**
  * Convert a raw Overpass `way` element with embedded `geometry` into
  * the canonical polygon shape `[{ lat, lng }, …]`.
@@ -140,12 +208,19 @@ export function distanceM(a, b) {
  * Choose the best Overpass `way` element for the given point.
  *
  * Preference order:
- *   1. parcel polygon that contains the point (rare in OSM but highest)
+ *   1. parcel polygon that contains the point AND passes the lot-plausibility
+ *      classifier (small enough, simple enough, not a `landuse=*` district)
  *   2. building polygon that contains the point
  *   3. nearest building polygon (within 25 m of the point) — flagged
  *      non-authoritative so downstream gating treats it as estimated
  *
- * Returns `{ element, polygon, source }` or null when nothing usable.
+ * If a parcel candidate contained the point but failed the plausibility
+ * classifier, the returned record carries `estimateReason` describing why
+ * the parcel was demoted. Callers that still want to see that polygon for
+ * map preview can read `demotedParcel`.
+ *
+ * Returns `{ element, polygon, source, estimateReason?, demotedParcel? }`
+ * or null when nothing usable.
  */
 export function selectBestOverpassWay({
   buildingElements = [],
@@ -153,17 +228,31 @@ export function selectBestOverpassWay({
   point,
 }) {
   const checkPoint = point;
-  // 1. parcel containing the point
+  let demotedParcel = null;
+  let demotedReason = null;
+
+  // 1. parcel containing the point (with plausibility check)
   for (const el of parcelElements) {
     const polygon = extractPolygonFromOverpassWay(el);
-    if (polygon.length >= 3 && polygonContainsPoint(polygon, checkPoint)) {
+    if (polygon.length < 3 || !polygonContainsPoint(polygon, checkPoint)) {
+      continue;
+    }
+    const reason = classifyParcelCandidate({ polygon, element: el });
+    if (!reason) {
       return {
         element: el,
         polygon,
         source: BOUNDARY_SOURCE.OVERPASS_PARCEL_CONTAINS,
       };
     }
+    // Capture the first demoted parcel so we can flag the reason on the
+    // ultimate response even when we fall through to a building polygon.
+    if (!demotedParcel) {
+      demotedParcel = { element: el, polygon };
+      demotedReason = reason;
+    }
   }
+
   // 2. building containing the point
   for (const el of buildingElements) {
     const polygon = extractPolygonFromOverpassWay(el);
@@ -172,6 +261,8 @@ export function selectBestOverpassWay({
         element: el,
         polygon,
         source: BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS,
+        estimateReason: demotedReason,
+        demotedParcel,
       };
     }
   }
@@ -193,6 +284,9 @@ export function selectBestOverpassWay({
       element: nearest.element,
       polygon: nearest.polygon,
       source: BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST,
+      estimateReason:
+        demotedReason || ESTIMATE_REASON.BUILDING_NEAREST_FALLBACK,
+      demotedParcel,
     };
   }
   return null;
@@ -237,13 +331,26 @@ export function buildBoundaryResponse({
   queryRadiusM = 30,
   cached = false,
   now = null,
+  estimateReason = null,
+  demotedParcel = null,
 } = {}) {
   const hasShape = Array.isArray(polygon) && polygon.length >= 3;
   const resolvedSource = hasShape ? source : BOUNDARY_SOURCE.NONE;
-  const confidence = hasShape ? CONFIDENCE_BY_SOURCE[resolvedSource] || 0 : 0;
-  const boundaryAuthoritative = hasShape
-    ? AUTHORITATIVE_BY_SOURCE[resolvedSource] === true
-    : false;
+  const baseConfidence = hasShape
+    ? CONFIDENCE_BY_SOURCE[resolvedSource] || 0
+    : 0;
+  // When a parcel candidate was demoted to a building polygon, treat the
+  // result as estimated even if the building polygon itself is normally
+  // authoritative — the user-facing site boundary is no longer the parcel
+  // they were promised.
+  const isEstimatedByDemotion = Boolean(estimateReason);
+  const boundaryAuthoritative =
+    hasShape && !isEstimatedByDemotion
+      ? AUTHORITATIVE_BY_SOURCE[resolvedSource] === true
+      : false;
+  const confidence = isEstimatedByDemotion
+    ? Math.min(baseConfidence, 0.7)
+    : baseConfidence;
   const areaM2 = hasShape ? polygonAreaM2(polygon) : 0;
   const hash = hashBoundaryShape({ polygon, source: resolvedSource });
 
@@ -253,6 +360,7 @@ export function buildBoundaryResponse({
     source: resolvedSource,
     confidence,
     boundaryAuthoritative,
+    estimateReason: estimateReason || null,
     areaM2: Math.round(areaM2),
     hash,
     cached: Boolean(cached),
@@ -265,6 +373,14 @@ export function buildBoundaryResponse({
       addrHousenumber: osmElement?.tags?.["addr:housenumber"] || null,
       addrStreet: osmElement?.tags?.["addr:street"] || null,
       overpassQueryRadiusM: queryRadiusM,
+      demotedParcel: demotedParcel
+        ? {
+            osmId: demotedParcel.element?.id || null,
+            landuseTag: demotedParcel.element?.tags?.landuse || null,
+            vertexCount: demotedParcel.polygon?.length || 0,
+            areaM2: Math.round(polygonAreaM2(demotedParcel.polygon || [])),
+          }
+        : null,
     },
   };
 }
@@ -287,6 +403,7 @@ export function buildEmptyResponse({
     source: BOUNDARY_SOURCE.NONE,
     confidence: 0,
     boundaryAuthoritative: false,
+    estimateReason: null,
     areaM2: 0,
     hash: hashBoundaryShape({ polygon: [], source: null }),
     cached: Boolean(cached),

--- a/api/site/boundary.js
+++ b/api/site/boundary.js
@@ -223,6 +223,8 @@ export async function resolveBoundaryRequest({
       osmElement: best.element,
       queryRadiusM: buildingRadiusM,
       cached: false,
+      estimateReason: best.estimateReason || null,
+      demotedParcel: best.demotedParcel || null,
     });
   }
   if (useCache) cacheSet(key, body);

--- a/src/__tests__/components/BuildingTypeSelector.support.test.js
+++ b/src/__tests__/components/BuildingTypeSelector.support.test.js
@@ -28,9 +28,21 @@ describe("BuildingTypeSelector project type support", () => {
         route: "residential_v2",
       }),
     );
+    // Mansion was added to SUPPORTED_RESIDENTIAL_V2_SUBTYPES; it is now an
+    // enabled production V2 subtype. The residentialProgramEngine has a
+    // mansion template (resolveTemplate handles it), so end-to-end support
+    // is real.
     expect(
       getBuildingTypeSelectorSubTypeState("residential", mansion).isEnabled,
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      getBuildingTypeSelectorSubTypeState("residential", mansion).support,
+    ).toEqual(
+      expect.objectContaining({
+        badgeLabel: "Residential V2",
+        route: "residential_v2",
+      }),
+    );
   });
 
   test("enables supported non-residential ProjectGraph templates", () => {
@@ -184,7 +196,10 @@ describe("BuildingTypeSelector project type support", () => {
       expect.objectContaining({
         isEnabled: false,
         support: expect.objectContaining({
-          badgeLabel: "Experimental/off",
+          // Per-subtype DISABLED_REASONS now surfaces a "Coming soon"
+          // badge with a specific message, replacing the generic
+          // "Experimental/off" wording.
+          badgeLabel: "Coming soon",
           supportStatus: "disabled",
         }),
       }),
@@ -209,7 +224,8 @@ describe("BuildingTypeSelector project type support", () => {
         isEnabled: false,
         support: expect.objectContaining({
           supportStatus: "disabled",
-          badgeLabel: "Experimental/off",
+          badgeLabel: "Coming soon",
+          message: expect.stringContaining("Retail"),
         }),
       }),
     );

--- a/src/__tests__/components/SpecsStep.projectTypeSupport.test.js
+++ b/src/__tests__/components/SpecsStep.projectTypeSupport.test.js
@@ -3,10 +3,13 @@ import { canProceedWithProjectType } from "../../components/steps/SpecsStep.jsx"
 describe("SpecsStep project type support", () => {
   test.each([
     ["detached house", "residential", "detached-house"],
+    ["mansion", "residential", "mansion"],
     ["office", "commercial", "office"],
     ["school", "education", "school"],
     ["clinic", "healthcare", "clinic"],
     ["hospital", "healthcare", "hospital"],
+    ["hotel", "hospitality", "hotel"],
+    ["manufacturing", "industrial", "manufacturing"],
   ])("canProceed is true for supported %s", (_label, category, subType) => {
     expect(
       canProceedWithProjectType({
@@ -19,9 +22,10 @@ describe("SpecsStep project type support", () => {
 
   test.each([
     ["retail", "commercial", "retail"],
-    ["hotel", "hospitality", "hotel"],
-    ["manufacturing", "industrial", "manufacturing"],
-    ["mansion", "residential", "mansion"],
+    ["mixed-use", "commercial", "mixed-use"],
+    ["dental", "healthcare", "dental"],
+    ["university", "education", "university"],
+    ["kindergarten", "education", "kindergarten"],
   ])("canProceed is false for disabled %s", (_label, category, subType) => {
     expect(
       canProceedWithProjectType({

--- a/src/__tests__/services/projectTypeSupportRegistry.test.js
+++ b/src/__tests__/services/projectTypeSupportRegistry.test.js
@@ -149,9 +149,11 @@ describe("projectTypeSupportRegistry", () => {
           supportStatus: PROJECT_TYPE_SUPPORT_STATUS.DISABLED,
           route: null,
           canonicalBuildingType: null,
-          badgeLabel: "Experimental/off",
         }),
       );
+      // Either generic "Experimental/off" or per-subtype "Coming soon"
+      // for entries that have an explicit DISABLED_REASONS row.
+      expect(["Experimental/off", "Coming soon"]).toContain(entry.badgeLabel);
     }
 
     expect(getProjectTypeSupport("civic", "museum")).toEqual(
@@ -163,5 +165,46 @@ describe("projectTypeSupportRegistry", () => {
         badgeLabel: "Experimental/off",
       }),
     );
+  });
+
+  test("disabled commercial/healthcare/education subtypes surface a per-subtype 'Coming soon' message", () => {
+    const comingSoonKeys = [
+      ["commercial", "retail"],
+      ["commercial", "mixed-use"],
+      ["commercial", "shopping-mall"],
+      ["healthcare", "dental"],
+      ["healthcare", "lab"],
+      ["education", "university"],
+      ["education", "kindergarten"],
+    ];
+    for (const [category, subtype] of comingSoonKeys) {
+      const support = getProjectTypeSupport(category, subtype);
+      expect(support).toEqual(
+        expect.objectContaining({
+          enabledInUi: false,
+          badgeLabel: "Coming soon",
+          supportStatus: PROJECT_TYPE_SUPPORT_STATUS.DISABLED,
+        }),
+      );
+      expect(support.message).toBeTruthy();
+      expect(support.message).not.toEqual(
+        expect.stringContaining("Experimental/off"),
+      );
+    }
+  });
+
+  test("residential mansion is enabled on the production V2 route", () => {
+    const mansion = getProjectTypeSupport("residential", "mansion");
+    expect(mansion).toEqual(
+      expect.objectContaining({
+        enabledInUi: true,
+        route: PROJECT_TYPE_ROUTES.RESIDENTIAL_V2,
+        supportStatus: PROJECT_TYPE_SUPPORT_STATUS.PRODUCTION,
+        canonicalBuildingType: "dwelling",
+        programmeTemplateKey: "mansion",
+        badgeLabel: "Residential V2",
+      }),
+    );
+    expect(SUPPORTED_RESIDENTIAL_V2_SUBTYPES).toContain("mansion");
   });
 });

--- a/src/__tests__/services/residentialProgramEngine.test.js
+++ b/src/__tests__/services/residentialProgramEngine.test.js
@@ -139,4 +139,27 @@ describe("residentialProgramEngine", () => {
     expect(brief.clampedBy).toBe("subtype-max");
     expect(brief.maxLevels).toBe(2);
   });
+
+  test("mansion subtype produces a deterministic brief that respects the 3-level cap", () => {
+    const brief = generateResidentialProgramBrief({
+      subType: "mansion",
+      totalAreaM2: 320,
+      siteAreaM2: 1800,
+      entranceDirection: "S",
+    });
+    expect(brief.supportedResidentialSubtype).toBe(true);
+    expect(brief.levelCount).toBeGreaterThanOrEqual(1);
+    expect(brief.levelCount).toBeLessThanOrEqual(3);
+    expect(Array.isArray(brief.spaces)).toBe(true);
+    expect(brief.spaces.length).toBeGreaterThan(0);
+    expect(
+      brief.spaces.every(
+        (space) =>
+          Number.isFinite(space.area) &&
+          Number(space.area) > 0 &&
+          space.levelIndex >= 0 &&
+          space.levelIndex < brief.levelCount,
+      ),
+    ).toBe(true);
+  });
 });

--- a/src/__tests__/utils/projectTypeAutoDetect.test.js
+++ b/src/__tests__/utils/projectTypeAutoDetect.test.js
@@ -1,0 +1,130 @@
+import detectProjectTypeFromBrief, {
+  __testing,
+} from "../../utils/projectTypeAutoDetect.js";
+
+describe("detectProjectTypeFromBrief", () => {
+  test("returns null for empty input", () => {
+    expect(detectProjectTypeFromBrief({})).toBeNull();
+    expect(detectProjectTypeFromBrief({ customNotes: "   " })).toBeNull();
+  });
+
+  test("suggests a detached house from a clear residential brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes:
+        "Modern detached family home for two adults and two children, with garden and detached garage",
+    });
+    expect(result).not.toBeNull();
+    expect(result.category).toBe("residential");
+    expect(result.subType).toBe("detached-house");
+    expect(result.confidence).toBeGreaterThanOrEqual(0.5);
+    expect(result.matchedKeywords).toEqual(
+      expect.arrayContaining(["detached"]),
+    );
+  });
+
+  test("suggests a villa for a villa brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes: "Coastal villa with infinity pool",
+    });
+    expect(result?.category).toBe("residential");
+    expect(result?.subType).toBe("villa");
+  });
+
+  test("suggests an office for a coworking brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes: "Boutique co-working office for a small studio team",
+    });
+    expect(result?.category).toBe("commercial");
+    expect(result?.subType).toBe("office");
+  });
+
+  test("suggests a clinic for a medical-centre brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes: "Small medical centre with two consultation rooms",
+    });
+    expect(result?.category).toBe("healthcare");
+    expect(result?.subType).toBe("clinic");
+  });
+
+  test("suggests a school for a primary-school brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes: "Primary school for 120 pupils with a small playground",
+    });
+    expect(result?.category).toBe("education");
+    expect(result?.subType).toBe("school");
+  });
+
+  test("suggests a warehouse for a logistics brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes:
+        "Industrial warehouse for last-mile logistics with high-bay storage",
+    });
+    expect(result?.category).toBe("industrial");
+    expect(result?.subType).toBe("warehouse");
+  });
+
+  test("suggests a church for a chapel brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes: "Small countryside church with a bell tower",
+    });
+    expect(result?.category).toBe("religious");
+    expect(result?.subType).toBe("church");
+  });
+
+  test("returns null when the brief is genuinely ambiguous between two types", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes: "office hotel mixed-use plot",
+    });
+    // Office and hotel both score 1.0, no disambiguation possible
+    expect(result).toBeNull();
+  });
+
+  test("does not surface a disabled type even if keywords match", () => {
+    // "shopping mall" exists in our keyword tables but commercial:shopping-mall
+    // is gated to disabled. The detector must drop the suggestion.
+    const result = detectProjectTypeFromBrief({
+      customNotes: "shopping mall with food court",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null for an unrelated brief", () => {
+    const result = detectProjectTypeFromBrief({
+      customNotes: "the quick brown fox jumps over the lazy dog",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("merges title, description, and customNotes when classifying", () => {
+    const result = detectProjectTypeFromBrief({
+      title: "Family Home",
+      description: "Detached two-storey",
+      customNotes: "with a garden",
+    });
+    expect(result?.category).toBe("residential");
+    expect(result?.subType).toBe("detached-house");
+  });
+
+  test("normaliseText handles punctuation and case", () => {
+    expect(__testing.normaliseText("Co-Working OFFICE!")).toBe(
+      "co-working office",
+    );
+  });
+
+  test("containsKeyword matches plurals", () => {
+    expect(__testing.containsKeyword("two offices opening", "office")).toBe(
+      true,
+    );
+    expect(__testing.containsKeyword("a single villa estate", "villa")).toBe(
+      true,
+    );
+  });
+
+  test("containsKeyword does not match across word boundaries", () => {
+    expect(__testing.containsKeyword("portfolio website", "portfolio")).toBe(
+      true,
+    );
+    // "office" should NOT match "officer"
+    expect(__testing.containsKeyword("a senior officer", "office")).toBe(false);
+  });
+});

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -1707,12 +1707,20 @@ const ArchitectAIWizardContainer = () => {
 
       setAutoDetectResult(result);
 
-      if (result.confidence > 0.6) {
+      // Apply the auto-detected direction at confidence ≥ 0.5. Below 0.7
+      // we still apply but mark `entranceNeedsReview = true` so the
+      // EntranceDirectionSelector shows a "Please confirm" badge — the
+      // user can override on the compass without having to discover the
+      // auto-detect button. Manual selection always wins (the
+      // SpecsStep.handleEntranceChange path clears `entranceAutoDetected`
+      // implicitly because the user typed a direction).
+      if (result.confidence >= 0.5) {
         setProjectDetails((prev) => ({
           ...prev,
           entranceDirection: result.direction,
           entranceAutoDetected: true,
           entranceConfidence: result.confidence,
+          entranceNeedsReview: result.confidence < 0.7,
         }));
       }
 
@@ -1732,6 +1740,36 @@ const ArchitectAIWizardContainer = () => {
     setProjectDetails,
     siteMetrics,
     sitePolygon,
+  ]);
+
+  // Auto-trigger entrance orientation detection once a site polygon is
+  // available. This removes the discoverability problem with the
+  // "Auto-Detect Entrance" button (the user reported manual works but
+  // auto-detect "doesn't work" — the detector itself runs, but the user
+  // never noticed the button on the specs step). The hook fires exactly
+  // once per session: it gates on (a) a usable polygon, (b) no manual
+  // entrance already set by the user, and (c) no detection already
+  // recorded. Manual override still wins because the user changing the
+  // compass calls handleEntranceChange which sets a new direction
+  // without `entranceAutoDetected: true`.
+  useEffect(() => {
+    if (!sitePolygon || sitePolygon.length < 3) return;
+    if (isDetectingEntrance) return;
+    if (projectDetails.entranceAutoDetected) return;
+    if (
+      projectDetails.entranceDirection &&
+      !["", "N"].includes(projectDetails.entranceDirection)
+    ) {
+      // User has already picked a non-default direction — don't override.
+      return;
+    }
+    handleAutoDetectEntrance();
+  }, [
+    sitePolygon,
+    handleAutoDetectEntrance,
+    isDetectingEntrance,
+    projectDetails.entranceAutoDetected,
+    projectDetails.entranceDirection,
   ]);
 
   /**
@@ -1846,19 +1884,26 @@ const ArchitectAIWizardContainer = () => {
         capturedSnapshot = await captureSnapshotForPersistence({
           coordinates: locationData?.coordinates,
           polygon: siteSnapshotDisplayPolygon,
-          drawPolygonOverlay: siteSnapshotBoundaryAuthoritative,
+          // Always overlay the polygon when we have one — the user wants
+          // to see the auto-detected boundary even when it is non-
+          // authoritative. The metadata flag below preserves the
+          // estimated semantic for downstream gating.
+          drawPolygonOverlay: Boolean(
+            siteSnapshotDisplayPolygon &&
+            siteSnapshotDisplayPolygon.length >= 3,
+          ),
           polygonStyle: siteSnapshotBoundaryAuthoritative
             ? {
-                strokeColor: "#d64d35",
+                strokeColor: "#1976D2",
                 strokeWeight: 3,
-                fillColor: "#b7d7a8",
+                fillColor: "#1976D2",
                 fillOpacity: 0.18,
               }
             : {
-                strokeColor: "#e87524",
-                strokeWeight: 3,
-                fillColor: "#b7d7a8",
-                fillOpacity: 0.18,
+                strokeColor: "#1976D2",
+                strokeWeight: 2,
+                fillColor: "#1976D2",
+                fillOpacity: 0.1,
               },
           zoom: locationData?.mapZoom || 17,
           mapType: siteSnapshotMapType,

--- a/src/components/map/mapUtils.js
+++ b/src/components/map/mapUtils.js
@@ -245,8 +245,7 @@ export function isPointInPolygon(point, polygon) {
     const xj = polygon[j].lng;
     const yj = polygon[j].lat;
 
-    const intersectsLatitude =
-      (yi > point.lat) !== (yj > point.lat);
+    const intersectsLatitude = yi > point.lat !== yj > point.lat;
     const intersect =
       intersectsLatitude &&
       point.lng < ((xj - xi) * (point.lat - yi)) / (yj - yi) + xi;
@@ -257,12 +256,37 @@ export function isPointInPolygon(point, polygon) {
   return inside;
 }
 
+// Static Maps stroke colours for the site boundary.
+// Authoritative boundary uses Material Blue 700 (#1976D2) at full opacity.
+// Estimated boundary uses the same hue at slightly reduced stroke opacity
+// so it remains clearly visible but distinguishable. Static Maps does not
+// support dasharray on `path=`, so we differentiate by line weight + a thin
+// outer halo path.
+export const SITE_BOUNDARY_STATIC_MAP_COLORS = Object.freeze({
+  authoritative: {
+    stroke: "0x1976d2ff",
+    fill: "0x1976d233",
+    weight: 3,
+  },
+  estimated: {
+    stroke: "0x1976d2cc",
+    fill: "0x1976d21a",
+    weight: 2,
+  },
+});
+
 /**
  * Generate map snapshot URL
  * @param {Array<{lat: number, lng: number}>} polygon - Polygon coordinates
  * @param {string} apiKey - Google Maps API key
  * @param {number} width - Image width
  * @param {number} height - Image height
+ * @param {object} [options]
+ * @param {boolean} [options.estimated=false] - When true, render the
+ *   boundary with the "estimated" style (lighter stroke + thinner weight)
+ *   so the user can see the polygon is non-authoritative. The colour
+ *   stays blue in either case so the wizard preview and the final A1
+ *   site plan match.
  * @returns {string} Static map URL
  */
 export function generateMapSnapshotURL(
@@ -270,11 +294,15 @@ export function generateMapSnapshotURL(
   apiKey,
   width = 640,
   height = 480,
+  options = {},
 ) {
   if (!polygon || polygon.length === 0) return null;
 
   const centroid = getPolygonCentroid(polygon);
   const pathString = polygon.map((p) => `${p.lat},${p.lng}`).join("|");
+  const style = options?.estimated
+    ? SITE_BOUNDARY_STATIC_MAP_COLORS.estimated
+    : SITE_BOUNDARY_STATIC_MAP_COLORS.authoritative;
 
   return (
     `https://maps.googleapis.com/maps/api/staticmap?` +
@@ -282,7 +310,7 @@ export function generateMapSnapshotURL(
     `zoom=18&` +
     `size=${width}x${height}&` +
     `maptype=hybrid&` +
-    `path=color:0xff0000ff|weight:2|fillcolor:0xff000033|${pathString}&` +
+    `path=color:${style.stroke}|weight:${style.weight}|fillcolor:${style.fill}|${pathString}&` +
     `key=${apiKey}`
   );
 }

--- a/src/components/map/mapUtils.js
+++ b/src/components/map/mapUtils.js
@@ -245,7 +245,9 @@ export function isPointInPolygon(point, polygon) {
     const xj = polygon[j].lng;
     const yj = polygon[j].lat;
 
-    const intersectsLatitude = yi > point.lat !== yj > point.lat;
+    const yiAbove = yi > point.lat;
+    const yjAbove = yj > point.lat;
+    const intersectsLatitude = yiAbove !== yjAbove;
     const intersect =
       intersectsLatitude &&
       point.lng < ((xj - xi) * (point.lat - yi)) / (yj - yi) + xi;

--- a/src/components/site/polygonEditor.js
+++ b/src/components/site/polygonEditor.js
@@ -20,14 +20,42 @@
 
 /**
  * Default polygon styling
+ *
+ * Authoritative site boundary uses Material Blue 700 (#1976D2) at full
+ * stroke opacity. Estimated/non-authoritative boundaries use the same
+ * hue at reduced stroke opacity and lighter fill so the user can tell
+ * at a glance that the polygon is non-authoritative — the colour stays
+ * blue in both cases for consistency with the A1 site plan.
  */
 const DEFAULT_POLYGON_STYLES = {
-  fillColor: '#2962FF',
-  fillOpacity: 0.25,
-  strokeColor: '#2962FF',
+  fillColor: "#1976D2",
+  fillOpacity: 0.18,
+  strokeColor: "#1976D2",
   strokeWeight: 3,
-  strokeOpacity: 0.9,
+  strokeOpacity: 1,
 };
+
+const ESTIMATED_POLYGON_STYLES = {
+  fillColor: "#1976D2",
+  fillOpacity: 0.1,
+  strokeColor: "#1976D2",
+  strokeWeight: 2,
+  strokeOpacity: 0.85,
+};
+
+/**
+ * Resolve the polygon style for the editor. When `estimated` is true,
+ * the lighter style is returned so that auto-detected non-authoritative
+ * boundaries are visually distinguishable from confirmed ones.
+ *
+ * @param {{ estimated?: boolean }} [options]
+ * @returns {object} polygon style options
+ */
+export function getPolygonEditorStyles({ estimated = false } = {}) {
+  return estimated
+    ? { ...ESTIMATED_POLYGON_STYLES }
+    : { ...DEFAULT_POLYGON_STYLES };
+}
 
 /**
  * Default vertex marker styling
@@ -35,23 +63,23 @@ const DEFAULT_POLYGON_STYLES = {
 const DEFAULT_MARKER_STYLES = {
   default: {
     path: window.google?.maps?.SymbolPath?.CIRCLE || 0,
-    fillColor: '#FFFFFF',
+    fillColor: "#FFFFFF",
     fillOpacity: 1,
-    strokeColor: '#2962FF',
+    strokeColor: "#1976D2",
     strokeWeight: 3,
     scale: 8,
   },
   hover: {
-    fillColor: '#2962FF',
+    fillColor: "#1976D2",
     fillOpacity: 1,
-    strokeColor: '#FFFFFF',
+    strokeColor: "#FFFFFF",
     strokeWeight: 3,
     scale: 10,
   },
   dragging: {
-    fillColor: '#FF5722',
+    fillColor: "#FF5722",
     fillOpacity: 1,
-    strokeColor: '#FFFFFF',
+    strokeColor: "#FFFFFF",
     strokeWeight: 3,
     scale: 12,
   },
@@ -89,7 +117,7 @@ export class PolygonEditor {
    */
   init() {
     if (!this.map || !window.google) {
-      console.warn('PolygonEditor: Map or Google Maps API not available');
+      console.warn("PolygonEditor: Map or Google Maps API not available");
       return;
     }
 
@@ -136,7 +164,7 @@ export class PolygonEditor {
         position: vertex,
         map: this.map,
         draggable: true,
-        icon: this.getMarkerIcon('default'),
+        icon: this.getMarkerIcon("default"),
         zIndex: 10 + index,
         title: `Vertex ${index + 1}`,
       });
@@ -157,7 +185,8 @@ export class PolygonEditor {
    * @returns {Object} Icon configuration
    */
   getMarkerIcon(state) {
-    const styles = DEFAULT_MARKER_STYLES[state] || DEFAULT_MARKER_STYLES.default;
+    const styles =
+      DEFAULT_MARKER_STYLES[state] || DEFAULT_MARKER_STYLES.default;
     return {
       path: window.google.maps.SymbolPath.CIRCLE,
       ...styles,
@@ -171,12 +200,12 @@ export class PolygonEditor {
    */
   attachMarkerListeners(marker, index) {
     // Drag start
-    marker.addListener('dragstart', () => {
-      marker.setIcon(this.getMarkerIcon('dragging'));
+    marker.addListener("dragstart", () => {
+      marker.setIcon(this.getMarkerIcon("dragging"));
     });
 
     // Dragging
-    marker.addListener('drag', () => {
+    marker.addListener("drag", () => {
       const position = marker.getPosition();
       this.vertices[index] = {
         lat: position.lat(),
@@ -186,31 +215,31 @@ export class PolygonEditor {
     });
 
     // Drag end
-    marker.addListener('dragend', () => {
-      marker.setIcon(this.getMarkerIcon('default'));
+    marker.addListener("dragend", () => {
+      marker.setIcon(this.getMarkerIcon("default"));
       this.notifyUpdate();
     });
 
     // Hover effects
-    marker.addListener('mouseover', () => {
-      if (!marker.getIcon().fillColor?.includes('FF5722')) {
-        marker.setIcon(this.getMarkerIcon('hover'));
+    marker.addListener("mouseover", () => {
+      if (!marker.getIcon().fillColor?.includes("FF5722")) {
+        marker.setIcon(this.getMarkerIcon("hover"));
       }
     });
 
-    marker.addListener('mouseout', () => {
-      if (!marker.getIcon().fillColor?.includes('FF5722')) {
-        marker.setIcon(this.getMarkerIcon('default'));
+    marker.addListener("mouseout", () => {
+      if (!marker.getIcon().fillColor?.includes("FF5722")) {
+        marker.setIcon(this.getMarkerIcon("default"));
       }
     });
 
     // Right-click to delete
-    marker.addListener('rightclick', () => {
+    marker.addListener("rightclick", () => {
       this.deleteVertex(index);
     });
 
     // Double-click to delete (alternative)
-    marker.addListener('dblclick', () => {
+    marker.addListener("dblclick", () => {
       this.deleteVertex(index);
     });
   }
@@ -220,7 +249,7 @@ export class PolygonEditor {
    */
   attachMapListeners() {
     // Shift+Click to add vertex
-    const clickListener = this.map.addListener('click', (event) => {
+    const clickListener = this.map.addListener("click", (event) => {
       if (event.domEvent && event.domEvent.shiftKey) {
         this.addVertexAtLocation(event.latLng);
       }
@@ -319,7 +348,7 @@ export class PolygonEditor {
   deleteVertex(index) {
     // Ensure minimum 3 vertices
     if (this.vertices.length <= 3) {
-      console.warn('Cannot delete vertex: minimum 3 vertices required');
+      console.warn("Cannot delete vertex: minimum 3 vertices required");
       return;
     }
 

--- a/src/components/specs/BuildingTypeSelector.jsx
+++ b/src/components/specs/BuildingTypeSelector.jsx
@@ -4,7 +4,7 @@
  * Grid-based selector for building category and sub-type with icons
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import * as LucideIcons from "lucide-react";
 import { getAllCategories, getCategoryById } from "../../data/buildingTypes.js";
@@ -30,15 +30,51 @@ export function getBuildingTypeSelectorSubTypeState(categoryId, subType) {
   };
 }
 
+function confidenceBand(confidence) {
+  if (!Number.isFinite(confidence)) return "low";
+  if (confidence >= 0.85) return "high";
+  if (confidence >= 0.7) return "med";
+  return "low";
+}
+
 const BuildingTypeSelector = ({
   selectedCategory,
   selectedSubType,
   onSelectionChange,
   validationErrors = [],
+  autoDetectedType = null,
+  onApplyAutoDetectedType = null,
 }) => {
   const [expandedCategory, setExpandedCategory] = useState(
     selectedCategory || null,
   );
+
+  // Resolve the suggested label only when the suggestion still maps to an
+  // enabled subtype in the current registry. The detector already filters
+  // by enabledInUi, but we re-check here so a subtype that gets disabled
+  // mid-session does not surface a stale chip.
+  const suggestedLabel = (() => {
+    if (!autoDetectedType?.category || !autoDetectedType?.subType) return null;
+    const support = getProjectTypeSupport(
+      autoDetectedType.category,
+      autoDetectedType.subType,
+    );
+    if (!support || support.enabledInUi !== true) return null;
+    return support.label || autoDetectedType.subType;
+  })();
+
+  const showSuggestion = Boolean(
+    suggestedLabel && !selectedCategory && !selectedSubType,
+  );
+
+  // When the suggestion is shown and the user hasn't expanded any category,
+  // expand the suggested one so the user immediately sees the suggested
+  // subtype highlighted in the grid below.
+  useEffect(() => {
+    if (showSuggestion && !expandedCategory && autoDetectedType?.category) {
+      setExpandedCategory(autoDetectedType.category);
+    }
+  }, [showSuggestion, expandedCategory, autoDetectedType?.category]);
   const categories = getAllCategories();
 
   const isCategoryEnabled = (category) =>
@@ -83,6 +119,50 @@ const BuildingTypeSelector = ({
 
   return (
     <div className="space-y-4">
+      {showSuggestion && (
+        <motion.button
+          type="button"
+          onClick={() => {
+            if (typeof onApplyAutoDetectedType === "function") {
+              onApplyAutoDetectedType({
+                category: autoDetectedType.category,
+                subType: autoDetectedType.subType,
+              });
+            } else if (typeof onSelectionChange === "function") {
+              onSelectionChange({
+                category: autoDetectedType.category,
+                subType: autoDetectedType.subType,
+              });
+            }
+          }}
+          initial={{ opacity: 0, y: -6 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex w-full items-center justify-between gap-3 rounded-xl border border-sky-400/40 bg-sky-500/10 px-4 py-3 text-left transition-colors hover:border-sky-400 hover:bg-sky-500/15"
+          data-testid="building-type-auto-detect-chip"
+        >
+          <div className="flex items-center gap-3">
+            <LucideIcons.Sparkles className="h-4 w-4 text-sky-300" />
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-sky-200/80">
+                Suggested from your brief
+              </p>
+              <p className="text-sm font-medium text-white">{suggestedLabel}</p>
+              {Array.isArray(autoDetectedType.matchedKeywords) &&
+                autoDetectedType.matchedKeywords.length > 0 && (
+                  <p className="mt-0.5 text-xs text-white/55">
+                    Matched:{" "}
+                    {autoDetectedType.matchedKeywords.slice(0, 3).join(", ")}
+                  </p>
+                )}
+            </div>
+          </div>
+          <span className="text-[10px] uppercase tracking-wider text-sky-200/70">
+            {confidenceBand(autoDetectedType.confidence)} confidence · click to
+            apply
+          </span>
+        </motion.button>
+      )}
+
       {/* Category Grid */}
       <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-4">
         {categories.map((category) => {

--- a/src/components/specs/EntranceDirectionSelector.jsx
+++ b/src/components/specs/EntranceDirectionSelector.jsx
@@ -1,14 +1,14 @@
 /**
  * Entrance Direction Selector Component
- * 
+ *
  * Compass-based selector for main entrance direction with auto-detection
  */
 
-import React from 'react';
-import { motion } from 'framer-motion';
-import { Navigation, Loader2 } from 'lucide-react';
-import { getAllDirections } from '../../utils/entranceOrientation.js';
-import Button from '../ui/Button.jsx';
+import React from "react";
+import { motion } from "framer-motion";
+import { Navigation, Loader2 } from "lucide-react";
+import { getAllDirections } from "../../utils/entranceOrientation.js";
+import Button from "../ui/Button.jsx";
 
 const EntranceDirectionSelector = ({
   selectedDirection,
@@ -16,7 +16,8 @@ const EntranceDirectionSelector = ({
   onAutoDetect,
   isDetecting = false,
   autoDetectResult = null,
-  showAutoDetect = true
+  showAutoDetect = true,
+  needsReview = false,
 }) => {
   const directions = getAllDirections();
 
@@ -39,7 +40,7 @@ const EntranceDirectionSelector = ({
               const isSelected = selectedDirection === dir.code;
               const angle = dir.bearing;
               const radius = 100; // pixels from center
-              
+
               // Calculate position
               const x = Math.sin((angle * Math.PI) / 180) * radius;
               const y = -Math.cos((angle * Math.PI) / 180) * radius;
@@ -50,12 +51,12 @@ const EntranceDirectionSelector = ({
                   onClick={() => handleDirectionClick(dir.code)}
                   className={`absolute flex items-center justify-center w-12 h-12 rounded-full transition-all duration-200 ${
                     isSelected
-                      ? 'bg-royal-500 text-white scale-110 shadow-glow'
-                      : 'bg-navy-700 text-gray-300 hover:bg-navy-600'
+                      ? "bg-royal-500 text-white scale-110 shadow-glow"
+                      : "bg-navy-700 text-gray-300 hover:bg-navy-600"
                   }`}
                   style={{
                     left: `calc(50% + ${x}px - 24px)`,
-                    top: `calc(50% + ${y}px - 24px)`
+                    top: `calc(50% + ${y}px - 24px)`,
                   }}
                   whileHover={{ scale: isSelected ? 1.1 : 1.05 }}
                   whileTap={{ scale: 0.95 }}
@@ -75,12 +76,16 @@ const EntranceDirectionSelector = ({
                 <div
                   style={{
                     transform: `rotate(${
-                      directions.find(d => d.code === selectedDirection)?.bearing || 0
-                    }deg)`
+                      directions.find((d) => d.code === selectedDirection)
+                        ?.bearing || 0
+                    }deg)`,
                   }}
                   className="transition-transform duration-500"
                 >
-                  <Navigation className="w-8 h-8 text-royal-400" fill="currentColor" />
+                  <Navigation
+                    className="w-8 h-8 text-royal-400"
+                    fill="currentColor"
+                  />
                 </div>
               </motion.div>
             )}
@@ -110,8 +115,16 @@ const EntranceDirectionSelector = ({
           >
             <p className="text-sm text-gray-400">Main Entrance</p>
             <p className="text-lg font-semibold text-white">
-              {directions.find(d => d.code === selectedDirection)?.label}
+              {directions.find((d) => d.code === selectedDirection)?.label}
             </p>
+            {needsReview && (
+              <p
+                className="mt-2 inline-block rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-xs uppercase tracking-wide text-amber-200"
+                data-testid="entrance-needs-review-badge"
+              >
+                Auto-detected — please confirm
+              </p>
+            )}
           </motion.div>
         )}
       </div>
@@ -124,9 +137,15 @@ const EntranceDirectionSelector = ({
             size="md"
             onClick={onAutoDetect}
             disabled={isDetecting}
-            icon={isDetecting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Navigation className="w-4 h-4" />}
+            icon={
+              isDetecting ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Navigation className="w-4 h-4" />
+              )
+            }
           >
-            {isDetecting ? 'Detecting...' : 'Auto-Detect Entrance'}
+            {isDetecting ? "Detecting..." : "Auto-Detect Entrance"}
           </Button>
         </div>
       )}
@@ -139,13 +158,16 @@ const EntranceDirectionSelector = ({
           className="p-3 rounded-lg bg-navy-800/60 border border-navy-700"
         >
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-semibold text-white">Auto-Detected:</span>
+            <span className="text-sm font-semibold text-white">
+              Auto-Detected:
+            </span>
             <span className="text-xs uppercase tracking-wide px-2 py-1 rounded bg-royal-500/20 text-royal-300">
               {Math.round(autoDetectResult.confidence * 100)}% confidence
             </span>
           </div>
           <p className="text-sm text-gray-300">
-            {autoDetectResult.rationale?.[0]?.message || 'Based on site analysis'}
+            {autoDetectResult.rationale?.[0]?.message ||
+              "Based on site analysis"}
           </p>
         </motion.div>
       )}
@@ -154,4 +176,3 @@ const EntranceDirectionSelector = ({
 };
 
 export default EntranceDirectionSelector;
-

--- a/src/components/steps/SpecsStep.jsx
+++ b/src/components/steps/SpecsStep.jsx
@@ -4,7 +4,7 @@
  * Step 4: Project specifications with building type selector, entrance orientation, and program generator
  */
 
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import {
   Settings,
@@ -32,6 +32,7 @@ import {
   getProjectTypeSupportForDetails,
   PROJECT_TYPE_ROUTES,
 } from "../../services/project/projectTypeSupportRegistry.js";
+import detectProjectTypeFromBrief from "../../utils/projectTypeAutoDetect.js";
 import {
   levelIndexFromLabel,
   levelName,
@@ -134,16 +135,68 @@ const SpecsStep = ({
         category,
         subType,
         program: subType || category, // Maintain backward compatibility
+        // Mark the project type as explicitly chosen so the autodetect
+        // chip stays suppressed even if the brief text changes later.
+        // Manual choice always wins over auto-detect.
+        projectTypeExplicitlySetByUser: Boolean(category && subType),
       });
     },
     [projectDetails, onProjectDetailsChange],
   );
 
+  const handleApplyAutoDetectedType = useCallback(
+    ({ category, subType }) => {
+      onProjectDetailsChange({
+        ...projectDetails,
+        category,
+        subType,
+        program: subType || category,
+        projectTypeExplicitlySetByUser: true,
+      });
+    },
+    [projectDetails, onProjectDetailsChange],
+  );
+
+  // Debounced project-type auto-detect from the user's brief text.
+  // Output is purely a *suggestion* surfaced via BuildingTypeSelector — it
+  // never overwrites projectDetails.category/subType automatically; the
+  // chip requires an explicit click. Suppressed once the user has made
+  // a manual selection (preserves explicit choice).
+  const [autoDetectedProjectType, setAutoDetectedProjectType] = useState(null);
+  useEffect(() => {
+    if (projectDetails.projectTypeExplicitlySetByUser) {
+      setAutoDetectedProjectType(null);
+      return undefined;
+    }
+    const handle = setTimeout(() => {
+      const result = detectProjectTypeFromBrief({
+        title: projectDetails.title || "",
+        description: projectDetails.description || "",
+        brief: projectDetails.brief || "",
+        customNotes: projectDetails.customNotes || "",
+      });
+      setAutoDetectedProjectType(result);
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [
+    projectDetails.title,
+    projectDetails.description,
+    projectDetails.brief,
+    projectDetails.customNotes,
+    projectDetails.projectTypeExplicitlySetByUser,
+  ]);
+
   const handleEntranceChange = useCallback(
     (direction) => {
+      // Manual selection always wins — clear the auto-detect provenance so
+      // the "Please confirm" badge disappears and the wizard's
+      // auto-trigger useEffect does not re-run on the next polygon change.
       onProjectDetailsChange({
         ...projectDetails,
         entranceDirection: direction,
+        entranceAutoDetected: false,
+        entranceConfidence: 1,
+        entranceNeedsReview: false,
       });
     },
     [projectDetails, onProjectDetailsChange],
@@ -333,6 +386,8 @@ const SpecsStep = ({
               selectedSubType={projectDetails.subType}
               onSelectionChange={handleBuildingTypeChange}
               validationErrors={validationState?.buildingType || []}
+              autoDetectedType={autoDetectedProjectType}
+              onApplyAutoDetectedType={handleApplyAutoDetectedType}
             />
             {projectDetails.category &&
               projectDetails.subType &&
@@ -365,6 +420,7 @@ const SpecsStep = ({
                 isDetecting={isDetectingEntrance}
                 autoDetectResult={autoDetectResult}
                 showAutoDetect={!!onAutoDetectEntrance}
+                needsReview={Boolean(projectDetails.entranceNeedsReview)}
               />
             </Card>
           </motion.div>

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -3799,6 +3799,26 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
       ? "contextual_estimated_boundary"
       : "context_only";
 
+  // Site boundary stroke is Material Blue 700 in both states. The
+  // boundaryAuthoritative semantic stays exactly as before — the colour
+  // change is purely visual. Estimated boundaries get a slightly thinner
+  // stroke and lower fill opacity so they remain readable but the user
+  // can tell at a glance that the polygon is non-authoritative; the
+  // metadata block below still carries `boundaryAuthoritative` and
+  // `boundaryEstimated` flags for downstream gating.
+  const blueAuthoritative = {
+    strokeColor: "#1976D2",
+    strokeWeight: 3,
+    fillColor: "#1976D2",
+    fillOpacity: 0.18,
+  };
+  const blueEstimated = {
+    strokeColor: "#1976D2",
+    strokeWeight: 2,
+    fillColor: "#1976D2",
+    fillOpacity: 0.1,
+  };
+
   try {
     const snapshot = await getSiteSnapshotWithMetadata({
       coordinates: {
@@ -3806,20 +3826,12 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
         lng: Number(center?.lng ?? center?.lon ?? site.lon),
       },
       polygon: polygon.length >= 3 ? polygon : null,
-      drawPolygonOverlay: boundaryAuthoritative,
-      polygonStyle: boundaryAuthoritative
-        ? {
-            strokeColor: "#d64d35",
-            strokeWeight: 3,
-            fillColor: "#b7d7a8",
-            fillOpacity: 0.18,
-          }
-        : {
-            strokeColor: "#e87524",
-            strokeWeight: 3,
-            fillColor: "#b7d7a8",
-            fillOpacity: 0.18,
-          },
+      // Always draw the polygon overlay when we have one — the user needs
+      // to see the auto-detected boundary even when it is non-authoritative.
+      // The visual style and the `boundaryEstimated` metadata flag below
+      // continue to differentiate the two states.
+      drawPolygonOverlay: polygon.length >= 3,
+      polygonStyle: boundaryAuthoritative ? blueAuthoritative : blueEstimated,
       zoom: Number(input.siteSnapshot?.zoom || 18),
       size: [1200, 780],
       mapType: "roadmap",

--- a/src/services/project/projectTypeSupportRegistry.js
+++ b/src/services/project/projectTypeSupportRegistry.js
@@ -22,12 +22,66 @@ export const PROJECT_GRAPH_PROJECT_TYPE_PIPELINE_VERSION =
 const DEFAULT_DISABLED_MESSAGE =
   "Experimental/off in the current production ProjectGraph rollout.";
 
+// Per-subtype disabled reasons. Each entry replaces the generic
+// `DEFAULT_DISABLED_MESSAGE` for one specific `category:subtype` pair so
+// the UI can show the user *why* a type is not yet available rather than
+// a one-size-fits-all "Experimental/off" badge. Entries are intentionally
+// granular — when a programme template is authored end-to-end, the entry
+// is removed and an `ENABLED_OVERRIDES` row takes its place.
+const DISABLED_REASONS = Object.freeze({
+  "commercial:retail": {
+    badgeLabel: "Coming soon",
+    message:
+      "Retail programme template is not yet available. We are validating the deterministic ProjectGraph template before enabling.",
+    reason:
+      "ProjectGraph retail programme template is still in authoring; payload + title-block copy not ready.",
+  },
+  "commercial:mixed-use": {
+    badgeLabel: "Coming soon",
+    message:
+      "Mixed-use programme template is in development. The sheet-split policy for mixed-use is being validated separately.",
+    reason:
+      "Mixed-use sheet-split policy is still being validated; programme template not finalised.",
+  },
+  "commercial:shopping-mall": {
+    badgeLabel: "Coming soon",
+    message:
+      "Shopping mall programme template is not yet available end-to-end.",
+    reason:
+      "ProjectGraph shopping-mall programme template is still in authoring.",
+  },
+  "healthcare:dental": {
+    badgeLabel: "Coming soon",
+    message:
+      "Dental clinic programme template is not yet authored. Use Medical Clinic for now if the brief is general healthcare.",
+    reason: "Healthcare dental programme template not yet authored.",
+  },
+  "healthcare:lab": {
+    badgeLabel: "Coming soon",
+    message:
+      "Laboratory programme template is not yet authored. Specialist programme work is required for safe lab layouts.",
+    reason: "Laboratory programme template not yet authored.",
+  },
+  "education:university": {
+    badgeLabel: "Coming soon",
+    message:
+      "University programme template is not yet available. Use School for the smaller campus case for now.",
+    reason: "University programme template not yet authored.",
+  },
+  "education:kindergarten": {
+    badgeLabel: "Coming soon",
+    message: "Kindergarten programme template is not yet available end-to-end.",
+    reason: "Kindergarten programme template not yet authored.",
+  },
+});
+
 const RESIDENTIAL_CANONICAL_BY_SUBTYPE = Object.freeze({
   "detached-house": "dwelling",
   "semi-detached-house": "dwelling",
   "terraced-house": "dwelling",
   villa: "dwelling",
   cottage: "dwelling",
+  mansion: "dwelling",
   "apartment-building": "multi_residential",
   "multi-family": "multi_residential",
   duplex: "dwelling",
@@ -177,6 +231,8 @@ function labelFor(categoryId, subtypeId) {
 }
 
 function createDisabledEntry(category, subType) {
+  const key = registryKey(category.id, subType.id);
+  const override = DISABLED_REASONS[key];
   return {
     categoryId: category.id,
     subtypeId: subType.id,
@@ -185,10 +241,10 @@ function createDisabledEntry(category, subType) {
     canonicalBuildingType: null,
     route: null,
     enabledInUi: false,
-    reason: DEFAULT_DISABLED_MESSAGE,
-    message: DEFAULT_DISABLED_MESSAGE,
+    reason: override?.reason || DEFAULT_DISABLED_MESSAGE,
+    message: override?.message || DEFAULT_DISABLED_MESSAGE,
     programmeTemplateKey: null,
-    badgeLabel: "Experimental/off",
+    badgeLabel: override?.badgeLabel || "Experimental/off",
   };
 }
 

--- a/src/services/project/v2ProjectContracts.js
+++ b/src/services/project/v2ProjectContracts.js
@@ -6,6 +6,7 @@ export const SUPPORTED_RESIDENTIAL_V2_SUBTYPES = Object.freeze([
   "terraced-house",
   "villa",
   "cottage",
+  "mansion",
   "apartment-building",
   "multi-family",
   "duplex",

--- a/src/services/siteMapSnapshotService.js
+++ b/src/services/siteMapSnapshotService.js
@@ -115,12 +115,12 @@ export async function getSiteSnapshot({
     const fillAlpha = opacityToAlpha(polygonStyle?.fillOpacity, "33");
     const fillColor = normalizeStaticMapColor(
       polygonStyle?.fillColor,
-      "0xB7D7A833",
+      "0x1976d233",
       fillAlpha,
     );
     const strokeColor = normalizeStaticMapColor(
       polygonStyle?.strokeColor || polygonStyle?.color,
-      "0xf59e0bff",
+      "0x1976d2ff",
     );
     const strokeWeight = Math.max(
       1,
@@ -239,10 +239,10 @@ export async function captureSnapshotForPersistence({
   size = { width: 400, height: 300 },
   polygon = null,
   polygonStyle = {
-    strokeColor: "red",
-    strokeWeight: 2,
-    fillColor: "red",
-    fillOpacity: 0.2,
+    strokeColor: "#1976D2",
+    strokeWeight: 3,
+    fillColor: "#1976D2",
+    fillOpacity: 0.18,
   },
   drawPolygonOverlay = true,
 }) {

--- a/src/utils/projectTypeAutoDetect.js
+++ b/src/utils/projectTypeAutoDetect.js
@@ -1,0 +1,270 @@
+/**
+ * Project Type Auto-Detection
+ *
+ * Deterministic keyword classifier that suggests a `category:subType` pair
+ * from the user's textual brief / title / description on the wizard's main
+ * entry. The output is purely a *suggestion* — the wizard still requires
+ * an explicit user selection before generation. Confidence is scored from
+ * the matched keywords' total weight relative to the text length so that
+ * a single drive-by keyword in a long unrelated brief does not produce a
+ * false-positive suggestion.
+ *
+ * No LLM call — this runs synchronously in the browser and is safe to
+ * invoke on every keystroke (the wizard debounces, but the function itself
+ * is cheap).
+ *
+ * IMPORTANT: this only proposes types that are currently `enabledInUi` in
+ * the project type support registry. We never suggest a disabled type
+ * because doing so would surface a non-actionable chip to the user.
+ */
+
+import { getProjectTypeSupport } from "../services/project/projectTypeSupportRegistry.js";
+
+const MIN_CONFIDENCE_TO_SURFACE = 0.5;
+
+// Keyword tables. Each entry maps a `categoryId:subtypeId` to a list of
+// `{ keyword, weight }`. Higher weight = stronger signal; multiple
+// matches accumulate. Keywords match whole words (case-insensitive,
+// also tolerating short suffixes like "house" → "houses").
+//
+// Hand-curated against the registry's enabled types. When a new type is
+// enabled in the registry, add a row here so the auto-detector can suggest
+// it. When a type is disabled, leaving the row in place is harmless — the
+// helper filters disabled suggestions out at lookup time.
+const KEYWORDS = Object.freeze({
+  "residential:detached-house": [
+    { keyword: "detached", weight: 1.0 },
+    { keyword: "single family", weight: 0.9 },
+    { keyword: "family home", weight: 0.7 },
+    { keyword: "single-family", weight: 0.9 },
+    { keyword: "standalone home", weight: 0.7 },
+  ],
+  "residential:semi-detached-house": [
+    { keyword: "semi-detached", weight: 1.0 },
+    { keyword: "semi detached", weight: 1.0 },
+    { keyword: "semi", weight: 0.4 },
+  ],
+  "residential:terraced-house": [
+    { keyword: "terraced", weight: 1.0 },
+    { keyword: "terrace house", weight: 0.9 },
+    { keyword: "row house", weight: 0.7 },
+    { keyword: "townhouse", weight: 0.6 },
+  ],
+  "residential:villa": [
+    { keyword: "villa", weight: 1.0 },
+    { keyword: "estate", weight: 0.4 },
+  ],
+  "residential:cottage": [
+    { keyword: "cottage", weight: 1.0 },
+    { keyword: "country house", weight: 0.5 },
+  ],
+  "residential:apartment-building": [
+    { keyword: "apartment", weight: 1.0 },
+    { keyword: "flat block", weight: 0.9 },
+    { keyword: "block of flats", weight: 0.9 },
+    { keyword: "condo", weight: 0.7 },
+  ],
+  "residential:multi-family": [
+    { keyword: "multi-family", weight: 1.0 },
+    { keyword: "multi family", weight: 1.0 },
+    { keyword: "multi-unit", weight: 0.8 },
+  ],
+  "residential:duplex": [{ keyword: "duplex", weight: 1.0 }],
+  "commercial:office": [
+    { keyword: "office", weight: 1.0 },
+    { keyword: "co-working", weight: 0.9 },
+    { keyword: "coworking", weight: 0.9 },
+    { keyword: "workplace", weight: 0.6 },
+    { keyword: "workspace", weight: 0.6 },
+  ],
+  "healthcare:clinic": [
+    { keyword: "clinic", weight: 1.0 },
+    { keyword: "surgery", weight: 0.7 },
+    { keyword: "medical centre", weight: 0.9 },
+    { keyword: "medical center", weight: 0.9 },
+    { keyword: "gp practice", weight: 0.8 },
+  ],
+  "healthcare:hospital": [{ keyword: "hospital", weight: 1.0 }],
+  "education:school": [
+    { keyword: "school", weight: 1.0 },
+    { keyword: "academy", weight: 0.7 },
+    { keyword: "primary", weight: 0.6 },
+    { keyword: "secondary school", weight: 0.9 },
+  ],
+  "hospitality:hotel": [
+    { keyword: "hotel", weight: 1.0 },
+    { keyword: "boutique hotel", weight: 1.0 },
+  ],
+  "hospitality:resort": [{ keyword: "resort", weight: 1.0 }],
+  "hospitality:guest-house": [
+    { keyword: "guest house", weight: 1.0 },
+    { keyword: "guesthouse", weight: 1.0 },
+    { keyword: "bed and breakfast", weight: 0.9 },
+    { keyword: "b&b", weight: 0.8 },
+  ],
+  "industrial:warehouse": [
+    { keyword: "warehouse", weight: 1.0 },
+    { keyword: "logistics", weight: 0.6 },
+    { keyword: "storage facility", weight: 0.7 },
+  ],
+  "industrial:manufacturing": [
+    { keyword: "manufacturing", weight: 1.0 },
+    { keyword: "factory", weight: 0.9 },
+    { keyword: "production plant", weight: 0.8 },
+  ],
+  "industrial:workshop": [
+    { keyword: "workshop", weight: 1.0 },
+    { keyword: "maker space", weight: 0.7 },
+  ],
+  "cultural:museum": [
+    { keyword: "museum", weight: 1.0 },
+    { keyword: "gallery", weight: 0.7 },
+  ],
+  "cultural:library": [{ keyword: "library", weight: 1.0 }],
+  "cultural:theatre": [
+    { keyword: "theatre", weight: 1.0 },
+    { keyword: "theater", weight: 1.0 },
+    { keyword: "auditorium", weight: 0.7 },
+  ],
+  "government:town-hall": [
+    { keyword: "town hall", weight: 1.0 },
+    { keyword: "civic centre", weight: 0.8 },
+    { keyword: "civic center", weight: 0.8 },
+  ],
+  "government:police": [{ keyword: "police station", weight: 1.0 }],
+  "government:fire-station": [{ keyword: "fire station", weight: 1.0 }],
+  "religious:mosque": [
+    { keyword: "mosque", weight: 1.0 },
+    { keyword: "masjid", weight: 1.0 },
+  ],
+  "religious:church": [
+    { keyword: "church", weight: 1.0 },
+    { keyword: "chapel", weight: 0.7 },
+  ],
+  "religious:temple": [{ keyword: "temple", weight: 1.0 }],
+  "recreation:sports-center": [
+    { keyword: "sports centre", weight: 1.0 },
+    { keyword: "sports center", weight: 1.0 },
+    { keyword: "leisure centre", weight: 0.9 },
+  ],
+  "recreation:gym": [
+    { keyword: "gym", weight: 1.0 },
+    { keyword: "fitness studio", weight: 0.9 },
+    { keyword: "fitness centre", weight: 0.8 },
+  ],
+  "recreation:pool": [
+    { keyword: "swimming pool", weight: 1.0 },
+    { keyword: "lido", weight: 0.7 },
+  ],
+});
+
+function normaliseText(text) {
+  return String(text || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9&\s-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function containsKeyword(haystack, keyword) {
+  if (!haystack || !keyword) return false;
+  const needle = normaliseText(keyword);
+  if (!needle) return false;
+  // Word-boundary match. The replacement above turns `&` into a literal
+  // character, so escape regex specials.
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`(^|\\s)${escaped}(s|es)?(\\s|$)`, "i");
+  return pattern.test(haystack);
+}
+
+/**
+ * Run the keyword classifier against a brief / title / description.
+ *
+ * @param {object} params
+ * @param {string} [params.title]
+ * @param {string} [params.description]
+ * @param {string} [params.brief]
+ * @param {string} [params.customNotes]
+ * @returns {{
+ *   category: string,
+ *   subType: string,
+ *   confidence: number,
+ *   matchedKeywords: string[],
+ *   ranking: Array<{ key: string, score: number }>,
+ * } | null}
+ *   Returns the highest-scoring `enabledInUi` suggestion, or null when no
+ *   suggestion clears `MIN_CONFIDENCE_TO_SURFACE` or when the text is
+ *   empty.
+ */
+export function detectProjectTypeFromBrief({
+  title = "",
+  description = "",
+  brief = "",
+  customNotes = "",
+} = {}) {
+  const haystack = normaliseText(
+    [title, description, brief, customNotes].filter(Boolean).join(" "),
+  );
+  if (!haystack) return null;
+
+  const ranking = [];
+  for (const [key, keywords] of Object.entries(KEYWORDS)) {
+    let score = 0;
+    const matched = [];
+    for (const { keyword, weight } of keywords) {
+      if (containsKeyword(haystack, keyword)) {
+        score += weight;
+        matched.push(keyword);
+      }
+    }
+    if (score > 0) {
+      ranking.push({ key, score, matched });
+    }
+  }
+
+  if (ranking.length === 0) return null;
+  ranking.sort((a, b) => b.score - a.score);
+
+  // Length normaliser — divides by sqrt(words) so a long brief does not
+  // dilute a strong signal too aggressively. Single strong keyword in a
+  // short brief wins.
+  const wordCount = haystack.split(" ").length;
+  const lengthFactor = Math.max(1, Math.sqrt(Math.min(wordCount, 60) / 6));
+  const top = ranking[0];
+
+  // Disambiguation gate: when the second-best is within 0.2 of the top,
+  // the brief is genuinely ambiguous. Refuse to pick rather than guess.
+  const second = ranking[1];
+  if (second && top.score - second.score < 0.2 && top.score < 1.5) {
+    return null;
+  }
+
+  const confidence = Math.min(1, top.score / lengthFactor);
+  if (confidence < MIN_CONFIDENCE_TO_SURFACE) return null;
+
+  const [category, subType] = top.key.split(":");
+
+  // Final filter: the suggestion must correspond to a currently-enabled
+  // entry in the support registry. If the type was deactivated upstream
+  // we silently drop the suggestion rather than surfacing a chip the
+  // user cannot act on.
+  const support = getProjectTypeSupport(category, subType);
+  if (!support || support.enabledInUi !== true) return null;
+
+  return {
+    category,
+    subType,
+    confidence,
+    matchedKeywords: top.matched,
+    ranking: ranking.map((entry) => ({ key: entry.key, score: entry.score })),
+  };
+}
+
+export const __testing = Object.freeze({
+  KEYWORDS,
+  MIN_CONFIDENCE_TO_SURFACE,
+  containsKeyword,
+  normaliseText,
+});
+
+export default detectProjectTypeFromBrief;


### PR DESCRIPTION
## Summary

A coherent pass on four issues visible in the latest A1 result:

1. **Site plan boundary** is now blue (Material Blue 700 `#1976D2`) everywhere it is rendered — A1 sheet, wizard map preview, history-persistence snapshot, and the interactive polygon editor. Server-side, oversized `landuse=*` parcel candidates are demoted to estimated (with the building polygon used as fallback) so the Birmingham-style 20 ha district polygon no longer reaches the site plan as authoritative.
2. **Project type auto-detect** suggests a `category:subType` from the user's brief / customNotes via a deterministic keyword classifier (no LLM call). The chip is opt-in: clicking applies the suggestion, manual selection always wins and suppresses the chip permanently for the session.
3. **Project-type registry** enables `residential:mansion` on the V2 production route (the engine already had a mansion template — just needed to be added to `SUPPORTED_RESIDENTIAL_V2_SUBTYPES` and the canonical-type map). Disabled commercial / healthcare / education subtypes that are not actually ready end-to-end (retail, mixed-use, shopping-mall, dental, lab, university, kindergarten) now surface a per-subtype "Coming soon" message instead of the generic "Experimental/off" badge.
4. **Entrance auto-detect** now triggers automatically once a site polygon is available (was discoverability-gated behind a button), applies at confidence ≥ 0.5 (was > 0.6), and surfaces an amber "Auto-detected — please confirm" badge when confidence is below 0.7. Manual override clears the auto-detect provenance so the badge disappears and the auto-trigger does not re-run.

## Files changed

19 files — see the diff. New files:
- `src/utils/projectTypeAutoDetect.js`
- `src/__tests__/utils/projectTypeAutoDetect.test.js`
- `api/site/_lib/__tests__/boundaryNormalize.test.js`

## Type activation summary

**Newly enabled (1):**
- `residential:mansion` → Residential V2 (production), canonical `dwelling`, programmeTemplateKey `mansion`. The `residentialProgramEngine` already had a `mansion` template (resolveTemplate + level constraints) so end-to-end support is real. Added to `SUPPORTED_RESIDENTIAL_V2_SUBTYPES` and `RESIDENTIAL_CANONICAL_BY_SUBTYPE`. Tests added.

**Still disabled, with improved per-subtype messaging (7):**
- `commercial:retail` — programme template not yet authored
- `commercial:mixed-use` — sheet-split policy still being validated
- `commercial:shopping-mall` — programme template not yet authored
- `healthcare:dental` — programme template not yet authored (suggest using Medical Clinic)
- `healthcare:lab` — specialist programme work required for safe lab layouts
- `education:university` — programme template not yet authored (suggest using School for smaller campuses)
- `education:kindergarten` — programme template not yet authored

These honor the user's "no blind enable" rule — registry stays gated until a template is authored end-to-end.

## Auto-detection changes

- New deterministic keyword classifier in `src/utils/projectTypeAutoDetect.js`. One keyword table per `enabledInUi` registry entry, ambiguity disambiguation, length-normalised confidence.
- Wired into `SpecsStep` with a 400ms debounce reading from `customNotes` / `title` / `description` / `brief`.
- New `BuildingTypeSelector` chip ("Suggested from your brief") opens the suggested category and renders a confidence band (low/med/high). Click applies. Manual selection sets `projectTypeExplicitlySetByUser` and the chip stays suppressed.

## Boundary styling changes

- Server (`api/site/_lib/boundaryNormalize.js`): new `classifyParcelCandidate` filter rejects parcels > 5,000 m², > 30 vertices, or with `landuse=*` district tags. Falls back to building polygon and surfaces `estimateReason` on the response. The `boundaryAuthoritative` semantic is preserved.
- A1 site plan (`src/services/project/projectGraphVerticalSliceService.js:3802`): switched from red/orange to blue `#1976D2`. Estimated boundaries get a thinner stroke and lower fill opacity. Polygon now drawn even when non-authoritative so the user can see the auto-detected boundary.
- History snapshot (`src/components/ArchitectAIWizardContainer.jsx:1846`): same blue defaults.
- `src/components/map/mapUtils.js:generateMapSnapshotURL`: switched to blue with `SITE_BOUNDARY_STATIC_MAP_COLORS` constants and an `estimated` option.
- `src/components/site/polygonEditor.js`: blue defaults + new `getPolygonEditorStyles({ estimated })` helper.
- `src/services/siteMapSnapshotService.js`: blue default polygon style + blue normalize fallbacks.

## Validation results

| Check | Result |
|---|---|
| `npm run check:env` | **N/A in worktree** — pre-existing missing `.env`. The user's brief explicitly says do-not-touch env vars. CI will run with proper env. |
| `npm run check:contracts` | PASS |
| `npm run lint` | 0 errors, 4 pre-existing `no-mixed-operators` warnings on `polygonContainsPoint` (untouched code) |
| `npm run build:active` | PASS |
| `npm run test:a1:tofu` | PASS |
| `npm run test:compose:routing` | PASS (22/22) |
| `node scripts/tests/test-a1-layout-regression.mjs` | PASS (27/27) |
| Focused Jest (`projectTypeAutoDetect`, `projectTypeSupportRegistry`, `residentialProgramEngine`, `boundaryNormalize`, `BuildingTypeSelector.support`, `SpecsStep.projectTypeSupport`) | PASS (60+ tests across 6 suites) |

## Manual smoke

Visual smoke was deferred to the reviewer's environment because the worktree does not run a dev server with the production env keys (per the no-touch-env-vars rule). The relevant flows for the reviewer:

1. **Residential `detached-house`** — generate end-to-end; confirm blue boundary on site plan; confirm entrance compass shows arrow + "auto-detected — please confirm" badge when confidence is below 0.7; confirm A1 generation completes.
2. **Residential `mansion`** (newly enabled non-default) — confirm selectable in BuildingTypeSelector with "Residential V2" badge; confirm program compiles; confirm A1 generation completes.
3. **Brief auto-detect** — type *"Modern detached family home with garden"* into customNotes; confirm "Suggested from your brief" chip appears with `Detached House`; click chip, confirm category/subType applied; edit brief afterwards, confirm chip stays suppressed.

## Risks / follow-ups

1. **Cross-view consistency** (plan ↔ elevation ↔ section parity) is a deeper Phase 5 follow-up — the user observed inconsistencies in the latest A1 result that this PR does not address. Recommend a separate validator + repair pass.
2. **Programme-template authoring for the 7 still-disabled subtypes** is the gating work that would let them be enabled in a follow-up.
3. The `RESIDENTIAL_PARCEL_MAX_M2 = 5000` threshold is a baseline; if a user reports a legitimate large rural parcel being demoted, the threshold should be tunable per region rather than global.

## Test plan

- [ ] CI runs the focused Jest suites and full lint/contracts/build
- [ ] Reviewer runs the three manual smoke cases above and confirms blue boundary in screenshots
- [ ] Reviewer confirms auto-detect chip behavior end-to-end

STOPPED — draft PR awaiting review. No merge without approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)