### PR TITLE
feat(a1): block final A1 export on technical-panel content-empty + cross-view inconsistency

### DIFF
--- a/src/__tests__/services/a1/a1ExportGateTechnical.phase4.test.js
+++ b/src/__tests__/services/a1/a1ExportGateTechnical.phase4.test.js
@@ -1,0 +1,449 @@
+// Phase 4 — A1 export gate: promote technical content-empty + cross-view
+// inconsistency to blocking, keep visual-panel failures warning-only.
+//
+// Coverage:
+//   1. evaluateTechnicalPanelEvidence — floor plans now in technical set;
+//      schedules_notes excluded; per-panel blockedPanels detail; absent
+//      panels stay warning at every scope (stable gate contract).
+//   2. evaluateCrossViewConsistencyEvidence — drawingConsistencyChecks errors
+//      become CROSS_VIEW_INCONSISTENT blockers; warnings stay warnings;
+//      drawings absent → silent pass.
+//   3. extractTechnicalGroupBlockers — filters to technical sources only.
+//   4. evaluateFinalA1ExportGate end-to-end — technical issues block;
+//      visual-only issues warn but never block from technical group.
+//   5. applyUpstreamGateTechnicalBlockersToQa — folds technical blockers
+//      into qa.status=fail with code A1_EXPORT_GATE_TECHNICAL_BLOCKED.
+
+import {
+  evaluateFinalA1ExportGate,
+  extractTechnicalGroupBlockers,
+  resolveA1RenderContract,
+} from "../../../services/a1/a1FinalExportContract.js";
+import { __projectGraphVerticalSliceInternals } from "../../../services/project/projectGraphVerticalSliceService.js";
+
+const { applyUpstreamGateTechnicalBlockersToQa } =
+  __projectGraphVerticalSliceInternals;
+
+// A realistic 2-storey panel registry. Phase 4 doesn't widen the registry —
+// the slice still uses buildRequiredA1PanelTypes(target_storeys, template).
+// We mirror what that returns for a 2-storey presentation-v3 sheet so the
+// gate's evaluateRequiredPanelEvidence sees its inputs satisfied in the
+// happy-path tests below.
+const TWO_STOREY_REQUIRED_REGISTRY = [
+  "floor_plan_ground",
+  "floor_plan_first",
+  "elevation_north",
+  "elevation_south",
+  "elevation_east",
+  "elevation_west",
+  "section_AA",
+  "section_BB",
+  "hero_3d",
+  "interior_3d",
+  "axonometric",
+  "material_palette",
+  "schedules_notes",
+  "title_block",
+];
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function readyPanel(type) {
+  return { type, status: "ready", hasSvg: true };
+}
+
+function blankPanel(type) {
+  return { type, status: "blocked", hasSvg: false };
+}
+
+function planSvg({
+  northArrow = true,
+  titleBlock = true,
+  scaleBar = true,
+  roomLabel = true,
+  dimensionChain = true,
+} = {}) {
+  return [
+    '<svg xmlns="http://www.w3.org/2000/svg">',
+    northArrow ? '<g id="north-arrow"/>' : "",
+    titleBlock ? '<g id="title-block"/>' : "",
+    scaleBar ? '<g id="scale-bar"/>' : "",
+    roomLabel ? '<text class="room-label">Living Room</text>' : "",
+    dimensionChain ? '<g class="dimension-chain"/>' : "",
+    "</svg>",
+  ].join("");
+}
+
+function elevationSvg() {
+  return '<svg xmlns="http://www.w3.org/2000/svg"><line id="ground-line"/><text>FFL +0.000</text></svg>';
+}
+
+function sectionSvg() {
+  return '<svg xmlns="http://www.w3.org/2000/svg"><line id="ground-line"/><text>Section A-A</text></svg>';
+}
+
+function fullPanelSet() {
+  return [
+    readyPanel("floor_plan_ground"),
+    readyPanel("floor_plan_first"),
+    readyPanel("elevation_north"),
+    readyPanel("elevation_south"),
+    readyPanel("elevation_east"),
+    readyPanel("elevation_west"),
+    readyPanel("section_AA"),
+    readyPanel("section_BB"),
+    readyPanel("hero_3d"),
+    readyPanel("interior_3d"),
+    readyPanel("axonometric"),
+    readyPanel("exterior_render"),
+    readyPanel("material_palette"),
+    readyPanel("schedules_notes"),
+    readyPanel("title_block"),
+  ];
+}
+
+function fullDrawingSet() {
+  return {
+    plan: [
+      { level_id: "0", svg: planSvg() },
+      { level_id: "1", svg: planSvg() },
+    ],
+    elevation: [
+      { svg: elevationSvg(), window_count: 0 },
+      { svg: elevationSvg(), window_count: 0 },
+      { svg: elevationSvg(), window_count: 0 },
+      { svg: elevationSvg(), window_count: 0 },
+    ],
+    section: [
+      { svg: sectionSvg(), stair_count: 0 },
+      { svg: sectionSvg(), stair_count: 0 },
+    ],
+  };
+}
+
+function geometry({ levels = 2 } = {}) {
+  return {
+    levels: Array.from({ length: levels }, (_, idx) => ({ id: String(idx) })),
+    windows: [],
+    stairs: [],
+  };
+}
+
+function gateInputs(overrides = {}) {
+  return {
+    renderContract: resolveA1RenderContract({
+      renderIntent: "final_a1",
+      skipPdf: true,
+    }),
+    panels: fullPanelSet(),
+    panelRegistry: TWO_STOREY_REQUIRED_REGISTRY,
+    targetStoreys: 2,
+    visualManifest: {
+      manifestHash: "manifest-hash-1",
+    },
+    visualPanels: [],
+    materialPalette: { cards: [{ name: "Brick" }] },
+    openaiProvider: { ready: true },
+    drawings: fullDrawingSet(),
+    projectGeometry: geometry(),
+    scope: "upstream_partial",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. evaluateTechnicalPanelEvidence — covered indirectly via the gate.
+// ---------------------------------------------------------------------------
+
+describe("Phase 4 — evaluateTechnicalPanelEvidence (via gate)", () => {
+  test("floor plans are now in the technical set — blank floor_plan_ground blocks", () => {
+    const panels = fullPanelSet().map((panel) =>
+      panel.type === "floor_plan_ground" ? blankPanel(panel.type) : panel,
+    );
+    const gate = evaluateFinalA1ExportGate(gateInputs({ panels }));
+    expect(gate.evidence.technicalPanelStatus.status).toBe("blocked");
+    expect(gate.evidence.technicalPanelStatus.blank).toContain(
+      "floor_plan_ground",
+    );
+    expect(gate.evidence.technicalPanelStatus.codes).toContain(
+      "PANEL_CONTENT_EMPTY",
+    );
+    expect(gate.evidence.technicalPanelStatus.blockers[0]).toMatch(
+      /PANEL_CONTENT_EMPTY/,
+    );
+    expect(gate.evidence.technicalPanelStatus.blockedPanels[0]).toMatchObject({
+      type: "floor_plan_ground",
+      code: "PANEL_CONTENT_EMPTY",
+    });
+  });
+
+  test("schedules_notes (data panel) is NOT in the technical set — blank schedules_notes does not block", () => {
+    const panels = fullPanelSet().map((panel) =>
+      panel.type === "schedules_notes" ? blankPanel(panel.type) : panel,
+    );
+    const gate = evaluateFinalA1ExportGate(gateInputs({ panels }));
+    expect(gate.evidence.technicalPanelStatus.status).toBe("pass");
+    expect(gate.evidence.technicalPanelStatus.blank).toEqual([]);
+  });
+
+  test("axonometric and site_diagram are listed for later phases — blank blocks today", () => {
+    const panels = fullPanelSet().map((panel) =>
+      panel.type === "axonometric" ? blankPanel(panel.type) : panel,
+    );
+    const gate = evaluateFinalA1ExportGate(gateInputs({ panels }));
+    expect(gate.evidence.technicalPanelStatus.status).toBe("blocked");
+    expect(gate.evidence.technicalPanelStatus.blank).toContain("axonometric");
+  });
+
+  test("panels missing → warning at every scope (stable gate contract: absent evidence does not block)", () => {
+    // Phase 4 design rule: real content-empty enforcement fires via
+    // panelIsBlank only when panels ARE provided. Absent panels stays a
+    // warning at every scope so legacy compose callers that don't pass
+    // per-panel data continue to pass the gate (their hard failures come
+    // from PDF/OCR/glyph evidence, not technical panel presence).
+    const upstream = evaluateFinalA1ExportGate(
+      gateInputs({ panels: [], scope: "upstream_partial" }),
+    );
+    expect(upstream.evidence.technicalPanelStatus.status).toBe("warning");
+    expect(upstream.evidence.technicalPanelStatus.blockers).toEqual([]);
+
+    const composeFinal = evaluateFinalA1ExportGate(
+      gateInputs({ panels: [], scope: "compose_final" }),
+    );
+    expect(composeFinal.evidence.technicalPanelStatus.status).toBe("warning");
+    expect(composeFinal.evidence.technicalPanelStatus.blockers).toEqual([]);
+  });
+
+  test("all elevation panels OK → pass", () => {
+    const gate = evaluateFinalA1ExportGate(gateInputs());
+    expect(gate.evidence.technicalPanelStatus.status).toBe("pass");
+    expect(gate.evidence.technicalPanelStatus.blockers).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. evaluateCrossViewConsistencyEvidence — covered via the gate.
+// ---------------------------------------------------------------------------
+
+describe("Phase 4 — evaluateCrossViewConsistencyEvidence (via gate)", () => {
+  test("plan SVG missing north-arrow → CROSS_VIEW_INCONSISTENT blocker", () => {
+    const drawings = {
+      plan: [
+        { level_id: "0", svg: planSvg({ northArrow: false }) },
+        { level_id: "1", svg: planSvg() },
+      ],
+      elevation: fullDrawingSet().elevation,
+      section: fullDrawingSet().section,
+    };
+    const gate = evaluateFinalA1ExportGate(gateInputs({ drawings }));
+    expect(gate.evidence.crossViewConsistencyStatus.status).toBe("blocked");
+    expect(gate.evidence.crossViewConsistencyStatus.codes).toContain(
+      "CROSS_VIEW_INCONSISTENT",
+    );
+    expect(gate.evidence.crossViewConsistencyStatus.blockers[0]).toMatch(
+      /CROSS_VIEW_INCONSISTENT/,
+    );
+    expect(gate.evidence.crossViewConsistencyStatus.blockers[0]).toMatch(
+      /north-arrow/,
+    );
+  });
+
+  test("plan SVG missing scale-bar → warning only (not blocker)", () => {
+    const drawings = {
+      plan: [
+        { level_id: "0", svg: planSvg({ scaleBar: false }) },
+        { level_id: "1", svg: planSvg() },
+      ],
+      elevation: fullDrawingSet().elevation,
+      section: fullDrawingSet().section,
+    };
+    const gate = evaluateFinalA1ExportGate(gateInputs({ drawings }));
+    expect(gate.evidence.crossViewConsistencyStatus.status).toBe("warning");
+    expect(gate.evidence.crossViewConsistencyStatus.blockers).toEqual([]);
+    expect(
+      gate.evidence.crossViewConsistencyStatus.warnings.length,
+    ).toBeGreaterThan(0);
+  });
+
+  test("valid drawings → pass", () => {
+    const gate = evaluateFinalA1ExportGate(gateInputs());
+    expect(gate.evidence.crossViewConsistencyStatus.status).toBe("pass");
+  });
+
+  test("drawings absent → silent pass (no opinion, no warning)", () => {
+    // Phase 4: callers that don't opt into cross-view evidence (e.g., the
+    // compose route that has no drawings to pass) must not see a new
+    // warning materialise. The evaluator returns evaluated=false to signal
+    // "no opinion" instead.
+    const gate = evaluateFinalA1ExportGate(gateInputs({ drawings: null }));
+    expect(gate.evidence.crossViewConsistencyStatus.status).toBe("pass");
+    expect(gate.evidence.crossViewConsistencyStatus.blockers).toEqual([]);
+    expect(gate.evidence.crossViewConsistencyStatus.warnings).toEqual([]);
+    expect(gate.evidence.crossViewConsistencyStatus.evaluated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. extractTechnicalGroupBlockers
+// ---------------------------------------------------------------------------
+
+describe("Phase 4 — extractTechnicalGroupBlockers", () => {
+  test("returns blocked=false when nothing fails", () => {
+    const gate = evaluateFinalA1ExportGate(gateInputs());
+    const summary = extractTechnicalGroupBlockers(gate);
+    expect(summary.blocked).toBe(false);
+    expect(summary.blockers).toEqual([]);
+  });
+
+  test("returns blocked=true with PANEL_CONTENT_EMPTY when a floor plan is blank", () => {
+    const panels = fullPanelSet().map((panel) =>
+      panel.type === "floor_plan_first" ? blankPanel(panel.type) : panel,
+    );
+    const gate = evaluateFinalA1ExportGate(gateInputs({ panels }));
+    const summary = extractTechnicalGroupBlockers(gate);
+    expect(summary.blocked).toBe(true);
+    expect(summary.codes).toContain("PANEL_CONTENT_EMPTY");
+    expect(summary.sources).toContain("technicalPanelStatus");
+    expect(summary.blockedPanels[0].type).toBe("floor_plan_first");
+  });
+
+  test("returns blocked=true with CROSS_VIEW_INCONSISTENT when drawings are bad", () => {
+    const drawings = {
+      plan: [{ level_id: "0", svg: planSvg({ titleBlock: false }) }],
+      elevation: fullDrawingSet().elevation,
+      section: fullDrawingSet().section,
+    };
+    const gate = evaluateFinalA1ExportGate(
+      gateInputs({ drawings, projectGeometry: geometry({ levels: 1 }) }),
+    );
+    const summary = extractTechnicalGroupBlockers(gate);
+    expect(summary.blocked).toBe(true);
+    expect(summary.codes).toContain("CROSS_VIEW_INCONSISTENT");
+    expect(summary.sources).toContain("crossViewConsistencyStatus");
+  });
+
+  test("visual-panel manifest mismatch is NOT in technical group (warning-only)", () => {
+    const visualPanels = [
+      {
+        type: "hero_3d",
+        visualManifestHash: "different-hash",
+        visualIdentityLocked: true,
+      },
+    ];
+    const gate = evaluateFinalA1ExportGate(gateInputs({ visualPanels }));
+    const summary = extractTechnicalGroupBlockers(gate);
+    // The visual manifest mismatch produces a gate-level blocker, but
+    // extractTechnicalGroupBlockers must NOT include it in the technical
+    // summary — visual concerns stay non-fatal at the slice level.
+    expect(summary.sources).not.toContain("visualPanelStatus");
+    expect(summary.sources).not.toContain("visualManifestStatus");
+  });
+
+  test("not_applicable gate (preview, not final A1) → blocked=false", () => {
+    const gate = {
+      status: "not_applicable",
+      allowed: true,
+      blockers: [],
+      evidence: {},
+    };
+    expect(extractTechnicalGroupBlockers(gate).blocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. evaluateFinalA1ExportGate — visual-only failures stay warning-only.
+// ---------------------------------------------------------------------------
+
+describe("Phase 4 — gate-level visual vs technical separation", () => {
+  test("visual manifest mismatch blocks at gate level but is excluded from technical-group", () => {
+    const visualPanels = [
+      {
+        type: "hero_3d",
+        visualManifestHash: "different-hash",
+        visualIdentityLocked: true,
+      },
+    ];
+    const gate = evaluateFinalA1ExportGate(gateInputs({ visualPanels }));
+    // Gate may report blocked overall (because visualPanelStatus blocks),
+    // but the technical-group filter must keep blocked=false so the slice
+    // does not 422 on visual-only issues.
+    const summary = extractTechnicalGroupBlockers(gate);
+    expect(summary.blocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. applyUpstreamGateTechnicalBlockersToQa — folds blockers into qa.status.
+// ---------------------------------------------------------------------------
+
+describe("Phase 4 — applyUpstreamGateTechnicalBlockersToQa", () => {
+  function passingQa() {
+    return { status: "pass", checks: [], issues: [], score: 100 };
+  }
+
+  test("no upstream gate → qa unchanged", () => {
+    const qa = passingQa();
+    const result = applyUpstreamGateTechnicalBlockersToQa(qa, null);
+    expect(result).toBe(qa);
+  });
+
+  test("upstream gate with no technical blockers → qa unchanged", () => {
+    const gate = evaluateFinalA1ExportGate(gateInputs());
+    const qa = passingQa();
+    const result = applyUpstreamGateTechnicalBlockersToQa(qa, gate);
+    expect(result.status).toBe("pass");
+    expect(result.upstreamGateTechnicalBlocked).toBeUndefined();
+  });
+
+  test("PANEL_CONTENT_EMPTY → qa.status=fail with code A1_EXPORT_GATE_TECHNICAL_BLOCKED", () => {
+    const panels = fullPanelSet().map((panel) =>
+      panel.type === "floor_plan_ground" ? blankPanel(panel.type) : panel,
+    );
+    const gate = evaluateFinalA1ExportGate(gateInputs({ panels }));
+    const result = applyUpstreamGateTechnicalBlockersToQa(passingQa(), gate);
+    expect(result.status).toBe("fail");
+    expect(result.upstreamGateTechnicalBlocked).toBe(true);
+    expect(result.issues[0].code).toBe("A1_EXPORT_GATE_TECHNICAL_BLOCKED");
+    expect(result.issues[0].severity).toBe("error");
+    expect(result.issues[0].details.codes).toContain("PANEL_CONTENT_EMPTY");
+    expect(result.issues[0].details.blockedPanels[0].type).toBe(
+      "floor_plan_ground",
+    );
+    const check = result.checks.find(
+      (c) => c.code === "A1_EXPORT_GATE_TECHNICAL_PANELS_PASS",
+    );
+    expect(check).toBeDefined();
+    expect(check.status).toBe("fail");
+  });
+
+  test("CROSS_VIEW_INCONSISTENT → qa.status=fail", () => {
+    const drawings = {
+      plan: [{ level_id: "0", svg: planSvg({ northArrow: false }) }],
+      elevation: fullDrawingSet().elevation,
+      section: fullDrawingSet().section,
+    };
+    const gate = evaluateFinalA1ExportGate(
+      gateInputs({ drawings, projectGeometry: geometry({ levels: 1 }) }),
+    );
+    const result = applyUpstreamGateTechnicalBlockersToQa(passingQa(), gate);
+    expect(result.status).toBe("fail");
+    expect(result.issues[0].details.codes).toContain("CROSS_VIEW_INCONSISTENT");
+  });
+
+  test("visual-only failures → qa unchanged (warning-only at slice level)", () => {
+    const visualPanels = [
+      {
+        type: "hero_3d",
+        visualManifestHash: "different-hash",
+        visualIdentityLocked: true,
+      },
+    ];
+    const gate = evaluateFinalA1ExportGate(gateInputs({ visualPanels }));
+    const qa = passingQa();
+    const result = applyUpstreamGateTechnicalBlockersToQa(qa, gate);
+    expect(result.status).toBe("pass");
+    expect(result.upstreamGateTechnicalBlocked).toBeUndefined();
+  });
+});

--- a/src/services/a1/a1FinalExportContract.js
+++ b/src/services/a1/a1FinalExportContract.js
@@ -5,6 +5,7 @@ import {
   WORKING_WIDTH,
 } from "./composeCore.js";
 import { resolvePreComposeRegressionPolicy } from "./a1PreComposeRegressionPolicy.js";
+import { runDrawingConsistencyChecks } from "../validation/drawingConsistencyChecks.js";
 
 export const PREVIEW_RENDER_INTENT = "preview";
 export const FINAL_A1_RENDER_INTENT = "final_a1";
@@ -823,12 +824,59 @@ function evaluateRequiredPanelEvidence({
   };
 }
 
-function evaluateTechnicalPanelEvidence({ panels }) {
+// Phase 4: technical panel set is the deterministic-SVG drawings the A1
+// export depends on for geometry communication. Floor plans were missing
+// from the prior set — that's the gap the failing PDF exposed. axonometric
+// and site_diagram are listed here so that *once* later phases re-classify
+// them as compiled-technical-svg renderers, the content-empty gate covers
+// them automatically. Today they still route through the visual fallback,
+// so panelIsBlank only fires if the placement status is non-ready (i.e.
+// even the deterministic_fallback SVG is missing).
+const TECHNICAL_PANEL_TYPES_FOR_GATE = Object.freeze([
+  "floor_plan_ground",
+  "floor_plan_first",
+  "floor_plan_level2",
+  "floor_plan_level3",
+  "floor_plan_level4",
+  "floor_plan_level5",
+  "floor_plan_level6",
+  "floor_plan_level7",
+  "elevation_north",
+  "elevation_south",
+  "elevation_east",
+  "elevation_west",
+  "section_AA",
+  "section_BB",
+  // Effective once later phases re-classify these as technical:
+  "axonometric",
+  "site_diagram",
+]);
+
+function isTechnicalPanelType(type) {
+  if (!type) return false;
+  if (TECHNICAL_PANEL_TYPES_FOR_GATE.includes(type)) return true;
+  // Defensive: accept any floor_plan_* / elevation_* / section_* variant we
+  // may add later.
+  if (typeof type === "string") {
+    if (type.startsWith("floor_plan_")) return true;
+    if (type.startsWith("elevation_")) return true;
+    if (type.startsWith("section_")) return true;
+  }
+  return false;
+}
+
+function evaluateTechnicalPanelEvidence({ panels } = {}) {
   const blockers = [];
   const warnings = [];
   const blank = [];
+  const blockedPanels = [];
 
   if (!Array.isArray(panels) || panels.length === 0) {
+    // Stable gate contract: absent evidence degrades to warning, not block.
+    // Real content-empty enforcement fires via panelIsBlank when panels ARE
+    // provided. This keeps legacy compose flows that don't pass per-panel
+    // data passing the gate (their hard failures come from PDF/OCR/glyph
+    // evidence, not technical panel presence).
     return {
       status: "warning",
       blockers,
@@ -836,29 +884,30 @@ function evaluateTechnicalPanelEvidence({ panels }) {
         "Technical panel evidence not provided to gate; per-panel render status unknown.",
       ],
       blank: [],
+      blockedPanels: [],
+      codes: [],
     };
   }
 
-  const technicalTypes = new Set([
-    "elevation_north",
-    "elevation_south",
-    "elevation_east",
-    "elevation_west",
-    "section_AA",
-    "section_BB",
-    "schedules_notes",
-    "site_diagram",
-  ]);
-
   for (const panel of panels) {
     const type = panelTypeOf(panel);
-    if (!type || !technicalTypes.has(type)) continue;
-    if (panelIsBlank(panel)) blank.push(type);
+    if (!type || !isTechnicalPanelType(type)) continue;
+    if (panelIsBlank(panel)) {
+      blank.push(type);
+      blockedPanels.push({
+        type,
+        code: "PANEL_CONTENT_EMPTY",
+        status: panel?.status || null,
+        hasSvg: panel?.hasSvg === true,
+      });
+    }
   }
+
+  const codes = blockedPanels.length ? ["PANEL_CONTENT_EMPTY"] : [];
 
   if (blank.length) {
     blockers.push(
-      `Required technical panel(s) missing or blank: ${blank.join(", ")}.`,
+      `PANEL_CONTENT_EMPTY: Required technical panel(s) missing or blank: ${blank.join(", ")}.`,
     );
   }
 
@@ -871,6 +920,82 @@ function evaluateTechnicalPanelEvidence({ panels }) {
     blockers: unique(blockers),
     warnings: unique(warnings),
     blank,
+    blockedPanels,
+    codes,
+  };
+}
+
+// Phase 4: cross-view consistency evidence. Wraps drawingConsistencyChecks
+// (which already inspects SVG for required markers, dimension-chains, and
+// cross-view storey/window agreement). Errors are promoted to blockers
+// (technical group); warnings remain warnings. Returns silent pass when no
+// drawings are provided so callers that don't opt in (e.g. legacy compose
+// flows) keep their previous gate result.
+function evaluateCrossViewConsistencyEvidence({ drawings, projectGeometry }) {
+  const blockers = [];
+  const warnings = [];
+  const codes = [];
+
+  if (!drawings || typeof drawings !== "object") {
+    // Caller did not opt into cross-view evidence. Per Phase 4 design, this
+    // is silent (no opinion) — not a warning — so existing call sites that
+    // don't pass `drawings` keep their previous gate result. Cross-view
+    // blocking only fires when drawings are explicitly supplied.
+    return {
+      status: "pass",
+      blockers,
+      warnings,
+      errors: [],
+      codes,
+      raw: null,
+      evaluated: false,
+    };
+  }
+
+  let raw = null;
+  try {
+    raw = runDrawingConsistencyChecks({
+      projectGeometry: projectGeometry || {},
+      drawings,
+    });
+  } catch (error) {
+    return {
+      status: "warning",
+      blockers,
+      warnings: [
+        `Cross-view consistency evaluator threw: ${error?.message || error}.`,
+      ],
+      errors: [],
+      codes,
+      raw: null,
+      evaluated: false,
+    };
+  }
+
+  const errors = Array.isArray(raw?.errors) ? raw.errors : [];
+  if (errors.length) {
+    codes.push("CROSS_VIEW_INCONSISTENT");
+    for (const message of errors) {
+      blockers.push(`CROSS_VIEW_INCONSISTENT: ${message}`);
+    }
+  }
+
+  if (Array.isArray(raw?.warnings)) {
+    warnings.push(...raw.warnings);
+  }
+
+  let status = "pass";
+  if (blockers.length) status = "blocked";
+  else if (warnings.length) status = "warning";
+
+  return {
+    status,
+    blockers: unique(blockers),
+    warnings: unique(warnings),
+    errors,
+    codes,
+    raw,
+    evaluated: true,
   };
 }
 
@@ -1175,6 +1300,11 @@ export function evaluateFinalA1ExportGate({
   strictPhotoreal = false,
   imageGenEnabled = false,
   scope = PHASE_F_GATE_SCOPES.COMPOSE_FINAL,
+  // Phase 4 additions: cross-view consistency evidence inputs. Optional —
+  // absent inputs return silent pass (not a warning), so legacy callers
+  // that don't supply drawings see no behavior change.
+  drawings = null,
+  projectGeometry = null,
 } = {}) {
   if (!renderContract?.isFinalA1) {
     return {
@@ -1264,6 +1394,10 @@ export function evaluateFinalA1ExportGate({
     targetStoreys,
   });
   const technicalPanelStatus = evaluateTechnicalPanelEvidence({ panels });
+  const crossViewConsistencyStatus = evaluateCrossViewConsistencyEvidence({
+    drawings,
+    projectGeometry,
+  });
   const visualManifestStatus = evaluateVisualManifestEvidence({
     visualManifest,
     visualPanels,
@@ -1307,6 +1441,7 @@ export function evaluateFinalA1ExportGate({
     rasterEvidence,
     requiredPanelStatus,
     technicalPanelStatus,
+    crossViewConsistencyStatus,
     visualManifestStatus,
     materialPaletteStatus,
     openaiProviderStatus,
@@ -1339,6 +1474,7 @@ export function evaluateFinalA1ExportGate({
       rasterGlyphIntegrity: rasterEvidence,
       requiredPanelStatus,
       technicalPanelStatus,
+      crossViewConsistencyStatus,
       visualPanelStatus,
       visualManifestStatus,
       materialPaletteStatus,
@@ -1349,15 +1485,87 @@ export function evaluateFinalA1ExportGate({
   };
 }
 
+// Phase 4: technical-group blocker extraction. The gate aggregates evidence
+// from both technical-drawing concerns and visual/photoreal concerns. The
+// slice service must fail-closed only on the *technical* group — visual
+// failures stay warning-only per Phase 4 scope. This helper isolates that
+// subset so callers don't have to know which evidence keys are technical.
+//
+// Technical sources:
+//   - technicalPanelStatus      → PANEL_CONTENT_EMPTY
+//   - crossViewConsistencyStatus → CROSS_VIEW_INCONSISTENT
+//   - requiredPanelStatus       → A1_REQUIRED_PANEL_MISSING (panel registry)
+//   - layoutStatus              → A1_LAYOUT_BROKEN
+//   - sheetSplitStatus          → A1_SHEET_SPLIT_REQUIRED
+//
+// Visual sources (intentionally excluded):
+//   - visualPanelStatus, visualManifestStatus, materialPaletteStatus,
+//     openaiProviderStatus, pdfMetadata, rasterGlyphIntegrity
+export function extractTechnicalGroupBlockers(gateResult) {
+  const empty = {
+    blocked: false,
+    blockers: [],
+    warnings: [],
+    codes: [],
+    sources: [],
+    blockedPanels: [],
+  };
+  if (!gateResult || gateResult.status === "not_applicable") return empty;
+  const evidence = gateResult.evidence || {};
+  const technicalSources = [
+    { key: "technicalPanelStatus", ev: evidence.technicalPanelStatus },
+    {
+      key: "crossViewConsistencyStatus",
+      ev: evidence.crossViewConsistencyStatus,
+    },
+    { key: "requiredPanelStatus", ev: evidence.requiredPanelStatus },
+    { key: "layoutStatus", ev: evidence.layoutStatus },
+    { key: "sheetSplitStatus", ev: evidence.sheetSplitStatus },
+  ];
+  const blockers = [];
+  const warnings = [];
+  const codes = [];
+  const sources = [];
+  const blockedPanels = [];
+  for (const { key, ev } of technicalSources) {
+    if (!ev) continue;
+    if (Array.isArray(ev.blockers) && ev.blockers.length) {
+      blockers.push(...ev.blockers);
+      sources.push(key);
+    }
+    if (Array.isArray(ev.warnings) && ev.warnings.length) {
+      warnings.push(...ev.warnings);
+    }
+    if (Array.isArray(ev.codes) && ev.codes.length) {
+      codes.push(...ev.codes);
+    }
+    if (Array.isArray(ev.blockedPanels) && ev.blockedPanels.length) {
+      blockedPanels.push(...ev.blockedPanels);
+    }
+  }
+  return {
+    blocked: blockers.length > 0,
+    blockers: unique(blockers),
+    warnings: unique(warnings),
+    codes: unique(codes),
+    sources: unique(sources),
+    blockedPanels,
+  };
+}
+
+export { TECHNICAL_PANEL_TYPES_FOR_GATE };
+
 export default {
   A1_PHYSICAL_SHEET_SIZE_MM,
   FINAL_A1_PNG_DIMENSIONS,
   PHASE_F_EXPORT_GATE_VERSION,
   PREVIEW_PNG_DIMENSIONS,
+  TECHNICAL_PANEL_TYPES_FOR_GATE,
   buildA1SheetSetPlan,
   buildSheetTextContract,
   detectA1GlyphIntegrity,
   evaluateFinalA1ExportGate,
+  extractTechnicalGroupBlockers,
   normalizeSheetTextContract,
   resolveA1RenderContract,
 };

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -78,6 +78,7 @@ import {
   detectA1GlyphIntegrity,
   detectA1RasterGlyphIntegrity,
   evaluateFinalA1ExportGate,
+  extractTechnicalGroupBlockers,
   resolveA1RenderContract,
 } from "../a1/a1FinalExportContract.js";
 import {
@@ -7190,6 +7191,71 @@ function applyOpenAIReasoningBlockersToQa(qa, blockedCalls = []) {
   };
 }
 
+// Phase 4: fold technical-group blockers from the upstream A1 export gate
+// into qa. Mirrors applyOpenAIReasoningBlockersToQa. Visual-panel blockers
+// are intentionally NOT included here — they remain warning-only on
+// sheetArtifact.quality.exportGate per Phase 4 scope.
+//
+// Codes raised by this helper:
+//   PANEL_CONTENT_EMPTY        → technical drawing missing/blank
+//   CROSS_VIEW_INCONSISTENT    → drawingConsistencyChecks errors
+//   A1_REQUIRED_PANEL_MISSING  → required-panel registry mismatch
+//   A1_LAYOUT_BROKEN           → layout evaluator failure
+//   A1_SHEET_SPLIT_REQUIRED    → A1-01 overflow without companion
+//
+// All folded under a single qa issue code to keep the slice's response
+// shape stable: A1_EXPORT_GATE_TECHNICAL_BLOCKED. Per-source detail is
+// preserved on the issue.details + the addCheck payload.
+function applyUpstreamGateTechnicalBlockersToQa(qa, exportGate) {
+  if (!exportGate) return qa;
+  const summary = extractTechnicalGroupBlockers(exportGate);
+  if (!summary.blocked) return qa;
+  const checks = [...(qa.checks || [])];
+  addCheck(
+    checks,
+    "A1_EXPORT_GATE_TECHNICAL_PANELS_PASS",
+    false,
+    {
+      sources: summary.sources,
+      codes: summary.codes,
+      blockerCount: summary.blockers.length,
+      blockedPanels: summary.blockedPanels,
+      blockers: summary.blockers,
+    },
+    "graphic",
+    0,
+  );
+  const issues = [
+    ...(qa.issues || []),
+    buildIssue(
+      "A1_EXPORT_GATE_TECHNICAL_BLOCKED",
+      "error",
+      "A1 final export blocked by technical-panel evidence (content-empty or cross-view inconsistent).",
+      {
+        sources: summary.sources,
+        codes: summary.codes,
+        blockedPanels: summary.blockedPanels,
+        blockers: summary.blockers,
+      },
+    ),
+  ];
+  const warningCount = issues.filter(
+    (issue) => issue.severity === "warning",
+  ).length;
+  const errorCount = issues.filter(
+    (issue) => issue.severity === "error",
+  ).length;
+  return {
+    ...qa,
+    status: "fail",
+    checks,
+    issues,
+    score: Math.max(0, 100 - errorCount * 18 - warningCount * 6),
+    upstreamGateTechnicalBlocked: true,
+    upstreamGateTechnicalSummary: summary,
+  };
+}
+
 // Phase B closeout: per-panel-type fit policy for presentation-v3.
 // Technical drawings cropped tight to contentBounds (with small padding) so
 // drawings fill 80–92% of the slot; site/3D/data panels keep the previous
@@ -10590,6 +10656,26 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
         hasSvg: placement.status === "ready",
       }),
     );
+    // Phase 4: bucket the deterministic drawing SVGs by drawing type so the
+    // gate's cross-view evidence evaluator (drawingConsistencyChecks) can
+    // inspect them. Only artifacts with an `svgString` participate; the
+    // checker reads `svg` so we forward it through.
+    const drawingsForGate = { plan: [], elevation: [], section: [] };
+    for (const artifact of Object.values(drawingArtifacts || {})) {
+      const dt = artifact?.drawingType || artifact?.metadata?.drawingType;
+      const svg = artifact?.svgString;
+      if (!svg || !dt) continue;
+      if (dt === "plan") {
+        drawingsForGate.plan.push({
+          level_id: artifact?.metadata?.level_id || null,
+          svg,
+        });
+      } else if (dt === "elevation") {
+        drawingsForGate.elevation.push({ svg, window_count: 0 });
+      } else if (dt === "section") {
+        drawingsForGate.section.push({ svg, stair_count: 0 });
+      }
+    }
     const upstreamRenderContract = resolveA1RenderContract({
       renderIntent: "final_a1",
     });
@@ -10608,6 +10694,9 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
         process.env.OPENAI_STRICT_IMAGE_GEN === "true",
       imageGenEnabled: process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED === "true",
       scope: "upstream_partial",
+      // Phase 4: cross-view consistency evidence inputs.
+      drawings: drawingsForGate,
+      projectGeometry,
     });
     sheetArtifact.quality = {
       ...(sheetArtifact.quality || {}),
@@ -10789,6 +10878,15 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
   qa = applyOpenAIReasoningBlockersToQa(
     qa,
     getBlockedOpenAIReasoningCalls(providerCalls),
+  );
+  // Phase 4: fold the upstream A1 export gate's technical-group blockers
+  // (PANEL_CONTENT_EMPTY, CROSS_VIEW_INCONSISTENT, A1_REQUIRED_PANEL_MISSING,
+  // A1_LAYOUT_BROKEN, A1_SHEET_SPLIT_REQUIRED) into qa so the slice returns
+  // success: false → API maps to 422. Visual-panel blockers stay warning-only
+  // on sheetArtifact.quality.exportGate per Phase 4 scope.
+  qa = applyUpstreamGateTechnicalBlockersToQa(
+    qa,
+    artifacts?.a1Sheet?.quality?.exportGate || null,
   );
   qa.openai = openaiQaMetadata;
   __vsMark = __vsLog("validate_qa", __vsMark, `qa_status=${qa.status}`);
@@ -10979,6 +11077,8 @@ export const __projectGraphVerticalSliceInternals = Object.freeze({
   buildProjectGeometryFromProgramme,
   syncProgrammeActuals,
   compileProject,
+  // Phase 4: exposed for unit testing the upstream-gate technical-blocker fold.
+  applyUpstreamGateTechnicalBlockersToQa,
 });
 
 export default {


### PR DESCRIPTION
## Summary

Phase 4 closes the structural reason `qa_status=fail` was being shipped as a successful A1 export. The slice already evaluated `evaluateFinalA1ExportGate` at `upstream_partial` scope, but the result was *informational only* — `sheetArtifact.quality.exportGate` was set without affecting `qa.status`, so the slice returned `success: true` even when the gate reported `blocked`.

This PR:

1. Strengthens `evaluateTechnicalPanelEvidence` so floor plans, axonometric, and `site_diagram` are part of the technical-content set; removes `schedules_notes` (it is a data panel, rendered deterministically during composition).
2. Adds `evaluateCrossViewConsistencyEvidence` — a thin wrapper around the existing `runDrawingConsistencyChecks` that promotes its `errors` to `CROSS_VIEW_INCONSISTENT` blockers (warnings stay warnings; absent drawings → silent pass so legacy compose flows are unaffected).
3. Adds the helper `extractTechnicalGroupBlockers` that isolates the *technical* group from the gate result, and `applyUpstreamGateTechnicalBlockersToQa` in the slice that folds those blockers into `qa.issues` with code `A1_EXPORT_GATE_TECHNICAL_BLOCKED`. The slice's existing `success: qa.status === "pass"` then flips to `false` and `api/project/generate-vertical-slice.js:48` maps that to **HTTP 422**.

Visual-panel issues (`visualPanelStatus`, `visualManifestStatus`, `materialPaletteStatus`, `openaiProviderStatus`, etc.) are intentionally **NOT** folded into qa — they remain warning-only on `sheetArtifact.quality.exportGate` per Phase 4 scope.

### Worktree path
Implemented in an isolated git worktree to avoid sharing a working tree with parallel sessions:
`C:\Users\21366\OneDrive\Documents\GitHub\architect-ai-a1-phase4`

### Branch base
`main` @ `b210543` (includes PR #82 contextAggregator + PR #83 OS NGD building-footprint provider).

### Commits (3)
- `9f734c4` `feat(a1-export-gate): add technical content-empty + cross-view blockers (Phase 4 / part 1)`
- `43038a1` `feat(a1-slice): wire upstream gate technical blockers into qa.status (Phase 4 / part 2)`
- `34c58e6` `test(a1-export-gate): add Phase 4 unit tests (20 cases) for content-empty + cross-view blocking`

### Files changed (3 files, +772 / −15)
| File | Δ | Purpose |
|---|---|---|
| `src/services/a1/a1FinalExportContract.js` | +238 / −15 | New `TECHNICAL_PANEL_TYPES_FOR_GATE`; strengthened `evaluateTechnicalPanelEvidence`; new `evaluateCrossViewConsistencyEvidence`; gate signature accepts `drawings` + `projectGeometry`; new `extractTechnicalGroupBlockers` exported helper |
| `src/services/project/projectGraphVerticalSliceService.js` | +100 | Builds `drawingsForGate` from `drawingArtifacts`; passes `drawings` + `projectGeometry` into `evaluateFinalA1ExportGate`; new `applyUpstreamGateTechnicalBlockersToQa` helper folded into the qa pipeline; helper exposed via `__projectGraphVerticalSliceInternals` for unit tests |
| `src/__tests__/services/a1/a1ExportGateTechnical.phase4.test.js` | +449 (new) | 20 unit tests covering all five surfaces |

### Tests passed
- **Phase 4 tests (new):** 20/20 ✅ (`a1ExportGateTechnical.phase4.test.js`)
- **Regression check:** 61/61 ✅ across `a1FinalExportContract.test.js` + `drawingConsistencyChecks.test.js` + Phase 4 — no existing tests broken
- `npm run check:env` ✅ Environment validation passed
- `npm run check:contracts` ✅ Contract check PASSED
- `npm run test:compose:routing` ✅ 22/22
- `npm run lint` ✅
- `npm run build:active` ✅

### qa_status=fail now blocks final technical A1 export — confirmed
**Before Phase 4:** gate computed `blocked` but the slice's `success: qa.status === "pass"` ignored it → PDF shipped despite `qa_status=fail`.

**After Phase 4:** technical-group blockers are folded into `qa.issues` with severity `error`, recomputing `qa.status="fail"`. The slice's existing return therefore flips to `success: false`, and `api/project/generate-vertical-slice.js:48` returns **HTTP 422**.

The chain:
```
panelIsBlank / runDrawingConsistencyChecks errors
  → evaluateTechnicalPanelEvidence / evaluateCrossViewConsistencyEvidence  (gate side)
  → evaluateFinalA1ExportGate.evidence.{technical,crossView}
  → extractTechnicalGroupBlockers  (filter to technical group)
  → applyUpstreamGateTechnicalBlockersToQa  (fold into qa)
  → qa.status = "fail"
  → success: false
  → HTTP 422
```

### Codes raised
| Code | Source | What it catches |
|---|---|---|
| `PANEL_CONTENT_EMPTY` | `technicalPanelStatus` | A required technical drawing is missing or blank (`panelIsBlank` true) |
| `CROSS_VIEW_INCONSISTENT` | `crossViewConsistencyStatus` | `drawingConsistencyChecks` reported an `error` (e.g. plan SVG missing `north-arrow`/`title-block` marker, plan-vs-elevation count mismatch) |
| `A1_REQUIRED_PANEL_MISSING` | `requiredPanelStatus` | Already existed — registry mismatch |
| `A1_LAYOUT_BROKEN` | `layoutStatus` | Already existed — layout evaluator failure |
| `A1_SHEET_SPLIT_REQUIRED` | `sheetSplitStatus` | Already existed — A1-01 overflow without companion |

All five technical-group codes surface under a single stable `qa.issues[]` entry: `code: "A1_EXPORT_GATE_TECHNICAL_BLOCKED"`, with `details.codes`, `details.sources`, `details.blockedPanels`, and `details.blockers` carrying the fan-out detail.

### Sample 422 blocked-export payload (real, from `tmp/phase4-blocked-export-sample.mjs`)
Scenario: 2-storey detached house, `floor_plan_ground` placement returned `status=blocked, hasSvg=false`, and `drawings.plan[0]` SVG is missing the `north-arrow` marker. Result:

```json
{
  "httpStatus": 422,
  "body": {
    "success": false,
    "qa": {
      "status": "fail",
      "score": 82,
      "upstreamGateTechnicalBlocked": true,
      "issues": [
        {
          "code": "A1_EXPORT_GATE_TECHNICAL_BLOCKED",
          "severity": "error",
          "message": "A1 final export blocked by technical-panel evidence (content-empty or cross-view inconsistent).",
          "details": {
            "sources": ["technicalPanelStatus", "crossViewConsistencyStatus"],
            "codes": ["PANEL_CONTENT_EMPTY", "CROSS_VIEW_INCONSISTENT"],
            "blockedPanels": [
              {"type": "floor_plan_ground", "code": "PANEL_CONTENT_EMPTY", "status": "blocked", "hasSvg": false}
            ],
            "blockers": [
              "PANEL_CONTENT_EMPTY: Required technical panel(s) missing or blank: floor_plan_ground.",
              "CROSS_VIEW_INCONSISTENT: drawings.plan[0] is missing the north-arrow marker."
            ]
          }
        }
      ]
    },
    "artifacts": {
      "a1Sheet": {
        "quality": {
          "exportGate": {
            "status": "blocked",
            "allowed": false,
            "blockers": [
              "PANEL_CONTENT_EMPTY: Required technical panel(s) missing or blank: floor_plan_ground.",
              "CROSS_VIEW_INCONSISTENT: drawings.plan[0] is missing the north-arrow marker."
            ],
            "warnings": [
              "Material palette has 1 card(s) without complete provenance ..."
            ]
          }
        }
      }
    }
  }
}
```

Note: the visual concern (material-palette provenance warning) is correctly **not** in the technical-blocker fold — it stays on `quality.exportGate.warnings` and does not contribute to the slice failing closed.

### Visual-panel issues remain warning-only
Per Phase 4 scope, visual-panel concerns are kept advisory:
- `visualPanelStatus` (manifest hash mismatch on hero_3d / interior_3d / etc.)
- `visualManifestStatus`
- `materialPaletteStatus`
- `openaiProviderStatus`
- `pdfMetadata`, `rasterGlyphIntegrity` (PDF concerns owned by the compose route)

`extractTechnicalGroupBlockers` explicitly excludes these sources. They keep their previous warning-only behavior on `sheetArtifact.quality.exportGate.warnings`.

### Out of scope (deliberately not touched in this PR)
- ❌ No plan renderer fidelity changes (door swings, window symbols, dimension chains, furniture coverage, north arrow, scale bar)
- ❌ No axonometric renderer (Phase 2 — separate PR)
- ❌ No vector site renderer (Phase 3 — separate PR)
- ❌ No OS NGD building-footprint work (already in PR #83, merged)
- ❌ No climate provider work (PR #84 territory)
- ❌ No PR #84 logic touched

### Merge ordering note
**Merge after PR #84, then rebase if needed, because both touch `src/services/project/projectGraphVerticalSliceService.js`.** Specifically PR #84 may modify the qa pipeline area near `applyOpenAIReasoningBlockersToQa` and the gate invocation block, where this PR also makes additive changes (adds the `applyUpstreamGateTechnicalBlockersToQa` call after `applyOpenAIReasoningBlockersToQa`, and adds `drawings: drawingsForGate, projectGeometry` to the gate invocation). Conflicts (if any) should be straightforward additive merges.

## Test plan

- [x] `npm run check:env`
- [x] `npm run check:contracts`
- [x] `npm run test:compose:routing`
- [x] `npm run lint`
- [x] `npm run build:active`
- [x] `npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/a1/a1ExportGateTechnical.phase4.test.js src/__tests__/services/a1FinalExportContract.test.js src/__tests__/services/drawingConsistencyChecks.test.js` → 61/61 pass
- [x] `node tmp/phase4-blocked-export-sample.mjs` — sample 422 payload generated end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
