### PR TITLE
feat(climate): add Met Office primary weather provider chain

### DIFF
--- a/src/__tests__/services/climate/weatherProviders.test.js
+++ b/src/__tests__/services/climate/weatherProviders.test.js
@@ -6,6 +6,10 @@ import {
   UKCP18_DATASET,
   ukcp18ReferenceFor,
 } from "../../../services/climate/weatherProviders/ukcp18Reference.js";
+import { fetchWeather as fetchMetOffice } from "../../../services/climate/weatherProviders/metOfficeDataHubProvider.js";
+import { fetchWeather as fetchOpenMeteo } from "../../../services/climate/weatherProviders/openMeteoProvider.js";
+import { fetchWeather as fetchOpenWeather } from "../../../services/climate/weatherProviders/openWeatherProvider.js";
+import { weatherService } from "../../../services/weatherService.js";
 
 function fakeEpwHeader({ rowCount = 8760, lat = 51.5, lon = -0.1 } = {}) {
   const header = [
@@ -91,5 +95,311 @@ describe("ukcp18Reference", () => {
     const ref = ukcp18ReferenceFor({});
     expect(ref.site_query).toBeNull();
     expect(ref.dataset).toBe(UKCP18_DATASET);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Phase 3: Met Office DataHub → Open-Meteo → OpenWeather provider chain.
+// --------------------------------------------------------------------------
+
+function jsonResponse(body, status = 200) {
+  return { ok: status >= 200 && status < 400, status, json: async () => body };
+}
+
+const SAMPLE_METOFFICE_TIMESERIES = {
+  features: [
+    {
+      properties: {
+        timeSeries: [
+          {
+            screenTemperature: 12.5,
+            windSpeed10m: 4.2,
+            windDirectionFrom10m: 200,
+            totalPrecipAmount: 0.3,
+          },
+          {
+            screenTemperature: 11.8,
+            windSpeed10m: 4.5,
+            windDirectionFrom10m: 210,
+            totalPrecipAmount: 0.1,
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const SAMPLE_OPEN_METEO = {
+  current_weather: { temperature: 13.4, windspeed: 14, winddirection: 180 },
+  daily: {
+    temperature_2m_max: [16.5],
+    temperature_2m_min: [9.5],
+    precipitation_sum: [0.5],
+    wind_direction_10m_dominant: [180],
+  },
+};
+
+const SAMPLE_OPENWEATHER = {
+  main: { temp: 11.0, temp_min: 9.0, temp_max: 14.0 },
+  wind: { speed: 4.0, deg: 90 },
+  rain: { "1h": 0.2 },
+};
+
+describe("metOfficeDataHubProvider", () => {
+  const originalKey = process.env.METOFFICE_DATAHUB_API_KEY;
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.METOFFICE_DATAHUB_API_KEY;
+    else process.env.METOFFICE_DATAHUB_API_KEY = originalKey;
+  });
+
+  test("returns offline envelope when METOFFICE_DATAHUB_API_KEY is absent", async () => {
+    delete process.env.METOFFICE_DATAHUB_API_KEY;
+    const fetchImpl = jest.fn();
+    const out = await fetchMetOffice({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data).toBeNull();
+    expect(out.envelope.error).toBe("no-metoffice-datahub-key");
+    expect(out.provider).toBe("met-office-datahub");
+    expect(out.authority).toBe("high");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test("normalises a successful timeSeries response", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-key";
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse(SAMPLE_METOFFICE_TIMESERIES),
+    );
+    const out = await fetchMetOffice({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data.temperature.current).toBe(12.5);
+    expect(out.data.temperature.min).toBe(11.8);
+    expect(out.data.temperature.max).toBe(12.5);
+    expect(out.data.wind.speed).toBe(4.2);
+    expect(out.data.wind.cardinal).toBe("S");
+    expect(out.data.precipitation.daily).toBeCloseTo(0.4, 5);
+    expect(out.data.climateZone).toBe("Temperate");
+    expect(out.envelope.error).toBeNull();
+    expect(out.envelope.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test("returns error envelope on HTTP 503", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-key";
+    const fetchImpl = jest.fn(async () => jsonResponse({}, 503));
+    const out = await fetchMetOffice({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data).toBeNull();
+    expect(out.envelope.error).toMatch(/HTTP 503/);
+  });
+
+  test("times out after providerTimeoutMs and returns timeout envelope", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-key";
+    const fetchImpl = jest.fn(() => new Promise(() => {}));
+    const out = await fetchMetOffice({
+      lat: 51.5,
+      lon: -0.1,
+      fetchImpl,
+      timeoutMs: 25,
+    });
+    expect(out.__timedOut).toBe(true);
+    expect(out.envelope.error).toMatch(/timeout/);
+  });
+});
+
+describe("openMeteoProvider", () => {
+  test("normalises a successful Open-Meteo response (no key required)", async () => {
+    const fetchImpl = jest.fn(async () => jsonResponse(SAMPLE_OPEN_METEO));
+    const out = await fetchOpenMeteo({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data.temperature.current).toBe(13.4);
+    expect(out.data.wind.speed).toBe(14);
+    expect(out.data.wind.cardinal).toBe("S");
+    expect(out.data.precipitation.daily).toBe(0.5);
+    expect(out.envelope.error).toBeNull();
+    expect(out.authority).toBe("medium");
+  });
+
+  test("propagates HTTP 502 as error envelope", async () => {
+    const fetchImpl = jest.fn(async () => jsonResponse({}, 502));
+    const out = await fetchOpenMeteo({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data).toBeNull();
+    expect(out.envelope.error).toMatch(/HTTP 502/);
+  });
+});
+
+describe("openWeatherProvider", () => {
+  const originalKey = process.env.OPENWEATHER_API_KEY;
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.OPENWEATHER_API_KEY;
+    else process.env.OPENWEATHER_API_KEY = originalKey;
+  });
+
+  test("returns offline envelope when OPENWEATHER_API_KEY is absent", async () => {
+    delete process.env.OPENWEATHER_API_KEY;
+    const fetchImpl = jest.fn();
+    const out = await fetchOpenWeather({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data).toBeNull();
+    expect(out.envelope.error).toBe("no-openweather-key");
+    expect(out.authority).toBe("low");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test("normalises a successful OpenWeather response", async () => {
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = jest.fn(async () => jsonResponse(SAMPLE_OPENWEATHER));
+    const out = await fetchOpenWeather({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data.temperature.current).toBe(11);
+    expect(out.data.wind.speed).toBe(4);
+    expect(out.data.wind.cardinal).toBe("E");
+    expect(out.data.precipitation.daily).toBe(0.2);
+    expect(out.authority).toBe("low");
+    expect(out.envelope.error).toBeNull();
+  });
+});
+
+describe("weatherService chain", () => {
+  const originalMo = process.env.METOFFICE_DATAHUB_API_KEY;
+  const originalOw = process.env.OPENWEATHER_API_KEY;
+  afterEach(() => {
+    if (originalMo === undefined) delete process.env.METOFFICE_DATAHUB_API_KEY;
+    else process.env.METOFFICE_DATAHUB_API_KEY = originalMo;
+    if (originalOw === undefined) delete process.env.OPENWEATHER_API_KEY;
+    else process.env.OPENWEATHER_API_KEY = originalOw;
+  });
+
+  function chainFetch({ metOffice, openMeteo, openWeather }) {
+    return jest.fn(async (url) => {
+      if (typeof url !== "string") return jsonResponse({});
+      if (url.includes("data.hub.api.metoffice.gov.uk")) {
+        return metOffice ?? jsonResponse({}, 503);
+      }
+      if (url.includes("api.open-meteo.com")) {
+        return openMeteo ?? jsonResponse({}, 503);
+      }
+      if (url.includes("api.openweathermap.org")) {
+        return openWeather ?? jsonResponse({}, 503);
+      }
+      return jsonResponse({});
+    });
+  }
+
+  test("Met Office success → returns HIGH authority and does not call fallback providers", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse(SAMPLE_METOFFICE_TIMESERIES),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, { fetchImpl });
+    expect(out.provider).toBe("met-office-datahub");
+    expect(out.authority).toBe("high");
+    const codes = out.data_quality.map((q) => q.code);
+    expect(codes).toContain("WEATHER_AUTHORITY_HIGH");
+    expect(codes).not.toContain("WEATHER_PROVIDER_FALLBACK");
+    // The chain stopped after Met Office — only one provider record present.
+    expect(out.providers).toHaveLength(1);
+    expect(out.providers[0].name).toBe("met-office-datahub");
+    expect(out.providers[0].status).toBe("ok");
+    // Backwards-compatible output shape preserved.
+    expect(out.temperature).toEqual(
+      expect.objectContaining({ unit: "°C", current: expect.any(Number) }),
+    );
+    expect(out.wind).toEqual(
+      expect.objectContaining({ cardinal: expect.any(String) }),
+    );
+    expect(out.precipitation).toEqual(expect.objectContaining({ unit: "mm" }));
+    expect(typeof out.summary).toBe("string");
+    expect(typeof out.climateZone).toBe("string");
+  });
+
+  test("Met Office HTTP 503 → falls through to Open-Meteo (MEDIUM)", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse({}, 503),
+      openMeteo: jsonResponse(SAMPLE_OPEN_METEO),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, { fetchImpl });
+    expect(out.provider).toBe("open-meteo");
+    expect(out.authority).toBe("medium");
+    const codes = out.data_quality.map((q) => q.code);
+    expect(codes).toContain("WEATHER_PROVIDER_ERROR");
+    expect(codes).toContain("WEATHER_PROVIDER_FALLBACK");
+    expect(codes).toContain("WEATHER_AUTHORITY_MEDIUM");
+    expect(out.providers.map((p) => p.name)).toEqual([
+      "met-office-datahub",
+      "open-meteo",
+    ]);
+  });
+
+  test("Met Office + Open-Meteo fail → OpenWeather (LOW)", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse({}, 503),
+      openMeteo: jsonResponse({}, 503),
+      openWeather: jsonResponse(SAMPLE_OPENWEATHER),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, { fetchImpl });
+    expect(out.provider).toBe("openweather");
+    expect(out.authority).toBe("low");
+    const codes = out.data_quality.map((q) => q.code);
+    expect(codes).toContain("WEATHER_AUTHORITY_LOW");
+    expect(codes.filter((c) => c === "WEATHER_PROVIDER_FALLBACK").length).toBe(
+      2,
+    );
+    expect(out.providers).toHaveLength(3);
+  });
+
+  test("All providers fail → deterministic fallback marked WEATHER_AUTHORITY_LOW", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse({}, 503),
+      openMeteo: jsonResponse({}, 503),
+      openWeather: jsonResponse({}, 503),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, { fetchImpl });
+    expect(out.provider).toBe("deterministic-fallback");
+    expect(out.authority).toBe("low");
+    const codes = out.data_quality.map((q) => q.code);
+    expect(codes).toContain("WEATHER_PROVIDER_FALLBACK");
+    expect(codes).toContain("WEATHER_AUTHORITY_LOW");
+    expect(out.providers.map((p) => p.name)).toEqual(
+      expect.arrayContaining([
+        "met-office-datahub",
+        "open-meteo",
+        "openweather",
+        "deterministic-fallback",
+      ]),
+    );
+    // Backwards-compatible shape still present even on full fallback.
+    expect(out.temperature.unit).toBe("°C");
+    expect(out.wind.cardinal).toBe("SW");
+    expect(out.climateZone).toBe("Temperate");
+  });
+
+  test("OpenAI / GPT names never appear among weather provider records", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse(SAMPLE_METOFFICE_TIMESERIES),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, { fetchImpl });
+    for (const provider of out.providers) {
+      expect(provider.name).not.toMatch(/openai|gpt|chatgpt/i);
+    }
+  });
+
+  test("provider record carries name + authority + fetched_at + status + fields_supplied", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse(SAMPLE_METOFFICE_TIMESERIES),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, { fetchImpl });
+    const record = out.providers[0];
+    expect(record.name).toBe("met-office-datahub");
+    expect(record.authority).toBe("high");
+    expect(record).toHaveProperty("fetched_at");
+    expect(["ok", "error", "timeout", "not_used"]).toContain(record.status);
+    expect(record.fields_supplied).toEqual(
+      expect.arrayContaining([
+        "temperature",
+        "wind",
+        "precipitation",
+        "climateZone",
+      ]),
+    );
   });
 });

--- a/src/__tests__/services/climate/weatherProviders.test.js
+++ b/src/__tests__/services/climate/weatherProviders.test.js
@@ -220,6 +220,20 @@ describe("openMeteoProvider", () => {
     expect(out.data).toBeNull();
     expect(out.envelope.error).toMatch(/HTTP 502/);
   });
+
+  test("times out after providerTimeoutMs and returns timeout envelope", async () => {
+    const fetchImpl = jest.fn(() => new Promise(() => {}));
+    const out = await fetchOpenMeteo({
+      lat: 51.5,
+      lon: -0.1,
+      fetchImpl,
+      timeoutMs: 25,
+    });
+    expect(out.__timedOut).toBe(true);
+    expect(out.envelope.error).toMatch(/timeout/);
+    expect(out.provider).toBe("open-meteo");
+    expect(out.authority).toBe("medium");
+  });
 });
 
 describe("openWeatherProvider", () => {
@@ -249,6 +263,29 @@ describe("openWeatherProvider", () => {
     expect(out.data.precipitation.daily).toBe(0.2);
     expect(out.authority).toBe("low");
     expect(out.envelope.error).toBeNull();
+  });
+
+  test("propagates HTTP 401 as error envelope (invalid key)", async () => {
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = jest.fn(async () => jsonResponse({}, 401));
+    const out = await fetchOpenWeather({ lat: 51.5, lon: -0.1, fetchImpl });
+    expect(out.data).toBeNull();
+    expect(out.envelope.error).toMatch(/HTTP 401/);
+    expect(out.provider).toBe("openweather");
+    expect(out.authority).toBe("low");
+  });
+
+  test("times out after providerTimeoutMs and returns timeout envelope", async () => {
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = jest.fn(() => new Promise(() => {}));
+    const out = await fetchOpenWeather({
+      lat: 51.5,
+      lon: -0.1,
+      fetchImpl,
+      timeoutMs: 25,
+    });
+    expect(out.__timedOut).toBe(true);
+    expect(out.envelope.error).toMatch(/timeout/);
   });
 });
 
@@ -401,5 +438,109 @@ describe("weatherService chain", () => {
         "climateZone",
       ]),
     );
+  });
+
+  // --- Codex review additions: explicit timeout + chain-fallthrough coverage ---
+
+  test("Met Office error + Open-Meteo timeout → OpenWeather (LOW) with WEATHER_PROVIDER_TIMEOUT", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse({}, 503),
+      openMeteo: new Promise(() => {}), // hang only this provider
+      openWeather: jsonResponse(SAMPLE_OPENWEATHER),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, {
+      fetchImpl,
+      providerTimeoutMs: 25,
+    });
+    expect(out.provider).toBe("openweather");
+    expect(out.authority).toBe("low");
+    const codes = out.data_quality.map((q) => q.code);
+    expect(codes).toContain("WEATHER_PROVIDER_ERROR"); // Met Office HTTP 503
+    expect(codes).toContain("WEATHER_PROVIDER_TIMEOUT"); // Open-Meteo hung
+    expect(codes).toContain("WEATHER_PROVIDER_FALLBACK"); // chain advanced
+    expect(codes).toContain("WEATHER_AUTHORITY_LOW"); // OpenWeather succeeded
+    const names = out.providers.map((p) => p.name);
+    expect(names).toEqual(["met-office-datahub", "open-meteo", "openweather"]);
+    // The Open-Meteo record reflects the timeout outcome.
+    const openMeteoRecord = out.providers.find((p) => p.name === "open-meteo");
+    expect(openMeteoRecord.status).toBe("timeout");
+    expect(openMeteoRecord.fields_supplied).toEqual([]);
+  });
+
+  test("Met Office error + Open-Meteo error + OpenWeather error → deterministic fallback", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse({}, 503),
+      openMeteo: jsonResponse({}, 502),
+      openWeather: jsonResponse({}, 401),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, { fetchImpl });
+    expect(out.provider).toBe("deterministic-fallback");
+    expect(out.authority).toBe("low");
+    const codes = out.data_quality.map((q) => q.code);
+    // Each upstream provider emits its own WEATHER_PROVIDER_ERROR code.
+    expect(codes.filter((c) => c === "WEATHER_PROVIDER_ERROR").length).toBe(3);
+    expect(codes).toContain("WEATHER_PROVIDER_FALLBACK");
+    expect(codes).toContain("WEATHER_AUTHORITY_LOW");
+    // Backwards-compatible shape preserved on full-error fallback.
+    expect(out.temperature.unit).toBe("°C");
+    expect(out.summary).toMatch(/unavailable|fallback/i);
+  });
+
+  test("Met Office error + Open-Meteo error + OpenWeather timeout → deterministic fallback", async () => {
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    process.env.OPENWEATHER_API_KEY = "test-ow-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse({}, 503),
+      openMeteo: jsonResponse({}, 502),
+      openWeather: new Promise(() => {}), // hang only OpenWeather
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, {
+      fetchImpl,
+      providerTimeoutMs: 25,
+    });
+    expect(out.provider).toBe("deterministic-fallback");
+    expect(out.authority).toBe("low");
+    const codes = out.data_quality.map((q) => q.code);
+    expect(codes).toContain("WEATHER_PROVIDER_TIMEOUT");
+    expect(codes).toContain("WEATHER_PROVIDER_FALLBACK");
+    expect(codes).toContain("WEATHER_AUTHORITY_LOW");
+    const owRecord = out.providers.find((p) => p.name === "openweather");
+    expect(owRecord.status).toBe("timeout");
+    // Deterministic-fallback record present and marked ok with full fields.
+    const fallbackRecord = out.providers.find(
+      (p) => p.name === "deterministic-fallback",
+    );
+    expect(fallbackRecord.status).toBe("ok");
+    expect(fallbackRecord.fields_supplied).toEqual(
+      expect.arrayContaining([
+        "temperature",
+        "wind",
+        "precipitation",
+        "climateZone",
+      ]),
+    );
+  });
+
+  test("Met Office success + Open-Meteo timeout never invoked (chain stops at first success)", async () => {
+    // Sanity: a hanging Open-Meteo mock should not affect a Met Office success
+    // because the chain must short-circuit.
+    process.env.METOFFICE_DATAHUB_API_KEY = "test-mo-key";
+    const fetchImpl = chainFetch({
+      metOffice: jsonResponse(SAMPLE_METOFFICE_TIMESERIES),
+      openMeteo: new Promise(() => {}),
+    });
+    const out = await weatherService.getClimateData(51.5, -0.1, {
+      fetchImpl,
+      providerTimeoutMs: 25,
+    });
+    expect(out.provider).toBe("met-office-datahub");
+    expect(out.providers).toHaveLength(1);
+    const codes = out.data_quality.map((q) => q.code);
+    expect(codes).not.toContain("WEATHER_PROVIDER_TIMEOUT");
+    expect(codes).not.toContain("WEATHER_PROVIDER_FALLBACK");
   });
 });

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -531,9 +531,10 @@ describe("projectGraphVerticalSliceService", () => {
         }),
       }),
     );
