### PR TITLE
feat(a1): surface UK vernacular provenance and QA on sheet outputs

### DIFF
--- a/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
+++ b/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
@@ -584,6 +584,30 @@ describe("buildProjectGraphVerticalSliceRequest", () => {
     expect(request.projectDetails.floorCountLocked).toBe(true);
   });
 
+  test("metadata block surfaces styleProvenance + qaSummary from the vertical-slice result", () => {
+    const hookSource = fs.readFileSync(
+      path.join(process.cwd(), "src/hooks/useArchitectAIWorkflow.js"),
+      "utf8",
+    );
+    expect(hookSource).toContain(
+      "verticalSlice.projectGraph?.local_style?.style_provenance",
+    );
+    expect(hookSource).toContain("qaSummary: verticalSlice.qa");
+    expect(hookSource).toContain("verticalSlice.qa.programmeAdjacency.packId");
+  });
+
+  test("validateProjectGraphVerticalSlice preserves programmeAdjacency checks + issues", () => {
+    const sliceSource = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "src/services/project/projectGraphVerticalSliceService.js",
+      ),
+      "utf8",
+    );
+    expect(sliceSource).toContain("checks: adjacencyResult.checks || []");
+    expect(sliceSource).toContain("issues: adjacencyResult.issues || []");
+  });
+
   test("level authority: stale brief target_storeys cannot override current projectDetails", () => {
     const request = buildProjectGraphVerticalSliceRequest({
       designSpec: {

--- a/src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js
+++ b/src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js
@@ -1,0 +1,208 @@
+/**
+ * Commit 2 of feat/a1-surface-vernacular-qa-provenance:
+ *
+ * Verifies that the Key Notes panel surfaces the resolved UK vernacular pack
+ * (paper §4.3) and the QA summary (paper §4.6) when those data are available,
+ * and that the Material Palette panel leads with pack materials before the
+ * canonical 8-material top-up.
+ *
+ * All assertions are at the function level — orchestrator wiring is covered
+ * by the existing slice tests; here we want to confirm the panels themselves
+ * react correctly to the pack/QA inputs.
+ */
+
+import {
+  buildKeyNoteItems,
+  buildKeyNotesPanelArtifact,
+  buildMaterialPalettePanelArtifact,
+} from "../../services/project/projectGraphVerticalSliceService.js";
+import { resolveUKVernacular } from "../../services/style/ukVernacularPacks.js";
+
+function makeLocalStyleWithPack(pack) {
+  return {
+    primary_style: "test",
+    material_palette: ["yellow London stock brick", "natural slate"],
+    avoid_keywords: [],
+    local_blend_strength: 0.5,
+    innovation_strength: 0.5,
+    style_provenance: pack
+      ? {
+          ukVernacularPackId: pack.packId,
+          packLabel: pack.label,
+          region: pack.region,
+          descriptive_narrative: pack.descriptive_narrative,
+          historical_period: pack.historical_period,
+          source: "ukVernacularPacks",
+          materials: pack.materials,
+        }
+      : null,
+  };
+}
+
+const baseBrief = {
+  building_type: "dwelling",
+  canonical_building_type: "dwelling",
+  target_storeys: 2,
+  target_gia_m2: 150,
+  project_name: "test-house",
+};
+const baseSite = { region: "London" };
+const baseClimate = {};
+const baseRegulations = {};
+
+describe("buildKeyNoteItems — style provenance group", () => {
+  test("emits a 'Style provenance' group when localStyle carries a vernacular pack", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    expect(pack.packId).toBe("london-stucco-terrace");
+    const groups = buildKeyNoteItems({
+      brief: baseBrief,
+      site: baseSite,
+      climate: baseClimate,
+      regulations: baseRegulations,
+      localStyle: makeLocalStyleWithPack(pack),
+    });
+    const provenanceGroup = groups.find((g) => g.id === "style_provenance");
+    expect(provenanceGroup).toBeDefined();
+    expect(provenanceGroup.heading).toBe("Style provenance");
+    const allText = provenanceGroup.lines.join(" ");
+    expect(allText).toMatch(/London stucco terrace/);
+    expect(allText).toMatch(/Regency/);
+    // Narrative should mention something concrete from the pack.
+    expect(allText).toMatch(/parapet|stucco|sash/i);
+  });
+
+  test("omits the 'Style provenance' group entirely when no pack is resolved", () => {
+    const groups = buildKeyNoteItems({
+      brief: baseBrief,
+      site: baseSite,
+      climate: baseClimate,
+      regulations: baseRegulations,
+      localStyle: makeLocalStyleWithPack(null),
+    });
+    const provenanceGroup = groups.find((g) => g.id === "style_provenance");
+    expect(provenanceGroup).toBeUndefined();
+  });
+});
+
+describe("buildKeyNoteItems — QA summary group", () => {
+  test("emits a 'QA summary' group when qaSummary carries adjacency + quantitative scores", () => {
+    const groups = buildKeyNoteItems({
+      brief: baseBrief,
+      site: baseSite,
+      climate: baseClimate,
+      regulations: baseRegulations,
+      localStyle: makeLocalStyleWithPack(null),
+      qaSummary: {
+        programmeAdjacency: {
+          score: 64,
+          status: "warn",
+          packId: "residential-v1",
+          ruleCount: 12,
+        },
+        quantitative: { score: 63 },
+      },
+    });
+    const qaGroup = groups.find((g) => g.id === "qa_summary");
+    expect(qaGroup).toBeDefined();
+    expect(qaGroup.heading).toBe("QA summary");
+    const allText = qaGroup.lines.join(" ");
+    expect(allText).toMatch(/Quantitative QA: 63\/100/);
+    expect(allText).toMatch(/Programme adjacency: 64\/100/);
+    expect(allText).toMatch(/warn/);
+    expect(allText).toMatch(/residential-v1/);
+    expect(allText).toMatch(/12 rules/);
+  });
+
+  test("omits the 'QA summary' group when qaSummary is null (panel built before QA)", () => {
+    const groups = buildKeyNoteItems({
+      brief: baseBrief,
+      site: baseSite,
+      climate: baseClimate,
+      regulations: baseRegulations,
+      localStyle: makeLocalStyleWithPack(null),
+      qaSummary: null,
+    });
+    const qaGroup = groups.find((g) => g.id === "qa_summary");
+    expect(qaGroup).toBeUndefined();
+  });
+});
+
+describe("buildKeyNotesPanelArtifact — embedded SVG carries style + QA when supplied", () => {
+  test("SVG contains both 'Style provenance' and 'QA summary' headings when both inputs are present", () => {
+    const pack = resolveUKVernacular({ postcode: "EH8 9YL" });
+    expect(pack.packId).toBe("edinburgh-tenement");
+    const artifact = buildKeyNotesPanelArtifact({
+      projectGraphId: "pg-test",
+      brief: baseBrief,
+      site: baseSite,
+      climate: baseClimate,
+      regulations: baseRegulations,
+      localStyle: makeLocalStyleWithPack(pack),
+      geometryHash: "h-test-1234",
+      qaSummary: {
+        programmeAdjacency: {
+          score: 78,
+          status: "pass",
+          packId: "residential-v1",
+          ruleCount: 12,
+        },
+        quantitative: { score: 81 },
+      },
+    });
+    expect(artifact.panel_type).toBe("key_notes");
+    expect(artifact.svgString).toContain("Style provenance");
+    expect(artifact.svgString).toContain("Edinburgh tenement");
+    expect(artifact.svgString).toContain("QA summary");
+    expect(artifact.svgString).toContain("78/100");
+    expect(artifact.svgString).toContain("81/100");
+  });
+});
+
+describe("buildMaterialPalettePanelArtifact — pack materials lead the grid", () => {
+  test("W2 (london-stucco-terrace) pack materials appear before the canonical fallback", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    const artifact = buildMaterialPalettePanelArtifact({
+      projectGraphId: "pg-test",
+      localStyle: makeLocalStyleWithPack(pack),
+      compiledProject: null,
+      styleDNA: null,
+      brief: baseBrief,
+      geometryHash: "h-test-mat-1",
+      sheetDesignContext: null,
+    });
+    expect(artifact.panel_type).toBe("material_palette");
+    expect(Array.isArray(artifact.cardMetadata)).toBe(true);
+    const cardLabel = (card) =>
+      String(card?.label || card?.name || "").toLowerCase();
+    const packNamesLower = pack.materials.map((m) => m.toLowerCase());
+    expect(packNamesLower).toContain(cardLabel(artifact.cardMetadata[0]));
+    // At least 2 of the first 4 cards should come from the pack — the rest
+    // can fall through to the canonical top-up.
+    const firstFourLower = artifact.cardMetadata.slice(0, 4).map(cardLabel);
+    const overlap = firstFourLower.filter((n) =>
+      packNamesLower.includes(n),
+    ).length;
+    expect(overlap).toBeGreaterThanOrEqual(2);
+  });
+
+  test("falls back to the existing canonical palette when no pack is resolved", () => {
+    const artifact = buildMaterialPalettePanelArtifact({
+      projectGraphId: "pg-test",
+      localStyle: makeLocalStyleWithPack(null),
+      compiledProject: null,
+      styleDNA: null,
+      brief: baseBrief,
+      geometryHash: "h-test-mat-2",
+      sheetDesignContext: null,
+    });
+    expect(artifact.panel_type).toBe("material_palette");
+    expect(artifact.cardMetadata.length).toBeGreaterThan(0);
+    const firstFourNames = artifact.cardMetadata
+      .slice(0, 4)
+      .map((c) => String(c?.label || c?.name || "").toLowerCase());
+    // No pack-source entries in cardMetadata when style_provenance is absent.
+    expect(firstFourNames.some((n) => n.includes("white stucco render"))).toBe(
+      false,
+    );
+  });
+});

--- a/src/__tests__/services/elevationAndPromptVernacularPack.test.js
+++ b/src/__tests__/services/elevationAndPromptVernacularPack.test.js
@@ -164,6 +164,50 @@ describe("renderElevationSvg — pack-driven hints", () => {
     );
   });
 
+  // Codex P1 regression: localStylePack.buildLocalStylePackV2 always emits a
+  // style_provenance object — when no UK pack resolves the source field is
+  // "buildingTypeDefault" with every other field null. A naive truthiness
+  // gate would still treat that as a real pack and leak empty
+  // data-vernacular-pack="" + data-pack-* attrs into legacy elevations. The
+  // renderer must require source === "ukVernacularPacks" (or a non-empty
+  // packId) before emitting any vernacular markup.
+  test("buildingTypeDefault fallback style_provenance is treated as no-pack (no leaked attrs)", () => {
+    const fallbackProvenance = {
+      ukVernacularPackId: null,
+      packLabel: null,
+      region: null,
+      descriptive_narrative: null,
+      historical_period: null,
+      resolution_source: null,
+      source: "buildingTypeDefault",
+    };
+    const result = renderElevationSvg(
+      makeFixtureGeometry(),
+      {},
+      {
+        orientation: "south",
+        vernacularPack: fallbackProvenance,
+        allowWeakFacadeFallback: true,
+      },
+    );
+    expect(result.svg).toBeTruthy();
+    expect(result.svg).not.toContain("data-vernacular-pack=");
+    expect(result.svg).not.toContain("data-pack-parapet=");
+    expect(result.svg).not.toContain("data-pack-semi-basement=");
+    expect(result.svg).not.toContain("data-pack-window-language=");
+    expect(result.svg).not.toContain("data-pack-facade-stucco=");
+    expect(result.svg).not.toContain("data-vernacular-feature=");
+    expect(result.svg).not.toContain("Vernacular:");
+    expect(result.technical_quality_metadata.vernacular_pack_id).toBeNull();
+    expect(result.technical_quality_metadata.vernacular_pack_label).toBeNull();
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      false,
+    );
+    expect(
+      result.technical_quality_metadata.vernacular_pack_semi_basement,
+    ).toBe(false);
+  });
+
   test("edinburgh-tenement pack produces sandstone + parapet hints, distinct from london", () => {
     const pack = resolveUKVernacular({ postcode: "EH8 9YL" });
     expect(pack.packId).toBe("edinburgh-tenement");
@@ -240,6 +284,30 @@ describe("buildHero3DPrompt + buildExteriorRenderPrompt — pack injection", () 
     // The existing baseline prompt structure is preserved.
     expect(prompt).toContain("Front-elevation hero render");
     expect(prompt).toContain("Photoreal architectural front-elevation render");
+  });
+
+  // Codex P1 regression: the buildingTypeDefault fallback object from
+  // localStylePack should NOT trigger the REGIONAL VERNACULAR block — the
+  // prompt must remain identical to the no-pack path.
+  test("buildExteriorRenderPrompt with buildingTypeDefault fallback emits no REGIONAL VERNACULAR block", () => {
+    const fallbackProvenance = {
+      ukVernacularPackId: null,
+      packLabel: null,
+      region: null,
+      descriptive_narrative: null,
+      historical_period: null,
+      resolution_source: null,
+      source: "buildingTypeDefault",
+    };
+    const { prompt } = buildExteriorRenderPrompt({
+      masterDNA,
+      locationData,
+      projectContext,
+      vernacularPack: fallbackProvenance,
+    });
+    expect(prompt).not.toContain("REGIONAL VERNACULAR");
+    expect(prompt).not.toContain("london-stucco-terrace");
+    expect(prompt).not.toContain("edinburgh-tenement");
   });
 
   test("buildExteriorRenderPrompt preserves geometry constraint when pack is added", () => {

--- a/src/__tests__/services/elevationAndPromptVernacularPack.test.js
+++ b/src/__tests__/services/elevationAndPromptVernacularPack.test.js
@@ -1,0 +1,263 @@
+/**
+ * Commit 3 of feat/a1-surface-vernacular-qa-provenance:
+ *
+ * Verifies that:
+ *   1. The deterministic SVG elevation renderer surfaces pack-driven hints
+ *      (parapet roofline, semi-basement strip, stucco/sash labels, data
+ *      attributes) when a UK regional vernacular pack is supplied via
+ *      options.vernacularPack.
+ *   2. The flag-off / no-pack path renders the existing canonical SVG with
+ *      no vernacular markup so existing fixtures keep passing.
+ *   3. Different packs (W2 vs EH8) produce visually distinguishable output.
+ *   4. The hero/exterior LLM prompt builders inject a "REGIONAL VERNACULAR"
+ *      block with the pack narrative + facade/window/material language when
+ *      a pack is supplied, and remain pack-free when none is.
+ *   5. Existing geometry-authority / fingerprint locks are preserved when
+ *      the pack block is added.
+ */
+
+import { renderElevationSvg } from "../../services/drawing/svgElevationRenderer.js";
+import {
+  buildHero3DPrompt,
+  buildExteriorRenderPrompt,
+} from "../../services/a1/panelPromptBuilders.js";
+import { resolveUKVernacular } from "../../services/style/ukVernacularPacks.js";
+
+// A minimal-but-valid compiled-project geometry: one level, one rectangular
+// room, four exterior walls, two windows on the south face, one door. Enough
+// for renderElevationSvg to succeed in non-blocked mode.
+function makeFixtureGeometry() {
+  return {
+    metadata: {},
+    levels: [{ id: "level-0", index: 0, height_m: 3.0 }],
+    rooms: [
+      {
+        id: "room-1",
+        levelId: "level-0",
+        polygon: [
+          { x: 0, y: 0 },
+          { x: 8, y: 0 },
+          { x: 8, y: 6 },
+          { x: 0, y: 6 },
+        ],
+        bbox: { min: { x: 0, y: 0 }, max: { x: 8, y: 6 } },
+      },
+    ],
+    walls: [
+      {
+        id: "wall-s",
+        levelId: "level-0",
+        start: { x: 0, y: 0 },
+        end: { x: 8, y: 0 },
+        height_m: 3.0,
+        thickness_m: 0.24,
+        exterior: true,
+      },
+      {
+        id: "wall-e",
+        levelId: "level-0",
+        start: { x: 8, y: 0 },
+        end: { x: 8, y: 6 },
+        height_m: 3.0,
+        thickness_m: 0.24,
+        exterior: true,
+      },
+      {
+        id: "wall-n",
+        levelId: "level-0",
+        start: { x: 8, y: 6 },
+        end: { x: 0, y: 6 },
+        height_m: 3.0,
+        thickness_m: 0.24,
+        exterior: true,
+      },
+      {
+        id: "wall-w",
+        levelId: "level-0",
+        start: { x: 0, y: 6 },
+        end: { x: 0, y: 0 },
+        height_m: 3.0,
+        thickness_m: 0.24,
+        exterior: true,
+      },
+    ],
+    windows: [
+      {
+        id: "win-1",
+        wallId: "wall-s",
+        levelId: "level-0",
+        position_m: 1.5,
+        width_m: 1.2,
+        sill_height_m: 0.9,
+        head_height_m: 2.1,
+      },
+      {
+        id: "win-2",
+        wallId: "wall-s",
+        levelId: "level-0",
+        position_m: 5.0,
+        width_m: 1.2,
+        sill_height_m: 0.9,
+        head_height_m: 2.1,
+      },
+    ],
+    doors: [
+      {
+        id: "door-1",
+        wallId: "wall-s",
+        levelId: "level-0",
+        position_m: 3.0,
+        width_m: 0.9,
+        head_height_m: 2.1,
+      },
+    ],
+    openings: [],
+    envelope: { min: { x: 0, y: 0 }, max: { x: 8, y: 6 } },
+  };
+}
+
+describe("renderElevationSvg — pack-driven hints", () => {
+  test("london-stucco-terrace pack produces parapet + semi-basement + stucco cues", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    expect(pack.packId).toBe("london-stucco-terrace");
+    const result = renderElevationSvg(
+      makeFixtureGeometry(),
+      {},
+      {
+        orientation: "south",
+        vernacularPack: pack,
+        allowWeakFacadeFallback: true,
+      },
+    );
+    expect(result.svg).toBeTruthy();
+    expect(result.svg).toContain(
+      'data-vernacular-pack="london-stucco-terrace"',
+    );
+    expect(result.svg).toContain('data-pack-parapet="true"');
+    expect(result.svg).toContain('data-pack-semi-basement="true"');
+    expect(result.svg).toContain('data-pack-facade-stucco="true"');
+    expect(result.svg).toContain('data-vernacular-feature="semi_basement"');
+    // Vernacular caption is omitted in sheetMode; default mode shows it.
+    expect(result.svg).toContain("Vernacular: London stucco terrace");
+    // Roofline language was overridden to parapet.
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      true,
+    );
+    expect(result.technical_quality_metadata.vernacular_pack_id).toBe(
+      "london-stucco-terrace",
+    );
+  });
+
+  test("no pack supplied: SVG carries no vernacular markup (flag-off fallback)", () => {
+    const result = renderElevationSvg(
+      makeFixtureGeometry(),
+      {},
+      { orientation: "south", allowWeakFacadeFallback: true },
+    );
+    expect(result.svg).toBeTruthy();
+    expect(result.svg).not.toContain("data-vernacular-pack=");
+    expect(result.svg).not.toContain("data-vernacular-feature=");
+    expect(result.svg).not.toContain("Vernacular:");
+    expect(result.technical_quality_metadata.vernacular_pack_id).toBeNull();
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      false,
+    );
+  });
+
+  test("edinburgh-tenement pack produces sandstone + parapet hints, distinct from london", () => {
+    const pack = resolveUKVernacular({ postcode: "EH8 9YL" });
+    expect(pack.packId).toBe("edinburgh-tenement");
+    const result = renderElevationSvg(
+      makeFixtureGeometry(),
+      {},
+      {
+        orientation: "south",
+        vernacularPack: pack,
+        allowWeakFacadeFallback: true,
+      },
+    );
+    expect(result.svg).toContain('data-vernacular-pack="edinburgh-tenement"');
+    // Edinburgh tenement is sandstone, not stucco — stucco flag must stay false.
+    expect(result.svg).not.toContain('data-pack-facade-stucco="true"');
+    expect(result.technical_quality_metadata.vernacular_pack_id).toBe(
+      "edinburgh-tenement",
+    );
+    expect(result.technical_quality_metadata.vernacular_pack_label).toMatch(
+      /Edinburgh/i,
+    );
+    expect(result.technical_quality_metadata.vernacular_pack_label).toMatch(
+      /tenement/i,
+    );
+  });
+});
+
+describe("buildHero3DPrompt + buildExteriorRenderPrompt — pack injection", () => {
+  const masterDNA = {
+    architecturalStyle: "Contemporary",
+    materials: [
+      { name: "warm brick", hexColor: "#8c5a3a", application: "facade" },
+    ],
+    roof: { type: "gable" },
+    dimensions: {
+      length_m: 8,
+      width_m: 6,
+      height_m: 6,
+      floor_count: 2,
+    },
+  };
+  const locationData = { climate: { type: "temperate" } };
+  const projectContext = { buildingProgram: "residential" };
+
+  test("buildHero3DPrompt with London pack injects narrative, parapet, sash, materials", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    const { prompt } = buildHero3DPrompt({
+      masterDNA,
+      locationData,
+      projectContext,
+      vernacularPack: pack,
+    });
+    expect(prompt).toContain("REGIONAL VERNACULAR (UK pack):");
+    expect(prompt).toContain("London stucco terrace");
+    expect(prompt).toContain("Regency");
+    expect(prompt).toMatch(/parapet/i);
+    expect(prompt).toMatch(/sash/i);
+    expect(prompt).toMatch(/stucco|render/i);
+    expect(prompt).toMatch(/semi.?basement|cast.?iron|york stone/i);
+    // Geometry / massing constraints still present.
+    expect(prompt).toContain("FLOOR COUNT: EXACTLY");
+    expect(prompt).toContain("DESIGN SPECIFICATION");
+  });
+
+  test("buildExteriorRenderPrompt without a pack produces no London-specific text", () => {
+    const { prompt } = buildExteriorRenderPrompt({
+      masterDNA,
+      locationData,
+      projectContext,
+    });
+    expect(prompt).not.toContain("REGIONAL VERNACULAR");
+    expect(prompt).not.toContain("London stucco terrace");
+    expect(prompt).not.toContain("Notting Hill");
+    // The existing baseline prompt structure is preserved.
+    expect(prompt).toContain("Front-elevation hero render");
+    expect(prompt).toContain("Photoreal architectural front-elevation render");
+  });
+
+  test("buildExteriorRenderPrompt preserves geometry constraint when pack is added", () => {
+    const pack = resolveUKVernacular({ postcode: "EH8 9YL" });
+    const geometryHint = { type: "tenement_block_4_storey" };
+    const { prompt } = buildExteriorRenderPrompt({
+      masterDNA,
+      locationData,
+      projectContext,
+      geometryHint,
+      vernacularPack: pack,
+    });
+    expect(prompt).toContain("REGIONAL VERNACULAR (UK pack):");
+    expect(prompt).toMatch(/Edinburgh.*tenement/i);
+    // Geometry authority must still appear despite the pack injection.
+    expect(prompt).toContain("FOLLOW PROVIDED GEOMETRY silhouette");
+    expect(prompt).toContain("(tenement_block_4_storey)");
+    // Floor count + roof requirements still anchored.
+    expect(prompt).toContain("FLOOR COUNT: EXACTLY");
+  });
+});

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -1001,6 +1001,28 @@ async function runProjectGraphVerticalSliceWorkflow({
       sheetSeries: verticalSlice.artifacts?.sheetSeries || [],
       sheetSplitDecision: verticalSlice.artifacts?.sheetSplitDecision || null,
       qaStatus: verticalSlice.qa?.status || null,
+      styleProvenance:
+        verticalSlice.projectGraph?.local_style?.style_provenance || null,
+      qaSummary: verticalSlice.qa
+        ? {
+            status: verticalSlice.qa.status,
+            score: verticalSlice.qa.score,
+            programmeAdjacency: verticalSlice.qa.programmeAdjacency
+              ? {
+                  score: verticalSlice.qa.programmeAdjacency.score,
+                  status: verticalSlice.qa.programmeAdjacency.status,
+                  packId: verticalSlice.qa.programmeAdjacency.packId,
+                  ruleCount: verticalSlice.qa.programmeAdjacency.ruleCount,
+                }
+              : null,
+            quantitative: verticalSlice.qa.quantitative
+              ? { score: verticalSlice.qa.quantitative.score }
+              : null,
+            qualitative: verticalSlice.qa.qualitative
+              ? { score: verticalSlice.qa.qualitative.score }
+              : null,
+          }
+        : null,
     },
   };
 }

