### PR TITLE
fix(a1): allow sheet-mode plans to use global north arrow and title block

### DIFF
--- a/src/__tests__/services/drawingConsistencyChecks.test.js
+++ b/src/__tests__/services/drawingConsistencyChecks.test.js
@@ -128,6 +128,187 @@ describe("runDrawingConsistencyChecks — per-view reliability", () => {
       true,
     );
   });
+
+  // Hotfix coverage: in the A1 sheet, the global title-block + north arrow
+  // are rendered ONCE on the sheet chrome, so the per-panel plan SVGs
+  // intentionally omit those markers when sheetMode:true. Standalone exports
+  // (single-plan PDFs / vector previews) still must carry them.
+  describe("sheet-mode plan marker relaxation", () => {
+    test("standalone plan missing north-arrow still fails", () => {
+      const result = runDrawingConsistencyChecks({
+        projectGeometry: { levels: [{ id: 0 }] },
+        drawings: {
+          plan: [
+            {
+              level_id: "0",
+              svg: planSvg({ northArrow: false }),
+            },
+          ],
+          elevation: [{ svg: elevationSvg() }],
+          section: [{ svg: sectionSvg() }],
+        },
+        enableCrossViewChecks: false,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("north-arrow marker"))).toBe(
+        true,
+      );
+    });
+
+    test("standalone plan missing title-block still fails", () => {
+      const result = runDrawingConsistencyChecks({
+        projectGeometry: { levels: [{ id: 0 }] },
+        drawings: {
+          plan: [{ level_id: "0", svg: planSvg({ titleBlock: false }) }],
+          elevation: [{ svg: elevationSvg() }],
+          section: [{ svg: sectionSvg() }],
+        },
+        enableCrossViewChecks: false,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("title-block marker"))).toBe(
+        true,
+      );
+    });
+
+    test("sheet-mode plan missing north-arrow does NOT fail for that reason", () => {
+      const result = runDrawingConsistencyChecks({
+        projectGeometry: { levels: [{ id: 0 }] },
+        drawings: {
+          plan: [
+            {
+              level_id: "0",
+              sheet_mode: true,
+              svg: planSvg({ northArrow: false }),
+            },
+          ],
+          elevation: [{ svg: elevationSvg() }],
+          section: [{ svg: sectionSvg() }],
+        },
+        enableCrossViewChecks: false,
+      });
+      expect(result.errors.some((e) => e.includes("north-arrow marker"))).toBe(
+        false,
+      );
+    });
+
+    test("sheet-mode plan missing title-block does NOT fail for that reason", () => {
+      const result = runDrawingConsistencyChecks({
+        projectGeometry: { levels: [{ id: 0 }] },
+        drawings: {
+          plan: [
+            {
+              level_id: "0",
+              sheet_mode: true,
+              svg: planSvg({ titleBlock: false }),
+            },
+          ],
+          elevation: [{ svg: elevationSvg() }],
+          section: [{ svg: sectionSvg() }],
+        },
+        enableCrossViewChecks: false,
+      });
+      expect(result.errors.some((e) => e.includes("title-block marker"))).toBe(
+        false,
+      );
+    });
+
+    test("sheet-mode signal also accepted via technical_quality_metadata", () => {
+      const result = runDrawingConsistencyChecks({
+        projectGeometry: { levels: [{ id: 0 }] },
+        drawings: {
+          plan: [
+            {
+              level_id: "0",
+              technical_quality_metadata: { sheet_mode: true },
+              svg: planSvg({ northArrow: false, titleBlock: false }),
+            },
+          ],
+          elevation: [{ svg: elevationSvg() }],
+          section: [{ svg: sectionSvg() }],
+        },
+        enableCrossViewChecks: false,
+      });
+      expect(
+        result.errors.some(
+          (e) =>
+            e.includes("north-arrow marker") ||
+            e.includes("title-block marker"),
+        ),
+      ).toBe(false);
+    });
+
+    test("sheet-mode signal also accepted via camelCase technicalQualityMetadata", () => {
+      const result = runDrawingConsistencyChecks({
+        projectGeometry: { levels: [{ id: 0 }] },
+        drawings: {
+          plan: [
+            {
+              level_id: "0",
+              technicalQualityMetadata: { sheet_mode: true },
+              svg: planSvg({ northArrow: false, titleBlock: false }),
+            },
+          ],
+          elevation: [{ svg: elevationSvg() }],
+          section: [{ svg: sectionSvg() }],
+        },
+        enableCrossViewChecks: false,
+      });
+      expect(
+        result.errors.some(
+          (e) =>
+            e.includes("north-arrow marker") ||
+            e.includes("title-block marker"),
+        ),
+      ).toBe(false);
+    });
+
+    test("sheet-mode plan with another real error (missing SVG) still fails", () => {
+      const result = runDrawingConsistencyChecks({
+        projectGeometry: { levels: [{ id: 0 }] },
+        drawings: {
+          plan: [{ level_id: "0", sheet_mode: true /* svg omitted */ }],
+          elevation: [{ svg: elevationSvg() }],
+          section: [{ svg: sectionSvg() }],
+        },
+        enableCrossViewChecks: false,
+      });
+      // Sheet-mode plans still must carry SVG content; the relaxation is
+      // limited to the two specific marker checks.
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("missing SVG content"))).toBe(
+        true,
+      );
+    });
+
+    test("sheet-mode does not silence cross-view storey/window inconsistency", () => {
+      // Cross-view warnings still fire — sheet-mode only relaxes the two
+      // chrome marker requirements, not the consistency checks themselves.
+      const warnings = validateCrossViewConsistency({
+        drawings: {
+          plan: [
+            {
+              sheet_mode: true,
+              window_count: 8,
+              svg: planSvg({ northArrow: false, titleBlock: false }),
+            },
+          ],
+          elevation: [
+            { svg: elevationSvg(), window_count: 2 },
+            { svg: elevationSvg(), window_count: 2 },
+          ],
+          section: [{ svg: sectionSvg() }],
+        },
+        projectGeometry: { levels: [{ id: 0 }] },
+      });
+      // 8 plan windows vs 4 elevation windows → mismatch warning still fires.
+      expect(
+        warnings.some(
+          (w) => w.includes("plan reports") && w.includes("windows"),
+        ),
+      ).toBe(true);
+    });
+  });
 });
 
 describe("validateCrossViewConsistency — Phase 5 cross-view checks", () => {

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -10659,16 +10659,23 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     // Phase 4: bucket the deterministic drawing SVGs by drawing type so the
     // gate's cross-view evidence evaluator (drawingConsistencyChecks) can
     // inspect them. Only artifacts with an `svgString` participate; the
-    // checker reads `svg` so we forward it through.
+    // checker reads `svg` so we forward it through. We also forward
+    // `sheet_mode` for plan entries so the validator can relax the per-panel
+    // north-arrow / title-block marker requirements that the sheet composes
+    // globally (the plan renderer omits them when sheetMode:true was used).
     const drawingsForGate = { plan: [], elevation: [], section: [] };
     for (const artifact of Object.values(drawingArtifacts || {})) {
       const dt = artifact?.drawingType || artifact?.metadata?.drawingType;
       const svg = artifact?.svgString;
       if (!svg || !dt) continue;
       if (dt === "plan") {
+        const planSheetMode =
+          artifact?.technicalQualityMetadata?.sheet_mode === true ||
+          artifact?.metadata?.technicalQualityMetadata?.sheet_mode === true;
         drawingsForGate.plan.push({
           level_id: artifact?.metadata?.level_id || null,
           svg,
+          sheet_mode: planSheetMode,
         });
       } else if (dt === "elevation") {
         drawingsForGate.elevation.push({ svg, window_count: 0 });

--- a/src/services/validation/drawingConsistencyChecks.js
+++ b/src/services/validation/drawingConsistencyChecks.js
@@ -2,6 +2,39 @@ function hasSvgPayload(entry) {
   return Boolean(entry?.svg && String(entry.svg).includes("<svg"));
 }
 
+// A plan SVG is "sheet-mode" when it is being composed inside the global A1
+// sheet (which renders ONE north arrow and ONE title block at the sheet
+// chrome level, not per panel). The plan renderer intentionally omits the
+// per-panel north-arrow / title-block in that case to avoid double-rendering.
+// We accept any of the well-known signals callers may attach so the check is
+// resilient to future plumbing tweaks:
+//   - explicit `entry.sheet_mode === true` (slice-level forwarded flag)
+//   - `entry.technicalQualityMetadata.sheet_mode === true`
+//     (camelCase key used by canonical pack builder)
+//   - `entry.technical_quality_metadata.sheet_mode === true`
+//     (snake_case key as the renderer originally emits it)
+//   - `entry.metadata.technicalQualityMetadata.sheet_mode === true`
+//   - `entry.metadata.technical_quality_metadata.sheet_mode === true`
+//   - SVG carries the `data-sheet-mode="true"` attribute (defensive — not
+//     emitted today, allows the renderer to opt in later without re-touching
+//     this validator).
+function isSheetModePlan(entry) {
+  if (!entry || typeof entry !== "object") return false;
+  if (entry.sheet_mode === true || entry.sheetMode === true) return true;
+  const metaCandidates = [
+    entry.technicalQualityMetadata,
+    entry.technical_quality_metadata,
+    entry.metadata?.technicalQualityMetadata,
+    entry.metadata?.technical_quality_metadata,
+  ];
+  for (const meta of metaCandidates) {
+    if (meta && meta.sheet_mode === true) return true;
+  }
+  const svg = String(entry.svg || "");
+  if (svg.includes('data-sheet-mode="true"')) return true;
+  return false;
+}
+
 function validateCollection(name, entries = [], minimumCount = 1) {
   const warnings = [];
   const errors = [];
@@ -38,10 +71,18 @@ function validatePlanCollection(entries = [], levelCount = 1) {
     }
 
     const svg = String(entry?.svg || "");
-    if (svg && !svg.includes('id="north-arrow"')) {
+    const sheetModeEntry = isSheetModePlan(entry);
+    // Per-panel north-arrow and title-block are required for STANDALONE
+    // technical exports (single-plan PDFs, vector previews, etc). They are
+    // INTENTIONALLY omitted when the plan is composed into the A1 sheet,
+    // because the sheet renders a single global north arrow + title block.
+    // Only relax these two specific marker requirements for sheet-mode —
+    // everything else (scale-bar, room-label, dimension-chain warnings,
+    // cross-view storey/window agreement, SVG payload presence) stays.
+    if (svg && !sheetModeEntry && !svg.includes('id="north-arrow"')) {
       errors.push(`drawings.plan[${index}] is missing the north-arrow marker.`);
     }
-    if (svg && !svg.includes('id="title-block"')) {
+    if (svg && !sheetModeEntry && !svg.includes('id="title-block"')) {
       errors.push(`drawings.plan[${index}] is missing the title-block marker.`);
     }
     // Reliability checks added 2026-05-02 to surface common A1 floor-plan


### PR DESCRIPTION
## Problem

Real A1 generation has been blocked since PR #85's cross-view validator landed. The validator treats `north-arrow` + `title-block` as REQUIRED markers on every plan SVG, but the plan renderer intentionally omits both per panel when `sheetMode: true` because the A1 sheet renders ONE global north arrow and ONE global title block on the sheet chrome.

Live error from production main:
```
A1_EXPORT_GATE_TECHNICAL_BLOCKED
codes: [\"CROSS_VIEW_INCONSISTENT\"]
blockers:
  drawings.plan[0] is missing the north-arrow marker.
  drawings.plan[0] is missing the title-block marker.
  drawings.plan[1] is missing the north-arrow marker.
  drawings.plan[1] is missing the title-block marker.
```

## Fix (Option A — relax the validator)

- `drawingConsistencyChecks` learns to detect sheet-mode plans via any of: `entry.sheet_mode`, `entry.technicalQualityMetadata.sheet_mode`, `entry.technical_quality_metadata.sheet_mode`, nested `metadata.*` paths, or a `data-sheet-mode=\"true\"` attribute on the SVG root.
- Skip ONLY the north-arrow + title-block error pushes for sheet-mode plans.
- All other checks (SVG payload presence, scale-bar / room-label / dimension-chain warnings, cross-view storey/window agreement) remain active.
- `projectGraphVerticalSliceService` forwards the `sheet_mode` flag from `artifact.technicalQualityMetadata` into `drawingsForGate.plan` entries so the gate sees the signal end-to-end.

**No plan renderer visuals modified.** PR #85 export gate behaviour intact for standalone exports.

## What this does NOT change

- Standalone / non-sheet-mode plan exports (single-plan PDFs, vector previews) still fail when missing those two markers
- All other cross-view consistency errors still block
- No boundary / OS NGD / climate / axonometric / site-plan code touched

## Test plan

8 new test cases added in `src/__tests__/services/drawingConsistencyChecks.test.js` (under describe block `sheet-mode plan marker relaxation`) covering all 6 user-listed scenarios plus alternate metadata-key plumbing:

| # | Case | Asserts |
|---|---|---|
| 1 | Standalone plan missing north-arrow | still FAILS |
| 2 | Standalone plan missing title-block | still FAILS |
| 3 | Sheet-mode plan missing north-arrow | does NOT fail for that reason |
| 4 | Sheet-mode plan missing title-block | does NOT fail for that reason |
| 5a | Sheet-mode via `technical_quality_metadata` | accepted |
| 5b | Sheet-mode via camelCase `technicalQualityMetadata` | accepted |
| 6a | Sheet-mode plan with another real error (missing SVG payload) | still FAILS |
| 6b | Sheet-mode does NOT silence cross-view storey/window inconsistency | warning still fires |

## Validation

- [x] `npm run check:contracts` ✅
- [x] `npm run test:compose:routing` ✅ 22 / 22
- [x] `npm run lint` ✅ exit 0
- [x] `npm run build:active` ✅ compiled
- [x] Manual smoke test of the validator against committed source — 9 / 9 assertions pass:
  - 1+2: standalone missing markers → both fail correctly (`naErr:true tbErr:true`)
  - 3+4: sheet-mode missing markers → both pass (`naErr:false tbErr:false`)
  - 5a+5b+5c: detector accepts all three sheet-mode signals
  - 6: sheet-mode but no SVG payload → fails correctly with `missing SVG content`
  - 7: cross-view window-count mismatch warning fires under sheet-mode

The committed Jest test file would assert the same — focused `react-scripts test` invocation could not run inside the worktree due to the same Windows `.claude` path normalisation issue documented for PR #88. CI on Linux + parent path will run it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)