### PR TITLE
feat(a1-plan): Phase 1 fidelity — section markers, dim chains, jamb ticks, wider furniture

### DIFF
--- a/src/__tests__/services/drawing/svgPlanRendererFidelity.test.js
+++ b/src/__tests__/services/drawing/svgPlanRendererFidelity.test.js
@@ -1,0 +1,361 @@
+/**
+ * Phase 1 — plan renderer fidelity coverage.
+ *
+ * Verifies the visual upgrades in svgPlanRenderer + furnitureSymbolService:
+ *   - furniture symbols cover the new room types (hallway, garage,
+ *     utility, wardrobe) in addition to the existing 8
+ *   - door swing arcs render
+ *   - window double-lines + jamb ticks render
+ *   - north arrow + scale bar render
+ *   - dimension chain segments render alongside the overall dimension
+ *   - section markers A-A / B-B render from compiledProject.sections
+ *   - the renderer is deterministic (same input → identical SVG)
+ *   - the renderer never mutates its geometry input (geometryHash safety)
+ */
+
+import { renderPlanSvg } from "../../../services/drawing/svgPlanRenderer.js";
+import {
+  renderFurnitureSymbol,
+  resolveFurnitureToken,
+  FURNITURE_TOKENS,
+  FURNITURE_SYMBOL_VERSION,
+} from "../../../services/drawing/furnitureSymbolService.js";
+import { getBlueprintTheme } from "../../../services/drawing/drawingBounds.js";
+
+function rect(minX, minY, maxX, maxY) {
+  return [
+    { x: minX, y: minY },
+    { x: maxX, y: minY },
+    { x: maxX, y: maxY },
+    { x: minX, y: maxY },
+  ];
+}
+
+function room(id, name, minX, minY, maxX, maxY, extra = {}) {
+  return {
+    id,
+    level_id: "ground",
+    name,
+    actual_area: (maxX - minX) * (maxY - minY),
+    polygon: rect(minX, minY, maxX, maxY),
+    bbox: { min_x: minX, min_y: minY, max_x: maxX, max_y: maxY },
+    centroid: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+    ...extra,
+  };
+}
+
+function exteriorWall(id, sx, sy, ex, ey) {
+  return {
+    id,
+    level_id: "ground",
+    exterior: true,
+    thickness_m: 0.3,
+    orientation: sy === ey ? "horizontal" : "vertical",
+    start: { x: sx, y: sy },
+    end: { x: ex, y: ey },
+  };
+}
+
+function fixture(extra = {}) {
+  const buildingPolygon = rect(0, 0, 24, 16);
+  return {
+    schema_version: "canonical-project-geometry-v2",
+    project_id: "phase1-fidelity-fixture",
+    site: {
+      boundary_bbox: {
+        min_x: -5,
+        min_y: -5,
+        max_x: 30,
+        max_y: 22,
+        width: 35,
+        height: 27,
+      },
+      buildable_bbox: {
+        min_x: 0,
+        min_y: 0,
+        max_x: 24,
+        max_y: 16,
+        width: 24,
+        height: 16,
+      },
+      boundary_polygon: rect(-5, -5, 30, 22),
+      buildable_polygon: buildingPolygon,
+      north_orientation_deg: 0,
+    },
+    metadata: { geometry_rules: { roof_pitch_degrees: 35 } },
+    footprints: [
+      {
+        id: "fp-ground",
+        level_id: "ground",
+        polygon: buildingPolygon,
+        bbox: { min_x: 0, min_y: 0, max_x: 24, max_y: 16 },
+      },
+    ],
+    slabs: [
+      {
+        id: "slab-ground",
+        level_id: "ground",
+        polygon: buildingPolygon,
+        bbox: { min_x: 0, min_y: 0, max_x: 24, max_y: 16 },
+      },
+    ],
+    levels: [
+      {
+        id: "ground",
+        level_number: 0,
+        name: "Ground Floor",
+        height_m: 3.0,
+        footprint_id: "fp-ground",
+      },
+    ],
+    rooms: [
+      room("living", "Living Room", 0, 0, 8, 8),
+      room("kitchen", "Kitchen Diner", 8, 0, 16, 8),
+      room("hall", "Hallway", 16, 0, 19, 16),
+      room("garage", "Garage", 19, 0, 24, 8),
+      room("utility", "Utility", 19, 8, 24, 12),
+      room("wc", "Cloak / WC", 0, 8, 4, 12),
+      room("study", "Study", 4, 8, 8, 12),
+      room("dining", "Dining", 8, 8, 16, 16),
+      room("master", "Master Bedroom", 0, 12, 8, 16),
+      room("dressing", "Dressing Room", 19, 12, 24, 16),
+    ],
+    walls: [
+      exteriorWall("w-s", 0, 0, 24, 0),
+      exteriorWall("w-n", 0, 16, 24, 16),
+      exteriorWall("w-e", 24, 0, 24, 16),
+      exteriorWall("w-w", 0, 0, 0, 16),
+    ],
+    doors: [
+      {
+        id: "front",
+        level_id: "ground",
+        wall_id: "w-s",
+        position_m: { x: 17, y: 0 },
+        width_m: 0.95,
+        head_height_m: 2.1,
+      },
+    ],
+    windows: [
+      {
+        id: "win-living",
+        level_id: "ground",
+        wall_id: "w-s",
+        position_m: { x: 4, y: 0 },
+        width_m: 1.6,
+        sill_height_m: 0.9,
+        head_height_m: 2.1,
+      },
+      {
+        id: "win-kitchen",
+        level_id: "ground",
+        wall_id: "w-s",
+        position_m: { x: 12, y: 0 },
+        width_m: 1.4,
+        sill_height_m: 0.9,
+        head_height_m: 2.1,
+      },
+    ],
+    stairs: [],
+    sections: [
+      {
+        id: "section-long",
+        sectionType: "longitudinal",
+        title: "Section Longitudinal",
+        cutLine: { from: { x: 12, y: 0 }, to: { x: 12, y: 16 } },
+      },
+      {
+        id: "section-trans",
+        sectionType: "transverse",
+        title: "Section Transverse",
+        cutLine: { from: { x: 0, y: 8 }, to: { x: 24, y: 8 } },
+      },
+    ],
+    ...extra,
+  };
+}
+
+const theme = getBlueprintTheme();
+
+describe("furnitureSymbolService — Phase 1 expanded coverage", () => {
+  test("FURNITURE_TOKENS includes all four new tokens", () => {
+    expect(FURNITURE_TOKENS).toEqual(
+      expect.arrayContaining([
+        "hallway_runner",
+        "garage_doors",
+        "utility_appliances",
+        "wardrobe",
+      ]),
+    );
+    expect(FURNITURE_SYMBOL_VERSION).toBe("phase3-furniture-symbol-v2");
+  });
+
+  test("resolveFurnitureToken matches new room name keywords", () => {
+    expect(resolveFurnitureToken({ name: "Hallway" })).toBe("hallway_runner");
+    expect(resolveFurnitureToken({ name: "Entrance Foyer" })).toBe(
+      "hallway_runner",
+    );
+    expect(resolveFurnitureToken({ name: "Corridor" })).toBe("hallway_runner");
+    expect(resolveFurnitureToken({ name: "Garage" })).toBe("garage_doors");
+    expect(resolveFurnitureToken({ name: "Carport" })).toBe("garage_doors");
+    expect(resolveFurnitureToken({ name: "Utility" })).toBe(
+      "utility_appliances",
+    );
+    expect(resolveFurnitureToken({ name: "Walk-in Wardrobe" })).toBe(
+      "wardrobe",
+    );
+    expect(resolveFurnitureToken({ name: "Dressing Room" })).toBe("wardrobe");
+  });
+
+  test("renderFurnitureSymbol returns deterministic SVG for new tokens", () => {
+    const big = { x: 100, y: 100, width: 240, height: 160 };
+    for (const name of ["Garage", "Utility Room", "Walk-in Wardrobe"]) {
+      const a = renderFurnitureSymbol({ name }, big, theme);
+      const b = renderFurnitureSymbol({ name }, big, theme);
+      expect(a).toBe(b);
+      expect(a.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("renderFurnitureSymbol now permits narrow hallway-shaped rectangles", () => {
+    // Real corridor: ~1.2 m wide × 4 m long → ~36 px × 120 px at scale.
+    const corridor = { x: 0, y: 0, width: 36, height: 120 };
+    const markup = renderFurnitureSymbol({ name: "Hallway" }, corridor, theme);
+    expect(markup).toContain('class="furniture-hallway-runner"');
+  });
+
+  test("renderFurnitureSymbol still rejects pathologically tiny rectangles", () => {
+    const tiny = { x: 0, y: 0, width: 12, height: 12 };
+    expect(renderFurnitureSymbol({ name: "Living Room" }, tiny, theme)).toBe(
+      "",
+    );
+    expect(renderFurnitureSymbol({ name: "Garage" }, tiny, theme)).toBe("");
+  });
+});
+
+describe("renderPlanSvg — Phase 1 fidelity features", () => {
+  test("renders door swing arc + hinge marker for every door", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    expect(result.svg).toContain('class="plan-door"');
+    // Swing arc is the SVG path A command; the hinge is the small filled
+    // circle at the hinge point.
+    expect(result.svg).toMatch(/<path d="M [^"]+A /);
+    expect(result.svg).toMatch(
+      /<circle cx="[^"]+" cy="[^"]+" r="1\.8"[^/]*\/>/,
+    );
+    expect(result.technical_quality_metadata.door_swing_count).toBe(1);
+  });
+
+  test("renders window double-lines plus the new jamb ticks", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    expect(result.svg).toContain('class="plan-window"');
+    // Each window now emits 2 jamb-tick lines (one per end).
+    const jambMatches = result.svg.match(/class="window-jamb-tick"/g);
+    expect(jambMatches?.length).toBe(4); // 2 windows × 2 ticks
+    expect(result.technical_quality_metadata.window_jamb_tick_count).toBe(4);
+  });
+
+  test("renders the north arrow group on plan views", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    expect(result.svg).toContain('id="north-arrow"');
+    expect(result.technical_quality_metadata.has_north_arrow).toBe(true);
+  });
+
+  test("renders the scale bar with a metres label", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    expect(result.svg).toContain('id="blueprint-scale-bar"');
+    expect(result.svg).toMatch(/>\s*\d+\s*m\s*</);
+    expect(result.technical_quality_metadata.has_scale_bar).toBe(true);
+    expect(result.technical_quality_metadata.scale_bar_meters).toBeGreaterThan(
+      0,
+    );
+  });
+
+  test("renders dimension chain segments alongside the overall dimensions", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    expect(result.svg).toContain('class="dimension-chain horizontal"');
+    expect(result.svg).toContain('class="dimension-chain vertical"');
+    // Fixture has rooms breaking the building into 3+ horizontal segments
+    // (x edges at 8, 16, 19) and 3+ vertical segments (y edges at 8, 12).
+    const meta = result.technical_quality_metadata;
+    expect(meta.dimension_chain_horizontal_segments).toBeGreaterThanOrEqual(3);
+    expect(meta.dimension_chain_vertical_segments).toBeGreaterThanOrEqual(3);
+  });
+
+  test("renders section markers A-A and B-B from compiledProject.sections", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    expect(result.svg).toContain('id="plan-section-markers"');
+    expect(result.svg).toContain('data-section-letter="A"');
+    expect(result.svg).toContain('data-section-letter="B"');
+    expect(result.svg).toContain('data-section-type="longitudinal"');
+    expect(result.svg).toContain('data-section-type="transverse"');
+    expect(result.technical_quality_metadata.section_marker_count).toBe(2);
+    expect(result.technical_quality_metadata.section_marker_labels).toEqual([
+      "A-A",
+      "B-B",
+    ]);
+  });
+
+  test("section markers degrade gracefully when no sections exist", () => {
+    const noSections = fixture({ sections: [] });
+    const result = renderPlanSvg(noSections, { width: 1200, height: 900 });
+    expect(result.svg).not.toContain('id="plan-section-markers"');
+    expect(result.technical_quality_metadata.section_marker_count).toBe(0);
+    expect(result.technical_quality_metadata.section_marker_labels).toEqual([]);
+  });
+
+  test("furniture coverage spans common UK residential rooms", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    // The fixture mixes living, kitchen, hall, garage, utility, wc, study,
+    // dining, master bedroom, dressing room — at least 6 distinct furniture
+    // groups should surface on the plan.
+    const hintGroups = result.svg.match(/class="plan-furniture-hint"/g) || [];
+    expect(hintGroups.length).toBeGreaterThanOrEqual(6);
+    // Spot-check the new symbol classes appear at least once.
+    expect(result.svg).toContain('class="furniture-hallway-runner"');
+    expect(result.svg).toContain('class="furniture-garage"');
+    expect(result.svg).toContain('class="furniture-utility"');
+    expect(result.svg).toContain('class="furniture-wardrobe"');
+  });
+});
+
+describe("renderPlanSvg — determinism + geometry-hash safety", () => {
+  test("identical input produces byte-identical SVG", () => {
+    const a = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    const b = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    expect(a.svg).toBe(b.svg);
+    expect(a.technical_quality_metadata).toEqual(b.technical_quality_metadata);
+  });
+
+  test("section letter assignment is stable across reordering", () => {
+    const baseline = fixture();
+    const reordered = fixture();
+    reordered.sections = [
+      reordered.sections[1], // transverse first
+      reordered.sections[0], // longitudinal second
+    ];
+    const a = renderPlanSvg(baseline, { width: 1200, height: 900 });
+    const b = renderPlanSvg(reordered, { width: 1200, height: 900 });
+    // Despite the input order change, A-A must remain the longitudinal cut
+    // and B-B the transverse cut (sort key = section type).
+    expect(a.technical_quality_metadata.section_marker_labels).toEqual([
+      "A-A",
+      "B-B",
+    ]);
+    expect(b.technical_quality_metadata.section_marker_labels).toEqual([
+      "A-A",
+      "B-B",
+    ]);
+    expect(
+      a.svg.includes('data-section-letter="A"') &&
+        a.svg.includes('data-section-type="longitudinal"'),
+    ).toBe(true);
+  });
+
+  test("renderer does not mutate the geometry input (geometryHash safety)", () => {
+    const original = fixture();
+    const snapshot = JSON.parse(JSON.stringify(original));
+    renderPlanSvg(original, { width: 1200, height: 900 });
+    expect(original).toEqual(snapshot);
+  });
+});