-    // Offline run never invoked any factual provider, so siteDataProviders is
-    // empty and the OFFLINE flag is in dataQuality.
+    // Offline run never invoked any factual provider, so siteDataProviders +
+    // climateDataProviders are empty and the OFFLINE flag is in dataQuality.
     expect(result.provenanceManifest.siteDataProviders).toEqual([]);
+    expect(result.provenanceManifest.climateDataProviders).toEqual([]);
     expect(
       result.provenanceManifest.dataQuality.some(
         (q) => q.code === "CONTEXT_PROVIDERS_OFFLINE",
@@ -876,6 +877,269 @@ describe("projectGraphVerticalSliceService", () => {
     expect(result.qa.categoryScores.regulation.max).toBe(10);
     expect(result.qa.categoryScores.architecture.max).toBe(10);
     expect(result.qa.categoryScores.graphic.max).toBe(10);
+  });
+
+  // Phase 3 / Codex review: prove that climate.providers[] propagates through
+  // buildClimatePack and feeds the slice's provenanceManifest.climateDataProviders.
+  // This is a focused unit test against the internals to avoid a second ~80s
+  // full slice run while still asserting every required field per record.
+  test("buildClimatePack propagates weather.providers[] into climate.providers[] for the manifest", () => {
+    const { buildClimatePack, normalizeBrief, buildSiteContext } =
+      __projectGraphVerticalSliceInternals;
+    const brief = normalizeBrief({
+      project_name: "Climate Provenance Probe",
+      building_type: "dwelling",
+      site_input: {
+        address: "1 Test Street",
+        postcode: "N1 1AA",
+        lat: 51.5,
+        lon: -0.1,
+      },
+      target_gia_m2: 120,
+      target_storeys: 2,
+      client_goals: ["compact dwelling"],
+      style_keywords: ["red brick"],
+      sustainability_ambition: "low_energy",
+    });
+    const site = buildSiteContext({
+      brief,
+      sitePolygon: [
+        { lat: 51.5005, lng: -0.1005 },
+        { lat: 51.5005, lng: -0.0995 },
+        { lat: 51.4995, lng: -0.0995 },
+        { lat: 51.4995, lng: -0.1005 },
+      ],
+      siteMetrics: { areaM2: 1000, orientationDeg: 0 },
+      siteBoundarySanity: {
+        boundaryAuthoritative: true,
+        siteMetrics: { areaM2: 1000, orientationDeg: 0 },
+      },
+      mainEntry: null,
+    });
+
+    // Synthesised weather chain result mirroring what weatherService produces
+    // on a Met Office success: the chain stamps a single provider record and
+    // forwards WEATHER_AUTHORITY_HIGH onto data_quality.
+    const synthWeather = {
+      temperature: { current: 12, min: 10, max: 14, unit: "°C" },
+      wind: {
+        speed: 5,
+        direction: 200,
+        cardinal: "S",
+        prevailing: "S",
+        unit: "m/s",
+      },
+      precipitation: { daily: 0.5, daily_sum: 0.5, unit: "mm" },
+      climateZone: "Temperate",
+      summary: "synth",
+      provider: "met-office-datahub",
+      authority: "high",
+      providers: [
+        {
+          name: "met-office-datahub",
+          authority: "high",
+          fetched_at: "2026-05-03T12:00:00.000Z",
+          status: "ok",
+          fields_supplied: [
+            "temperature",
+            "wind",
+            "precipitation",
+            "climateZone",
+          ],
+        },
+      ],
+      data_quality: [
+        {
+          code: "WEATHER_AUTHORITY_HIGH",
+          severity: "info",
+          message: "synth Met Office record",
+          source: "met-office-datahub",
+        },
+      ],
+    };
+
+    const climate = buildClimatePack(brief, site, { weather: synthWeather });
+
+    // climate.providers === weather.providers — this is the array the slice
+    // service reads as `Array.isArray(climate?.providers) ? climate.providers : []`
+    // and assigns to provenanceManifest.climateDataProviders.
+    expect(climate.providers).toEqual(synthWeather.providers);
+    expect(climate.providers).toHaveLength(1);
+    const record = climate.providers[0];
+    // Per Codex request: every record must carry these five fields.
+    expect(record).toEqual(
+      expect.objectContaining({
+        name: expect.any(String),
+        authority: expect.stringMatching(/^(high|medium|low)$/),
+        fetched_at: expect.any(String),
+        status: expect.stringMatching(/^(ok|error|timeout|not_used)$/),
+        fields_supplied: expect.any(Array),
+      }),
+    );
+    expect(record.name).toBe("met-office-datahub");
+    expect(record.authority).toBe("high");
+    expect(record.fields_supplied).toEqual(
+      expect.arrayContaining([
+        "temperature",
+        "wind",
+        "precipitation",
+        "climateZone",
+      ]),
+    );
+    // Climate keeps its own data_quality array; it should carry both the
+    // pack-level CLIMATE_PACK_WEATHER_LIVE marker and forward the chain's
+    // WEATHER_AUTHORITY_HIGH entry.
+    const codes = climate.data_quality.map((q) => q.code);
+    expect(codes).toContain("CLIMATE_PACK_WEATHER_LIVE");
+    expect(codes).toContain("WEATHER_AUTHORITY_HIGH");
+    // Live weather populates wind/rainfall sources — these flow into the slice
+    // result and ultimately into the A1 sheet's climate panel.
+    expect(climate.weather_source).toBe("met-office-datahub");
+    expect(climate.weather_authority).toBe("high");
+    expect(climate.wind.source).toBe("met-office-datahub");
+    expect(climate.rainfall.source).toBe("met-office-datahub");
+    // OpenAI guardrail: no provider in the manifest may be branded as OpenAI.
+    for (const p of climate.providers) {
+      expect(p.name).not.toMatch(/openai|gpt|chatgpt/i);
+    }
+  });
+
+  test("buildClimatePack with deterministic-fallback weather forwards the fallback record into climate.providers[]", () => {
+    const { buildClimatePack, normalizeBrief, buildSiteContext } =
+      __projectGraphVerticalSliceInternals;
+    const brief = normalizeBrief({
+      project_name: "Fallback Provenance Probe",
+      building_type: "dwelling",
+      site_input: {
+        address: "2 Test Street",
+        postcode: "N1 1AA",
+        lat: 51.5,
+        lon: -0.1,
+      },
+      target_gia_m2: 120,
+      target_storeys: 2,
+      client_goals: ["compact dwelling"],
+      style_keywords: ["red brick"],
+      sustainability_ambition: "low_energy",
+    });
+    const site = buildSiteContext({
+      brief,
+      sitePolygon: [
+        { lat: 51.5005, lng: -0.1005 },
+        { lat: 51.5005, lng: -0.0995 },
+        { lat: 51.4995, lng: -0.0995 },
+        { lat: 51.4995, lng: -0.1005 },
+      ],
+      siteMetrics: { areaM2: 1000, orientationDeg: 0 },
+      siteBoundarySanity: {
+        boundaryAuthoritative: true,
+        siteMetrics: { areaM2: 1000, orientationDeg: 0 },
+      },
+      mainEntry: null,
+    });
+
+    // Synthesised "all upstream providers failed" chain result.
+    const synthFallback = {
+      temperature: { current: 15, min: 10, max: 20, unit: "°C" },
+      wind: {
+        speed: 10,
+        direction: 225,
+        cardinal: "SW",
+        prevailing: "SW",
+        unit: "km/h",
+      },
+      precipitation: { daily: 0, daily_sum: 0, unit: "mm" },
+      climateZone: "Temperate",
+      summary: "fallback",
+      provider: "deterministic-fallback",
+      authority: "low",
+      providers: [
+        {
+          name: "met-office-datahub",
+          authority: "high",
+          fetched_at: null,
+          status: "error",
+          fields_supplied: [],
+        },
+        {
+          name: "open-meteo",
+          authority: "medium",
+          fetched_at: null,
+          status: "error",
+          fields_supplied: [],
+        },
+        {
+          name: "openweather",
+          authority: "low",
+          fetched_at: null,
+          status: "timeout",
+          fields_supplied: [],
+        },
+        {
+          name: "deterministic-fallback",
+          authority: "low",
+          fetched_at: null,
+          status: "ok",
+          fields_supplied: [
+            "temperature",
+            "wind",
+            "precipitation",
+            "climateZone",
+          ],
+        },
+      ],
+      data_quality: [
+        {
+          code: "WEATHER_PROVIDER_ERROR",
+          severity: "warning",
+          message: "synth",
+          source: "met-office-datahub",
+        },
+        {
+          code: "WEATHER_PROVIDER_FALLBACK",
+          severity: "warning",
+          message: "synth",
+          source: "deterministic-fallback",
+        },
+        {
+          code: "WEATHER_AUTHORITY_LOW",
+          severity: "warning",
+          message: "synth",
+          source: "deterministic-fallback",
+        },
+      ],
+    };
+
+    const climate = buildClimatePack(brief, site, { weather: synthFallback });
+
+    // climate.providers reflects all four chain records, including the
+    // deterministic-fallback marker. The slice service maps these directly
+    // onto provenanceManifest.climateDataProviders.
+    expect(climate.providers).toEqual(synthFallback.providers);
+    const names = climate.providers.map((p) => p.name);
+    expect(names).toEqual([
+      "met-office-datahub",
+      "open-meteo",
+      "openweather",
+      "deterministic-fallback",
+    ]);
+    // weather_source flips to fallback and the pack emits the fallback marker.
+    expect(climate.weather_source).toBe("fallback");
+    const codes = climate.data_quality.map((q) => q.code);
+    expect(codes).toContain("CLIMATE_PACK_WEATHER_FALLBACK");
+    expect(codes).toContain("WEATHER_AUTHORITY_LOW");
+    // Each forwarded record still satisfies the required-fields contract.
+    for (const p of climate.providers) {
+      expect(p).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          authority: expect.stringMatching(/^(high|medium|low)$/),
+          status: expect.stringMatching(/^(ok|error|timeout|not_used)$/),
+          fields_supplied: expect.any(Array),
+        }),
+      );
+      expect(p).toHaveProperty("fetched_at");
+    }
   });
 
   test("executes OpenAI reasoning checkpoints when a provider mock is supplied", async () => {

--- a/src/services/climate/weatherProviders/_chainHelpers.js
+++ b/src/services/climate/weatherProviders/_chainHelpers.js
@@ -1,0 +1,179 @@
+/* global globalThis */
+/**
+ * Shared helpers for the Met Office → Open-Meteo → OpenWeather provider chain.
+ * Server-only guard, fetch resolution, per-provider timeout wrapper, climate
+ * zone inference, and degrees-to-cardinal conversion.
+ */
+
+export const DEFAULT_PROVIDER_TIMEOUT_MS = 8000;
+
+export function isRealBrowserRuntime() {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return false;
+  }
+  if (typeof process === "undefined") return true;
+  if (!process.versions || !process.versions.node) return true;
+  return false;
+}
+
+export function getInjectedFetch(injected) {
+  if (injected === null) return null;
+  if (typeof injected === "function") return injected;
+  if (typeof globalThis.fetch === "function")
+    return globalThis.fetch.bind(globalThis);
+  return null;
+}
+
+export function settleWithin(promise, timeoutMs, fallback) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve({ ...fallback, __timedOut: true, __timeoutMs: timeoutMs });
+    }, timeoutMs);
+    Promise.resolve(promise)
+      .then((value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve({ ...fallback, __error: err?.message || String(err) });
+      });
+  });
+}
+
+export function degreesToCardinal(deg) {
+  const dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+  const norm = ((Number(deg) % 360) + 360) % 360;
+  return dirs[Math.round(norm / 45) % 8];
+}
+
+export function inferClimateZone(tempC) {
+  if (!Number.isFinite(tempC)) return "Temperate";
+  if (tempC > 35) return "Arid";
+  if (tempC > 25) return "Tropical";
+  if (tempC < -5) return "Polar";
+  if (tempC < 5) return "Cold";
+  return "Temperate";
+}
+
+export function emptyEnvelope({ source, licenseNote, reason }) {
+  return {
+    data: null,
+    source,
+    license_note: licenseNote,
+    confidence: 0,
+    fetched_at: null,
+    error: reason,
+  };
+}
+
+export function successEnvelope({ source, licenseNote, confidence = 0.95 }) {
+  return {
+    data: true,
+    source,
+    license_note: licenseNote,
+    confidence,
+    fetched_at: new Date(0).toISOString(),
+    error: null,
+  };
+}
+
+export function errorEnvelope({ source, licenseNote, reason }) {
+  return {
+    data: null,
+    source,
+    license_note: licenseNote,
+    confidence: 0,
+    fetched_at: null,
+    error: typeof reason === "string" ? reason : reason?.message || "unknown",
+  };
+}
+
+/**
+ * Wraps a single provider's network call with browser-guard, key check,
+ * timeout, and uniform return shape: {data, provider, authority, envelope}.
+ *
+ * The `runFetch` callback receives a resolved fetch impl + key and is expected
+ * to perform the network call and return either a successEnvelope-shaped data
+ * payload or null (in which case errorEnvelope is synthesised from `error`).
+ */
+export async function runProviderCall({
+  providerName,
+  authority,
+  source,
+  licenseNote,
+  fetchImpl,
+  apiKey,
+  apiKeyRequired = true,
+  noKeyReason,
+  timeoutMs = DEFAULT_PROVIDER_TIMEOUT_MS,
+  runFetch,
+}) {
+  if (isRealBrowserRuntime()) {
+    return {
+      data: null,
+      provider: providerName,
+      authority,
+      envelope: emptyEnvelope({
+        source,
+        licenseNote,
+        reason: "browser-runtime-refused",
+      }),
+    };
+  }
+  const f = getInjectedFetch(fetchImpl);
+  if (!f) {
+    return {
+      data: null,
+      provider: providerName,
+      authority,
+      envelope: emptyEnvelope({
+        source,
+        licenseNote,
+        reason: "no-fetch-available",
+      }),
+    };
+  }
+  if (apiKeyRequired && !apiKey) {
+    return {
+      data: null,
+      provider: providerName,
+      authority,
+      envelope: emptyEnvelope({
+        source,
+        licenseNote,
+        reason: noKeyReason || "no-api-key",
+      }),
+    };
+  }
+  const fetchPromise = (async () => {
+    try {
+      return await runFetch({ fetchImpl: f, apiKey });
+    } catch (err) {
+      return {
+        data: null,
+        provider: providerName,
+        authority,
+        envelope: errorEnvelope({ source, licenseNote, reason: err }),
+      };
+    }
+  })();
+  const timeoutFallback = {
+    data: null,
+    provider: providerName,
+    authority,
+    envelope: errorEnvelope({
+      source,
+      licenseNote,
+      reason: `timeout-${timeoutMs}ms`,
+    }),
+  };
+  return settleWithin(fetchPromise, timeoutMs, timeoutFallback);
+}

