### PR TITLE
fix(a1): propagate full vernacular pack + clamp photoreal floors + per-pack footprint archetype

### DIFF
--- a/src/__tests__/services/design/designOptions.test.js
+++ b/src/__tests__/services/design/designOptions.test.js
@@ -29,7 +29,7 @@ function buildableSite(width, height) {
 }
 
 describe("optionGenerator", () => {
-  test("produces 4 candidate options with required keys", () => {
+  test("produces 4 candidate options with required keys when no archetype is supplied", () => {
     const options = generateRectangularOptions({
       brief: {
         building_type: "community",
@@ -78,6 +78,126 @@ describe("optionGenerator", () => {
     const longAxes = options.map((o) => o.long_axis);
     expect(longAxes).toContain("ew");
     expect(longAxes).toContain("ns");
+  });
+
+  // Phase C — UK regional vernacular layout archetypes. The slice passes
+  // localStyle.style_provenance.layout_archetype through to the option
+  // generator so a London terrace pack produces narrow-deep candidates,
+  // a Cotswolds cottage pack produces near-square candidates, etc. Pack-off
+  // / non-UK runs see the original 4-option set unchanged.
+  test("linear_side_hall archetype prepends narrow-deep terrace candidates", () => {
+    const options = generateRectangularOptions({
+      brief: {
+        building_type: "dwelling",
+        target_storeys: 2,
+        target_gia_m2: 150,
+      },
+      site: buildableSite(40, 40),
+      levelAreas: [75, 75],
+      archetype: "linear_side_hall",
+    });
+    expect(options.length).toBe(6); // 2 archetype + 4 default
+    const archetypeIds = options.slice(0, 2).map((o) => o.option_id);
+    expect(archetypeIds).toContain("option-archetype-terrace-narrow-deep");
+    expect(archetypeIds).toContain("option-archetype-terrace-medium");
+    // Aspect < 1 means deeper than wide, the canonical terrace shape.
+    expect(options[0].aspect).toBeLessThan(1);
+    expect(options[0].aspect).toBeLessThanOrEqual(0.5);
+    // Long axis runs front-to-back (north-south = perpendicular to the
+    // street).
+    expect(options[0].long_axis).toBe("ns");
+    expect(options[0].typology).toMatch(/linear_side_hall/);
+  });
+
+  test("central_stair_square archetype prepends near-square cottage candidate", () => {
+    const options = generateRectangularOptions({
+      brief: {
+        building_type: "dwelling",
+        target_storeys: 2,
+        target_gia_m2: 120,
+      },
+      site: buildableSite(40, 40),
+      levelAreas: [60, 60],
+      archetype: "central_stair_square",
+    });
+    expect(options.length).toBe(5);
+    expect(options[0].option_id).toBe("option-archetype-cottage-square");
+    expect(options[0].aspect).toBeGreaterThanOrEqual(0.95);
+    expect(options[0].aspect).toBeLessThan(1.2);
+    expect(options[0].typology).toBe("central_stair_square");
+  });
+
+  test("tenement_common_stair archetype prepends one Edinburgh tenement candidate", () => {
+    const options = generateRectangularOptions({
+      brief: {
+        building_type: "dwelling",
+        target_storeys: 2,
+        target_gia_m2: 150,
+      },
+      site: buildableSite(40, 40),
+      levelAreas: [75, 75],
+      archetype: "tenement_common_stair",
+    });
+    expect(options.length).toBe(5);
+    expect(options[0].option_id).toBe("option-archetype-tenement");
+    expect(options[0].typology).toBe("tenement_common_stair");
+  });
+
+  test("narrow_two_up_two_down archetype prepends Manchester back-to-back candidate", () => {
+    const options = generateRectangularOptions({
+      brief: {
+        building_type: "dwelling",
+        target_storeys: 2,
+        target_gia_m2: 110,
+      },
+      site: buildableSite(40, 40),
+      levelAreas: [55, 55],
+      archetype: "narrow_two_up_two_down",
+    });
+    expect(options.length).toBe(5);
+    expect(options[0].option_id).toBe("option-archetype-back-to-back");
+    expect(options[0].aspect).toBeLessThan(1);
+  });
+
+  test("unknown / null archetype produces the original 4-option set unchanged", () => {
+    const baseline = generateRectangularOptions({
+      brief: {
+        building_type: "dwelling",
+        target_storeys: 2,
+        target_gia_m2: 150,
+      },
+      site: buildableSite(40, 40),
+      levelAreas: [75, 75],
+    });
+    const withNull = generateRectangularOptions({
+      brief: {
+        building_type: "dwelling",
+        target_storeys: 2,
+        target_gia_m2: 150,
+      },
+      site: buildableSite(40, 40),
+      levelAreas: [75, 75],
+      archetype: null,
+    });
+    const withUnknown = generateRectangularOptions({
+      brief: {
+        building_type: "dwelling",
+        target_storeys: 2,
+        target_gia_m2: 150,
+      },
+      site: buildableSite(40, 40),
+      levelAreas: [75, 75],
+      archetype: "no-such-archetype",
+    });
+    expect(baseline.length).toBe(4);
+    expect(withNull.length).toBe(4);
+    expect(withUnknown.length).toBe(4);
+    expect(withNull.map((o) => o.option_id)).toEqual(
+      baseline.map((o) => o.option_id),
+    );
+    expect(withUnknown.map((o) => o.option_id)).toEqual(
+      baseline.map((o) => o.option_id),
+    );
   });
 });
 

--- a/src/__tests__/services/elevationAndPromptVernacularPack.test.js
+++ b/src/__tests__/services/elevationAndPromptVernacularPack.test.js
@@ -164,6 +164,68 @@ describe("renderElevationSvg — pack-driven hints", () => {
     );
   });
 
+  // Phase A regression: when buildLocalStylePackV2 propagates the FULL
+  // provenance shape (post-Phase-A), the elevation renderer reading
+  // localStyle.style_provenance must see parapet_default + semi_basement_default
+  // + materials and emit the corresponding pack hints. PR #92 unit tests passed
+  // with a full-pack fixture but production stripped these fields between
+  // localStylePack and renderElevationSvg, leaving W2 elevations with the
+  // generic gable. This test feeds the renderer the ACTUAL propagated shape
+  // (mirrors what buildLocalStylePackV2 emits) and asserts the parapet override
+  // fires end-to-end.
+  test("propagated style_provenance shape (post-Phase-A) drives parapet override on elevation SVG", () => {
+    const propagatedProvenance = {
+      ukVernacularPackId: "london-stucco-terrace",
+      packId: "london-stucco-terrace",
+      packLabel: "London stucco terrace",
+      label: "London stucco terrace",
+      region: "London — Westminster / Kensington / Chelsea / Notting Hill",
+      descriptive_narrative:
+        "Early-19th-century Regency / Italianate stucco terrace …",
+      historical_period: "Regency and early Victorian (c. 1820–1860)",
+      resolution_source: "postcode",
+      source: "ukVernacularPacks",
+      materials: [
+        "white stucco render",
+        "yellow London stock brick base",
+        "natural slate roof",
+      ],
+      facade_language:
+        "stucco-fronted with rusticated ground floor and parapet",
+      roof_language: "concealed-behind-parapet pitched slate",
+      window_language:
+        "tall sash windows, vertically proportioned, diminishing per floor",
+      fenestration_rhythm: "regular bay rhythm",
+      modernity_default: 0.3,
+      parapet_default: true,
+      semi_basement_default: true,
+      layout_archetype: "linear_side_hall",
+      conservation_typical: true,
+    };
+    const result = renderElevationSvg(
+      makeFixtureGeometry(),
+      {},
+      {
+        orientation: "south",
+        vernacularPack: propagatedProvenance,
+        allowWeakFacadeFallback: true,
+      },
+    );
+    expect(result.svg).toBeTruthy();
+    expect(result.svg).toContain(
+      'data-vernacular-pack="london-stucco-terrace"',
+    );
+    expect(result.svg).toContain('data-pack-parapet="true"');
+    expect(result.svg).toContain('data-pack-semi-basement="true"');
+    expect(result.svg).toContain('data-pack-facade-stucco="true"');
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      true,
+    );
+    expect(
+      result.technical_quality_metadata.vernacular_pack_semi_basement,
+    ).toBe(true);
+  });
+
   // Codex P1 regression: localStylePack.buildLocalStylePackV2 always emits a
   // style_provenance object — when no UK pack resolves the source field is
   // "buildingTypeDefault" with every other field null. A naive truthiness
@@ -284,6 +346,66 @@ describe("buildHero3DPrompt + buildExteriorRenderPrompt — pack injection", () 
     // The existing baseline prompt structure is preserved.
     expect(prompt).toContain("Front-elevation hero render");
     expect(prompt).toContain("Photoreal architectural front-elevation render");
+  });
+
+  // Phase B floor-count clamp — when a pack implies a semi-basement and
+  // the brief asks for ≤2 above-grade storeys, the LLM must be told the
+  // basement is a stylistic plinth only, not a third habitable storey.
+  // This was the root cause of the 3D-vs-2D floor-count mismatch the user
+  // observed on the post-PR-92 W2 generation (axonometric / exterior
+  // perspective showed 3 floors, plans/sections showed 2).
+  test("buildHero3DPrompt clamps floor count to brief when pack.semi_basement_default && floors=2", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    const dnaTwoFloors = {
+      ...masterDNA,
+      dimensions: { length_m: 8, width_m: 6, height_m: 6, floor_count: 2 },
+    };
+    const { prompt } = buildHero3DPrompt({
+      masterDNA: dnaTwoFloors,
+      locationData,
+      projectContext,
+      vernacularPack: pack,
+    });
+    expect(prompt).toMatch(/STYLISTIC PLINTH at street level only/);
+    expect(prompt).toMatch(/EXACTLY 2 above-grade storeys/);
+    expect(prompt).toMatch(/Do NOT add a third habitable floor/);
+  });
+
+  test("buildExteriorRenderPrompt does NOT emit the clamp when target storeys >= 3 (clamp scope)", () => {
+    const pack = resolveUKVernacular({ postcode: "EH8 9YL" });
+    const dnaFourFloors = {
+      ...masterDNA,
+      dimensions: { length_m: 8, width_m: 6, height_m: 12, floor_count: 4 },
+    };
+    const { prompt } = buildExteriorRenderPrompt({
+      masterDNA: dnaFourFloors,
+      locationData,
+      projectContext,
+      vernacularPack: pack,
+    });
+    // Edinburgh tenement is multi-storey; keep the original semi-basement
+    // language without the EXACTLY-N clamp.
+    expect(prompt).not.toMatch(/STYLISTIC PLINTH/);
+    expect(prompt).not.toMatch(/Do NOT add a third habitable floor/);
+    expect(prompt).toMatch(/Semi-basement.*cast-iron/);
+  });
+
+  test("buildExteriorRenderPrompt skips the clamp when the pack has no semi-basement", () => {
+    const pack = resolveUKVernacular({ postcode: "M14 5SH" });
+    const dnaTwoFloors = {
+      ...masterDNA,
+      dimensions: { length_m: 8, width_m: 6, height_m: 6, floor_count: 2 },
+    };
+    const { prompt } = buildExteriorRenderPrompt({
+      masterDNA: dnaTwoFloors,
+      locationData,
+      projectContext,
+      vernacularPack: pack,
+    });
+    // Manchester back-to-back has semi_basement_default = false → no
+    // semi-basement line should appear at all.
+    expect(prompt).not.toMatch(/STYLISTIC PLINTH/);
+    expect(prompt).not.toMatch(/Semi-basement/);
   });
 
   // Codex P1 regression: the buildingTypeDefault fallback object from

--- a/src/__tests__/services/style/localStylePack.ukVernacular.test.js
+++ b/src/__tests__/services/style/localStylePack.ukVernacular.test.js
@@ -88,6 +88,39 @@ describe("localStylePack — UK vernacular pack integration", () => {
     ).toBeGreaterThan(50);
   });
 
+  // Phase A regression — the propagated provenance must carry every field
+  // downstream consumers read (elevation parapet override, Material Palette
+  // pack-prepend, photoreal prompt builder vernacular block, archetype
+  // dispatcher). Earlier shape stripped these and silently broke PR #92's
+  // elevation hints + Material Palette pack-driven swatches at production
+  // runtime even though the tests passed with synthetic full-pack fixtures.
+  test("style_provenance carries every field consumed downstream (parapet, materials, archetype, etc.)", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    const site = { uk_vernacular_pack: pack };
+    const stylePack = buildLocalStylePackV2({
+      brief: baseBrief,
+      site,
+      climate: baseClimate,
+    });
+    const prov = stylePack.style_provenance;
+    expect(prov.parapet_default).toBe(true);
+    expect(prov.semi_basement_default).toBe(true);
+    expect(prov.layout_archetype).toBe("linear_side_hall");
+    expect(prov.facade_language).toEqual(expect.any(String));
+    expect(prov.facade_language).toMatch(/parapet|stucco/i);
+    expect(prov.roof_language).toEqual(expect.any(String));
+    expect(prov.window_language).toEqual(expect.any(String));
+    expect(prov.window_language).toMatch(/sash/i);
+    expect(prov.fenestration_rhythm).toEqual(expect.any(String));
+    expect(typeof prov.modernity_default).toBe("number");
+    expect(Array.isArray(prov.materials)).toBe(true);
+    expect(prov.materials.length).toBeGreaterThan(2);
+    expect(prov.materials.join(", ")).toMatch(/stucco|sash|slate/i);
+    // Mirror packId / label too so consumers that gate on either still work.
+    expect(prov.packId).toBe("london-stucco-terrace");
+    expect(prov.label).toBe("London stucco terrace");
+  });
+
   test("buildLocalStylePackV2 stamps buildingTypeDefault when no vernacular pack", () => {
     const stylePack = buildLocalStylePackV2({
       brief: baseBrief,
@@ -96,12 +129,24 @@ describe("localStylePack — UK vernacular pack integration", () => {
     });
     expect(stylePack.style_provenance).toEqual({
       ukVernacularPackId: null,
+      packId: null,
       packLabel: null,
+      label: null,
       region: null,
       descriptive_narrative: null,
       historical_period: null,
       resolution_source: null,
       source: "buildingTypeDefault",
+      materials: [],
+      facade_language: null,
+      roof_language: null,
+      window_language: null,
+      fenestration_rhythm: null,
+      modernity_default: null,
+      parapet_default: false,
+      semi_basement_default: false,
+      layout_archetype: null,
+      conservation_typical: false,
     });
   });
 

--- a/src/services/a1/panelPromptBuilders.js
+++ b/src/services/a1/panelPromptBuilders.js
@@ -158,7 +158,7 @@ function normalizeMaterials(masterDNA = {}) {
  * when no pack is supplied so existing flag-off behaviour is unchanged.
  * @private
  */
-function buildVernacularPackBlock(vernacularPack) {
+function buildVernacularPackBlock(vernacularPack, dimsFloors = null) {
   if (!vernacularPack || typeof vernacularPack !== "object") return "";
   // localStylePack always emits a style_provenance object — when no UK pack
   // resolved, source is "buildingTypeDefault" with all fields null. Guard
@@ -196,9 +196,24 @@ function buildVernacularPackBlock(vernacularPack) {
   if (materials.length) lines.push(`- Materials: ${materials.join(", ")}`);
   if (parapet) lines.push(`- Roofline: parapet concealing the roof.`);
   if (semiBasement) {
-    lines.push(
-      `- Semi-basement: render with cast-iron front-area railings and York stone front steps where appropriate.`,
-    );
+    // Phase B floor-count clamp — when the pack implies a semi-basement and
+    // the brief asks for ≤2 above-grade storeys, the LLM was rendering 3
+    // visible storeys (basement + ground + first) and breaking parity with
+    // the deterministic 2D plans/elevations/sections (which only have N
+    // levels). Lock the storey count explicitly when the brief is in that
+    // band so the photoreal panels match the technical drawings.
+    const floorsHint = Number.isFinite(Number(dimsFloors))
+      ? Number(dimsFloors)
+      : null;
+    if (floorsHint !== null && floorsHint <= 2) {
+      lines.push(
+        `- Semi-basement: render as a STYLISTIC PLINTH at street level only — cast-iron front-area railings and York stone front steps are visible at the pavement, but the building has EXACTLY ${floorsHint} above-grade storeys total. Do NOT add a third habitable floor or a basement window band that reads as a separate storey.`,
+      );
+    } else {
+      lines.push(
+        `- Semi-basement: render with cast-iron front-area railings and York stone front steps where appropriate.`,
+      );
+    }
   }
   return lines.join("\n");
 }
@@ -738,8 +753,11 @@ export function buildHero3DPrompt({
       ? masterDNA.localStyle.style_provenance
       : null) ||
     null;
-  const vernacularBlock = buildVernacularPackBlock(resolvedVernacularPack);
   const dims = normalizeDimensions(masterDNA);
+  const vernacularBlock = buildVernacularPackBlock(
+    resolvedVernacularPack,
+    dims?.floors ?? null,
+  );
   const materials = normalizeMaterials(masterDNA);
   const style = masterDNA?.architecturalStyle || "Contemporary";
   const projectType = projectContext?.buildingProgram || "residential";
@@ -889,8 +907,11 @@ export function buildExteriorRenderPrompt({
       ? masterDNA.localStyle.style_provenance
       : null) ||
     null;
-  const vernacularBlock = buildVernacularPackBlock(resolvedVernacularPack);
   const dims = normalizeDimensions(masterDNA);
+  const vernacularBlock = buildVernacularPackBlock(
+    resolvedVernacularPack,
+    dims?.floors ?? null,
+  );
   const materials = normalizeMaterials(masterDNA);
   const style = masterDNA?.architecturalStyle || "Contemporary";
   const projectType = projectContext?.buildingProgram || "residential";

--- a/src/services/design/optionGenerator.js
+++ b/src/services/design/optionGenerator.js
@@ -79,8 +79,84 @@ function makeOption({
 }
 
 /**
+ * Phase C — UK regional vernacular layout archetypes (paper §4.3).
+ *
+ * Each archetype declares an aspect preference + long-axis orientation that
+ * the option generator can emit alongside the default candidates. The
+ * archetype is read from `localStyle.style_provenance.layout_archetype`
+ * (propagated from `vernacularPack.layout_archetype` by Phase A). When the
+ * archetype is null / unknown, behaviour falls back to the existing 4-option
+ * set so non-UK and flag-off runs are unchanged.
+ *
+ * `aspect` is `width / depth`, so values < 1 mean the plot is deeper than
+ * wide (the long axis is street-to-back) — the canonical London terrace
+ * shape. Values > 1 mean wide-and-shallow.
+ *
+ * @private
+ */
+const ARCHETYPE_OPTION_SPECS = Object.freeze({
+  // London stucco terrace + Victorian terrace — narrow front, deep plot,
+  // long axis runs front-to-back (perpendicular to the street).
+  linear_side_hall: [
+    {
+      optionId: "option-archetype-terrace-narrow-deep",
+      label: "Terrace — narrow front, deep plot (side hall)",
+      typology: "linear_side_hall_narrow",
+      aspect: 0.42,
+      longAxis: "ns",
+    },
+    {
+      optionId: "option-archetype-terrace-medium",
+      label: "Terrace — medium front-to-back (side hall)",
+      typology: "linear_side_hall_medium",
+      aspect: 0.55,
+      longAxis: "ns",
+    },
+  ],
+  // Manchester back-to-back — narrow frontage, two-up two-down, slightly
+  // less deep than London terrace because the back is shared with the next
+  // dwelling.
+  narrow_two_up_two_down: [
+    {
+      optionId: "option-archetype-back-to-back",
+      label: "Back-to-back — narrow frontage two-up two-down",
+      typology: "narrow_two_up_two_down",
+      aspect: 0.55,
+      longAxis: "ns",
+    },
+  ],
+  // Edinburgh tenement — square or slightly deep plan with a common stair
+  // off a single shared entrance.
+  tenement_common_stair: [
+    {
+      optionId: "option-archetype-tenement",
+      label: "Tenement — common-stair plan",
+      typology: "tenement_common_stair",
+      aspect: 0.85,
+      longAxis: "ns",
+    },
+  ],
+  // Cotswolds cottage — near-square plan, central stair, rooms around the
+  // stair core.
+  central_stair_square: [
+    {
+      optionId: "option-archetype-cottage-square",
+      label: "Cottage — near-square central-stair plan",
+      typology: "central_stair_square",
+      aspect: 1.05,
+      longAxis: "ew",
+    },
+  ],
+});
+
+/**
  * Generate ≥3 rectangular design options with different aspect/orientation.
  * Returns an array of OptionSpec; pass to optionScorer.scoreOption.
+ *
+ * When `localStyle.style_provenance.layout_archetype` resolves a UK regional
+ * archetype, the generator prepends archetype-specific candidates ahead of
+ * the default 4 so the scorer / selector picks one of them when it fits the
+ * site. Pack-off runs are unchanged.
  *
  * @returns {Array<object>}
  */
@@ -88,6 +164,7 @@ export function generateRectangularOptions({
   brief,
   site,
   levelAreas = [],
+  archetype = null,
 } = {}) {
   if (!brief || !site) {
     throw new Error("generateRectangularOptions requires {brief, site}");
@@ -105,7 +182,31 @@ export function generateRectangularOptions({
   // Default aspect from brief building type, used as the reference option.
   const defaultAspect = brief.building_type === "community" ? 1.45 : 1.25;
 
+  const archetypeKey =
+    typeof archetype === "string" && archetype.trim().length > 0
+      ? archetype.trim()
+      : null;
+  const archetypeSpecs = archetypeKey
+    ? ARCHETYPE_OPTION_SPECS[archetypeKey] || []
+    : [];
+  const archetypeOptions = archetypeSpecs.map((spec) =>
+    makeOption({
+      optionId: spec.optionId,
+      label: spec.label,
+      typology: spec.typology,
+      aspect: spec.aspect,
+      longAxis: spec.longAxis,
+      footprintArea,
+      buildableBbox,
+    }),
+  );
+
   return [
+    // Archetype-specific candidates lead so the scorer can promote them
+    // when they fit the buildable polygon. Falls through to the default
+    // four if no archetype is supplied or the buildable polygon rejects
+    // them.
+    ...archetypeOptions,
     makeOption({
       optionId: "option-bar-ew",
       label: "Bar — long axis east-west",
@@ -144,5 +245,9 @@ export function generateRectangularOptions({
     }),
   ];
 }
+
+export const __optionGeneratorTesting = Object.freeze({
+  ARCHETYPE_OPTION_SPECS,
+});
 
 export default { generateRectangularOptions };

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -6555,10 +6555,28 @@ export function buildProjectGraphRenderPrompt({
         vernacularLines.push(`- Materials: ${packMaterials.join(", ")}`);
       if (parapet)
         vernacularLines.push("- Roofline: parapet concealing the roof.");
-      if (semiBasement)
-        vernacularLines.push(
-          "- Semi-basement with cast-iron front-area railings and York stone front steps where appropriate.",
-        );
+      if (semiBasement) {
+        // Phase B floor-count clamp — when the brief asks for ≤2 above-grade
+        // storeys but the pack implies a semi-basement, the LLM was rendering
+        // 3 visible storeys (basement + ground + first) and breaking parity
+        // with the deterministic 2D drawings (which only have target_storeys
+        // levels). Lock the storey count explicitly when the brief is in
+        // that band.
+        const targetStoreys = Number(brief?.target_storeys || 0);
+        if (
+          Number.isFinite(targetStoreys) &&
+          targetStoreys > 0 &&
+          targetStoreys <= 2
+        ) {
+          vernacularLines.push(
+            `- Semi-basement: render as a STYLISTIC PLINTH at street level only — cast-iron front-area railings and York stone front steps are visible at the pavement, but the building has EXACTLY ${targetStoreys} above-grade storeys total. Do NOT add a third habitable floor or a basement window band that reads as a separate storey.`,
+          );
+        } else {
+          vernacularLines.push(
+            "- Semi-basement with cast-iron front-area railings and York stone front steps where appropriate.",
+          );
+        }
+      }
     }
   }
   const vernacularBlock = vernacularLines.length

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -4628,10 +4628,22 @@ function buildProjectGeometryFromProgramme({
   );
   // Plan §6.7: generate ≥3 typological options, score each, and use the
   // highest-scoring footprint that fits the buildable polygon.
+  // Phase C — when the resolved UK vernacular pack declares a
+  // `layout_archetype` (linear_side_hall for London terraces,
+  // tenement_common_stair for Edinburgh, central_stair_square for
+  // Cotswolds, narrow_two_up_two_down for Manchester), prepend
+  // archetype-specific candidates so the scorer can promote a
+  // narrow-deep terrace plan over the default wide-and-shallow bar.
+  // Pack-off / non-UK runs see the original 4-option set unchanged.
+  const archetypeKey =
+    localStyle?.style_provenance?.source === "ukVernacularPacks"
+      ? localStyle?.style_provenance?.layout_archetype || null
+      : null;
   const candidateOptions = generateRectangularOptions({
     brief,
     site,
     levelAreas,
+    archetype: archetypeKey,
   });
   const scoredOptions = candidateOptions.map((option) =>
     scoreOption({ option, brief, site, climate, programme }),

--- a/src/services/style/localStylePack.js
+++ b/src/services/style/localStylePack.js
@@ -354,24 +354,63 @@ export function buildLocalStylePackV2({
     ? brief.user_intent.avoid_keywords
     : [];
   const vernacularPack = site?.uk_vernacular_pack || null;
+  // Phase A (post-PR-92 fix): propagate the full pack payload through
+  // style_provenance — not just the descriptive metadata. The PR #92
+  // elevation renderer, Material Palette pack-prepend, and photoreal
+  // prompt builders all read fields like `parapet_default`, `materials`,
+  // `facade_language`, etc. The earlier shape dropped those, so the W2
+  // elevation kept rendering a generic gable in production even though
+  // the pack resolved correctly. Every consumer must still gate on
+  // `source === "ukVernacularPacks"` (or non-empty packId) to stay safe
+  // against the buildingTypeDefault fallback (Codex P1 review on PR #92).
   const styleProvenance = vernacularPack
     ? {
         ukVernacularPackId: vernacularPack.packId || null,
+        packId: vernacularPack.packId || null,
         packLabel: vernacularPack.label || null,
+        label: vernacularPack.label || null,
         region: vernacularPack.region || null,
         descriptive_narrative: vernacularPack.descriptive_narrative || null,
         historical_period: vernacularPack.historical_period || null,
         resolution_source: vernacularPack.resolution_source || null,
         source: "ukVernacularPacks",
+        materials: Array.isArray(vernacularPack.materials)
+          ? [...vernacularPack.materials]
+          : [],
+        facade_language: vernacularPack.facade_language || null,
+        roof_language: vernacularPack.roof_language || null,
+        window_language: vernacularPack.window_language || null,
+        fenestration_rhythm: vernacularPack.fenestration_rhythm || null,
+        modernity_default: Number.isFinite(
+          Number(vernacularPack.modernity_default),
+        )
+          ? Number(vernacularPack.modernity_default)
+          : null,
+        parapet_default: vernacularPack.parapet_default === true,
+        semi_basement_default: vernacularPack.semi_basement_default === true,
+        layout_archetype: vernacularPack.layout_archetype || null,
+        conservation_typical: vernacularPack.conservation_typical === true,
       }
     : {
         ukVernacularPackId: null,
+        packId: null,
         packLabel: null,
+        label: null,
         region: null,
         descriptive_narrative: null,
         historical_period: null,
         resolution_source: null,
         source: "buildingTypeDefault",
+        materials: [],
+        facade_language: null,
+        roof_language: null,
+        window_language: null,
+        fenestration_rhythm: null,
+        modernity_default: null,
+        parapet_default: false,
+        semi_basement_default: false,
+        layout_archetype: null,
+        conservation_typical: false,
       };
   return {
     style_pack_id: createStableId

--- a/src/services/style/ukVernacularPacks.js
+++ b/src/services/style/ukVernacularPacks.js
@@ -51,6 +51,7 @@ const PACKS = Object.freeze({
     modernity_default: 0.3,
     parapet_default: true,
     semi_basement_default: true,
+    layout_archetype: "linear_side_hall",
     descriptive_narrative:
       "Early-19th-century Regency / Italianate stucco terrace typical of Notting Hill, Belgravia, and Bayswater — white painted stucco upper floors over a rusticated yellow-brick or stucco base, a parapet concealing a slate roof, tall sash windows reducing in height with each storey, cast-iron front-area railings, and York stone front steps over a semi-basement.",
     historical_period: "Regency and early Victorian (c. 1820–1860)",
@@ -82,6 +83,7 @@ const PACKS = Object.freeze({
     modernity_default: 0.32,
     parapet_default: false,
     semi_basement_default: false,
+    layout_archetype: "linear_side_hall",
     descriptive_narrative:
       "Mid-to-late Victorian terraced house typical of inner and outer London — yellow London stock brick walls with red-brick dressings around openings, slate roofs visible from the street, painted-timber double-hung sash windows, a ground-floor canted or square bay window, and a tessellated tile entrance path. Privately speculative housing built en masse 1860–1900.",
     historical_period: "Victorian (1837–1901)",
@@ -112,6 +114,7 @@ const PACKS = Object.freeze({
     modernity_default: 0.3,
     parapet_default: false,
     semi_basement_default: false,
+    layout_archetype: "narrow_two_up_two_down",
     descriptive_narrative:
       "Worker housing of the 19th-century industrial north — narrow-frontage two-storey terraces in red engineering brick with blue Welsh slate roofs, plain stone sills and lintels, no front garden (door opens directly onto the pavement), and shared rear yards or alleys (ginnels). Many surviving examples are listed conservation-area stock; modern interventions favour respectful infill.",
     historical_period: "Mid-late Victorian to Edwardian (1840–1910)",
@@ -142,6 +145,7 @@ const PACKS = Object.freeze({
     modernity_default: 0.28,
     parapet_default: false,
     semi_basement_default: true,
+    layout_archetype: "tenement_common_stair",
     descriptive_narrative:
       "Four-to-five-storey-plus-attic Edinburgh tenement — Craigleith or Hailes sandstone ashlar elevation, natural Scotch slate roof, tall painted-timber sash-and-case windows with twelve or six panes diminishing in height per floor, a common (shared) stair entered from the street, and basement flats below pavement level reached via a sunken area. The dominant Georgian-to-Edwardian housing form of the New Town and the late-Victorian colonies.",
     historical_period: "Georgian to Edwardian (1770–1910)",
@@ -173,6 +177,7 @@ const PACKS = Object.freeze({
     modernity_default: 0.22,
     parapet_default: false,
     semi_basement_default: false,
+    layout_archetype: "central_stair_square",
     descriptive_narrative:
       "Vernacular Cotswolds cottage — coursed-rubble or rough-ashlar oolitic limestone walls in a honey-yellow tone, very steep-pitched roofs of locally quarried Cotswold stone slates that diminish in size up the slope, oak-framed leaded-light casement windows under stone mullions, gables with kneelers, and stone copings. Generally listed or in conservation areas; new build in this region must justify deviation from the local character.",
     historical_period: "17th–19th century vernacular (continuous tradition)",
@@ -194,6 +199,7 @@ const PACKS = Object.freeze({
     modernity_default: 0.5,
     parapet_default: false,
     semi_basement_default: false,
+    layout_archetype: null,
     descriptive_narrative:
       "Default UK contextual masonry pack used when no regional vernacular has been resolved. Favours weather-resistant masonry envelopes, moderate roof pitches, and contextual street rhythm without committing to a specific regional language.",
     historical_period: null,


### PR DESCRIPTION
## Summary

Three-phase fix for the issues the user reported on the post-PR-#92 W2 generation:
1. **Elevations still showed pitched gables** — pack hint reached `localStyle.style_provenance` but the propagated shape stripped `parapet_default`/`semi_basement_default`/`materials`/etc., so the renderer's pack-driven hints silently no-op'd at runtime even though unit tests passed with full-pack fixtures.
2. **Photoreal panels rendered 3 storeys** when brief asked for 2 — the LLM treated the pack's "semi-basement" descriptive narrative as a third habitable floor.
3. **Floor plans looked the same regardless of pack** — `buildProjectGeometryFromProgramme` always picked from the same wide-and-shallow rectangular candidates regardless of vernacular.

This is the followup to [PR #92](https://github.com/MOH131185/architect-ai-platform/pull/92), branched off `main` at the post-#92 merge commit.

### Phase A — propagate full pack through `style_provenance` ([`e036ddc`](https://github.com/MOH131185/architect-ai-platform/commit/e036ddc))
- `buildLocalStylePackV2` now copies `materials`, `parapet_default`, `semi_basement_default`, `facade_language`, `roof_language`, `window_language`, `fenestration_rhythm`, `modernity_default`, `layout_archetype`, plus `packId`/`label` aliases. The `buildingTypeDefault` fallback shape mirrors the keys with safe null/false/empty defaults so the source-gate from the Codex P1 review still catches it.
- Added `layout_archetype` to every pack so Phase C has something to dispatch on.
- Test suite extended: integration test on `renderElevationSvg` using the **actual propagated provenance shape** (would have caught today's bug); `buildingTypeDefault` strict-shape test extended with the new keys.

### Phase B — clamp photoreal storey count when pack implies a basement (also `e036ddc`)
- `buildVernacularPackBlock` (panelPromptBuilders.js) and the slice's inline `buildProjectGraphRenderPrompt` both append: *"render as a STYLISTIC PLINTH at street level only — EXACTLY {N} above-grade storeys total. Do NOT add a third habitable floor or a basement window band that reads as a separate storey."* when `pack.semi_basement_default && target_storeys <= 2`.
- 3 new tests: clamp present for W2 + 2 storeys, absent for EH8 + 4 storeys, skipped entirely for packs without semi-basement (Manchester).

### Phase C — layout archetype dispatcher ([`d47cd3e`](https://github.com/MOH131185/architect-ai-platform/commit/d47cd3e))
- `generateRectangularOptions` accepts an `archetype` and prepends archetype-specific candidates ahead of the existing 4-option set:

| Pack | Archetype | Candidates prepended |
|------|-----------|-----------------------|
| london-stucco-terrace, london-victorian-terrace | `linear_side_hall` | 2 narrow-deep (aspect 0.42 + 0.55, NS) |
| manchester-back-to-back | `narrow_two_up_two_down` | 1 narrow (aspect 0.55, NS) |
| edinburgh-tenement | `tenement_common_stair` | 1 slightly-deep square (aspect 0.85, NS) |
| cotswolds-cottage | `central_stair_square` | 1 near-square (aspect 1.05, EW) |
| uk-generic / no archetype | null | unchanged |

- Slice gates archetype on `style_provenance.source === "ukVernacularPacks"` so the buildingTypeDefault fallback never triggers archetype geometry.
- 5 new tests: each archetype prepends correct shapes; unknown/null/no-archetype paths return the baseline 4-option set with the same `option_id` sequence.

This is the simplest archetype hook — **footprint shape only**. Per-archetype room-band orientation (e.g. side hall on east edge for London terrace, central stair core for Cotswolds) is a deliberate Phase D follow-up to keep this PR focused.

## Test plan
- [x] `npm run lint` — exit 0
- [x] Phase A focused suite: `localStylePack.ukVernacular` + `ukVernacularPacks` (28/28)
- [x] Phase B focused suite: `elevationAndPromptVernacularPack` (12/12)
- [x] Phase C focused suite: `designOptions` optionGenerator block (8/8)
- [x] Combined regression (8 suites, 102 tests): 1 pre-existing failure on `Reading Room slice surfaces ≥3 scored design options` — confirmed flaky on `main` (Jest async-teardown), not caused by this PR
- [ ] Live W2 5SH generation on production after merge — confirm:
  - Elevation SVG carries `data-pack-parapet="true"`, `data-pack-semi-basement="true"`, `data-pack-facade-stucco="true"`
  - Visible parapet roofline (no gable triangle), semi-basement strip below ground line
  - Hero/Exterior/Axonometric photoreal panels render exactly 2 visible above-grade storeys (no third habitable floor)
  - Floor plans use a narrow-deep terrace aspect (front frontage ~5-6 m, depth ~12-14 m)
- [ ] Live EH8 generation — confirm `tenement_common_stair` archetype picks the slightly-deep square candidate
- [ ] Live GL56 (Cotswolds) generation — confirm `central_stair_square` archetype picks the near-square cottage candidate

## Files
**Modified:**
- `src/services/style/localStylePack.js` — full pack payload through `styleProvenance`
- `src/services/style/ukVernacularPacks.js` — `layout_archetype` field on every pack
- `src/services/a1/panelPromptBuilders.js` — `dimsFloors` clamp in `buildVernacularPackBlock`
- `src/services/project/projectGraphVerticalSliceService.js` — clamp in inline `buildProjectGraphRenderPrompt`, archetype thread into `generateRectangularOptions`
- `src/services/design/optionGenerator.js` — `archetype` parameter + `ARCHETYPE_OPTION_SPECS`

**Tests:**
- `src/__tests__/services/style/localStylePack.ukVernacular.test.js` — extended
- `src/__tests__/services/elevationAndPromptVernacularPack.test.js` — Phase A integration + Phase B clamp tests
- `src/__tests__/services/design/designOptions.test.js` — 5 new archetype tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)