--- a/src/services/a1/panelPromptBuilders.js
+++ b/src/services/a1/panelPromptBuilders.js
@@ -147,6 +147,52 @@ function normalizeMaterials(masterDNA = {}) {
 }
 
 /**
+/**
+ * Build a REGIONAL VERNACULAR block (paper §4.3 transfer-by-curation).
+ * When the slice resolved a UK regional pack (london-stucco-terrace,
+ * edinburgh-tenement, cotswolds-cottage, etc.) the pack carries a
+ * descriptive narrative + facade/roof/window/material language. We inject
+ * those verbatim so the photoreal model produces stucco terraces in
+ * Notting Hill instead of generic gable cottages, Sandstone tenements in
+ * Edinburgh instead of yellow stock brick, etc. Returns an empty string
+ * when no pack is supplied so existing flag-off behaviour is unchanged.
+ * @private
+ */
+function buildVernacularPackBlock(vernacularPack) {
+  if (!vernacularPack || typeof vernacularPack !== "object") return "";
+  const label = vernacularPack.packLabel || vernacularPack.label || null;
+  const period = vernacularPack.historical_period || null;
+  const narrative = vernacularPack.descriptive_narrative || null;
+  const facadeLanguage = vernacularPack.facade_language || null;
+  const roofLanguage = vernacularPack.roof_language || null;
+  const windowLanguage = vernacularPack.window_language || null;
+  const materials = Array.isArray(vernacularPack.materials)
+    ? vernacularPack.materials.filter(
+        (m) => typeof m === "string" && m.trim().length,
+      )
+    : [];
+  const parapet = vernacularPack.parapet_default === true;
+  const semiBasement = vernacularPack.semi_basement_default === true;
+  if (!label && !narrative && !facadeLanguage && materials.length === 0) {
+    return "";
+  }
+  const lines = ["REGIONAL VERNACULAR (UK pack):"];
+  if (label) lines.push(`- Pack: ${label}${period ? ` (${period})` : ""}`);
+  if (narrative) lines.push(`- Narrative: ${narrative}`);
+  if (facadeLanguage) lines.push(`- Facade language: ${facadeLanguage}`);
+  if (roofLanguage) lines.push(`- Roof language: ${roofLanguage}`);
+  if (windowLanguage) lines.push(`- Window language: ${windowLanguage}`);
+  if (materials.length) lines.push(`- Materials: ${materials.join(", ")}`);
+  if (parapet) lines.push(`- Roofline: parapet concealing the roof.`);
+  if (semiBasement) {
+    lines.push(
+      `- Semi-basement: render with cast-iron front-area railings and York stone front steps where appropriate.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
  * Build a concise BUILDING IDENTITY block for prompt injection.
  * Placed at the TOP of every panel prompt so FLUX sees it first.
  * @private
@@ -670,7 +716,18 @@ export function buildHero3DPrompt({
   projectContext,
   consistencyLock,
   geometryHint,
+  vernacularPack = null,
 }) {
+  const resolvedVernacularPack =
+    (vernacularPack && typeof vernacularPack === "object"
+      ? vernacularPack
+      : null) ||
+    (masterDNA?.localStyle?.style_provenance &&
+    typeof masterDNA.localStyle.style_provenance === "object"
+      ? masterDNA.localStyle.style_provenance
+      : null) ||
+    null;
+  const vernacularBlock = buildVernacularPackBlock(resolvedVernacularPack);
   const dims = normalizeDimensions(masterDNA);
   const materials = normalizeMaterials(masterDNA);
   const style = masterDNA?.architecturalStyle || "Contemporary";
@@ -757,6 +814,7 @@ Dimensions: ${dims.length}m × ${dims.width}m × ${dims.height}m, ${dims.floors}
 Materials: ${materialDesc}
 Roof: ${roofType} roof
 ${canonicalIdentityBlock}
+${vernacularBlock ? `\n${vernacularBlock}\n` : ""}
 
 DESIGN SPECIFICATION (All subsequent panels MUST match this):
 - Building massing: ${storeyDesc}
@@ -809,7 +867,18 @@ export function buildExteriorRenderPrompt({
   projectContext,
   consistencyLock,
   geometryHint,
+  vernacularPack = null,
 }) {
+  const resolvedVernacularPack =
+    (vernacularPack && typeof vernacularPack === "object"
+      ? vernacularPack
+      : null) ||
+    (masterDNA?.localStyle?.style_provenance &&
+    typeof masterDNA.localStyle.style_provenance === "object"
+      ? masterDNA.localStyle.style_provenance
+      : null) ||
+    null;
+  const vernacularBlock = buildVernacularPackBlock(resolvedVernacularPack);
   const dims = normalizeDimensions(masterDNA);
   const materials = normalizeMaterials(masterDNA);
   const style = masterDNA?.architecturalStyle || "Contemporary";
@@ -856,7 +925,7 @@ Building: ${style} ${projectType}
 Dimensions: ${dims.length}m × ${dims.width}m × ${dims.height}m, ${dims.floors} floor(s)
 Materials: ${matDesc}
 Roof type: ${roofType}
-
+${vernacularBlock ? `\n${vernacularBlock}\n` : ""}
 ${fingerprintConstraint ? `DESIGN FINGERPRINT (match hero exactly):\n${fingerprintConstraint}\n` : ""}
 
 REQUIREMENTS:

--- a/src/services/a1/panelPromptBuilders.js
+++ b/src/services/a1/panelPromptBuilders.js
@@ -160,6 +160,17 @@ function normalizeMaterials(masterDNA = {}) {
  */
 function buildVernacularPackBlock(vernacularPack) {
   if (!vernacularPack || typeof vernacularPack !== "object") return "";
+  // localStylePack always emits a style_provenance object — when no UK pack
+  // resolved, source is "buildingTypeDefault" with all fields null. Guard
+  // against that so flag-off / non-UK runs produce no REGIONAL VERNACULAR
+  // block (and the prompt remains identical to the pre-PR-91 baseline).
+  const hasResolvedPack =
+    vernacularPack.source === "ukVernacularPacks" ||
+    (typeof vernacularPack.ukVernacularPackId === "string" &&
+      vernacularPack.ukVernacularPackId.trim().length > 0) ||
+    (typeof vernacularPack.packId === "string" &&
+      vernacularPack.packId.trim().length > 0);
+  if (!hasResolvedPack) return "";
   const label = vernacularPack.packLabel || vernacularPack.label || null;
   const period = vernacularPack.historical_period || null;
   const narrative = vernacularPack.descriptive_narrative || null;

--- a/src/services/canonical/compiledProjectTechnicalPackBuilder.js
+++ b/src/services/canonical/compiledProjectTechnicalPackBuilder.js
@@ -904,6 +904,7 @@ export function buildCompiledProjectTechnicalPanels(source = {}, options = {}) {
         orientation,
         sheetMode: true,
         allowWeakFacadeFallback: true,
+        vernacularPack: options.vernacularPack || null,
       });
       const normalized = buildPanelRecord(
         panelType,

--- a/src/services/drawing/svgElevationRenderer.js
+++ b/src/services/drawing/svgElevationRenderer.js
@@ -1340,6 +1340,33 @@ export function renderElevationSvg(
       : resolveCompiledProjectStyleDNA(geometryInput, styleDNA);
   const theme = getBlueprintTheme();
   const orientation = orientationToSide(options.orientation || "south");
+  // UK regional vernacular pack (paper §4.3 transfer-by-curation): when a
+  // pack is supplied via options.vernacularPack, derive a small set of
+  // pack-driven hints (parapet roofline, sash diminishing, semi-basement,
+  // stucco/render facade language) so the elevation reflects the resolved
+  // regional grammar rather than the generic gable+brick fallback. Pack-off
+  // path is unchanged.
+  const vernacularPack =
+    options.vernacularPack && typeof options.vernacularPack === "object"
+      ? options.vernacularPack
+      : null;
+  const packParapet = !!vernacularPack?.parapet_default;
+  const packSemiBasement = !!vernacularPack?.semi_basement_default;
+  const packWindowLanguageRaw = String(
+    vernacularPack?.window_language || "",
+  ).toLowerCase();
+  const packDiminishingSashes =
+    /sash/i.test(packWindowLanguageRaw) &&
+    /diminish|reduc/i.test(packWindowLanguageRaw);
+  const packMaterialNames = Array.isArray(vernacularPack?.materials)
+    ? vernacularPack.materials.filter(
+        (m) => typeof m === "string" && m.trim().length > 0,
+      )
+    : [];
+  const packHasStucco = packMaterialNames.some((m) => /stucco|render/i.test(m));
+  const packLabel = vernacularPack?.packLabel || vernacularPack?.label || null;
+  const packId =
+    vernacularPack?.ukVernacularPackId || vernacularPack?.packId || null;
   const sideFacade = extractSideFacade(geometry, resolvedStyleDNA, {
     ...options,
     orientation,
@@ -1364,11 +1391,19 @@ export function renderElevationSvg(
     : { left: 80, top: 62, right: 94, bottom: 118 };
   const availableWidth = Math.max(1, width - layout.left - layout.right);
   const availableHeight = Math.max(1, height - layout.top - layout.bottom);
-  const roofLanguage = normalizeRoofLanguage(
+  const baseRoofLanguage = normalizeRoofLanguage(
     resolvedStyleDNA,
     facadeOrientation,
     geometry,
   );
+  // Pack override: when the vernacular pack declares a parapet typology
+  // (London stucco terrace, Edinburgh tenement, etc.), force a parapet
+  // roofLanguage so the gable triangle is suppressed in renderRoof and
+  // ridgeYpx falls back to the parapet upstand path. Otherwise keep the
+  // canonical roofLanguage derivation untouched.
+  const roofLanguage = packParapet
+    ? `${baseRoofLanguage || "flat"} parapet`.trim()
+    : baseRoofLanguage;
   const roofPitchInfoBase = buildCanonicalRoofPitchInfo(geometry, {
     roofLanguage,
     spanM: metrics.width_m,
@@ -1634,8 +1669,35 @@ export function renderElevationSvg(
           ...sheetPolish,
         },
   );
+  // Pack-driven semi-basement strip: a thin band beneath the ground line
+  // with a railings-tick top edge — visual cue for London stucco /
+  // Edinburgh tenement areas where a semi-basement is part of the typology.
+  const semiBasementHeightPx = packSemiBasement
+    ? Math.max(8, Math.min(18, scale * 1.0))
+    : 0;
+  const semiBasementMarkup =
+    packSemiBasement && semiBasementHeightPx > 0
+      ? `
+  <g data-vernacular-feature="semi_basement">
+    <rect x="${formatNumber(baseX)}" y="${formatNumber(baseY)}" width="${formatNumber(
+      widthPx,
+    )}" height="${formatNumber(semiBasementHeightPx)}" fill="${theme.paperMuted || theme.paper}" stroke="${theme.line}" stroke-width="0.7" stroke-dasharray="4 2" />
+    <line x1="${formatNumber(baseX)}" y1="${formatNumber(baseY - 3)}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(baseY - 3)}" stroke="${theme.line}" stroke-width="0.5" stroke-dasharray="2 3" />
+  </g>`
+      : "";
+  // Pack label: small caption near the elevation title so the resolved
+  // pack is legible even on the technical sheet (mirrors the Key Notes
+  // entry from Commit 2).
+  const packLabelMarkup =
+    !sheetMode && packLabel
+      ? `<text x="${formatNumber(layout.left)}" y="${formatNumber(50)}" font-size="11" font-family="Arial, sans-serif" font-style="italic" fill="${theme.lineMuted || "#475569"}">${escapeXml(`Vernacular: ${packLabel}${packParapet ? " (parapet)" : ""}${packDiminishingSashes ? ", diminishing sashes" : ""}${packHasStucco ? ", stucco/render" : ""}`)}</text>`
+      : "";
+  const packDataAttrs = vernacularPack
+    ? ` data-vernacular-pack="${escapeXml(packId || "")}" data-pack-parapet="${packParapet}" data-pack-semi-basement="${packSemiBasement}" data-pack-window-language="${escapeXml(packWindowLanguageRaw)}" data-pack-facade-stucco="${packHasStucco}"`
+    : "";
+
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${theme.name}" data-bounds-source="${envelope.source}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${theme.name}" data-bounds-source="${envelope.source}"${packDataAttrs}>
   ${buildMaterialPatternDefs(theme)}
   <rect width="${width}" height="${height}" fill="${theme.paper}" />
   ${
@@ -1645,7 +1707,9 @@ export function renderElevationSvg(
           `Elevation - ${orientation.toUpperCase()}`,
         )}</text>`
   }
+  ${packLabelMarkup}
   ${renderGroundLine(baseX, baseY, widthPx, theme)}
+  ${semiBasementMarkup}
   ${materialZones.markup}
   ${articulation.markup}
   ${roof}
@@ -1735,6 +1799,12 @@ export function renderElevationSvg(
       a1_quality_polish: sheetMode ? "elevation_datums_dimensions_v1" : null,
       slot_occupancy_ratio: slotOccupancyRatio,
       scale_bar_meters: scaleBar.barMeters,
+      vernacular_pack_id: packId,
+      vernacular_pack_label: packLabel,
+      vernacular_pack_parapet: packParapet,
+      vernacular_pack_semi_basement: packSemiBasement,
+      vernacular_pack_window_language: packWindowLanguageRaw || null,
+      vernacular_pack_has_stucco: packHasStucco,
     },
   };
 }

--- a/src/services/drawing/svgElevationRenderer.js
+++ b/src/services/drawing/svgElevationRenderer.js
@@ -1346,10 +1346,26 @@ export function renderElevationSvg(
   // stucco/render facade language) so the elevation reflects the resolved
   // regional grammar rather than the generic gable+brick fallback. Pack-off
   // path is unchanged.
-  const vernacularPack =
+  //
+  // localStylePack always returns a style_provenance object even when no UK
+  // pack was resolved (source: "buildingTypeDefault" with all fields null),
+  // so a truthiness check on options.vernacularPack would leak empty
+  // data-vernacular-pack/data-pack-* attributes into legacy elevations.
+  // Gate strictly on a real resolved pack: source === "ukVernacularPacks"
+  // OR a non-empty packId/ukVernacularPackId. Otherwise null out so the
+  // SVG matches the pre-PR-91 baseline exactly.
+  const rawVernacularPack =
     options.vernacularPack && typeof options.vernacularPack === "object"
       ? options.vernacularPack
       : null;
+  const hasResolvedVernacularPack =
+    !!rawVernacularPack &&
+    (rawVernacularPack.source === "ukVernacularPacks" ||
+      (typeof rawVernacularPack.ukVernacularPackId === "string" &&
+        rawVernacularPack.ukVernacularPackId.trim().length > 0) ||
+      (typeof rawVernacularPack.packId === "string" &&
+        rawVernacularPack.packId.trim().length > 0));
+  const vernacularPack = hasResolvedVernacularPack ? rawVernacularPack : null;
   const packParapet = !!vernacularPack?.parapet_default;
   const packSemiBasement = !!vernacularPack?.semi_basement_default;
   const packWindowLanguageRaw = String(

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -5639,9 +5639,44 @@ export function buildMaterialPalettePanelArtifact({
           styleDNA,
           brief,
         });
+  // UK regional vernacular pack (paper §4.3): when the slice resolved a
+  // London-stucco / Edinburgh-tenement / Cotswolds-cottage / etc. pack on
+  // localStyle.style_provenance, prepend the pack's named materials so they
+  // lead the 2×4 grid instead of being drowned by the canonical 8-material
+  // top-up. The shared normaliser only consults localStyle.material_palette
+  // (which is overridden by sheetDesignContext.materials, see ctxMaterials
+  // above), so this prepend is the surgical fix without touching the
+  // SheetDesignContext canonical-materials path.
+  const packMaterialNames = Array.isArray(
+    localStyle?.style_provenance?.materials,
+  )
+    ? localStyle.style_provenance.materials
+        .map((m) => (typeof m === "string" ? m.trim() : ""))
+        .filter(Boolean)
+    : [];
+  const knownNames = new Set(
+    (Array.isArray(baseMaterials) ? baseMaterials : []).map((entry) =>
+      String(entry?.name || "")
+        .trim()
+        .toLowerCase(),
+    ),
+  );
+  const packEntries = [];
+  packMaterialNames.forEach((name) => {
+    const key = name.toLowerCase();
+    if (knownNames.has(key)) return;
+    knownNames.add(key);
+    packEntries.push({
+      name,
+      source: "uk_vernacular_pack",
+    });
+  });
+  const mergedBaseMaterials = packEntries.length
+    ? [...packEntries, ...(Array.isArray(baseMaterials) ? baseMaterials : [])]
+    : baseMaterials;
   // Always render up to 8 cards; if the collection is short, top up from the
   // canonical 8-material fallback so the 2×4 grid stays visually balanced.
-  const materials = topUpMaterialPaletteWithCanonical(baseMaterials, 8);
+  const materials = topUpMaterialPaletteWithCanonical(mergedBaseMaterials, 8);
   const { defs, cards, cardMetadata } = buildMaterialPaletteCards({
     materials,
     layout: {
@@ -5742,6 +5777,7 @@ function splitNoteLines(note = "", maxChars = 36, maxLines = 3) {
 // Phase 2 — canonical Key Notes group order. The structure stays stable
 // across runs so the panel order is deterministic regardless of input.
 const KEY_NOTE_GROUP_ORDER = Object.freeze([
+  "style_provenance",
   "external_walls",
   "roof",
   "windows_doors",
@@ -5750,6 +5786,7 @@ const KEY_NOTE_GROUP_ORDER = Object.freeze([
   "sustainability",
   "climate_strategy",
   "dimensions_tolerances",
+  "qa_summary",
   "copyright",
 ]);
 
@@ -5777,6 +5814,7 @@ export function buildKeyNoteItems({
   regulations,
   localStyle,
   sheetDesignContext = null,
+  qaSummary = null,
 }) {
   const ctxMaterials =
     Array.isArray(sheetDesignContext?.materials) &&
@@ -5868,7 +5906,74 @@ export function buildKeyNoteItems({
     "UK";
   const dateLabel = brief?.brief_date || brief?.date || null;
 
+  // Style provenance — surfaces the resolved UK regional vernacular pack
+  // (paper §4.3 transfer-by-curation). Empty group when no pack resolved
+  // (flag off, non-UK site, etc.) → filtered out by the lines.filter(Boolean)
+  // step at the bottom of this function.
+  const styleProvenance =
+    localStyle?.style_provenance &&
+    typeof localStyle.style_provenance === "object"
+      ? localStyle.style_provenance
+      : null;
+  const styleProvenanceLines = [];
+  if (styleProvenance && styleProvenance.packLabel) {
+    const period = styleProvenance.historical_period
+      ? ` (${String(styleProvenance.historical_period).slice(0, 80)})`
+      : "";
+    styleProvenanceLines.push(
+      `Regional vernacular pack: ${styleProvenance.packLabel}${period}.`,
+    );
+    if (styleProvenance.descriptive_narrative) {
+      styleProvenanceLines.push(
+        String(styleProvenance.descriptive_narrative).slice(0, 320),
+      );
+    }
+  }
+
+  // QA summary — paper §4.6 dual-track assessment. Optional; when the caller
+  // hasn't supplied a qaSummary (panel built before QA computed), the group
+  // emits no lines and is filtered out. When supplied, surfaces the
+  // adjacency + quantitative scores so the user can see the grey-box
+  // numbers on the sheet.
+  const qaSummaryLines = [];
+  if (qaSummary && typeof qaSummary === "object") {
+    const adj =
+      qaSummary.programmeAdjacency &&
+      typeof qaSummary.programmeAdjacency === "object"
+        ? qaSummary.programmeAdjacency
+        : null;
+    const quant =
+      qaSummary.quantitative && typeof qaSummary.quantitative === "object"
+        ? qaSummary.quantitative
+        : null;
+    if (typeof quant?.score === "number") {
+      qaSummaryLines.push(`Quantitative QA: ${Math.round(quant.score)}/100.`);
+    }
+    if (adj && typeof adj.score === "number") {
+      const adjStatus = adj.status ? ` (${adj.status})` : "";
+      const adjPack = adj.packId ? `, pack ${adj.packId}` : "";
+      const adjRules =
+        typeof adj.ruleCount === "number" ? `, ${adj.ruleCount} rules` : "";
+      qaSummaryLines.push(
+        `Programme adjacency: ${Math.round(adj.score)}/100${adjStatus}${adjPack}${adjRules}.`,
+      );
+    }
+    if (qaSummary.status && typeof qaSummary.score === "number") {
+      qaSummaryLines.push(
+        `Overall QA status: ${qaSummary.status} (${Math.round(qaSummary.score)}/100).`,
+      );
+    }
+  }
+
   const groups = {
+    style_provenance: {
+      heading: "Style provenance",
+      lines: styleProvenanceLines,
+    },
+    qa_summary: {
+      heading: "QA summary",
+      lines: qaSummaryLines,
+    },
     external_walls: {
       heading: "External walls",
       lines: [
@@ -5962,7 +6067,7 @@ export function buildKeyNoteItems({
       heading: group.heading,
       lines: (group.lines || []).filter(Boolean),
     };
-  });
+  }).filter((group) => group.lines.length > 0);
 }
 
 export function buildKeyNotesPanelArtifact({
@@ -5974,6 +6079,7 @@ export function buildKeyNotesPanelArtifact({
   localStyle,
   geometryHash,
   sheetDesignContext = null,
+  qaSummary = null,
 }) {
   const width = 560;
   const height = 900;
@@ -5984,6 +6090,7 @@ export function buildKeyNotesPanelArtifact({
     regulations,
     localStyle,
     sheetDesignContext,
+    qaSummary,
   });
   let cursorY = 102;
   const groupSvg = groups
@@ -6633,6 +6740,11 @@ async function buildSheetPanelArtifacts({
   // consumers; not consumed by the existing data-panel builders yet.
   // eslint-disable-next-line no-unused-vars
   sheetDesignContext = null,
+  // Optional partial QA summary precomputed before panels (programme
+  // adjacency + quantitative metrics — both pure functions of compiledProject
+  // and projectGraph and therefore safe to compute pre-panel). Surfaces on
+  // the Key Notes panel; null leaves the QA summary group empty.
+  qaSummary = null,
 }) {
   const siteContext = buildSiteContextPanelArtifact({
     projectGraphId,
@@ -6661,6 +6773,7 @@ async function buildSheetPanelArtifacts({
     localStyle,
     geometryHash,
     sheetDesignContext,
+    qaSummary,
   });
   const titleBlock = buildTitleBlockPanelArtifact({
     projectGraphId,
@@ -7830,6 +7943,68 @@ async function buildA1Sheet({
   let __a1mark = __a1sheetStart;
   const drawingNumber = sheetPlan?.sheet_number || "A1-00";
   const sheetLabel = sheetPlan?.label || "RIBA Stage 2 Master";
+  // Pre-panel partial QA summary: the programme adjacency + quantitative
+  // scorers are pure functions of compiledProject + projectGraph (no panel
+  // dependency), so we run them once early to feed the Key Notes panel a real
+  // QA summary. The full validateProjectGraphVerticalSlice call later still
+  // re-runs both validators to produce the authoritative qa object — the cost
+  // is two cheap validator calls in exchange for visible scores on the sheet.
+  let panelQaSummary = null;
+  if (
+    isFeatureEnabled("programmeAdjacencyValidator") ||
+    isFeatureEnabled("dualQaQuantitativeScoring")
+  ) {
+    let earlyAdjacencyResult = null;
+    if (isFeatureEnabled("programmeAdjacencyValidator")) {
+      try {
+        earlyAdjacencyResult = validateProgrammeAdjacency({
+          compiledProject: compiledProject || null,
+          canonicalProjectType:
+            brief?.canonical_building_type ||
+            brief?.canonicalBuildingType ||
+            brief?.project_type_support?.canonicalBuildingType ||
+            "",
+        });
+      } catch (_) {
+        earlyAdjacencyResult = null;
+      }
+    }
+    let earlyQuantitative = null;
+    if (isFeatureEnabled("dualQaQuantitativeScoring")) {
+      try {
+        // Pre-panel — programme.spaces is not in scope here, so the
+        // programme_area_satisfied metric will be null. Other metrics (geometry
+        // hash consistency, adjacency score, window/wall ratio) still compute
+        // and produce a representative quantitative score for the Key Notes
+        // panel. The full QA pass at validateProjectGraphVerticalSlice later
+        // re-runs with the complete projectGraph and is authoritative.
+        earlyQuantitative = computeQuantitativeMetrics({
+          projectGraph: { brief, local_style: localStyle },
+          artifacts: { compiledProject },
+          adjacencyResult: earlyAdjacencyResult,
+        });
+      } catch (_) {
+        earlyQuantitative = null;
+      }
+    }
+    panelQaSummary = {
+      programmeAdjacency: earlyAdjacencyResult
+        ? {
+            score: earlyAdjacencyResult.score,
+            status: earlyAdjacencyResult.status,
+            packId: earlyAdjacencyResult.packId,
+            ruleCount: earlyAdjacencyResult.ruleCount,
+          }
+        : null,
+      quantitative: earlyQuantitative
+        ? { score: earlyQuantitative.score }
+        : null,
+      qualitative: null,
+      status: null,
+      score: null,
+    };
+  }
+
   const supplementalPanelArtifacts = await buildSheetPanelArtifacts({
     projectGraphId,
     site,
@@ -7850,6 +8025,7 @@ async function buildA1Sheet({
     },
     visualManifest,
     sheetDesignContext,
+    qaSummary: panelQaSummary,
   });
   __a1mark = __a1sheetLog("build_panel_artifacts", __a1mark);
   const panelArtifacts = {

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -6507,11 +6507,22 @@ export function buildProjectGraphRenderPrompt({
   // exterior + axonometric + interior panels reflect the regional grammar
   // instead of the generic ML default. Pack-off path: empty string,
   // unchanged behaviour.
-  const provenance =
+  //
+  // localStylePack always emits style_provenance — when no UK pack
+  // resolved, source is "buildingTypeDefault" with every field null.
+  // Gate strictly on a real resolved pack so flag-off / non-UK sites
+  // produce no REGIONAL VERNACULAR block in the prompt.
+  const rawProvenance =
     localStyle?.style_provenance &&
     typeof localStyle.style_provenance === "object"
       ? localStyle.style_provenance
       : null;
+  const hasResolvedProvenance =
+    !!rawProvenance &&
+    (rawProvenance.source === "ukVernacularPacks" ||
+      (typeof rawProvenance.ukVernacularPackId === "string" &&
+        rawProvenance.ukVernacularPackId.trim().length > 0));
+  const provenance = hasResolvedProvenance ? rawProvenance : null;
   const vernacularLines = [];
   if (provenance) {
     const packLabel = provenance.packLabel || provenance.label || null;

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -10351,6 +10351,8 @@ export function validateProjectGraphVerticalSlice({
           status: adjacencyResult.status,
           packId: adjacencyResult.packId,
           ruleCount: adjacencyResult.ruleCount,
+          checks: adjacencyResult.checks || [],
+          issues: adjacencyResult.issues || [],
         }
       : null,
     quantitative,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -4964,6 +4964,7 @@ function buildDrawingSet(compiledProject, options = {}) {
       : "board-v2";
   const technicalBuild = buildCompiledProjectTechnicalPanels(compiledProject, {
     layoutTemplate,
+    vernacularPack: options.vernacularPack || null,
   });
   const technicalPanels = technicalBuild.technicalPanels || {};
   const drawingViews = Object.entries(technicalPanels).map(
@@ -6500,11 +6501,64 @@ export function buildProjectGraphRenderPrompt({
   const identityLock = buildVisualIdentityLockBlock(visualManifest);
   const visualContinuity =
     buildProjectGraphVisualContinuityBlock(visualManifest);
+  // Regional vernacular block — when the slice resolved a UK pack
+  // (london-stucco-terrace, edinburgh-tenement, etc.), inject the pack's
+  // narrative + facade/roof/window/material language so the photoreal
+  // exterior + axonometric + interior panels reflect the regional grammar
+  // instead of the generic ML default. Pack-off path: empty string,
+  // unchanged behaviour.
+  const provenance =
+    localStyle?.style_provenance &&
+    typeof localStyle.style_provenance === "object"
+      ? localStyle.style_provenance
+      : null;
+  const vernacularLines = [];
+  if (provenance) {
+    const packLabel = provenance.packLabel || provenance.label || null;
+    const period = provenance.historical_period || null;
+    const narrative = provenance.descriptive_narrative || null;
+    const facadeLanguage = provenance.facade_language || null;
+    const roofLanguage = provenance.roof_language || null;
+    const windowLanguage = provenance.window_language || null;
+    const packMaterials = Array.isArray(provenance.materials)
+      ? provenance.materials.filter(
+          (m) => typeof m === "string" && m.trim().length,
+        )
+      : [];
+    const parapet = provenance.parapet_default === true;
+    const semiBasement = provenance.semi_basement_default === true;
+    if (packLabel || narrative || facadeLanguage || packMaterials.length) {
+      vernacularLines.push("REGIONAL VERNACULAR (UK pack):");
+      if (packLabel)
+        vernacularLines.push(
+          `- Pack: ${packLabel}${period ? ` (${period})` : ""}`,
+        );
+      if (narrative) vernacularLines.push(`- Narrative: ${narrative}`);
+      if (facadeLanguage)
+        vernacularLines.push(`- Facade language: ${facadeLanguage}`);
+      if (roofLanguage)
+        vernacularLines.push(`- Roof language: ${roofLanguage}`);
+      if (windowLanguage)
+        vernacularLines.push(`- Window language: ${windowLanguage}`);
+      if (packMaterials.length)
+        vernacularLines.push(`- Materials: ${packMaterials.join(", ")}`);
+      if (parapet)
+        vernacularLines.push("- Roofline: parapet concealing the roof.");
+      if (semiBasement)
+        vernacularLines.push(
+          "- Semi-basement with cast-iron front-area railings and York stone front steps where appropriate.",
+        );
+    }
+  }
+  const vernacularBlock = vernacularLines.length
+    ? vernacularLines.join("\n")
+    : null;
   return [
     identityLock,
     visualContinuity,
     `Project: ${projectName} — ${buildingType}.`,
     intent,
+    vernacularBlock,
     reasoning,
     "STYLE: V-Ray + 3ds Max quality, octane-grade physically-based rendering, photoreal PBR materials, HDRI sky lighting, shallow depth of field, Dezeen / ArchDaily magazine cover quality, 8K, no watermark, no text, no diagrams. Single freestanding building, no neighbours.",
   ]
@@ -10829,7 +10883,10 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
   const drawingSetLayoutTemplate = resolvePresentationLayoutTemplate(brief);
   const { drawingSet, drawingArtifacts, technicalBuild } = buildDrawingSet(
     compiledProject,
-    { layoutTemplate: drawingSetLayoutTemplate },
+    {
+      layoutTemplate: drawingSetLayoutTemplate,
+      vernacularPack: localStyle?.style_provenance || null,
+    },
   );
   __vsMark = __vsLog(
     "build_drawing_set",


### PR DESCRIPTION
## Summary

Make the UK regional vernacular pack and dual-scored QA already resolved by PR #91 actually visible and influential in the A1 output, so a Notting Hill (W2) generation reflects London stucco-terrace language instead of a generic gable cottage. Three sequenced commits, each additive, each gated on existing flags (`ukVernacularStylePacks`, `programmeAdjacencyValidator`, `dualQaQuantitativeScoring`).

- **Commit 1 (`eb27feb`)** — Promote `metadata.styleProvenance` + `metadata.qaSummary` from the response payload; preserve `qa.programmeAdjacency.checks` and `.issues` (was being stripped to score only).
- **Commit 2 (`71da832`)** — Surface a "Style provenance" and "QA summary" group on the Key Notes panel; drive the Material Palette panel from the resolved pack's materials before the canonical 8-material top-up. A pre-panel partial QA (programme adjacency + quantitative metrics — pure functions of compiledProject) is computed and threaded into the Key Notes panel so the scores are visible on the sheet.
- **Commit 3 (`ea1eef1`)** — Wire the pack into `renderElevationSvg` (parapet override, semi-basement strip with railings, italic vernacular caption, root SVG data attributes, `technical_quality_metadata` stamps) and into both photoreal prompt builders (`buildHero3DPrompt`, `buildExteriorRenderPrompt`) plus the slice's inline `buildProjectGraphRenderPrompt` so the LLM-rendered exterior + axonometric panels also see the pack narrative.

The contract: when `ukVernacularStylePacks` is off (or the site is outside UK pack coverage), `localStyle.style_provenance` is null, every new code path short-circuits, and the output is identical to PR #91.

This PR does **not** start design-archetype / layout variation, vector axonometric, or vector site plan; does not enable `dualQaQualitativeScoring` or `programmeAdjacencyValidatorBlocking`; does not touch geometry, floor-plan layout, boundary, OS NGD, climate provider, env, or A1 export gates.

## Test plan

- [x] `npm run check:env` ✅
- [x] `npm run check:contracts` ✅
- [x] `npm run test:compose:routing` (22/22) ✅
- [x] `npm run lint` ✅
- [x] `npm run build:active` ✅
- [x] Focused suite (10 files, 147 tests) — Commit 1 hook payload, Commit 2 panel pack-driven, Commit 3 elevation + prompt pack injection, plus existing UK packs / localStyle / adjacency / quantitative / qualitative scorers / panel prompt reasoning chain
- [x] Elevation regression (4 files, 25 tests) — `drawingBlueprintRendererRegression`, `svgRendererPhase1`, `technicalDrawingPolishPhase3`, `technicalDrawingNormalization` — confirms the elevation pack hints don't break existing renders when no pack is supplied
- [ ] Live W2 generation on production after merge — confirm `metadata.styleProvenance.ukVernacularPackId === "london-stucco-terrace"`, Key Notes panel shows the provenance + QA lines, Material Palette leads with stucco/slate, elevation has parapet + semi-basement instead of pitched gable, exterior perspective reflects London stucco terrace
- [ ] Live EH8 generation — confirm `ukVernacularPackId === "edinburgh-tenement"`, palette switches to sandstone, no London-specific text in prompts/elevations

## Files

**Modified:**
- `src/services/project/projectGraphVerticalSliceService.js` — preserve adjacency checks/issues; new Key Notes groups + qaSummary thread; pre-panel partial QA; pack into Material Palette + render prompt; thread vernacularPack to drawing set
- `src/hooks/useArchitectAIWorkflow.js` — stamp metadata.styleProvenance + metadata.qaSummary
- `src/services/canonical/compiledProjectTechnicalPackBuilder.js` — forward vernacularPack to renderElevationSvg
- `src/services/drawing/svgElevationRenderer.js` — accept options.vernacularPack; parapet override, semi-basement strip, caption, data-attrs, metadata
- `src/services/a1/panelPromptBuilders.js` — buildVernacularPackBlock helper; pack injection in buildHero3DPrompt + buildExteriorRenderPrompt

**New tests:**
- `src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js` — extended (2 new assertions)
- `src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js` — 7 new tests
- `src/__tests__/services/elevationAndPromptVernacularPack.test.js` — 6 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)