--- a/src/services/climate/weatherProviders/metOfficeDataHubProvider.js
+++ b/src/services/climate/weatherProviders/metOfficeDataHubProvider.js
@@ -1,0 +1,169 @@
+/**
+ * Met Office DataHub site-specific forecast provider — primary climate source
+ * for the project_graph pipeline. UK national weather service; authority='high'.
+ *
+ * Server-only: METOFFICE_DATAHUB_API_KEY is read from process.env. Never via
+ * REACT_APP_*. Returns an offline-safe envelope when the key or fetch is
+ * unavailable so the chain in weatherService.js falls through cleanly.
+ */
+
+import {
+  degreesToCardinal,
+  inferClimateZone,
+  successEnvelope,
+  errorEnvelope,
+  runProviderCall,
+} from "./_chainHelpers.js";
+
+const PROVIDER_NAME = "met-office-datahub";
+const AUTHORITY = "high";
+const SOURCE_ID = "met-office-datahub";
+const LICENSE_NOTE =
+  "Met Office DataHub site-specific forecast (https://www.metoffice.gov.uk/services/data/datapoint). Requires METOFFICE_DATAHUB_API_KEY; covered by your DataHub subscription.";
+const DEFAULT_BASE_URL = "https://data.hub.api.metoffice.gov.uk";
+
+function getApiKey(envOverride) {
+  if (typeof envOverride === "string" && envOverride) return envOverride;
+  if (
+    typeof process !== "undefined" &&
+    process.env?.METOFFICE_DATAHUB_API_KEY
+  ) {
+    return process.env.METOFFICE_DATAHUB_API_KEY;
+  }
+  return null;
+}
+
+function getBaseUrl(override) {
+  if (typeof override === "string" && override) return override;
+  if (
+    typeof process !== "undefined" &&
+    process.env?.METOFFICE_DATAHUB_BASE_URL
+  ) {
+    return process.env.METOFFICE_DATAHUB_BASE_URL;
+  }
+  return DEFAULT_BASE_URL;
+}
+
+function summariseTimeSeries(timeSeries) {
+  // Met Office DataHub site-specific responses contain timeSeries entries
+  // with screenTemperature (°C), windSpeed10m (m/s),
+  // windDirectionFrom10m (degrees), totalPrecipAmount (mm).
+  const first = timeSeries[0] || {};
+  const temps = timeSeries
+    .map((row) => Number(row?.screenTemperature ?? row?.airTemperature))
+    .filter((t) => Number.isFinite(t));
+  const min = temps.length ? Math.min(...temps) : null;
+  const max = temps.length ? Math.max(...temps) : null;
+  const current = Number.isFinite(Number(first.screenTemperature))
+    ? Number(first.screenTemperature)
+    : Number.isFinite(Number(first.airTemperature))
+      ? Number(first.airTemperature)
+      : null;
+  const windSpeed = Number(first.windSpeed10m ?? first.windSpeedAt10m);
+  const windDirRaw = Number(
+    first.windDirectionFrom10m ?? first.windDirection ?? 0,
+  );
+  const windDir = Number.isFinite(windDirRaw) ? windDirRaw : 0;
+  const cardinal = degreesToCardinal(windDir);
+  const precipNext24h = timeSeries.slice(0, 24).reduce((sum, row) => {
+    const v = Number(row?.totalPrecipAmount);
+    return sum + (Number.isFinite(v) ? v : 0);
+  }, 0);
+  return {
+    temperature: { current, min, max, unit: "°C" },
+    wind: {
+      speed: Number.isFinite(windSpeed) ? windSpeed : null,
+      direction: windDir,
+      cardinal,
+      prevailing: cardinal,
+      unit: "m/s",
+    },
+    precipitation: {
+      daily: precipNext24h,
+      daily_sum: precipNext24h,
+      unit: "mm",
+    },
+    climateZone: inferClimateZone(current),
+    summary: `Met Office: ${current ?? "—"}°C, wind ${cardinal} ${
+      Number.isFinite(windSpeed) ? `${windSpeed.toFixed(1)} m/s` : "n/a"
+    }`,
+  };
+}
+
+export async function fetchWeather({
+  lat,
+  lon,
+  fetchImpl,
+  apiKey,
+  baseUrl,
+  timeoutMs,
+} = {}) {
+  return runProviderCall({
+    providerName: PROVIDER_NAME,
+    authority: AUTHORITY,
+    source: SOURCE_ID,
+    licenseNote: LICENSE_NOTE,
+    fetchImpl,
+    apiKey: getApiKey(apiKey),
+    apiKeyRequired: true,
+    noKeyReason: "no-metoffice-datahub-key",
+    timeoutMs,
+    async runFetch({ fetchImpl: f, apiKey: key }) {
+      const url = `${getBaseUrl(baseUrl)}/sitespecific/v0/point/hourly?latitude=${encodeURIComponent(
+        lat,
+      )}&longitude=${encodeURIComponent(lon)}`;
+      const response = await f(url, {
+        headers: { apikey: key, accept: "application/json" },
+      });
+      if (!response.ok) {
+        return {
+          data: null,
+          provider: PROVIDER_NAME,
+          authority: AUTHORITY,
+          envelope: errorEnvelope({
+            source: SOURCE_ID,
+            licenseNote: LICENSE_NOTE,
+            reason: `HTTP ${response.status}`,
+          }),
+        };
+      }
+      const json = await response.json();
+      const timeSeries = Array.isArray(
+        json?.features?.[0]?.properties?.timeSeries,
+      )
+        ? json.features[0].properties.timeSeries
+        : Array.isArray(json?.timeSeries)
+          ? json.timeSeries
+          : [];
+      if (timeSeries.length === 0) {
+        return {
+          data: null,
+          provider: PROVIDER_NAME,
+          authority: AUTHORITY,
+          envelope: errorEnvelope({
+            source: SOURCE_ID,
+            licenseNote: LICENSE_NOTE,
+            reason: "empty-timeseries",
+          }),
+        };
+      }
+      return {
+        data: summariseTimeSeries(timeSeries),
+        provider: PROVIDER_NAME,
+        authority: AUTHORITY,
+        envelope: successEnvelope({
+          source: SOURCE_ID,
+          licenseNote: LICENSE_NOTE,
+        }),
+      };
+    },
+  });
+}
+
+export const __metOfficeInternals = Object.freeze({
+  summariseTimeSeries,
+  PROVIDER_NAME,
+  AUTHORITY,
+});
+
+export default { fetchWeather };