--- a/src/__tests__/services/drawing/technicalDrawingPolishPhase3.test.js
+++ b/src/__tests__/services/drawing/technicalDrawingPolishPhase3.test.js
@@ -256,7 +256,7 @@ describe("Phase 3 — furnitureSymbolService", () => {
         "stair_arrow",
       ]),
     );
-    expect(FURNITURE_SYMBOL_VERSION).toBe("phase3-furniture-symbol-v1");
+    expect(FURNITURE_SYMBOL_VERSION).toBe("phase3-furniture-symbol-v2");
   });
 
   test("resolveFurnitureToken matches by room name keywords", () => {

--- a/src/services/drawing/furnitureSymbolService.js
+++ b/src/services/drawing/furnitureSymbolService.js
@@ -20,10 +20,17 @@ const TOKEN_PATTERNS = Object.freeze([
   { token: "wc", pattern: /\b(wc|toilet|cloak|powder)\b/i },
   { token: "basin", pattern: /\b(basin|wash|vanity|hand\s*wash)\b/i },
   { token: "kitchen_island", pattern: /\bisland\b/i },
-  { token: "kitchen_counter", pattern: /\bkitchen|utility|pantry\b/i },
+  { token: "kitchen_counter", pattern: /\bkitchen|pantry\b/i },
+  { token: "utility_appliances", pattern: /\butility\b/i },
   { token: "dining_table", pattern: /\bdining\b/i },
   { token: "bed", pattern: /\bbed(room)?|master\b/i },
+  { token: "wardrobe", pattern: /\b(wardrobe|closet|dressing)\b/i },
   { token: "sofa", pattern: /\b(living|lounge|sitting|family|reception)\b/i },
+  { token: "garage_doors", pattern: /\b(garage|carport)\b/i },
+  {
+    token: "hallway_runner",
+    pattern: /\b(hall(way)?|corridor|entrance|foyer|vestibule|porch)\b/i,
+  },
   // Bath has both basin + WC + tub; we render the bath block elsewhere
   // (existing renderer covers it). Skipping here to avoid double-render.
 ]);
@@ -173,6 +180,84 @@ function stairArrowSymbol(rect, theme) {
   </g>`;
 }
 
+function hallwayRunnerSymbol(rect, theme) {
+  // Subtle floor runner / threshold chevron — long thin rectangle along the
+  // long axis of the hall, centred. Conveys circulation direction without
+  // pretending we know furnishings the user has not specified.
+  const horizontal = rect.width >= rect.height;
+  const runnerLen = Math.min(
+    horizontal ? rect.width * 0.66 : rect.height * 0.66,
+    180,
+  );
+  const runnerWidth = Math.min(
+    horizontal ? rect.height * 0.16 : rect.width * 0.16,
+    18,
+  );
+  const cx = rect.x + rect.width / 2;
+  const cy = rect.y + rect.height / 2;
+  const x = horizontal ? cx - runnerLen / 2 : cx - runnerWidth / 2;
+  const y = horizontal ? cy - runnerWidth / 2 : cy - runnerLen / 2;
+  const w = horizontal ? runnerLen : runnerWidth;
+  const h = horizontal ? runnerWidth : runnerLen;
+  return `<g class="furniture-hallway-runner">
+    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(w)}" height="${fmt(h)}" fill="none" stroke="${theme.lineLight}" stroke-width="0.85" stroke-dasharray="4 3" rx="3" ry="3"/>
+  </g>`;
+}
+
+function garageDoorsSymbol(rect, theme) {
+  // Garage car-bay outline + segmented door at the front edge.
+  const bayW = Math.min(rect.width * 0.62, 110);
+  const bayH = Math.min(rect.height * 0.5, 80);
+  const x = rect.x + (rect.width - bayW) / 2;
+  const y = rect.y + (rect.height - bayH) / 2;
+  // Sectional garage door across the south edge of the bay.
+  const doorY = rect.y + rect.height - 8;
+  const doorX = rect.x + 10;
+  const doorW = rect.width - 20;
+  const panels = [];
+  for (let i = 1; i < 4; i += 1) {
+    const px = doorX + (doorW * i) / 4;
+    panels.push(
+      `<line x1="${fmt(px)}" y1="${fmt(doorY)}" x2="${fmt(px)}" y2="${fmt(doorY + 6)}" stroke="${theme.guide}" stroke-width="0.8"/>`,
+    );
+  }
+  return `<g class="furniture-garage">
+    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(bayW)}" height="${fmt(bayH)}" fill="none" stroke="${theme.lineLight}" stroke-width="0.95" stroke-dasharray="6 3" rx="2" ry="2"/>
+    <rect x="${fmt(doorX)}" y="${fmt(doorY)}" width="${fmt(doorW)}" height="6" fill="none" stroke="${theme.lineMuted}" stroke-width="1.1"/>
+    ${panels.join("")}
+  </g>`;
+}
+
+function utilityAppliancesSymbol(rect, theme) {
+  // Two stacked appliance boxes (washer + dryer or boiler + tank) along the
+  // wall closest to the top-left of the room.
+  const boxW = Math.min(rect.width * 0.32, 24);
+  const boxH = Math.min(rect.height * 0.34, 28);
+  const x = rect.x + 6;
+  const y = rect.y + 6;
+  const gap = 4;
+  return `<g class="furniture-utility">
+    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(boxW)}" height="${fmt(boxH)}" fill="none" stroke="${theme.lineLight}" stroke-width="0.95" rx="2" ry="2"/>
+    <circle cx="${fmt(x + boxW / 2)}" cy="${fmt(y + boxH / 2)}" r="${fmt(Math.min(boxW, boxH) / 4, 1)}" fill="none" stroke="${theme.guide}" stroke-width="0.7"/>
+    <rect x="${fmt(x + boxW + gap)}" y="${fmt(y)}" width="${fmt(boxW)}" height="${fmt(boxH)}" fill="none" stroke="${theme.lineLight}" stroke-width="0.95" rx="2" ry="2"/>
+    <circle cx="${fmt(x + boxW + gap + boxW / 2)}" cy="${fmt(y + boxH / 2)}" r="${fmt(Math.min(boxW, boxH) / 4, 1)}" fill="none" stroke="${theme.guide}" stroke-width="0.7"/>
+  </g>`;
+}
+
+function wardrobeSymbol(rect, theme) {
+  // Wardrobe block along the longest interior wall + diagonal indicator
+  // showing it is a closet (door slide or hinge swing direction).
+  const wW = Math.min(rect.width * 0.78, 120);
+  const wH = Math.min(rect.height * 0.18, 16);
+  const x = rect.x + (rect.width - wW) / 2;
+  const y = rect.y + 8;
+  return `<g class="furniture-wardrobe">
+    <rect x="${fmt(x)}" y="${fmt(y)}" width="${fmt(wW)}" height="${fmt(wH)}" fill="none" stroke="${theme.lineLight}" stroke-width="0.95"/>
+    <line x1="${fmt(x)}" y1="${fmt(y + wH)}" x2="${fmt(x + wW * 0.5)}" y2="${fmt(y)}" stroke="${theme.guide}" stroke-width="0.7"/>
+    <line x1="${fmt(x + wW * 0.5)}" y1="${fmt(y + wH)}" x2="${fmt(x + wW)}" y2="${fmt(y)}" stroke="${theme.guide}" stroke-width="0.7"/>
+  </g>`;
+}
+
 const SYMBOL_RENDERERS = Object.freeze({
   sofa: sofaSymbol,
   bed: bedSymbol,
@@ -182,6 +267,10 @@ const SYMBOL_RENDERERS = Object.freeze({
   wc: wcSymbol,
   basin: basinSymbol,
   stair_arrow: stairArrowSymbol,
+  hallway_runner: hallwayRunnerSymbol,
+  garage_doors: garageDoorsSymbol,
+  utility_appliances: utilityAppliancesSymbol,
+  wardrobe: wardrobeSymbol,
 });
 
 /**
@@ -190,11 +279,23 @@ const SYMBOL_RENDERERS = Object.freeze({
  * (svgPlanRenderer) decides whether to wrap the markup in a group; this
  * helper returns the inner SVG fragment only.
  */
+// Per-token minimum projected size (px) below which the symbol becomes
+// visual noise. Most furniture needs ~60×50 to read clearly; corridor
+// runners and small fixtures (WC, basin) only need ~30×30.
+const TOKEN_MIN_RECT = Object.freeze({
+  hallway_runner: { width: 30, height: 30 },
+  wc: { width: 36, height: 36 },
+  basin: { width: 36, height: 30 },
+  wardrobe: { width: 50, height: 40 },
+});
+const DEFAULT_MIN_RECT = Object.freeze({ width: 60, height: 50 });
+
 export function renderFurnitureSymbol(room, rect, theme) {
   if (!rect || !theme) return "";
-  if (rect.width < 60 || rect.height < 50) return "";
   const token = resolveFurnitureToken(room);
   if (!token) return "";
+  const minRect = TOKEN_MIN_RECT[token] || DEFAULT_MIN_RECT;
+  if (rect.width < minRect.width || rect.height < minRect.height) return "";
   const renderer = SYMBOL_RENDERERS[token];
   if (!renderer) return "";
   try {
@@ -205,4 +306,4 @@ export function renderFurnitureSymbol(room, rect, theme) {
 }
 
 export const FURNITURE_TOKENS = Object.freeze(Array.from(KNOWN_TOKENS));
-export const FURNITURE_SYMBOL_VERSION = "phase3-furniture-symbol-v1";
+export const FURNITURE_SYMBOL_VERSION = "phase3-furniture-symbol-v2";

--- a/src/services/drawing/svgPlanRenderer.js
+++ b/src/services/drawing/svgPlanRenderer.js
@@ -517,6 +517,32 @@ function renderWindowMarkup(
       const gapB = project(b);
       const gapWidth = Math.max(6, thicknessM * scale + 2);
 
+      // Jamb ticks: short perpendicular marks (along the wall thickness
+      // direction) at each end of the opening, just inside the wall faces.
+      // They communicate the masonry jamb / reveal at the window frame and
+      // visually anchor the opening to the wall, which the bare double-line
+      // glass alone does not. Length = full wall thickness in px so the
+      // tick spans face-to-face.
+      const jambHalfPx = Math.max(3, (thicknessM * scale) / 2);
+      const jambNxPx = vectors.normal.x;
+      const jambNyPx = vectors.normal.y;
+      const jambStartFace1 = {
+        x: gapA.x + jambNxPx * jambHalfPx,
+        y: gapA.y + jambNyPx * jambHalfPx,
+      };
+      const jambStartFace2 = {
+        x: gapA.x - jambNxPx * jambHalfPx,
+        y: gapA.y - jambNyPx * jambHalfPx,
+      };
+      const jambEndFace1 = {
+        x: gapB.x + jambNxPx * jambHalfPx,
+        y: gapB.y + jambNyPx * jambHalfPx,
+      };
+      const jambEndFace2 = {
+        x: gapB.x - jambNxPx * jambHalfPx,
+        y: gapB.y - jambNyPx * jambHalfPx,
+      };
+
       return `
         <g class="plan-window" data-window-id="${escapeXml(windowElement.id || "")}">
           <line x1="${formatNumber(gapA.x)}" y1="${formatNumber(gapA.y)}" x2="${formatNumber(
