### PR TITLE
fix(site): reject oversized building polygons from auto-detect

### DIFF
--- a/api/site/_lib/__tests__/boundaryNormalize.test.js
+++ b/api/site/_lib/__tests__/boundaryNormalize.test.js
@@ -156,7 +156,11 @@ describe("selectBestOverpassWay", () => {
     expect(result).toBeNull();
   });
 
-  test("flags an oversized building polygon as estimated", () => {
+  test("rejects an oversized building polygon (terraced row joined as one OSM building)", () => {
+    // Returning a 1600 m² terrace polygon as the user's site boundary is
+    // wildly wrong for an individual ~67 m² house. The selector must
+    // refuse the oversized candidate and return null so the caller can
+    // prompt the user to draw manually.
     const oversizedBuilding = squarePolygonAround(POINT.lat, POINT.lng, 20); // ~1600 m²
     const result = selectBestOverpassWay({
       parcelElements: [],
@@ -165,8 +169,7 @@ describe("selectBestOverpassWay", () => {
       ],
       point: POINT,
     });
-    expect(result?.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS);
-    expect(result?.estimateReason).toBe(ESTIMATE_REASON.BUILDING_OVERSIZED);
+    expect(result).toBeNull();
   });
 
   test("a small building stays authoritative when no parcel was demoted", () => {

--- a/api/site/_lib/boundaryNormalize.js
+++ b/api/site/_lib/boundaryNormalize.js
@@ -343,29 +343,42 @@ export function selectBestBoundaryCandidate({
     }
   }
 
-  // 2. building containing the point. We still return the building even
-  // when it fails the size classifier — it is better than nothing — but
-  // the response is tagged with `BUILDING_OVERSIZED` so downstream code
-  // (and the map UI) can render it as estimated rather than authoritative.
+  // 2. building containing the point. A plausibly-sized building wins
+  // immediately. An oversized building (terraced row joined into one OSM
+  // polygon, factory shed, school block, etc.) is NOT returned as the
+  // primary candidate — it would mis-set the user's site by an order of
+  // magnitude. We capture it as `demotedParcel` so callers can render it
+  // as a faint reference, then fall through to the nearest-building
+  // search and ultimately to a null result that prompts manual drawing.
   for (const el of buildingElements) {
     const polygon = extractPolygonFromOverpassWay(el);
-    if (polygon.length >= 3 && polygonContainsPoint(polygon, checkPoint)) {
-      const buildingReason = classifyBuildingCandidate({ polygon });
+    if (polygon.length < 3 || !polygonContainsPoint(polygon, checkPoint)) {
+      continue;
+    }
+    const buildingReason = classifyBuildingCandidate({ polygon });
+    if (!buildingReason) {
       return {
         element: el,
         polygon,
         source: BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS,
-        estimateReason: demotedReason || buildingReason || null,
+        estimateReason: demotedReason || null,
         demotedParcel,
       };
     }
+    if (!demotedParcel) {
+      demotedParcel = { element: el, polygon };
+      demotedReason = demotedReason || buildingReason;
+    }
   }
-  // 3. nearest building within 25 m
+  // 3. nearest building within 25 m, with the same plausibility check —
+  // an oversized building does not become a plausible site boundary just
+  // because no closer candidate exists.
   let nearest = null;
   let nearestDistance = Infinity;
   for (const el of buildingElements) {
     const polygon = extractPolygonFromOverpassWay(el);
     if (polygon.length < 3) continue;
+    if (classifyBuildingCandidate({ polygon })) continue;
     const centroid = polygonCentroid(polygon);
     const d = distanceM(centroid, checkPoint);
     if (d < nearestDistance && d <= 25) {

--- a/src/__tests__/api/site-boundary.test.js
+++ b/src/__tests__/api/site-boundary.test.js
@@ -360,6 +360,58 @@ describe("api/site/boundary — pure helpers", () => {
     expect(best?.element?.id).toBe(1);
     expect(best?.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_CONTAINS);
   });
+
+  // Regression: 17 Kensington Rd DN15 8BQ — UK terraced house ~67 m² where
+  // OS/OSM treats the whole row as one ~1260 m² building polygon. Returning
+  // that polygon as the user's site boundary mis-sets area by ~19x. The
+  // selector must reject the oversized candidate so the caller can surface
+  // a "please draw" prompt instead of an authoritative-looking wrong shape.
+  test("selectBestOverpassWay rejects an oversized building polygon (terrace block)", () => {
+    // ~40 m × 30 m polygon centred on POINT → ~1200 m² (well above 600 m²
+    // RESIDENTIAL_BUILDING_MAX_M2 threshold). At lat 52.4722, 1° lat ≈ 111 km
+    // and 1° lng ≈ 67.6 km, so 0.00018° lat ≈ 20 m and 0.00022° lng ≈ 15 m.
+    const oversizedTerrace = makeBuildingWay(99, [
+      [52.4722 - 0.00018, -1.8839 - 0.00022],
+      [52.4722 - 0.00018, -1.8839 + 0.00022],
+      [52.4722 + 0.00018, -1.8839 + 0.00022],
+      [52.4722 + 0.00018, -1.8839 - 0.00022],
+    ]);
+    const best = selectBestOverpassWay({
+      buildingElements: [oversizedTerrace],
+      parcelElements: [],
+      point: POINT,
+    });
+    expect(best).toBeNull();
+  });
+
+  test("selectBestOverpassWay falls through oversized building to a plausible neighbour", () => {
+    const oversizedTerrace = makeBuildingWay(99, [
+      [52.4722 - 0.00018, -1.8839 - 0.00022],
+      [52.4722 - 0.00018, -1.8839 + 0.00022],
+      [52.4722 + 0.00018, -1.8839 + 0.00022],
+      [52.4722 + 0.00018, -1.8839 - 0.00022],
+    ]);
+    // Plausible ~7 m × 7 m house (~49 m²) ~10 m east of POINT, well within
+    // the 25 m nearest-fallback radius and well under 600 m².
+    const eastLngOffset = 10 / 67_600; // ~10 m east
+    const smallNeighbour = makeBuildingWay(
+      100,
+      [
+        [52.4722 - 0.00003, -1.8839 + eastLngOffset - 0.00005],
+        [52.4722 - 0.00003, -1.8839 + eastLngOffset + 0.00005],
+        [52.4722 + 0.00003, -1.8839 + eastLngOffset + 0.00005],
+        [52.4722 + 0.00003, -1.8839 + eastLngOffset - 0.00005],
+      ],
+      { building: "house" },
+    );
+    const best = selectBestOverpassWay({
+      buildingElements: [oversizedTerrace, smallNeighbour],
+      parcelElements: [],
+      point: POINT,
+    });
+    expect(best?.element?.id).toBe(100);
+    expect(best?.source).toBe(BOUNDARY_SOURCE.OVERPASS_BUILDING_NEAREST);
+  });
 });
 
 describe("api/site/boundary — Overpass query construction", () => {


### PR DESCRIPTION
## Summary

For UK terraced houses, OSM/OS data treats the entire row as one ~1,260 m² building polygon. The boundary auto-detect (`/api/site/boundary` → `selectBestBoundaryCandidate`) was returning that polygon as the user's site boundary, then the V2 boundary editor's geometry-only \"Status: Valid\" badge silently presented it as confirmed — mis-setting plot area by ~19×.

This PR makes the boundary selector **refuse** oversized building polygons (over `RESIDENTIAL_BUILDING_MAX_M2` = 600 m²) as primary candidates and forces a fall-through to nearest-within-25m → null. The oversized polygon is still captured in `demotedParcel` so callers can render it as a faint reference.

**Reproduction**: enter \"17 Kensington Rd, DN15 8BQ\" (a ~67 m² single house). Before this PR, auto-detect highlights the whole terrace block as the site (8 vertices, 1.26×10³ m², green \"Valid\" badge). After this PR, auto-detect returns no polygon and the user is prompted to draw, instead of silently storing wildly wrong geometry that flows into the A1 sheet.

## Why

`selectBestBoundaryCandidate` was already classifying these polygons as `BUILDING_OVERSIZED` and stamping `boundaryAuthoritative: false`, but it returned the polygon anyway under the rationale \"better than nothing.\" In practice the V2 editor's status badge ignores `boundaryAuthoritative` (it only checks geometric validity), so the user sees a green \"Valid\" badge on a polygon that's wrong by an order of magnitude. Refusing the polygon at the source prevents downstream UI from misreporting it.

## Test plan

- [x] New regression: \`selectBestOverpassWay rejects an oversized building polygon (terrace block)\` → returns \`null\`
- [x] New regression: \`selectBestOverpassWay falls through oversized building to a plausible neighbour\` → returns the small neighbour via \`OVERPASS_BUILDING_NEAREST\`
- [x] Both new tests pass in \`npm test -- --testPathPattern=api/site-boundary\`
- [x] \`npx eslint api/site/_lib/boundaryNormalize.js src/__tests__/api/site-boundary.test.js\` → exit 0
- [ ] Manual smoke on Vercel preview: enter \"17 Kensington Rd, DN15 8BQ\" → confirm no auto-polygon (was: 1.26×10³ m² terrace)
- [ ] Manual smoke: enter a known semi-detached / detached UK address → confirm small building polygon still auto-fills as before

## Pre-existing test failures (out of scope)

Three tests in \`src/__tests__/api/site-boundary.test.js\` (lines 73, 110, 247) fail on \`main\` and continue to fail with this PR — verified by stashing the change and re-running. They are not introduced by this fix.

## Out of scope (follow-up)

- Surfacing \`boundaryAuthoritative\` / \`estimateReason\` in the V2 \"Status\" badge (currently geometry-only)
- Wiring the OS NGD provider into the browser \`/api/site/boundary\` proxy (currently only used by the server pipeline's `enrichSiteContext`)
- Rendering \`demotedParcel\` as a faint reference layer in the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)