--- a/src/services/climate/weatherProviders/openMeteoProvider.js
+++ b/src/services/climate/weatherProviders/openMeteoProvider.js
@@ -1,0 +1,145 @@
+/**
+ * Open-Meteo provider — free, key-less, public API. Authority='medium' because
+ * it's a model-driven aggregator rather than a national weather service.
+ *
+ * This is the existing weatherService.js Open-Meteo logic refactored as a
+ * provider so weatherService can chain it after Met Office DataHub.
+ */
+
+import {
+  degreesToCardinal,
+  inferClimateZone,
+  successEnvelope,
+  errorEnvelope,
+  runProviderCall,
+} from "./_chainHelpers.js";
+
+const PROVIDER_NAME = "open-meteo";
+const AUTHORITY = "medium";
+const SOURCE_ID = "open-meteo";
+const LICENSE_NOTE =
+  "Open-Meteo (https://open-meteo.com). Non-commercial use is free; no API key required.";
+const DEFAULT_BASE_URL = "https://api.open-meteo.com";
+
+function getBaseUrl(override) {
+  if (typeof override === "string" && override) return override;
+  if (typeof process !== "undefined" && process.env?.OPEN_METEO_BASE_URL) {
+    return process.env.OPEN_METEO_BASE_URL;
+  }
+  return DEFAULT_BASE_URL;
+}
+
+function summariseOpenMeteo(json) {
+  const current = json?.current_weather || {};
+  const daily = json?.daily || {};
+  const tempCurrent = Number.isFinite(Number(current.temperature))
+    ? Number(current.temperature)
+    : null;
+  const min = Number(daily.temperature_2m_min?.[0]);
+  const max = Number(daily.temperature_2m_max?.[0]);
+  const windDirRaw = Number(
+    current.winddirection ?? daily.wind_direction_10m_dominant?.[0] ?? 0,
+  );
+  const windDir = Number.isFinite(windDirRaw) ? windDirRaw : 0;
+  const cardinal = degreesToCardinal(windDir);
+  return {
+    temperature: {
+      current: tempCurrent,
+      min: Number.isFinite(min) ? min : null,
+      max: Number.isFinite(max) ? max : null,
+      unit: "°C",
+    },
+    wind: {
+      speed: Number.isFinite(Number(current.windspeed))
+        ? Number(current.windspeed)
+        : null,
+      direction: windDir,
+      cardinal,
+      prevailing: cardinal,
+      unit: "km/h",
+    },
+    precipitation: {
+      daily: Number(daily.precipitation_sum?.[0]) || 0,
+      daily_sum: Number(daily.precipitation_sum?.[0]) || 0,
+      unit: "mm",
+    },
+    climateZone: inferClimateZone(tempCurrent),
+    summary: `Open-Meteo: ${tempCurrent ?? "—"}°C, wind ${cardinal} ${
+      Number.isFinite(Number(current.windspeed))
+        ? `${current.windspeed} km/h`
+        : "n/a"
+    }`,
+  };
+}
+
+export async function fetchWeather({
+  lat,
+  lon,
+  fetchImpl,
+  baseUrl,
+  timeoutMs,
+} = {}) {
+  return runProviderCall({
+    providerName: PROVIDER_NAME,
+    authority: AUTHORITY,
+    source: SOURCE_ID,
+    licenseNote: LICENSE_NOTE,
+    fetchImpl,
+    apiKey: null,
+    apiKeyRequired: false,
+    timeoutMs,
+    async runFetch({ fetchImpl: f }) {
+      const url = `${getBaseUrl(
+        baseUrl,
+      )}/v1/forecast?latitude=${encodeURIComponent(
+        lat,
+      )}&longitude=${encodeURIComponent(
+        lon,
+      )}&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,wind_speed_10m_max,wind_direction_10m_dominant&current_weather=true&timezone=auto&forecast_days=1`;
+      const response = await f(url);
+      if (!response.ok) {
+        return {
+          data: null,
+          provider: PROVIDER_NAME,
+          authority: AUTHORITY,
+          envelope: errorEnvelope({
+            source: SOURCE_ID,
+            licenseNote: LICENSE_NOTE,
+            reason: `HTTP ${response.status}`,
+          }),
+        };
+      }
+      const json = await response.json();
+      if (!json?.current_weather && !json?.daily) {
+        return {
+          data: null,
+          provider: PROVIDER_NAME,
+          authority: AUTHORITY,
+          envelope: errorEnvelope({
+            source: SOURCE_ID,
+            licenseNote: LICENSE_NOTE,
+            reason: "empty-response",
+          }),
+        };
+      }
+      return {
+        data: summariseOpenMeteo(json),
+        provider: PROVIDER_NAME,
+        authority: AUTHORITY,
+        envelope: successEnvelope({
+          source: SOURCE_ID,
+          licenseNote: LICENSE_NOTE,
+          confidence: 0.85,
+        }),
+      };
+    },
+  });
+}
+
+export const __openMeteoInternals = Object.freeze({
+  summariseOpenMeteo,
+  PROVIDER_NAME,
+  AUTHORITY,
+});
+
+export default { fetchWeather };