@@ -541,6 +567,16 @@ function renderWindowMarkup(
           )}" x2="${formatNumber((b1.x + b2.x) / 2)}" y2="${formatNumber(
             (b1.y + b2.y) / 2,
           )}" stroke="${theme.lineLight}" stroke-width="0.8"/>
+          <line class="window-jamb-tick" x1="${formatNumber(jambStartFace1.x)}" y1="${formatNumber(
+            jambStartFace1.y,
+          )}" x2="${formatNumber(jambStartFace2.x)}" y2="${formatNumber(
+            jambStartFace2.y,
+          )}" stroke="${theme.line}" stroke-width="1.05" stroke-linecap="square"/>
+          <line class="window-jamb-tick" x1="${formatNumber(jambEndFace1.x)}" y1="${formatNumber(
+            jambEndFace1.y,
+          )}" x2="${formatNumber(jambEndFace2.x)}" y2="${formatNumber(
+            jambEndFace2.y,
+          )}" stroke="${theme.line}" stroke-width="1.05" stroke-linecap="square"/>
         </g>
       `;
     })
@@ -804,9 +840,124 @@ function renderNorthArrow(width, layout, theme, northRotationDeg = 0) {
   `;
 }
 
-function renderExternalDimensions(bounds, project, layout, width, theme) {
+function collectChainStops(rooms, axis, bounds) {
+  // Gather distinct edge coords from room bboxes along the requested axis.
+  // Returns sorted, deduplicated metres values clamped to bounds, used to
+  // render dimension chain ticks (each room edge becomes a witness line).
+  const lo = axis === "x" ? Number(bounds.min_x) : Number(bounds.min_y);
+  const hi = axis === "x" ? Number(bounds.max_x) : Number(bounds.max_y);
+  if (!Number.isFinite(lo) || !Number.isFinite(hi) || hi <= lo) {
+    return [];
+  }
+  const set = new Set();
+  for (const room of rooms || []) {
+    const bbox = resolveRoomBBox(room);
+    const edges =
+      axis === "x"
+        ? [Number(bbox.min_x), Number(bbox.max_x)]
+        : [Number(bbox.min_y), Number(bbox.max_y)];
+    for (const edge of edges) {
+      if (!Number.isFinite(edge)) continue;
+      if (edge <= lo + 1e-3 || edge >= hi - 1e-3) continue;
+      // Quantise to mm so floating-point dust doesn't create near-duplicates.
+      set.add(Math.round(edge * 1000));
+    }
+  }
+  return Array.from(set)
+    .map((v) => v / 1000)
+    .sort((a, b) => a - b);
+}
+
+function renderHorizontalChain({ bounds, rooms, project, topY, theme }) {
+  const stops = collectChainStops(rooms, "x", bounds);
+  if (!stops.length) {
+    return { markup: "", segmentCount: 0 };
+  }
+  const chainY = topY + 14;
+  const allStops = [Number(bounds.min_x), ...stops, Number(bounds.max_x)];
+  const parts = [];
+  // Witness ticks for each interior stop (the start/end ticks already exist
+  // from the overall dimension band).
+  for (const stopX of stops) {
+    const px = project({ x: stopX, y: bounds.min_y });
+    parts.push(
+      `<line x1="${formatNumber(px.x)}" y1="${formatNumber(chainY - 3)}" x2="${formatNumber(px.x)}" y2="${formatNumber(chainY + 3)}" stroke="${theme.line}" stroke-width="1.0"/>`,
+    );
+  }
+  // Chain bar across all stops.
+  const chainStart = project({ x: allStops[0], y: bounds.min_y });
+  const chainEnd = project({
+    x: allStops[allStops.length - 1],
+    y: bounds.min_y,
+  });
+  parts.push(
+    `<line x1="${formatNumber(chainStart.x)}" y1="${formatNumber(chainY)}" x2="${formatNumber(chainEnd.x)}" y2="${formatNumber(chainY)}" stroke="${theme.lineMuted}" stroke-width="0.95"/>`,
+  );
+  // Per-segment metre labels.
+  for (let i = 0; i < allStops.length - 1; i += 1) {
+    const a = allStops[i];
+    const b = allStops[i + 1];
+    const segM = b - a;
+    if (segM <= 0.01) continue;
+    const ax = project({ x: a, y: bounds.min_y }).x;
+    const bx = project({ x: b, y: bounds.min_y }).x;
+    parts.push(
+      `<text x="${formatNumber((ax + bx) / 2)}" y="${formatNumber(chainY + 12)}" font-size="8" font-family="Arial, sans-serif" text-anchor="middle" fill="${theme.lineMuted}">${escapeXml(formatMeters(segM))}</text>`,
+    );
+  }
+  return { markup: parts.join(""), segmentCount: allStops.length - 1 };
+}
+
+function renderVerticalChain({ bounds, rooms, project, rightX, theme }) {
+  const stops = collectChainStops(rooms, "y", bounds);
+  if (!stops.length) {
+    return { markup: "", segmentCount: 0 };
+  }
+  const chainX = rightX - 14;
+  const allStops = [Number(bounds.min_y), ...stops, Number(bounds.max_y)];
+  const parts = [];
+  for (const stopY of stops) {
+    const py = project({ x: bounds.max_x, y: stopY });
+    parts.push(
+      `<line x1="${formatNumber(chainX - 3)}" y1="${formatNumber(py.y)}" x2="${formatNumber(chainX + 3)}" y2="${formatNumber(py.y)}" stroke="${theme.line}" stroke-width="1.0"/>`,
+    );
+  }
+  const chainStart = project({ x: bounds.max_x, y: allStops[0] });
+  const chainEnd = project({
+    x: bounds.max_x,
+    y: allStops[allStops.length - 1],
+  });
+  parts.push(
+    `<line x1="${formatNumber(chainX)}" y1="${formatNumber(chainStart.y)}" x2="${formatNumber(chainX)}" y2="${formatNumber(chainEnd.y)}" stroke="${theme.lineMuted}" stroke-width="0.95"/>`,
+  );
+  for (let i = 0; i < allStops.length - 1; i += 1) {
+    const a = allStops[i];
+    const b = allStops[i + 1];
+    const segM = b - a;
+    if (segM <= 0.01) continue;
+    const ay = project({ x: bounds.max_x, y: a }).y;
+    const by = project({ x: bounds.max_x, y: b }).y;
+    const midY = (ay + by) / 2;
+    parts.push(
+      `<text x="${formatNumber(chainX - 6)}" y="${formatNumber(midY)}" font-size="8" font-family="Arial, sans-serif" text-anchor="middle" fill="${theme.lineMuted}" transform="rotate(90 ${formatNumber(chainX - 6)} ${formatNumber(midY)})">${escapeXml(formatMeters(segM))}</text>`,
+    );
+  }
+  return { markup: parts.join(""), segmentCount: allStops.length - 1 };
+}
+
+function renderExternalDimensions(
+  bounds,
+  project,
+  layout,
+  width,
+  theme,
+  options = {},
+) {
   if (!bounds?.width || !bounds?.height) {
-    return "";
+    return {
+      markup: "",
+      chain: { horizontalSegmentCount: 0, verticalSegmentCount: 0 },
+    };
   }
 
   const topLeft = project({ x: bounds.min_x, y: bounds.min_y });
@@ -815,7 +966,23 @@ function renderExternalDimensions(bounds, project, layout, width, theme) {
   const topY = layout.top - 16;
   const rightX = width - layout.right + 22;
 
-  return `
+  const rooms = Array.isArray(options.rooms) ? options.rooms : [];
+  const horizontalChain = renderHorizontalChain({
+    bounds,
+    rooms,
+    project,
+    topY,
+    theme,
+  });
+  const verticalChain = renderVerticalChain({
+    bounds,
+    rooms,
+    project,
+    rightX,
+    theme,
+  });
+
+  const markup = `
     <g id="external-dimensions">
       <line x1="${formatNumber(topLeft.x)}" y1="${formatNumber(
         topLeft.y,
@@ -880,8 +1047,18 @@ function renderExternalDimensions(bounds, project, layout, width, theme) {
       )} ${formatNumber(
         (topRight.y + bottomRight.y) / 2,
       )})" text-anchor="middle">${escapeXml(formatMeters(bounds.height))}</text>
+      ${horizontalChain.markup ? `<g class="dimension-chain horizontal">${horizontalChain.markup}</g>` : ""}
+      ${verticalChain.markup ? `<g class="dimension-chain vertical">${verticalChain.markup}</g>` : ""}
     </g>
   `;
+
+  return {
+    markup,
+    chain: {
+      horizontalSegmentCount: horizontalChain.segmentCount,
+      verticalSegmentCount: verticalChain.segmentCount,
+    },
+  };
 }
 
 function renderScaleBar(
@@ -937,6 +1114,87 @@ function renderScaleBar(
       </g>
     `,
     barMeters,
+  };
+}
+
+function renderSectionMarkers(sections, project, theme) {
+  // Render plan-side section call-out markers (A-A, B-B, …) for each section
+  // candidate in compiledProject.sections that carries a usable cutLine.
+  // Convention: a heavy dashed line traces the cut, with a circle + capital
+  // letter at each end. Letters are assigned deterministically by section
+  // type then id, so the same compiledProject input always renders A-A as
+  // the longitudinal cut and B-B as the transverse cut.
+  if (!Array.isArray(sections) || !sections.length) {
+    return { markup: "", count: 0, labels: [] };
+  }
+  const usable = sections
+    .map((entry) => entry || {})
+    .filter((section) => {
+      const cut = section?.cutLine;
+      return (
+        cut &&
+        Number.isFinite(Number(cut.from?.x)) &&
+        Number.isFinite(Number(cut.from?.y)) &&
+        Number.isFinite(Number(cut.to?.x)) &&
+        Number.isFinite(Number(cut.to?.y))
+      );
+    })
+    .sort((left, right) => {
+      // longitudinal → transverse → other; tie-break on id for determinism.
+      const order = (s) =>
+        s.sectionType === "longitudinal"
+          ? 0
+          : s.sectionType === "transverse"
+            ? 1
+            : 2;
+      const delta = order(left) - order(right);
+      if (delta !== 0) return delta;
+      return String(left.id || "").localeCompare(String(right.id || ""));
+    });
+  if (!usable.length) {
+    return { markup: "", count: 0, labels: [] };
+  }
+  const letters = ["A", "B", "C", "D", "E", "F"];
+  const labels = [];
+  const parts = usable.slice(0, letters.length).map((section, index) => {
+    const letter = letters[index];
+    const from = project({
+      x: Number(section.cutLine.from.x),
+      y: Number(section.cutLine.from.y),
+    });
+    const to = project({
+      x: Number(section.cutLine.to.x),
+      y: Number(section.cutLine.to.y),
+    });
+    // Direction-of-view arrowheads point perpendicular to the cut, towards
+    // the side of the plan being drawn. Default to "down" for transverse
+    // (looking south) and "right" for longitudinal (looking east) — this
+    // matches the most common architectural convention for unspecified
+    // section view directions.
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const length = Math.hypot(dx, dy) || 1;
+    const ux = dx / length;
+    const uy = dy / length;
+    // Perpendicular (rotated 90° CW in screen coords).
+    const px = -uy;
+    const py = ux;
+    const tickLen = 8;
+    labels.push(`${letter}-${letter}`);
+    return `<g class="section-marker" data-section-id="${escapeXml(section.id || "")}" data-section-type="${escapeXml(section.sectionType || "")}" data-section-letter="${letter}">
+      <line x1="${formatNumber(from.x)}" y1="${formatNumber(from.y)}" x2="${formatNumber(to.x)}" y2="${formatNumber(to.y)}" stroke="${theme.line}" stroke-width="1.4" stroke-dasharray="10 4 2 4"/>
+      <circle cx="${formatNumber(from.x)}" cy="${formatNumber(from.y)}" r="9" fill="${theme.paper}" stroke="${theme.line}" stroke-width="1.3"/>
+      <circle cx="${formatNumber(to.x)}" cy="${formatNumber(to.y)}" r="9" fill="${theme.paper}" stroke="${theme.line}" stroke-width="1.3"/>
+      <text x="${formatNumber(from.x)}" y="${formatNumber(from.y + 4)}" font-size="11" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" fill="${theme.line}">${letter}</text>
+      <text x="${formatNumber(to.x)}" y="${formatNumber(to.y + 4)}" font-size="11" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" fill="${theme.line}">${letter}</text>
+      <line x1="${formatNumber(from.x + px * tickLen)}" y1="${formatNumber(from.y + py * tickLen)}" x2="${formatNumber(from.x + px * (tickLen + 6))}" y2="${formatNumber(from.y + py * (tickLen + 6))}" stroke="${theme.line}" stroke-width="1.2"/>
+      <line x1="${formatNumber(to.x + px * tickLen)}" y1="${formatNumber(to.y + py * tickLen)}" x2="${formatNumber(to.x + px * (tickLen + 6))}" y2="${formatNumber(to.y + py * (tickLen + 6))}" stroke="${theme.line}" stroke-width="1.2"/>
+    </g>`;
+  });
+  return {
+    markup: `<g id="plan-section-markers">${parts.join("")}</g>`,
+    count: parts.length,
+    labels,
   };
 }
 
