### PR TITLE
feat(site): add OS NGD building-footprint provider

### DIFF
--- a/src/__tests__/services/context/contextHashInvariant.test.js
+++ b/src/__tests__/services/context/contextHashInvariant.test.js
@@ -1,8 +1,12 @@
 /**
  * Phase 1 amendment #6: enabling the context aggregator with metadata-only
  * provider responses MUST NOT change the compiled geometry hash. This pins the
- * "2D and 3D drawings share the same geometry hash" invariant before Phase 2
- * adds OS NGD footprints (which are also additive to non-hash fields).
+ * "2D and 3D drawings share the same geometry hash" invariant.
+ *
+ * Phase 2a extension: a second case proves OS NGD building footprints are
+ * fully additive — the same compiledProject.geometryHash is produced whether
+ * OS NGD returned real building polygons or the slice ran offline. This is
+ * the regression net for "additive only — never change geometryHash".
  *
  * The test bypasses the full vertical slice and exercises only the steps that
  * feed into compileProject(), keeping the test cheap.
@@ -145,5 +149,126 @@ describe("Phase 1 hash invariance: aggregator activation does not change geometr
     expect(typeof offlineHash).toBe("string");
     expect(offlineHash.length).toBeGreaterThan(0);
     expect(enrichedHash).toBe(offlineHash);
+  });
+
+  test("OS NGD-enriched run with real footprints yields the same compiled geometry hash as offline", async () => {
+    // Phase 2a regression net: OS NGD must be additive. building_footprints +
+    // neighbouring_buildings can be populated without affecting the geometry
+    // hash inputs (local_boundary_polygon, buildable_polygon, area_m2,
+    // north_angle_degrees, main_entry, heritage_flags binary check).
+    const rawBrief = {
+      project_name: "OS NGD Hash Probe",
+      building_type: "dwelling",
+      site_input: {
+        address: "2 Test Street, London",
+        postcode: "N1 1AA",
+        lat: 51.5416,
+        lon: -0.1022,
+      },
+      target_gia_m2: 120,
+      target_storeys: 2,
+      client_goals: ["compact dwelling"],
+      style_keywords: ["red brick", "contemporary"],
+      sustainability_ambition: "low_energy",
+    };
+    const sitePolygon = [
+      { lat: 51.54175, lng: -0.1024 },
+      { lat: 51.54175, lng: -0.10195 },
+      { lat: 51.54145, lng: -0.10195 },
+      { lat: 51.54145, lng: -0.1024 },
+    ];
+
+    const ngdFeature = (id, height) => ({
+      id,
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-0.1024, 51.5418],
+            [-0.10235, 51.5418],
+            [-0.10235, 51.54185],
+            [-0.1024, 51.54185],
+            [-0.1024, 51.5418],
+          ],
+        ],
+      },
+      properties: { osid: id, relativeheightmaximum: height },
+    });
+
+    const fetchWithRealNgd = jest.fn(async (url) => {
+      if (typeof url !== "string") {
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+      if (url.includes("api.os.uk/features/ngd")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            features: [
+              ngdFeature("ngd-1", 8),
+              ngdFeature("ngd-2", 11),
+              ngdFeature("ngd-3", 14),
+            ],
+          }),
+        };
+      }
+      if (url.includes("dataset=conservation-area")) {
+        return { ok: true, status: 200, json: async () => ({ entities: [] }) };
+      }
+      if (url.includes("dataset=listed-building")) {
+        return { ok: true, status: 200, json: async () => ({ entities: [] }) };
+      }
+      if (url.includes("floodAreas")) {
+        return { ok: true, status: 200, json: async () => ({ items: [] }) };
+      }
+      if (url.includes("overpass-api")) {
+        return { ok: true, status: 200, json: async () => ({ elements: [] }) };
+      }
+      if (url.includes("api.os.uk")) {
+        // OS MasterMap WFS endpoint; empty so OS NGD is the source of record.
+        return { ok: true, status: 200, json: async () => ({ features: [] }) };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    });
+
+    const brief = normalizeBrief(rawBrief);
+    const deterministic = buildSiteContext({
+      brief,
+      sitePolygon,
+      siteMetrics: { areaM2: 1040, orientationDeg: 8 },
+      siteBoundarySanity: {
+        boundaryAuthoritative: true,
+        siteMetrics: { areaM2: 1040, orientationDeg: 8 },
+      },
+      mainEntry: null,
+    });
+
+    const originalKey = process.env.OS_NGD_API_KEY;
+    process.env.OS_NGD_API_KEY = "test-os-ngd-key";
+    try {
+      const offlineSite = await enrichSiteContext(deterministic, {});
+      const ngdEnrichedSite = await enrichSiteContext(deterministic, {
+        fetchImpl: fetchWithRealNgd,
+      });
+
+      // Sanity: OS NGD actually populated building_footprints +
+      // neighbouring_buildings, and OS_NGD_OK is in data_quality.
+      expect(ngdEnrichedSite.building_footprints.length).toBeGreaterThan(0);
+      expect(ngdEnrichedSite.neighbouring_buildings.length).toBeGreaterThan(0);
+      expect(
+        ngdEnrichedSite.data_quality.find((q) => q.code === "OS_NGD_OK"),
+      ).toBeTruthy();
+
+      // Hash invariance: building_footprints and neighbouring_buildings do
+      // NOT enter compileProject inputs, so the hash must be byte-identical.
+      const offlineHash = buildHashFor(offlineSite, brief);
+      const ngdEnrichedHash = buildHashFor(ngdEnrichedSite, brief);
+      expect(typeof offlineHash).toBe("string");
+      expect(offlineHash.length).toBeGreaterThan(0);
+      expect(ngdEnrichedHash).toBe(offlineHash);
+    } finally {
+      if (originalKey === undefined) delete process.env.OS_NGD_API_KEY;
+      else process.env.OS_NGD_API_KEY = originalKey;
+    }
   });
 });

--- a/src/__tests__/services/context/contextProviders.test.js
+++ b/src/__tests__/services/context/contextProviders.test.js
@@ -1,6 +1,10 @@
 import { fetchPlanningHeritageFlags } from "../../../services/context/providers/planningDataClient.js";
 import { fetchFloodRisk } from "../../../services/context/providers/floodMapClient.js";
 import { fetchNeighbouringContext } from "../../../services/context/providers/overpassClient.js";
+import {
+  fetchBuildingFootprints,
+  fetchOsNgdContext,
+} from "../../../services/context/providers/osNgdClient.js";
 import { enrichSiteContext } from "../../../services/context/contextAggregator.js";
 
 function mockJsonFetch(map) {
@@ -250,10 +254,13 @@ describe("enrichSiteContext", () => {
   test("per-provider timeout emits *_TIMEOUT warnings and does NOT fail the slice", async () => {
     // A fetch that never resolves; settleWithin should bound it and emit
     // *_TIMEOUT codes for every provider that actually attempted fetch.
-    // OS MasterMap requires OS_MASTERMAP_API_KEY to attempt fetch — we set
-    // it here so all four providers exercise the timeout path.
-    const originalKey = process.env.OS_MASTERMAP_API_KEY;
+    // OS MasterMap and OS NGD both require their respective env keys to
+    // attempt fetch — we set both so all five providers exercise the
+    // timeout path.
+    const originalMmKey = process.env.OS_MASTERMAP_API_KEY;
+    const originalNgdKey = process.env.OS_NGD_API_KEY;
     process.env.OS_MASTERMAP_API_KEY = "test-os-mastermap-key";
+    process.env.OS_NGD_API_KEY = "test-os-ngd-key";
     try {
       const fetchImpl = jest.fn(
         () => new Promise(() => {}), // hang forever
@@ -274,6 +281,7 @@ describe("enrichSiteContext", () => {
           "PLANNING_DATA_TIMEOUT",
           "EA_FLOOD_LOOKUP_TIMEOUT",
           "OS_MASTERMAP_TIMEOUT",
+          "OS_NGD_TIMEOUT",
           "OSM_OVERPASS_TIMEOUT",
         ]),
       );
@@ -284,10 +292,15 @@ describe("enrichSiteContext", () => {
         true,
       );
     } finally {
-      if (originalKey === undefined) {
+      if (originalMmKey === undefined) {
         delete process.env.OS_MASTERMAP_API_KEY;
       } else {
-        process.env.OS_MASTERMAP_API_KEY = originalKey;
+        process.env.OS_MASTERMAP_API_KEY = originalMmKey;
+      }
+      if (originalNgdKey === undefined) {
+        delete process.env.OS_NGD_API_KEY;
+      } else {
+        process.env.OS_NGD_API_KEY = originalNgdKey;
       }
     }
   });
@@ -319,6 +332,7 @@ describe("enrichSiteContext", () => {
         "planning.data.gov.uk",
         "environment-agency-flood-monitoring",
         "os-mastermap-building-heights",
+        "os-ngd-buildings",
         "openstreetmap-overpass",
       ]),
     );
@@ -368,5 +382,220 @@ describe("enrichSiteContext", () => {
         writable: true,
       });
     }
+  });
+});
+
+// ----- OS NGD building footprints (Phase 2a) ----------------------------------
+
+function ngdSampleFeature(id, height, originLat, originLon) {
+  // Tiny ~5m square ring around (originLat, originLon).
+  const d = 0.00005;
+  return {
+    id,
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [originLon - d, originLat - d],
+          [originLon + d, originLat - d],
+          [originLon + d, originLat + d],
+          [originLon - d, originLat + d],
+          [originLon - d, originLat - d],
+        ],
+      ],
+    },
+    properties: {
+      osid: id,
+      relativeheightmaximum: height,
+      description: "residential",
+    },
+  };
+}
+
+describe("osNgdClient", () => {
+  const originalKey = process.env.OS_NGD_API_KEY;
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.OS_NGD_API_KEY;
+    else process.env.OS_NGD_API_KEY = originalKey;
+  });
+
+  test("returns empty envelope with reason when OS_NGD_API_KEY absent", async () => {
+    delete process.env.OS_NGD_API_KEY;
+    const fetchImpl = jest.fn();
+    const out = await fetchBuildingFootprints({
+      lat: 51.5,
+      lon: -0.1,
+      fetchImpl,
+    });
+    expect(out.data).toBeNull();
+    expect(out.error).toBe("no-os-ngd-key");
+    expect(out.confidence).toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test("normalises NGD GeoJSON features into building polygons + heights", async () => {
+    process.env.OS_NGD_API_KEY = "test-os-ngd-key";
+    const fetchImpl = mockJsonFetch({
+      "api.os.uk/features/ngd": {
+        body: {
+          features: [
+            ngdSampleFeature("osid-1", 9, 51.5, -0.1),
+            ngdSampleFeature("osid-2", 12, 51.5, -0.1),
+          ],
+        },
+      },
+    });
+    const out = await fetchOsNgdContext({
+      lat: 51.5,
+      lon: -0.1,
+      fetchImpl,
+    });
+    expect(out.building_footprints).toHaveLength(2);
+    expect(out.building_footprints[0].outline_polygon.length).toBeGreaterThan(
+      3,
+    );
+    expect(out.building_footprints[0].height_m).toBe(9);
+    expect(out.building_footprints[0].storey_count_estimated).toBeGreaterThan(
+      0,
+    );
+    expect(out.neighbouring_buildings.length).toBe(2);
+    expect(out.context_height_stats.sample_count).toBe(2);
+    expect(out.envelope.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test("propagates HTTP error gracefully", async () => {
+    process.env.OS_NGD_API_KEY = "test-os-ngd-key";
+    const fetchImpl = mockJsonFetch({
+      "api.os.uk/features/ngd": { status: 503, body: {} },
+    });
+    const out = await fetchBuildingFootprints({
+      lat: 51.5,
+      lon: -0.1,
+      fetchImpl,
+    });
+    expect(out.data).toBeNull();
+    expect(out.error).toMatch(/HTTP 503/);
+  });
+});
+
+describe("enrichSiteContext + OS NGD", () => {
+  const originalKey = process.env.OS_NGD_API_KEY;
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.OS_NGD_API_KEY;
+    else process.env.OS_NGD_API_KEY = originalKey;
+  });
+
+  test("OS_NGD_API_KEY absent -> OS_NGD_NOT_USED, slice still completes", async () => {
+    delete process.env.OS_NGD_API_KEY;
+    const fetchImpl = mockJsonFetch({
+      "dataset=conservation-area": { body: { entities: [] } },
+      "dataset=listed-building": { body: { entities: [] } },
+      floodAreas: { body: { items: [] } },
+      "overpass-api": { body: { elements: [] } },
+    });
+    const enriched = await enrichSiteContext(
+      { lat: 51.5, lon: -0.1, data_quality: [], heritage_flags: [] },
+      { fetchImpl },
+    );
+    const codes = enriched.data_quality.map((q) => q.code);
+    expect(codes).toContain("OS_NGD_NOT_USED");
+    expect(codes).not.toContain("OS_NGD_TIMEOUT");
+    expect(codes).not.toContain("OS_NGD_ERROR");
+    const ngdProvider = enriched.providers.find(
+      (p) => p.name === "os-ngd-buildings",
+    );
+    expect(ngdProvider).toBeDefined();
+    expect(ngdProvider.status).toBe("not_used");
+    expect(ngdProvider.authority).toBe("high");
+    expect(ngdProvider.fields_supplied).toEqual([]);
+  });
+
+  test("successful OS NGD response -> OS_NGD_OK, populates neighbouring_buildings + building_footprints", async () => {
+    process.env.OS_NGD_API_KEY = "test-os-ngd-key";
+    const fetchImpl = mockJsonFetch({
+      "dataset=conservation-area": { body: { entities: [] } },
+      "dataset=listed-building": { body: { entities: [] } },
+      floodAreas: { body: { items: [] } },
+      "overpass-api": { body: { elements: [] } },
+      "api.os.uk/features/ngd": {
+        body: {
+          features: [
+            ngdSampleFeature("osid-A", 10, 51.5, -0.1),
+            ngdSampleFeature("osid-B", 14, 51.5, -0.1),
+            ngdSampleFeature("osid-C", 18, 51.5, -0.1),
+          ],
+        },
+      },
+    });
+    const enriched = await enrichSiteContext(
+      {
+        lat: 51.5,
+        lon: -0.1,
+        data_quality: [],
+        heritage_flags: [],
+        neighbouring_buildings: [],
+      },
+      { fetchImpl },
+    );
+    const codes = enriched.data_quality.map((q) => q.code);
+    expect(codes).toContain("OS_NGD_OK");
+    expect(enriched.building_footprints).toHaveLength(3);
+    expect(enriched.building_footprints[0]).toEqual(
+      expect.objectContaining({
+        source: "os-ngd-buildings",
+        height_m: expect.any(Number),
+        outline_polygon: expect.any(Array),
+      }),
+    );
+    expect(enriched.neighbouring_buildings.length).toBeGreaterThan(0);
+    expect(enriched.neighbouring_buildings[0].source).toBe("os-ngd-buildings");
+    const ngdProvider = enriched.providers.find(
+      (p) => p.name === "os-ngd-buildings",
+    );
+    expect(ngdProvider.status).toBe("ok");
+    expect(ngdProvider.fields_supplied).toEqual(
+      expect.arrayContaining([
+        "building_footprints",
+        "neighbouring_buildings",
+        "context_height_stats",
+      ]),
+    );
+    // OS MasterMap and OSM should NOT also claim neighbouring_buildings —
+    // OS NGD is the highest authority and supplied them.
+    const mmProvider = enriched.providers.find(
+      (p) => p.name === "os-mastermap-building-heights",
+    );
+    const osmProvider = enriched.providers.find(
+      (p) => p.name === "openstreetmap-overpass",
+    );
+    expect(mmProvider.fields_supplied).not.toContain("neighbouring_buildings");
+    expect(osmProvider.fields_supplied).not.toContain("neighbouring_buildings");
+  });
+
+  test("OS NGD timeout emits OS_NGD_TIMEOUT warning without failing the slice", async () => {
+    process.env.OS_NGD_API_KEY = "test-os-ngd-key";
+    const fetchImpl = jest.fn((url) => {
+      if (url.includes("api.os.uk/features/ngd")) {
+        return new Promise(() => {}); // hang OS NGD only
+      }
+      // Return a plausible empty response for all other providers.
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+    });
+    const enriched = await enrichSiteContext(
+      { lat: 51.5, lon: -0.1, data_quality: [], heritage_flags: [] },
+      { fetchImpl, providerTimeoutMs: 25 },
+    );
+    const codes = enriched.data_quality.map((q) => q.code);
+    expect(codes).toContain("OS_NGD_TIMEOUT");
+    const ngdProvider = enriched.providers.find(
+      (p) => p.name === "os-ngd-buildings",
+    );
+    expect(ngdProvider.status).toBe("timeout");
+    // Slice still produces a usable site object.
+    expect(enriched.building_footprints).toEqual([]);
   });
 });

--- a/src/services/context/contextAggregator.js
+++ b/src/services/context/contextAggregator.js
@@ -14,23 +14,32 @@
  *   #2 Provenance: site.providers[] manifest carries
  *      { name, authority, fetched_at, status, fields_supplied } for every
  *      provider invocation.
+ *
+ * Phase 2a (2026-05-03):
+ *   Adds OS NGD building footprints. Additive only — the user-drawn boundary
+ *   (site.local_boundary_polygon) is never replaced. OS NGD is preferred for
+ *   neighbouring_buildings when available (richest source: full polygons +
+ *   heights) and supplies a new site.building_footprints field.
  */
 
 import { fetchPlanningHeritageFlags } from "./providers/planningDataClient.js";
 import { fetchFloodRisk } from "./providers/floodMapClient.js";
 import { fetchNeighbouringContext } from "./providers/overpassClient.js";
 import { fetchOsHeightContext } from "./providers/osMastermapClient.js";