--- a/src/services/climate/weatherProviders/openWeatherProvider.js
+++ b/src/services/climate/weatherProviders/openWeatherProvider.js
@@ -1,0 +1,150 @@
+/**
+ * OpenWeather provider — final fallback in the chain. Authority='low' because
+ * it's a commercial aggregator and not the UK national weather authority.
+ *
+ * Server-only: OPENWEATHER_API_KEY is read from process.env. Never via
+ * REACT_APP_* (client-side OpenWeather usage stays in the legacy
+ * src/services/climateService.js path which is not in this PR's scope).
+ */
+
+import {
+  degreesToCardinal,
+  inferClimateZone,
+  successEnvelope,
+  errorEnvelope,
+  runProviderCall,
+} from "./_chainHelpers.js";
+
+const PROVIDER_NAME = "openweather";
+const AUTHORITY = "low";
+const SOURCE_ID = "openweather";
+const LICENSE_NOTE =
+  "OpenWeather (https://openweathermap.org). Subject to OpenWeather licence; requires OPENWEATHER_API_KEY.";
+const DEFAULT_BASE_URL = "https://api.openweathermap.org";
+
+function getApiKey(envOverride) {
+  if (typeof envOverride === "string" && envOverride) return envOverride;
+  if (typeof process !== "undefined" && process.env?.OPENWEATHER_API_KEY) {
+    return process.env.OPENWEATHER_API_KEY;
+  }
+  return null;
+}
+
+function getBaseUrl(override) {
+  if (typeof override === "string" && override) return override;
+  if (typeof process !== "undefined" && process.env?.OPENWEATHER_BASE_URL) {
+    return process.env.OPENWEATHER_BASE_URL;
+  }
+  return DEFAULT_BASE_URL;
+}
+
+function summariseOpenWeather(json) {
+  const main = json?.main || {};
+  const wind = json?.wind || {};
+  const rain = json?.rain || {};
+  const tempCurrent = Number.isFinite(Number(main.temp))
+    ? Number(main.temp)
+    : null;
+  const min = Number.isFinite(Number(main.temp_min))
+    ? Number(main.temp_min)
+    : null;
+  const max = Number.isFinite(Number(main.temp_max))
+    ? Number(main.temp_max)
+    : null;
+  const windSpeed = Number.isFinite(Number(wind.speed))
+    ? Number(wind.speed)
+    : null;
+  const windDirRaw = Number(wind.deg ?? 0);
+  const windDir = Number.isFinite(windDirRaw) ? windDirRaw : 0;
+  const cardinal = degreesToCardinal(windDir);
+  const precip = Number(rain["1h"]) || Number(rain["3h"]) || 0;
+  return {
+    temperature: { current: tempCurrent, min, max, unit: "°C" },
+    wind: {
+      speed: windSpeed,
+      direction: windDir,
+      cardinal,
+      prevailing: cardinal,
+      unit: "m/s",
+    },
+    precipitation: { daily: precip, daily_sum: precip, unit: "mm" },
+    climateZone: inferClimateZone(tempCurrent),
+    summary: `OpenWeather: ${tempCurrent ?? "—"}°C, wind ${cardinal} ${
+      Number.isFinite(windSpeed) ? `${windSpeed} m/s` : "n/a"
+    }`,
+  };
+}
+
+export async function fetchWeather({
+  lat,
+  lon,
+  fetchImpl,
+  apiKey,
+  baseUrl,
+  timeoutMs,
+} = {}) {
+  return runProviderCall({
+    providerName: PROVIDER_NAME,
+    authority: AUTHORITY,
+    source: SOURCE_ID,
+    licenseNote: LICENSE_NOTE,
+    fetchImpl,
+    apiKey: getApiKey(apiKey),
+    apiKeyRequired: true,
+    noKeyReason: "no-openweather-key",
+    timeoutMs,
+    async runFetch({ fetchImpl: f, apiKey: key }) {
+      const url = `${getBaseUrl(
+        baseUrl,
+      )}/data/2.5/weather?lat=${encodeURIComponent(
+        lat,
+      )}&lon=${encodeURIComponent(lon)}&appid=${encodeURIComponent(key)}&units=metric`;
+      const response = await f(url, {
+        headers: { accept: "application/json" },
+      });
+      if (!response.ok) {
+        return {
+          data: null,
+          provider: PROVIDER_NAME,
+          authority: AUTHORITY,
+          envelope: errorEnvelope({
+            source: SOURCE_ID,
+            licenseNote: LICENSE_NOTE,
+            reason: `HTTP ${response.status}`,
+          }),
+        };
+      }
+      const json = await response.json();
+      if (!json?.main && !json?.wind) {
+        return {
+          data: null,
+          provider: PROVIDER_NAME,
+          authority: AUTHORITY,
+          envelope: errorEnvelope({
+            source: SOURCE_ID,
+            licenseNote: LICENSE_NOTE,
+            reason: "empty-response",
+          }),
+        };
+      }
+      return {
+        data: summariseOpenWeather(json),
+        provider: PROVIDER_NAME,
+        authority: AUTHORITY,
+        envelope: successEnvelope({
+          source: SOURCE_ID,
+          licenseNote: LICENSE_NOTE,
+          confidence: 0.7,
+        }),
+      };
+    },
+  });
+}
+
+export const __openWeatherInternals = Object.freeze({
+  summariseOpenWeather,
+  PROVIDER_NAME,
+  AUTHORITY,
+});
+
+export default { fetchWeather };

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -46,6 +46,7 @@ import {
 import { isFeatureEnabled } from "../../config/featureFlags.js";
 import { getSiteSnapshotWithMetadata } from "../siteMapSnapshotService.js";
 import { computeSunPath } from "../climate/sunPath.js";
+import weatherService from "../weatherService.js";
 import { listSourceDocumentsForParts } from "../regulation/sourceRegistry.js";
 import {
   resolveJurisdiction,
@@ -3938,7 +3939,18 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
   }
 }
 