@@ -1100,13 +1358,15 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
   const buildableOutline = includeSiteContext
     ? polygonPath(geometry.site?.buildable_polygon || [], project)
     : "";
-  const dimensionMarkup = renderExternalDimensions(
+  const dimensionResult = renderExternalDimensions(
     bounds,
     project,
     layout,
     width,
     theme,
+    { rooms: levelRooms },
   );
+  const dimensionMarkup = dimensionResult.markup;
   const scaleBar = renderScaleBar(
     transform.scale,
     width,
@@ -1124,6 +1384,17 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
       })
     : "";
   const furnitureHints = renderFurnitureHints(levelRooms, project, theme);
+  // Section markers (A-A, B-B) — render the global section cuts on every
+  // level's plan, which matches standard architectural practice (the cut
+  // runs through the full building, not per-storey). When a section is
+  // explicitly scoped to a single level via `level_id`, we honour that.
+  // Sorting + letter assignment is deterministic inside renderSectionMarkers.
+  const levelSections = (geometry.sections || []).filter((section) => {
+    if (!section?.cutLine) return false;
+    if (section.level_id && section.level_id !== level.id) return false;
+    return true;
+  });
+  const sectionMarkers = renderSectionMarkers(levelSections, project, theme);
   const doorCount = doorEntries.length;
   const windowCount = windowEntries.length;
   const stairCount = stairEntries.length;