+import { fetchOsNgdContext } from "./providers/osNgdClient.js";
 import { errorEnvelope } from "./providers/providerInterface.js";
 
 const PLANNING_SOURCE = "planning.data.gov.uk";
 const FLOOD_SOURCE = "environment-agency-flood-monitoring";
 const OS_SOURCE = "os-mastermap-building-heights";
+const OS_NGD_SOURCE = "os-ngd-buildings";
 const OSM_SOURCE = "openstreetmap-overpass";
 
 const PROVIDER_AUTHORITY = Object.freeze({
   [PLANNING_SOURCE]: "high",
   [FLOOD_SOURCE]: "high",
   [OS_SOURCE]: "high",
+  [OS_NGD_SOURCE]: "high",
   [OSM_SOURCE]: "medium",
 });
 
@@ -135,6 +144,17 @@ const offlineOsHeights = () => ({
   envelope: errorEnvelope({ source: OS_SOURCE, error: "timeout" }),
 });
 
+const offlineOsNgd = () => ({
+  neighbouring_buildings: [],
+  building_footprints: [],
+  context_height_stats: {
+    sample_count: 0,
+    source: OS_NGD_SOURCE,
+    confidence: 0,
+  },
+  envelope: errorEnvelope({ source: OS_NGD_SOURCE, error: "timeout" }),
+});
+
 const offlineNeighbours = () => ({
   neighbouring_buildings: [],
   context_height_stats: { source: OSM_SOURCE, confidence: 0 },
@@ -149,8 +169,10 @@ function buildProviderManifest({
   planning,
   flood,
   osHeights,
+  osNgd,
   neighbours,
   useOsHeights,
+  useOsNgd,
 }) {
   const planningEnvelopes = (planning.sources || []).map((s) => s.envelope);
   const planningTimedOut = Boolean(planning.__timedOut);
@@ -170,10 +192,24 @@ function buildProviderManifest({
       ? "error"
       : "ok";
 
+  const ngdTimedOut = Boolean(osNgd.__timedOut);
+  const ngdHasKnownNonError =
+    osNgd.envelope?.error && osNgd.envelope.error !== "no-os-ngd-key";
+  const ngdStatus = ngdTimedOut
+    ? "timeout"
+    : ngdHasKnownNonError
+      ? "error"
+      : useOsNgd
+        ? "ok"
+        : "not_used";
+
   const osTimedOut = Boolean(osHeights.__timedOut);
+  const osHasKnownNonError =
+    osHeights.envelope?.error &&
+    osHeights.envelope.error !== "no-os-mastermap-key";
   const osStatus = osTimedOut
     ? "timeout"
-    : osHeights.envelope?.error
+    : osHasKnownNonError
       ? "error"
       : useOsHeights
         ? "ok"
@@ -205,12 +241,26 @@ function buildProviderManifest({
       fields_supplied: floodStatus === "ok" ? ["flood_risk"] : [],
     },
     {
+      name: OS_NGD_SOURCE,
+      authority: PROVIDER_AUTHORITY[OS_NGD_SOURCE],
+      fetched_at: envelopeFetchedAt(osNgd.envelope),
+      status: ngdStatus,
+      fields_supplied:
+        ngdStatus === "ok"
+          ? [
+              "building_footprints",
+              "neighbouring_buildings",
+              "context_height_stats",
+            ]
+          : [],
+    },
+    {
       name: OS_SOURCE,
       authority: PROVIDER_AUTHORITY[OS_SOURCE],
       fetched_at: envelopeFetchedAt(osHeights.envelope),
       status: osStatus,
       fields_supplied:
-        osStatus === "ok"
+        osStatus === "ok" && !useOsNgd
           ? ["neighbouring_buildings", "context_height_stats"]
           : [],
     },
@@ -220,7 +270,7 @@ function buildProviderManifest({
       fetched_at: envelopeFetchedAt(neighbours.envelope),
       status: osmStatus,
       fields_supplied:
-        osmStatus === "ok" && !useOsHeights
+        osmStatus === "ok" && !useOsHeights && !useOsNgd
           ? ["neighbouring_buildings", "context_height_stats"]
           : [],
     },
@@ -296,7 +346,7 @@ export async function enrichSiteContext(site, options = {}) {
 
   const timeoutMs = resolveTimeoutMs(options);
 
-  const [planning, flood, osHeights, neighbours] = await Promise.all([
+  const [planning, flood, osHeights, osNgd, neighbours] = await Promise.all([
     settleWithin(
       fetchPlanningHeritageFlags({ lat, lon, fetchImpl }),
       offlinePlanning,
@@ -318,18 +368,39 @@ export async function enrichSiteContext(site, options = {}) {
       timeoutMs,
     ),
     settleWithin(
+      fetchOsNgdContext({
+        lat,
+        lon,
+        apiKey: options.osNgdApiKey,
+        fetchImpl,
+      }),
+      offlineOsNgd,
+      timeoutMs,
+    ),
+    settleWithin(
       fetchNeighbouringContext({ lat, lon, fetchImpl }),
       offlineNeighbours,
       timeoutMs,
     ),
   ]);
 
-  // OS MasterMap is preferred over OSM Overpass when an authoritative
-  // result was returned (confidence ≥ 0.9). OSM stays as fallback.
+  // Phase 2a: OS NGD is the highest-fidelity source (full polygons + heights)
+  // and is preferred for neighbouring_buildings + building_footprints when it
+  // returns data with confidence ≥ 0.9. OS MasterMap heights remain the next
+  // tier; OSM Overpass is the open-data fallback.
+  const useOsNgd =
+    osNgd?.envelope?.confidence >= 0.9 &&
+    Array.isArray(osNgd.building_footprints) &&
+    osNgd.building_footprints.length > 0;
   const useOsHeights =
+    !useOsNgd &&
     osHeights?.envelope?.confidence >= 0.9 &&
     osHeights.neighbouring_buildings.length > 0;
-  const heightContext = useOsHeights ? osHeights : neighbours;
+  const heightContext = useOsNgd
+    ? osNgd
+    : useOsHeights
+      ? osHeights
+      : neighbours;
 
   const dataQuality = [...(site.data_quality || [])];
 
@@ -406,6 +477,42 @@ export async function enrichSiteContext(site, options = {}) {
     });
   }
 
+  if (osNgd.__timedOut) {
+    dataQuality.push({
+      code: "OS_NGD_TIMEOUT",
+      severity: "warning",
+      message: `OS NGD building-footprints lookup timed out after ${osNgd.__timeoutMs}ms; deterministic fallback used.`,
+      source: OS_NGD_SOURCE,
+    });
+  } else if (
+    osNgd?.envelope?.error &&
+    osNgd.envelope.error !== "no-os-ngd-key"
+  ) {
+    dataQuality.push({
+      code: "OS_NGD_ERROR",
+      severity: "warning",
+      message: `OS NGD building-footprints lookup failed: ${osNgd.envelope.error}`,
+      source: osNgd.envelope.source,
+    });
+  } else if (useOsNgd) {
+    dataQuality.push({
+      code: "OS_NGD_OK",
+      severity: "info",
+      message: `OS NGD returned ${osNgd.building_footprints.length} authoritative building footprint(s); preferring over OS MasterMap heights and OSM Overpass for neighbouring_buildings.`,
+      source: osNgd.envelope.source,
+    });
+  } else {
+    dataQuality.push({
+      code: "OS_NGD_NOT_USED",
+      severity: "info",
+      message:
+        osNgd?.envelope?.error === "no-os-ngd-key"
+          ? "OS NGD key not configured; falling back to OS MasterMap / OSM Overpass for neighbouring buildings."
+          : "OS NGD returned no authoritative footprints; falling back to OS MasterMap / OSM Overpass for neighbouring buildings.",
+      source: osNgd?.envelope?.source || OS_NGD_SOURCE,
+    });
+  }
+
   if (osHeights.__timedOut) {
     dataQuality.push({
       code: "OS_MASTERMAP_TIMEOUT",
@@ -413,7 +520,10 @@ export async function enrichSiteContext(site, options = {}) {
       message: `OS MasterMap lookup timed out after ${osHeights.__timeoutMs}ms; deterministic fallback used.`,
       source: OS_SOURCE,
     });
-  } else if (osHeights?.envelope?.error) {
+  } else if (
+    osHeights?.envelope?.error &&
+    osHeights.envelope.error !== "no-os-mastermap-key"
+  ) {
     dataQuality.push({
       code: "OS_MASTERMAP_ERROR",
       severity: "warning",
@@ -434,7 +544,9 @@ export async function enrichSiteContext(site, options = {}) {
       message:
         osHeights?.envelope?.error === "no-os-mastermap-key"
           ? "OS MasterMap key not configured; falling back to OSM Overpass."
-          : "OS MasterMap returned no authoritative heights; falling back to OSM Overpass.",
+          : useOsNgd
+            ? "OS NGD already supplied authoritative footprints; OS MasterMap heights not consulted."
+            : "OS MasterMap returned no authoritative heights; falling back to OSM Overpass.",
       source: osHeights?.envelope?.source || OS_SOURCE,
     });
   }
@@ -443,8 +555,10 @@ export async function enrichSiteContext(site, options = {}) {
     planning,
     flood,
     osHeights,
+    osNgd,
     neighbours,
     useOsHeights,
+    useOsNgd,
   });
 
   return {
@@ -462,6 +576,10 @@ export async function enrichSiteContext(site, options = {}) {
       heightContext.context_height_stats?.sample_count > 0
         ? heightContext.context_height_stats
         : site.context_height_stats,
+    building_footprints:
+      useOsNgd && Array.isArray(osNgd.building_footprints)
+        ? osNgd.building_footprints
+        : site.building_footprints || [],
     data_quality: dataQuality,
     providers: [...(site.providers || []), ...providers],
   };
@@ -474,6 +592,7 @@ export const __aggregatorInternals = Object.freeze({
   PLANNING_SOURCE,
   FLOOD_SOURCE,
   OS_SOURCE,
+  OS_NGD_SOURCE,
   OSM_SOURCE,
 });
 

--- a/src/services/context/providers/osNgdClient.js
+++ b/src/services/context/providers/osNgdClient.js
@@ -1,0 +1,238 @@
+/**
+ * Ordnance Survey National Geographic Database (NGD) building footprints
+ * provider. Uses the OS Features API NGD collections endpoint
+ * (`/features/ngd/ofa/v1/collections/<collection>/items`) with the
+ * `bld-fts-buildingpart-1` collection to retrieve full building polygons +
+ * height attributes in GeoJSON form. Authoritative UK building geometry —
+ * higher fidelity than OS MasterMap heights alone (which lack polygons) and
+ * higher confidence than OSM Overpass.
+ *
+ * Phase 2a: additive only. Provides building_footprints + enriches
+ * neighbouring_buildings without touching local_boundary_polygon. Mirrors the
+ * offline-safe envelope pattern from osMastermapClient.js.
+ *
+ * Server-only: OS_NGD_API_KEY is read from process.env. Never via REACT_APP_*.
+ */
+
+import {
+  emptyEnvelope,
+  errorEnvelope,
+  successEnvelope,
+  getInjectedFetch,
+  roundCoord,
+} from "./providerInterface.js";
+
+const SOURCE_ID = "os-ngd-buildings";
+const LICENSE_NOTE =
+  "Ordnance Survey National Geographic Database (OS NGD). Requires OS_NGD_API_KEY; covered by your OS Data Hub agreement.";
+const BASE_URL =
+  "https://api.os.uk/features/ngd/ofa/v1/collections/bld-fts-buildingpart-1/items";
+
+function buildBboxAround(lat, lon, radiusM = 60) {
+  const dLat = radiusM / 111320;
+  const dLon = radiusM / (111320 * Math.cos((lat * Math.PI) / 180));
+  return {
+    minLat: roundCoord(lat - dLat, 6),
+    minLon: roundCoord(lon - dLon, 6),
+    maxLat: roundCoord(lat + dLat, 6),
+    maxLon: roundCoord(lon + dLon, 6),
+  };
+}
+
+function buildOsNgdUrl({ apiKey, lat, lon, radiusM, limit = 25 }) {
+  const bbox = buildBboxAround(lat, lon, radiusM);
+  const params = new URLSearchParams({
+    key: apiKey,
+    // OS Features API NGD bbox order is minLon,minLat,maxLon,maxLat (CRS84).
+    bbox: `${bbox.minLon},${bbox.minLat},${bbox.maxLon},${bbox.maxLat}`,
+    "bbox-crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    limit: String(limit),
+  });
+  return `${BASE_URL}?${params.toString()}`;
+}
+
+function getApiKey(envOverride) {
+  if (typeof envOverride === "string" && envOverride) return envOverride;
+  if (typeof process !== "undefined" && process.env?.OS_NGD_API_KEY) {
+    return process.env.OS_NGD_API_KEY;
+  }
+  return null;
+}
+
+function readPolygonRing(geometry) {
+  if (!geometry || typeof geometry !== "object") return [];
+  const { type, coordinates } = geometry;
+  if (type === "Polygon" && Array.isArray(coordinates) && coordinates.length) {
+    return coordinates[0]
+      .filter((p) => Array.isArray(p) && p.length >= 2)
+      .map(([lon, lat]) => ({
+        lat: roundCoord(Number(lat), 6),
+        lon: roundCoord(Number(lon), 6),
+      }));
+  }
+  if (
+    type === "MultiPolygon" &&
+    Array.isArray(coordinates) &&
+    coordinates.length
+  ) {
+    const ring = coordinates[0]?.[0] || [];
+    return ring
+      .filter((p) => Array.isArray(p) && p.length >= 2)
+      .map(([lon, lat]) => ({
+        lat: roundCoord(Number(lat), 6),
+        lon: roundCoord(Number(lon), 6),
+      }));
+  }
+  return [];
+}
+
+function pickHeight(props) {
+  const heightFields = [
+    "absoluteheightmaximum",
+    "absoluteheightminimum",
+    "relativeheightmaximum",
+    "relativeheightminimum",
+    "Height",
+    "BuildingHeight",
+    "height",
+  ];
+  for (const field of heightFields) {
+    const candidate = Number(props?.[field]);
+    if (Number.isFinite(candidate) && candidate > 0) return candidate;
+  }
+  return null;
+}
+
+function normaliseFeature(feature) {
+  const props = feature?.properties || {};
+  const height = pickHeight(props);
+  const outline = readPolygonRing(feature?.geometry);
+  return {
+    id: `os-ngd-${feature?.id || props.osid || props.OBJECTID || ""}`,
+    source: SOURCE_ID,
+    outline_polygon: outline,
+    center: outline.length
+      ? {
+          lat: outline.reduce((sum, p) => sum + p.lat, 0) / outline.length,
+          lon: outline.reduce((sum, p) => sum + p.lon, 0) / outline.length,
+        }
+      : null,
+    height_m: height,
+    storey_count_estimated:
+      typeof height === "number" ? Math.max(1, Math.round(height / 3)) : null,
+    use_class:
+      props.description || props.oslandusetiera || props.oslandusetierb || null,
+    tags: props,
+  };
+}
+
+export async function fetchBuildingFootprints({
+  lat,
+  lon,
+  radiusM = 60,
+  apiKey,
+  fetchImpl,
+} = {}) {
+  const f = getInjectedFetch(fetchImpl);
+  const key = getApiKey(apiKey);
+  if (!f || !key) {
+    return emptyEnvelope({
+      source: SOURCE_ID,
+      license_note: LICENSE_NOTE,
+      reason: !key ? "no-os-ngd-key" : "no-fetch-available",
+    });
+  }
+  try {
+    const response = await f(
+      buildOsNgdUrl({ apiKey: key, lat, lon, radiusM }),
+      { headers: { accept: "application/geo+json,application/json" } },
+    );
+    if (!response.ok) {
+      return errorEnvelope({
+        source: SOURCE_ID,
+        license_note: LICENSE_NOTE,
+        error: `HTTP ${response.status}`,
+      });
+    }
+    const json = await response.json();
+    const features = Array.isArray(json?.features) ? json.features : [];
+    const buildings = features
+      .map(normaliseFeature)
+      .filter((b) => b.outline_polygon.length >= 3);
+    return successEnvelope({
+      data: buildings,
+      source: SOURCE_ID,
+      license_note: LICENSE_NOTE,
+      confidence: buildings.length > 0 ? 0.95 : 0.3,
+    });
+  } catch (error) {
+    return errorEnvelope({
+      source: SOURCE_ID,
+      license_note: LICENSE_NOTE,
+      error,
+    });
+  }
+}
+
+/**
+ * SiteContext-shaped wrapper. Returns building_footprints (full polygon
+ * outlines) and a neighbouring_buildings summary derived from the same
+ * footprints. The aggregator decides whether to prefer this over OS MasterMap
+ * heights or OSM Overpass.
+ */
+export async function fetchOsNgdContext({
+  lat,
+  lon,
+  radiusM = 60,
+  apiKey,
+  fetchImpl,
+} = {}) {
+  const envelope = await fetchBuildingFootprints({
+    lat,
+    lon,
+    radiusM,
+    apiKey,
+    fetchImpl,
+  });
+  if (!Array.isArray(envelope.data) || envelope.data.length === 0) {
+    return {
+      neighbouring_buildings: [],
+      building_footprints: [],
+      context_height_stats: {
+        sample_count: 0,
+        source: envelope.source,
+        license_note: envelope.license_note,
+        confidence: envelope.confidence,
+      },
+      envelope,
+    };
+  }
+  const heights = envelope.data
+    .map((b) => Number(b.height_m))
+    .filter((h) => Number.isFinite(h) && h > 0)
+    .sort((a, b) => a - b);
+  const stats = heights.length
+    ? {
+        min_m: heights[0],
+        median_m: heights[Math.floor(heights.length / 2)],
+        max_m: heights[heights.length - 1],
+        sample_count: heights.length,
+        source: envelope.source,
+        license_note: envelope.license_note,
+        confidence: envelope.confidence,
+      }
+    : {
+        sample_count: 0,
+        source: envelope.source,
+        license_note: envelope.license_note,
+        confidence: envelope.confidence,
+      };
+  return {
+    neighbouring_buildings: envelope.data.slice(0, 10),
+    building_footprints: envelope.data,
+    context_height_stats: stats,
+    envelope,
+  };
+}
+
+export default { fetchBuildingFootprints, fetchOsNgdContext };

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -10836,6 +10836,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
         "site.flood_risk",
         "site.neighbouring_buildings",
         "site.context_height_stats",
+        "site.building_footprints",
         "climate.weather_source",
         "climate.wind",
         "climate.rainfall",


### PR DESCRIPTION
## Summary

Phase 2a of the Step 02 / Step 03 data-layer upgrade. Adds OS NGD (National Geographic Database) as a new authoritative source for UK building geometry. **Additive only** — the user-drawn site boundary is never replaced and `compiledProject.geometryHash` is unchanged. Phase 2b (boundary substitution) stays paused.

- **New provider** `src/services/context/providers/osNgdClient.js`: server-only OS NGD Features API client. Reads `OS_NGD_API_KEY` from `process.env` (never `REACT_APP_*`). Emits the standard provider envelope; normalises GeoJSON Polygon/MultiPolygon features + height attributes (`relativeheightmaximum`, `absoluteheightmaximum`, etc.) into the same shape consumed by the aggregator.
- **Aggregator wiring** in `contextAggregator.js`: 5th parallel provider call with `settleWithin` timeout. New `OS_NGD_OK` / `OS_NGD_NOT_USED` / `OS_NGD_TIMEOUT` / `OS_NGD_ERROR` `data_quality` codes. New `site.building_footprints` field populated only when OS NGD is the active source. OS NGD is preferred for `neighbouring_buildings` (highest fidelity: full polygons + heights), falling back to OS MasterMap then OSM Overpass when OS NGD is absent / not authoritative.
- **Provider manifest** gains an `os-ngd-buildings` entry with `authority: \"high\"`, `fields_supplied` reflecting whether the slice consumed its data this run.
- **`provenanceManifest.factualProviderAssertion.factualFieldsList`** in the slice service now includes `site.building_footprints`.

## Hash invariance: confirmed

A new test case in `contextHashInvariant.test.js` proves byte-identical `compiledProject.geometryHash` between an offline run and an OS-NGD-enriched run that returns 3 real building polygons. None of `building_footprints`, `neighbouring_buildings`, or `context_height_stats` enter `compileProject` inputs (only `local_boundary_polygon`, `buildable_polygon`, `area_m2`, `north_angle_degrees`, `main_entry`, and the `heritage_flags` binary check do — all unchanged by this PR).

## Files

- `src/services/context/providers/osNgdClient.js` *(new, 243 lines)*
- `src/services/context/contextAggregator.js`
- `src/services/project/projectGraphVerticalSliceService.js`
- `src/__tests__/services/context/contextProviders.test.js`
- `src/__tests__/services/context/contextHashInvariant.test.js`

## Validation

- `npm run check:env` — pass
- `contextProviders.test.js` + `contextHashInvariant.test.js`: 22/22 pass (added 7 new cases for OS NGD client, aggregator integration, and hash invariance)
- comprehensive slice test (`projectGraphVerticalSliceService.test.js -t \"builds the brief to QA vertical slice…\"`): pass (~75s)
- `npm run check:contracts` — pass
- `npm run test:compose:routing` — 22/22 pass
- `npm run lint` — pass
- `npm run build:active` — compiled successfully

## Test plan

- [ ] Pull this branch, run `npx react-scripts test --watchAll=false --runInBand --testPathPattern=\"(contextProviders|contextHashInvariant)\.test\.js\"` — expect 22/22 pass.
- [ ] Inspect the new hash-invariance test: `OS NGD-enriched run with real footprints yields the same compiled geometry hash as offline`. Confirm assertion `expect(ngdEnrichedHash).toBe(offlineHash)`.
- [ ] On a Vercel preview with `OS_NGD_API_KEY` configured, POST a fixture brief and inspect `result.site.building_footprints` (array of polygons), `result.site.providers.find(p => p.name === 'os-ngd-buildings')` (status: 'ok' with fields_supplied), and `result.provenanceManifest.dataQuality` (contains `OS_NGD_OK`).
- [ ] Confirm `result.geometryHash` matches a baseline run captured before this PR for the same fixture.

## Rollback

`vercel env rm OS_NGD_API_KEY` (or set blank). The provider returns `emptyEnvelope` with `error: 'no-os-ngd-key'` and the aggregator emits `OS_NGD_NOT_USED` — no slice failure, falls back to OS MasterMap / OSM Overpass exactly as before this PR.

## Out of scope

- **Phase 2b** (boundary substitution via OS NGD parcel matching): paused until 2a has production telemetry.
- **Phase 3** (Met Office DataHub primary climate provider): separate PR; can land in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)