-function buildClimatePack(brief, site) {
+function buildClimatePack(brief, site, options = {}) {
+  // Phase 3: optional `weather` is the result of weatherService.getClimateData()
+  // (Met Office → Open-Meteo → OpenWeather chain). When present, it supplies
+  // wind / rainfall facts and brings WEATHER_AUTHORITY_* + WEATHER_PROVIDER_*
+  // codes into climate.data_quality. Climate keeps its own data_quality array
+  // by design (Plan-agent ruling, Phase 1) — we do NOT merge weather codes
+  // into site.data_quality. The slice's provenanceManifest reads
+  // climate.providers separately.
+  const weather =
+    options.weather && typeof options.weather === "object"
+      ? options.weather
+      : null;
   let sunPath = null;
   let sunPathError = null;
   try {
@@ -3972,13 +3984,38 @@ function buildClimatePack(brief, site) {
       passiveMoves.push(note);
     }
   }
-  const dataQuality = [
-    {
+  const dataQuality = [];
+  // Live-weather-or-fallback messaging on data_quality.
+  if (
+    weather &&
+    weather.provider &&
+    weather.provider !== "deterministic-fallback"
+  ) {
+    dataQuality.push({
+      code: "CLIMATE_PACK_WEATHER_LIVE",
+      severity: "info",
+      message: `Live weather supplied by ${weather.provider} (authority=${weather.authority}).`,
+      source: weather.provider,
+    });
+  } else {
+    dataQuality.push({
       code: "CLIMATE_PACK_WEATHER_FALLBACK",
       severity: "warning",
-      message: "No live weather source was used in this vertical slice.",
-    },
-  ];
+      message: weather
+        ? "All weather providers failed; deterministic fallback used."
+        : "No live weather source was used in this vertical slice.",
+    });
+  }
+  // Forward the chain's own data_quality entries onto the climate pack so QA
+  // can read WEATHER_AUTHORITY_* / WEATHER_PROVIDER_FALLBACK / *_TIMEOUT /
+  // *_ERROR codes alongside the climate-pack-level entries above.
+  if (weather && Array.isArray(weather.data_quality)) {
+    for (const entry of weather.data_quality) {
+      if (entry && typeof entry === "object" && entry.code) {
+        dataQuality.push(entry);
+      }
+    }
+  }
   if (sunPathError) {
     dataQuality.push({
       code: "SUN_PATH_COMPUTATION_FAILED",
@@ -3993,10 +4030,16 @@ function buildClimatePack(brief, site) {
         "Sun path computed deterministically from site lat/lon via suncalc.",
     });
   }
+  const usingLiveWeather = Boolean(
+    weather &&
+    weather.provider &&
+    weather.provider !== "deterministic-fallback",
+  );
   return {
     lat: site.lat,
     lon: site.lon,
-    weather_source: "fallback",
+    weather_source: usingLiveWeather ? weather.provider : "fallback",
+    weather_authority: weather?.authority || (usingLiveWeather ? "low" : null),
     weather_file_asset_id: null,
     climate_projection_refs: [
       "UKCP18 reference required before production use",
@@ -4016,14 +4059,24 @@ function buildClimatePack(brief, site) {
           orientation_note:
             "Sun-path computation failed; defaulting to UK southern-glazing heuristic.",
         },
-    wind: {
-      exposure: "unknown",
-      source: "fallback",
-    },
-    rainfall: {
-      exposure: "uk_temperate_assumption",
-      source: "fallback",
-    },
+    wind:
+      usingLiveWeather && weather.wind
+        ? {
+            exposure: weather.wind.cardinal || "unknown",
+            source: weather.provider,
+            speed: weather.wind.speed ?? null,
+            direction: weather.wind.direction ?? null,
+            unit: weather.wind.unit || null,
+          }
+        : { exposure: "unknown", source: "fallback" },
+    rainfall:
+      usingLiveWeather && weather.precipitation
+        ? {
+            exposure: "live_provider_24h",
+            source: weather.provider,
+            daily_mm: weather.precipitation.daily ?? 0,
+          }
+        : { exposure: "uk_temperate_assumption", source: "fallback" },
     overheating: {
       risk_level: overheatingRisk,
       part_o_required: brief.building_type === "dwelling",
@@ -4040,6 +4093,8 @@ function buildClimatePack(brief, site) {
       "Select robust UK external materials and detail exposed edges for rain.",
     ],
     data_quality: dataQuality,
+    providers:
+      weather && Array.isArray(weather.providers) ? weather.providers : [],
   };
 }
 
@@ -10068,14 +10123,36 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
   // enrichSiteContext so the resulting `site` always carries the providers
   // manifest. The aggregator handles the offline / browser-guard / bad-coords
   // branches internally and stamps the appropriate data_quality codes.
-  const site = await enrichSiteContext(
-    deterministicSite,
-    input.contextProviders || {},
+  //
+  // Phase 3: weather is pulled in parallel via the Met Office → Open-Meteo →
+  // OpenWeather chain when context providers are enabled. The chain itself
+  // is server-only and falls back to deterministic data on any failure, so
+  // the slice never fails on weather alone. buildClimatePack stays sync —
+  // we resolve the weather promise first and pass the result in.
+  const contextProviderOptions = input.contextProviders || {};
+  const providersEnabled = Boolean(
+    contextProviderOptions.fetchImpl ||
+    contextProviderOptions.useDefaultFetch === true,
   );
+  const detLat = Number(deterministicSite?.lat);
+  const detLon = Number(deterministicSite?.lon);
+  const weatherFetchPromise =
+    providersEnabled && Number.isFinite(detLat) && Number.isFinite(detLon)
+      ? weatherService.getClimateData(detLat, detLon, {
+          fetchImpl: contextProviderOptions.fetchImpl,
+          providerTimeoutMs: contextProviderOptions.providerTimeoutMs,
+          metOfficeApiKey: contextProviderOptions.metOfficeApiKey,
+          openWeatherApiKey: contextProviderOptions.openWeatherApiKey,
+        })
+      : Promise.resolve(null);
+  const [site, weather] = await Promise.all([
+    enrichSiteContext(deterministicSite, contextProviderOptions),
+    weatherFetchPromise,
+  ]);
   __vsMark = __vsLog("site_context", __vsMark);
   const siteMapSnapshot = await resolveSiteMapSnapshot({ input, brief, site });
   __vsMark = __vsLog("site_map_snapshot", __vsMark);
-  const climate = buildClimatePack(brief, site);
+  const climate = buildClimatePack(brief, site, { weather });
   const regulationsMetadata = buildRegulationPack(brief);
   const localStyle = buildLocalStylePack(brief, site, climate);
   const draftProgramme = buildProgramme({

--- a/src/services/weatherService.js
+++ b/src/services/weatherService.js
@@ -1,109 +1,337 @@
-import logger from '../utils/logger.js';
+import logger from "../utils/logger.js";
+import { fetchWeather as fetchMetOffice } from "./climate/weatherProviders/metOfficeDataHubProvider.js";
+import { fetchWeather as fetchOpenMeteo } from "./climate/weatherProviders/openMeteoProvider.js";
+import { fetchWeather as fetchOpenWeather } from "./climate/weatherProviders/openWeatherProvider.js";
 
 /**
  * Weather Service
- * 
- * Fetches real-time and historical climate data using the Open-Meteo API.
- * No API key required for non-commercial use.
+ *
+ * Phase 3: provider chain Met Office DataHub → Open-Meteo → OpenWeather →
+ * deterministic fallback. Output remains backwards-compatible with the
+ * pre-Phase-3 shape — { temperature, wind, precipitation, climateZone,
+ * summary } — and gains additive fields { provider, authority, providers[],
+ * data_quality[] } so the slice service can populate
+ * provenanceManifest.climateDataProviders without further plumbing.
+ *
+ * Server-only: API keys are read from process.env on the server. Each
+ * provider also layers a real-browser-runtime guard, so even if a client
+ * accidentally calls weatherService.getClimateData it will fall straight
+ * through to the deterministic fallback without leaking keys or making
+ * cross-origin calls.
  */
+
+function buildProviderRecord({ result, fieldsSupplied }) {
+  return {
+    name: result.provider,
+    authority: result.authority,
+    fetched_at: result.envelope?.fetched_at || null,
+    status: result.__timedOut
+      ? "timeout"
+      : result.envelope?.error
+        ? "error"
+        : "ok",
+    fields_supplied:
+      result.envelope?.error || result.__timedOut ? [] : fieldsSupplied,
+  };
+}
+
+function buildAuthorityCode(authority) {
+  if (authority === "high") return "WEATHER_AUTHORITY_HIGH";
+  if (authority === "medium") return "WEATHER_AUTHORITY_MEDIUM";
+  return "WEATHER_AUTHORITY_LOW";
+}
+
+function fallbackReasonOf(result) {
+  if (result.__timedOut) return `timeout-${result.__timeoutMs}ms`;
+  return result.envelope?.error || "unknown";
+}
+
+function recordProviderOutcome({ providers, dataQuality, result, fields }) {
+  providers.push(buildProviderRecord({ result, fieldsSupplied: fields }));
+  if (result.__timedOut) {
+    dataQuality.push({
+      code: "WEATHER_PROVIDER_TIMEOUT",
+      severity: "warning",
+      message: `${result.provider} timed out after ${result.__timeoutMs}ms; chain falling through.`,
+      source: result.provider,
+    });
+  } else if (result.envelope?.error) {
+    dataQuality.push({
+      code: "WEATHER_PROVIDER_ERROR",
+      severity: "warning",
+      message: `${result.provider} failed: ${result.envelope.error}; chain falling through.`,
+      source: result.provider,
+    });
+  }
+}
+
+function buildDeterministicFallback(providers, dataQuality) {
+  dataQuality.push({
+    code: "WEATHER_PROVIDER_FALLBACK",
+    severity: "warning",
+    message:
+      "All weather providers (Met Office DataHub, Open-Meteo, OpenWeather) failed; deterministic fallback used.",
+    source: "deterministic-fallback",
+  });
+  dataQuality.push({
+    code: "WEATHER_AUTHORITY_LOW",
+    severity: "warning",
+    message:
+      "No live weather authority available; climate pack uses deterministic fallback.",
+    source: "deterministic-fallback",
+  });
+  providers.push({
+    name: "deterministic-fallback",
+    authority: "low",
+    fetched_at: null,
+    status: "ok",
+    fields_supplied: ["temperature", "wind", "precipitation", "climateZone"],
+  });
+  return {
+    ...weatherService.getFallbackData(),
+    provider: "deterministic-fallback",
+    authority: "low",
+    providers,
+    data_quality: dataQuality,
+  };
+}
 
 export const weatherService = {
   /**
-   * Fetch climate data for a specific location
-   * @param {number} lat - Latitude
-   * @param {number} lng - Longitude
-   * @returns {Promise<Object>} Climate data including temperature, wind, and precipitation
+   * Fetch climate data via the Met Office → Open-Meteo → OpenWeather chain.
+   *
+   * @param {number} lat - Latitude.
+   * @param {number} lng - Longitude.
+   * @param {object} [options]
+   * @param {Function} [options.fetchImpl] - Custom fetch (test stub).
+   * @param {string} [options.metOfficeApiKey] - Override env key.
+   * @param {string} [options.openWeatherApiKey] - Override env key.
+   * @param {number} [options.providerTimeoutMs] - Per-provider timeout.
+   * @returns {Promise<object>} Climate object with the original
+   *   { temperature, wind, precipitation, climateZone, summary } shape plus
+   *   { provider, authority, providers[], data_quality[] } provenance.
    */
-  async getClimateData(lat, lng) {
+  async getClimateData(lat, lng, options = {}) {
+    const providers = [];
+    const dataQuality = [];
+    const callOptions = {
+      fetchImpl: options.fetchImpl,
+      timeoutMs: options.providerTimeoutMs,
+    };
+
     try {
-      // Fetch current weather and daily climate stats
-      // Variables: temperature_2m_max, temperature_2m_min, precipitation_sum, wind_speed_10m_max, wind_direction_10m_dominant
-      const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,wind_speed_10m_max,wind_direction_10m_dominant&current_weather=true&timezone=auto&forecast_days=1`;
-
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw new Error(`Weather API error: ${response.statusText}`);
+      // 1. Met Office DataHub (primary, authority=high)
+      const metOffice = await fetchMetOffice({
+        lat,
+        lon: lng,
+        apiKey: options.metOfficeApiKey,
+        ...callOptions,
+      });
+      if (metOffice.data && !metOffice.envelope?.error) {
+        providers.push(
+          buildProviderRecord({
+            result: metOffice,
+            fieldsSupplied: [
+              "temperature",
+              "wind",
+              "precipitation",
+              "climateZone",
+            ],
+          }),
+        );
+        dataQuality.push({
+          code: buildAuthorityCode(metOffice.authority),
+          severity: "info",
+          message: `Met Office DataHub returned authoritative weather (authority=${metOffice.authority}).`,
+          source: metOffice.provider,
+        });
+        return {
+          ...metOffice.data,
+          provider: metOffice.provider,
+          authority: metOffice.authority,
+          providers,
+          data_quality: dataQuality,
+        };
       }
+      recordProviderOutcome({
+        providers,
+        dataQuality,
+        result: metOffice,
+        fields: ["temperature", "wind", "precipitation", "climateZone"],
+      });
+      dataQuality.push({
+        code: "WEATHER_PROVIDER_FALLBACK",
+        severity: "info",
+        message: `Falling back from Met Office DataHub to Open-Meteo (reason: ${fallbackReasonOf(
+          metOffice,
+        )}).`,
+        source: "weather-chain",
+      });
 
-      const data = await response.json();
+      // 2. Open-Meteo (fallback, authority=medium)
+      const openMeteo = await fetchOpenMeteo({
+        lat,
+        lon: lng,
+        ...callOptions,
+      });
+      if (openMeteo.data && !openMeteo.envelope?.error) {
+        providers.push(
+          buildProviderRecord({
+            result: openMeteo,
+            fieldsSupplied: [
+              "temperature",
+              "wind",
+              "precipitation",
+              "climateZone",
+            ],
+          }),
+        );
+        dataQuality.push({
+          code: buildAuthorityCode(openMeteo.authority),
+          severity: "info",
+          message: `Open-Meteo returned weather data (authority=${openMeteo.authority}).`,
+          source: openMeteo.provider,
+        });
+        return {
+          ...openMeteo.data,
+          provider: openMeteo.provider,
+          authority: openMeteo.authority,
+          providers,
+          data_quality: dataQuality,
+        };
+      }
+      recordProviderOutcome({
+        providers,
+        dataQuality,
+        result: openMeteo,
+        fields: ["temperature", "wind", "precipitation", "climateZone"],
+      });
+      dataQuality.push({
+        code: "WEATHER_PROVIDER_FALLBACK",
+        severity: "info",
+        message: `Falling back from Open-Meteo to OpenWeather (reason: ${fallbackReasonOf(
+          openMeteo,
+        )}).`,
+        source: "weather-chain",
+      });
 
-      // Fetch historical data for annual averages (simplified approximation using current forecast for now, 
-      // ideally would use archive API but that requires more complex setup)
-      // For a robust architectural analysis, we'll infer climate zone and averages from the single point 
-      // and general geographic knowledge if historical API is too heavy.
-
-      return this.processWeatherData(data);
+      // 3. OpenWeather (final fallback, authority=low)
+      const openWeather = await fetchOpenWeather({
+        lat,
+        lon: lng,
+        apiKey: options.openWeatherApiKey,
+        ...callOptions,
+      });
+      if (openWeather.data && !openWeather.envelope?.error) {
+        providers.push(
+          buildProviderRecord({
+            result: openWeather,
+            fieldsSupplied: [
+              "temperature",
+              "wind",
+              "precipitation",
+              "climateZone",
+            ],
+          }),
+        );
+        dataQuality.push({
+          code: buildAuthorityCode(openWeather.authority),
+          severity: "info",
+          message: `OpenWeather returned weather data (authority=${openWeather.authority}).`,
+          source: openWeather.provider,
+        });
+        return {
+          ...openWeather.data,
+          provider: openWeather.provider,
+          authority: openWeather.authority,
+          providers,
+          data_quality: dataQuality,
+        };
+      }
+      recordProviderOutcome({
+        providers,
+        dataQuality,
+        result: openWeather,
+        fields: ["temperature", "wind", "precipitation", "climateZone"],
+      });
     } catch (error) {
-      logger.error('Failed to fetch weather data:', error);
-      // Return fallback data to prevent crash
-      return this.getFallbackData();
+      logger.error("Weather provider chain threw unexpectedly:", error);
+      dataQuality.push({
+        code: "WEATHER_PROVIDER_ERROR",
+        severity: "warning",
+        message: `Weather provider chain threw: ${error?.message || error}`,
+        source: "weather-chain",
+      });
     }
+
+    // 4. Deterministic fallback when all providers fail / are unavailable.
+    return buildDeterministicFallback(providers, dataQuality);
   },
 
   /**
-   * Process raw API response into architectural climate summary
+   * Process raw API response into architectural climate summary.
+   * Retained for any consumers that imported processWeatherData directly
+   * before the chain refactor; new code should use getClimateData and read
+   * the provenance fields.
    */
   processWeatherData(data) {
     const current = data.current_weather || {};
     const daily = data.daily || {};
-
-    // Determine prevailing wind direction (cardinal)
-    const windDir = current.winddirection || daily.wind_direction_10m_dominant?.[0] || 0;
+    const windDir =
+      current.winddirection || daily.wind_direction_10m_dominant?.[0] || 0;
     const cardinalWind = this.degreesToCardinal(windDir);
-
-    // Estimate climate zone based on temperature (very rough heuristic)
     const temp = current.temperature || 15;
-    let climateZone = 'Temperate';
-    if (temp > 25) climateZone = 'Tropical';
-    if (temp > 35) climateZone = 'Arid';
-    if (temp < 5) climateZone = 'Cold';
-    if (temp < -5) climateZone = 'Polar';
-
+    let climateZone = "Temperate";
+    if (temp > 25) climateZone = "Tropical";
+    if (temp > 35) climateZone = "Arid";
+    if (temp < 5) climateZone = "Cold";
+    if (temp < -5) climateZone = "Polar";
     return {
       temperature: {
         current: current.temperature,
         min: daily.temperature_2m_min?.[0],
         max: daily.temperature_2m_max?.[0],
-        unit: '°C'
+        unit: "°C",
       },
       wind: {
         speed: current.windspeed,
         direction: windDir,
         cardinal: cardinalWind,
-        prevailing: cardinalWind, // Alias for compatibility
-        unit: 'km/h'
+        prevailing: cardinalWind,
+        unit: "km/h",
       },
       precipitation: {
         daily: daily.precipitation_sum?.[0] || 0,
-        daily_sum: daily.precipitation_sum?.[0] || 0, // Alias for compatibility
-        unit: 'mm'
+        daily_sum: daily.precipitation_sum?.[0] || 0,
+        unit: "mm",
       },
-      climateZone: climateZone,
-      summary: `Current conditions: ${current.temperature}°C, Wind ${cardinalWind} at ${current.windspeed} km/h`
+      climateZone,
+      summary: `Current conditions: ${current.temperature}°C, Wind ${cardinalWind} at ${current.windspeed} km/h`,
     };
   },
 
-  /**
-   * Convert degrees to cardinal direction
-   */
   degreesToCardinal(degrees) {
-    const dirs = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
-    const index = Math.round(((degrees %= 360) < 0 ? degrees + 360 : degrees) / 45) % 8;
+    const dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+    const index =
+      Math.round(((degrees %= 360) < 0 ? degrees + 360 : degrees) / 45) % 8;
     return dirs[index];
   },
 
-  /**
-   * Fallback data if API fails
-   */
   getFallbackData() {
     return {
-      temperature: { current: 15, min: 10, max: 20, unit: '°C' },
-      wind: { speed: 10, direction: 225, cardinal: 'SW', unit: 'km/h' },
-      precipitation: { daily: 0, unit: 'mm' },
-      climateZone: 'Temperate',
-      summary: 'Weather data unavailable'
+      temperature: { current: 15, min: 10, max: 20, unit: "°C" },
+      wind: {
+        speed: 10,
+        direction: 225,
+        cardinal: "SW",
+        prevailing: "SW",
+        unit: "km/h",
+      },
+      precipitation: { daily: 0, daily_sum: 0, unit: "mm" },
+      climateZone: "Temperate",
+      summary: "Weather data unavailable; UK temperate fallback assumption.",
     };
-  }
+  },
 };
 
 export default weatherService;


### PR DESCRIPTION
## Summary

Phase 3 of the Step 02 / Step 03 data-layer upgrade. Refactors `src/services/weatherService.js` into a server-side provider chain — **Met Office DataHub → Open-Meteo → OpenWeather → deterministic fallback** — and threads `{ provider, authority, providers[], data_quality[] }` provenance through to the slice manifest.

**Backwards-compatible:** the chain output preserves the original `{ temperature, wind, precipitation, climateZone, summary }` shape consumed by existing callers (e.g. `enhancedLocationIntelligence.js`); provenance is purely additive.

- **Met Office DataHub** (`metOfficeDataHubProvider.js`) — primary, `authority='high'`. UK national weather service. Reads `METOFFICE_DATAHUB_API_KEY`.
- **Open-Meteo** (`openMeteoProvider.js`) — fallback, `authority='medium'`. No key required.
- **OpenWeather** (`openWeatherProvider.js`) — final fallback, `authority='low'`. Reads `OPENWEATHER_API_KEY`.
- **Deterministic fallback** — when all three providers fail; emits `WEATHER_AUTHORITY_LOW` so QA can warn.
- **Shared helpers** (`_chainHelpers.js`) — server-only browser guard, fetch resolution, `settleWithin` per-provider timeout (8s default), `runProviderCall` wrapper.

`buildClimatePack` in the slice service stays synchronous; weather is pulled in parallel with `enrichSiteContext` via `Promise.all` and passed in. `provenanceManifest.climateDataProviders` is now populated from `climate.providers[]`.

## Codes added to `climate.data_quality`

- `WEATHER_AUTHORITY_HIGH` / `WEATHER_AUTHORITY_MEDIUM` / `WEATHER_AUTHORITY_LOW`
- `WEATHER_PROVIDER_FALLBACK` (info when chain falls through; warning when the deterministic fallback fires)
- `WEATHER_PROVIDER_TIMEOUT` (warning, per-provider)
- `WEATHER_PROVIDER_ERROR` (warning, per-provider)
- `CLIMATE_PACK_WEATHER_LIVE` (info; new — replaces `CLIMATE_PACK_WEATHER_FALLBACK` when a provider supplied data)

## OpenAI guardrail

The chain provider names are statically restricted to `met-office-datahub`, `open-meteo`, `openweather`, and `deterministic-fallback`. The slice's `provenanceManifest.factualProviderAssertion.openaiAsFactualProvider` will continue to be `false`, asserted both by the existing slice test and by a new chain test (\"OpenAI / GPT names never appear among weather provider records\").

## Files

- `src/services/climate/weatherProviders/_chainHelpers.js` *(new, 179 lines)*
- `src/services/climate/weatherProviders/metOfficeDataHubProvider.js` *(new, 163 lines)*
- `src/services/climate/weatherProviders/openMeteoProvider.js` *(new, 145 lines)*
- `src/services/climate/weatherProviders/openWeatherProvider.js` *(new, 150 lines)*
- `src/services/weatherService.js` (refactor)
- `src/services/project/projectGraphVerticalSliceService.js` (parallel weather pull + buildClimatePack signature)
- `src/__tests__/services/climate/weatherProviders.test.js` (14 new cases)

`.env.example` already declares `METOFFICE_DATAHUB_API_KEY`, `METOFFICE_DATAHUB_BASE_URL`, `OPEN_METEO_*`, and `OPENWEATHER_API_KEY` (no edit needed).

## Validation

- `npm run check:env` — pass
- weatherProviders tests: 24/24 (10 prior + 14 new)
- contextProviders + contextHashInvariant: 22/22 still pass
- comprehensive slice test (~78s): pass with existing manifest assertion
- `npm run check:contracts` — pass
- `npm run test:compose:routing` — 22/22 pass
- `npm run lint` — pass
- `npm run build:active` — compiled successfully

## Test plan

- [ ] Pull this branch, run `npx react-scripts test --watchAll=false --runInBand --testPathPattern=\"weatherProviders\.test\.js\"` — expect 24/24 pass.
- [ ] Inspect chain order: \"Met Office HTTP 503 → falls through to Open-Meteo (MEDIUM)\" and \"All providers fail → deterministic fallback marked WEATHER_AUTHORITY_LOW\".
- [ ] On a Vercel preview with `METOFFICE_DATAHUB_API_KEY` set and the test fixture, POST a brief and verify `result.provenanceManifest.climateDataProviders[0]` reports `name: 'met-office-datahub'`, `authority: 'high'`, `status: 'ok'`, with `WEATHER_AUTHORITY_HIGH` in `result.provenanceManifest.dataQuality`.
- [ ] Without `METOFFICE_DATAHUB_API_KEY`, expect chain to land on Open-Meteo (`WEATHER_AUTHORITY_MEDIUM`); without `OPENWEATHER_API_KEY` either, but with all providers reachable, expect `WEATHER_AUTHORITY_MEDIUM` plus `WEATHER_PROVIDER_FALLBACK`.

## Rollback

`vercel env rm METOFFICE_DATAHUB_API_KEY` removes the primary provider; the chain falls through to Open-Meteo with no slice failure. To bypass the chain entirely set `CONTEXT_PROVIDERS_ENABLED=false` (Phase 1 kill switch) — weather is gated on the same flag.

## Out of scope

- **Phase 2b** (boundary substitution): paused.
- **Phase 4** (UKCP18 live): paused; reference stub remains in `ukcp18Reference.js` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)