@@ -1159,6 +1430,7 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
   ${circulationMarkup ? `<g id="plan-circulation">${circulationMarkup}</g>` : ""}
   ${stairMarkup ? `<g id="plan-stairs">${stairMarkup}</g>` : ""}
   ${roomLabelMarkup ? `<g id="plan-room-labels">${roomLabelMarkup}</g>` : ""}
+  ${sectionMarkers.markup}
   ${dimensionMarkup}
   ${!sheetMode ? renderNorthArrow(width, layout, theme, geometry.site?.north_orientation_deg || 0) : ""}
   ${titleBlock}
@@ -1193,12 +1465,19 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
       has_scale_bar: true,
       furniture_hint_count: furnitureHints.count,
       door_swing_count: doorCount,
+      window_jamb_tick_count: windowCount * 2,
       plan_density_score: Number(roomDensityScore.toFixed(3)),
       bounds_source: boundsSource,
       blueprint_theme: theme.name,
       slot_occupancy_ratio: slotOccupancyRatio,
       sheet_occupancy_quality: slotOccupancyRatio >= 0.55 ? "strong" : "weak",
       scale_bar_meters: scaleBar.barMeters,
+      section_marker_count: sectionMarkers.count,
+      section_marker_labels: sectionMarkers.labels,
+      dimension_chain_horizontal_segments:
+        dimensionResult.chain.horizontalSegmentCount,
+      dimension_chain_vertical_segments:
+        dimensionResult.chain.verticalSegmentCount,
       line_hierarchy: {
         exterior_wall: 2.05,
         interior_wall: 1.28,


### PR DESCRIPTION
## Summary

Plan-renderer visual upgrades on top of Phase 8. All outputs remain deterministic SVG built from `compiledProject`; `geometryHash` is unchanged; the renderer never mutates its input geometry.

- **Section markers A-A / B-B** drawn from `compiledProject.sections`. Letter assignment is stable (longitudinal → A, transverse → B; `id` tie-break) so input ordering does not flip labels.
- **Window jamb ticks** at each end of every opening — full wall-thickness ticks anchoring glass to wall faces. New `class="window-jamb-tick"`.
- **External dimension chains** alongside the existing overall dimension band: per-room intermediate ticks + per-segment metre labels along both top (x) and right (y) axes. New `class="dimension-chain horizontal|vertical"`.
- **Furniture coverage 8 → 12 tokens**: `hallway_runner`, `garage_doors`, `utility_appliances`, `wardrobe`. Per-token min-rect thresholds let narrow corridors carry a runner symbol.
- **New `technical_quality_metadata`** fields: `section_marker_count`, `section_marker_labels`, `window_jamb_tick_count`, `dimension_chain_horizontal_segments`, `dimension_chain_vertical_segments`.
- **`FURNITURE_SYMBOL_VERSION`** bumped `phase3-furniture-symbol-v1` → `v2`.

## Out of scope

- vector cutaway axonometric / vector site plan
- boundary fallback work
- OS NGD / climate / env work
- visual image generation
- PR #85 A1 export gate

## Test plan

- [x] Added `svgPlanRendererFidelity.test.js` (16 cases) covering each visual upgrade + determinism + geometry-hash safety
- [x] `npm run check:contracts` ✅
- [x] `npm run test:compose:routing` ✅ (22/22)
- [x] `npm run lint` ✅
- [x] `npm run build:active` ✅
- [x] Manual fidelity smoke (Node ESM import) — 18/18 assertions pass
- [ ] Reviewer: confirm SVG renders cleanly when opened in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)