### PR TITLE
fix(a1): scrub semi-basement language in 2-storey prompts + section parapet override

### DIFF
--- a/src/__tests__/services/elevationAndPromptVernacularPack.test.js
+++ b/src/__tests__/services/elevationAndPromptVernacularPack.test.js
@@ -17,6 +17,7 @@
  */
 
 import { renderElevationSvg } from "../../services/drawing/svgElevationRenderer.js";
+import { renderSectionSvg } from "../../services/drawing/svgSectionRenderer.js";
 import {
   buildHero3DPrompt,
   buildExteriorRenderPrompt,
@@ -354,7 +355,11 @@ describe("buildHero3DPrompt + buildExteriorRenderPrompt — pack injection", () 
   // This was the root cause of the 3D-vs-2D floor-count mismatch the user
   // observed on the post-PR-92 W2 generation (axonometric / exterior
   // perspective showed 3 floors, plans/sections showed 2).
-  test("buildHero3DPrompt clamps floor count to brief when pack.semi_basement_default && floors=2", () => {
+  // Phase D1 supersedes Phase B's clamp text. Positive constraints
+  // ("BUILDING STOREYS: EXACTLY N", "Plinth at pavement level only") work on
+  // LLMs where negative clamps ("Do NOT add a third floor") failed in the
+  // post-PR-93 production W2 test (still rendered 3 storeys with basement).
+  test("buildHero3DPrompt: Phase D1 storey-count + basement-scrub for pack.semi_basement_default && floors=2", () => {
     const pack = resolveUKVernacular({ postcode: "W2 5SH" });
     const dnaTwoFloors = {
       ...masterDNA,
@@ -366,9 +371,26 @@ describe("buildHero3DPrompt + buildExteriorRenderPrompt — pack injection", () 
       projectContext,
       vernacularPack: pack,
     });
-    expect(prompt).toMatch(/STYLISTIC PLINTH at street level only/);
-    expect(prompt).toMatch(/EXACTLY 2 above-grade storeys/);
-    expect(prompt).toMatch(/Do NOT add a third habitable floor/);
+    // Hard storey-count line up front (positive constraint).
+    expect(prompt).toMatch(
+      /BUILDING STOREYS:\s*EXACTLY\s+2\s+above-grade\s+stor[ei]ys?/,
+    );
+    // The "no basement" disclaimer is part of the storey statement.
+    expect(prompt).toMatch(
+      /No semi-basement, no basement window band, no additional habitable floor below ground level/,
+    );
+    // Replacement bullet — pavement-level plinth only.
+    expect(prompt).toMatch(
+      /Plinth at pavement level only.*NO semi-basement.*NO front-area railings/,
+    );
+    // The descriptive narrative must NOT mention a semi-basement when the
+    // clamp is active (LLMs read "semi-basement" as a third visible storey
+    // regardless of any later negation).
+    const narrativeMatch = prompt.match(/-\s*Narrative:[^\n]+/);
+    expect(narrativeMatch).not.toBeNull();
+    expect(narrativeMatch[0].toLowerCase()).not.toMatch(/semi[-\s]?basement/);
+    expect(narrativeMatch[0].toLowerCase()).not.toMatch(/cast[-\s]?iron/);
+    expect(narrativeMatch[0].toLowerCase()).not.toMatch(/york stone/);
   });
 
   test("buildExteriorRenderPrompt does NOT emit the clamp when target storeys >= 3 (clamp scope)", () => {
@@ -449,5 +471,104 @@ describe("buildHero3DPrompt + buildExteriorRenderPrompt — pack injection", () 
     expect(prompt).toContain("(tenement_block_4_storey)");
     // Floor count + roof requirements still anchored.
     expect(prompt).toContain("FLOOR COUNT: EXACTLY");
+  });
+});
+
+// Phase D2 — section renderer parapet awareness. The post-PR-93 W2 production
+// test showed elevations rendered a flat parapet (PR #92 worked there) but
+// sections still cut through a triangular gable, breaking section/elevation
+// parity. The section renderer must mirror the elevation override: when
+// pack.parapet_default is true, draw a horizontal coping band instead of a
+// gable triangle.
+describe("renderSectionSvg — Phase D2 parapet awareness", () => {
+  test("london-stucco-terrace section forces flat parapet (no gable triangle), tags root attrs", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    const result = renderSectionSvg(
+      makeFixtureGeometry(),
+      { roof_language: "pitched gable" },
+      {
+        sectionType: "longitudinal",
+        vernacularPack: pack,
+      },
+    );
+    expect(result.svg).toBeTruthy();
+    expect(result.svg).toContain(
+      'data-vernacular-pack="london-stucco-terrace"',
+    );
+    expect(result.svg).toContain('data-pack-parapet="true"');
+    // Flat-roof path emits a roof-pitch-status="flat" attribute via
+    // renderRoofPitchDataAttributes; gable path does not.
+    expect(result.svg).toMatch(/data-roof-pitch-status="flat"/);
+    // The flat path's renderRoof draws a horizontal coping rect at topY-12.
+    // The gable path draws a triangle with M..L..L..Z. Confirm we got the
+    // horizontal coping pattern, not the triangle.
+    expect(result.svg).not.toMatch(/<path[^>]*data-roof-truth/);
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      true,
+    );
+    expect(result.technical_quality_metadata.vernacular_pack_id).toBe(
+      "london-stucco-terrace",
+    );
+  });
+
+  test("section without a pack keeps the gable / pitched roof unchanged (flag-off fallback)", () => {
+    const result = renderSectionSvg(
+      makeFixtureGeometry(),
+      { roof_language: "pitched gable" },
+      { sectionType: "longitudinal" },
+    );
+    expect(result.svg).toBeTruthy();
+    expect(result.svg).not.toContain("data-vernacular-pack=");
+    expect(result.svg).not.toContain("data-pack-parapet=");
+    // Pitched roof should NOT show the flat-status data attr.
+    expect(result.svg).not.toMatch(/data-roof-pitch-status="flat"/);
+    expect(result.technical_quality_metadata.vernacular_pack_id).toBeNull();
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      false,
+    );
+  });
+
+  test("buildingTypeDefault fallback provenance does NOT trigger parapet override on section", () => {
+    const fallbackProvenance = {
+      ukVernacularPackId: null,
+      packId: null,
+      packLabel: null,
+      label: null,
+      source: "buildingTypeDefault",
+      parapet_default: false,
+      semi_basement_default: false,
+      materials: [],
+    };
+    const result = renderSectionSvg(
+      makeFixtureGeometry(),
+      { roof_language: "pitched gable" },
+      {
+        sectionType: "longitudinal",
+        vernacularPack: fallbackProvenance,
+      },
+    );
+    expect(result.svg).toBeTruthy();
+    expect(result.svg).not.toContain("data-vernacular-pack=");
+    expect(result.svg).not.toContain("data-pack-parapet=");
+    expect(result.technical_quality_metadata.vernacular_pack_id).toBeNull();
+  });
+
+  test("edinburgh-tenement (parapet false) does NOT force flat coping", () => {
+    const pack = resolveUKVernacular({ postcode: "EH8 9YL" });
+    expect(pack.parapet_default).toBe(false);
+    const result = renderSectionSvg(
+      makeFixtureGeometry(),
+      { roof_language: "pitched gable" },
+      {
+        sectionType: "longitudinal",
+        vernacularPack: pack,
+      },
+    );
+    expect(result.svg).toContain('data-vernacular-pack="edinburgh-tenement"');
+    expect(result.svg).toContain('data-pack-parapet="false"');
+    expect(result.svg).not.toMatch(/data-roof-pitch-status="flat"/);
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      false,
+    );
   });
 });

--- a/src/services/a1/panelPromptBuilders.js
+++ b/src/services/a1/panelPromptBuilders.js
@@ -187,31 +187,86 @@ function buildVernacularPackBlock(vernacularPack, dimsFloors = null) {
   if (!label && !narrative && !facadeLanguage && materials.length === 0) {
     return "";
   }
-  const lines = ["REGIONAL VERNACULAR (UK pack):"];
+  // Phase D1 — when the brief asks for ≤2 above-grade storeys, the
+  // descriptive narrative must NOT mention a semi-basement (LLMs read
+  // "semi-basement with railings" as a third visible storey, regardless of
+  // any negative-instruction clamp). Strip semi-basement language from the
+  // narrative and the dedicated semi-basement line entirely. The earlier
+  // post-PR-93 production test confirmed Phase B's negative clamp didn't
+  // bite — the photoreal still rendered 3 storeys because the pack's
+  // descriptive narrative talks about a basement explicitly.
+  const floorsHint = Number.isFinite(Number(dimsFloors))
+    ? Number(dimsFloors)
+    : null;
+  const stripBasementLanguage =
+    semiBasement && floorsHint !== null && floorsHint <= 2;
+  const sanitizeBasementText = (text) => {
+    if (!text || !stripBasementLanguage) return text;
+    return (
+      String(text)
+        // Drop semi-basement clause + adjacent descriptive phrasing.
+        .replace(
+          /\s*(?:and|with)?\s*(?:cast[-\s]?iron[^.,;]+|york\s*stone[^.,;]+|semi[-\s]?basement[^.,;]+)\s*[,.;]/gi,
+          ".",
+        )
+        .replace(/\s+over\s+a\s+semi[-\s]?basement[^.,;]*/gi, "")
+        .replace(/,\s*\./g, ".")
+        .replace(/\.\s*\./g, ".")
+        .replace(/\s+/g, " ")
+        .trim()
+    );
+  };
+
+  const lines = [];
+  // Phase D1 — hard storey-count statement up front. Positive constraints
+  // ("EXACTLY N above-grade storeys") work on LLMs where negative ones
+  // ("do NOT add a basement") do not.
+  if (floorsHint !== null && floorsHint > 0) {
+    lines.push(
+      `BUILDING STOREYS: EXACTLY ${floorsHint} above-grade storey${floorsHint === 1 ? "" : "s"}.${
+        stripBasementLanguage
+          ? " No semi-basement, no basement window band, no additional habitable floor below ground level."
+          : ""
+      }`,
+    );
+  }
+  lines.push("REGIONAL VERNACULAR (UK pack):");
   if (label) lines.push(`- Pack: ${label}${period ? ` (${period})` : ""}`);
-  if (narrative) lines.push(`- Narrative: ${narrative}`);
-  if (facadeLanguage) lines.push(`- Facade language: ${facadeLanguage}`);
+  if (narrative) {
+    const cleanedNarrative = sanitizeBasementText(narrative);
+    if (cleanedNarrative) lines.push(`- Narrative: ${cleanedNarrative}`);
+  }
+  if (facadeLanguage) {
+    const cleanedFacade = sanitizeBasementText(facadeLanguage);
+    if (cleanedFacade) lines.push(`- Facade language: ${cleanedFacade}`);
+  }
   if (roofLanguage) lines.push(`- Roof language: ${roofLanguage}`);
   if (windowLanguage) lines.push(`- Window language: ${windowLanguage}`);
-  if (materials.length) lines.push(`- Materials: ${materials.join(", ")}`);
+  if (materials.length) {
+    const filteredMaterials = stripBasementLanguage
+      ? materials.filter(
+          (m) =>
+            !/cast[-\s]?iron|york\s*stone|railing/i.test(String(m)) ||
+            // keep yellow London stock brick base etc. (still legitimate)
+            !/railing/i.test(String(m)),
+        )
+      : materials;
+    if (filteredMaterials.length) {
+      lines.push(`- Materials: ${filteredMaterials.join(", ")}`);
+    }
+  }
   if (parapet) lines.push(`- Roofline: parapet concealing the roof.`);
   if (semiBasement) {
-    // Phase B floor-count clamp — when the pack implies a semi-basement and
-    // the brief asks for ≤2 above-grade storeys, the LLM was rendering 3
-    // visible storeys (basement + ground + first) and breaking parity with
-    // the deterministic 2D plans/elevations/sections (which only have N
-    // levels). Lock the storey count explicitly when the brief is in that
-    // band so the photoreal panels match the technical drawings.
-    const floorsHint = Number.isFinite(Number(dimsFloors))
-      ? Number(dimsFloors)
-      : null;
-    if (floorsHint !== null && floorsHint <= 2) {
+    if (stripBasementLanguage) {
+      // Replacement: pavement-level plinth only, no railings, no basement
+      // window band. This is the positive statement that the LLM should
+      // follow. The explicit storey-count line above re-anchors total floors.
       lines.push(
-        `- Semi-basement: render as a STYLISTIC PLINTH at street level only — cast-iron front-area railings and York stone front steps are visible at the pavement, but the building has EXACTLY ${floorsHint} above-grade storeys total. Do NOT add a third habitable floor or a basement window band that reads as a separate storey.`,
+        "- Plinth at pavement level only (stucco / render to ground), NO semi-basement, NO front-area railings, NO basement window band. Entrance is at pavement grade.",
       );
     } else {
       lines.push(
-        `- Semi-basement: render with cast-iron front-area railings and York stone front steps where appropriate.`,
+        "- Semi-basement: render with cast-iron front-area railings and York stone front steps where appropriate.",
       );
     }
   }

--- a/src/services/canonical/compiledProjectTechnicalPackBuilder.js
+++ b/src/services/canonical/compiledProjectTechnicalPackBuilder.js
@@ -948,6 +948,7 @@ export function buildCompiledProjectTechnicalPanels(source = {}, options = {}) {
         sectionType,
         sectionProfile,
         sheetMode: true,
+        vernacularPack: options.vernacularPack || null,
       });
       const normalized = buildPanelRecord(
         panelType,

--- a/src/services/drawing/svgSectionRenderer.js
+++ b/src/services/drawing/svgSectionRenderer.js
@@ -813,9 +813,12 @@ function renderRoof(
     quality === "blocked" ? 0.52 : quality === "weak" ? 0.74 : 1;
   const roofX = roofGeometry?.band?.x ?? baseX;
   const roofWidth = roofGeometry?.band?.width ?? widthPx;
-  const flat = String(roofLanguage || "")
-    .toLowerCase()
-    .includes("flat");
+  // Phase D2 — accept "parapet" as a flat-roof signal so a UK vernacular
+  // pack with parapet_default (London stucco terrace, Edinburgh tenement,
+  // etc.) renders a horizontal coping band in section instead of cutting
+  // through a gable triangle. Mirrors PR #92's elevation behaviour.
+  const lowerLang = String(roofLanguage || "").toLowerCase();
+  const flat = lowerLang.includes("flat") || lowerLang.includes("parapet");
   const parapetMarkup = (roofGeometry?.parapets || [])
     .map(
       (entry) =>
@@ -1299,8 +1302,33 @@ export function renderSectionSvg(
       (sum, level) => sum + Number(level.height_m || 3.2),
       0,
     ) || 3.2;
-  const roofLanguage =
+  // Phase D2 — UK regional vernacular pack parapet override.
+  // Mirror PR #92's elevation behaviour: when the resolved pack declares
+  // parapet_default, force the section roofLanguage to include "parapet" so
+  // renderRoof's `flat`-path emits a horizontal coping band instead of a
+  // gable triangle. Without this the elevations show parapet but the
+  // sections still cut through a pitched gable, breaking parity. Pack-off /
+  // non-UK paths are unchanged. Gates on source === "ukVernacularPacks" or a
+  // non-empty packId so the buildingTypeDefault fallback never trips it
+  // (Codex P1 review pattern).
+  const rawVernacularPack =
+    options.vernacularPack && typeof options.vernacularPack === "object"
+      ? options.vernacularPack
+      : null;
+  const hasResolvedVernacularPack =
+    !!rawVernacularPack &&
+    (rawVernacularPack.source === "ukVernacularPacks" ||
+      (typeof rawVernacularPack.ukVernacularPackId === "string" &&
+        rawVernacularPack.ukVernacularPackId.trim().length > 0) ||
+      (typeof rawVernacularPack.packId === "string" &&
+        rawVernacularPack.packId.trim().length > 0));
+  const vernacularPack = hasResolvedVernacularPack ? rawVernacularPack : null;
+  const packParapet = vernacularPack?.parapet_default === true;
+  const baseRoofLanguage =
     resolvedStyleDNA.roof_language || geometry.roof?.type || "pitched gable";
+  const roofLanguage = packParapet
+    ? `${baseRoofLanguage || "flat"} parapet`.trim()
+    : baseRoofLanguage;
   const roofPitchInfoBase = buildCanonicalRoofPitchInfo(geometry, {
     roofLanguage,
     spanM: horizontalExtent,
@@ -1673,8 +1701,14 @@ export function renderSectionSvg(
   `
     : "";
 
+  // Phase D2 — root data attrs for vernacular pack parity with elevation.
+  const packDataAttrs = vernacularPack
+    ? ` data-vernacular-pack="${escapeXml(
+        vernacularPack.ukVernacularPackId || vernacularPack.packId || "",
+      )}" data-pack-parapet="${packParapet}"`
+    : "";
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${SECTION_THEME.name}" data-bounds-source="${envelopeBounds.source}" data-a1-quality-polish="${sheetMode ? "section_datums_dimensions_v2" : "section_standard"}" data-section-edge-clearance-status="${sectionVisualMetrics.edgeClearanceStatus}" data-section-body-occupancy="${sectionVisualMetrics.bodyOccupancyRatio}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${SECTION_THEME.name}" data-bounds-source="${envelopeBounds.source}" data-a1-quality-polish="${sheetMode ? "section_datums_dimensions_v2" : "section_standard"}" data-section-edge-clearance-status="${sectionVisualMetrics.edgeClearanceStatus}" data-section-body-occupancy="${sectionVisualMetrics.bodyOccupancyRatio}"${packDataAttrs}>
   <rect width="${width}" height="${height}" fill="${SECTION_THEME.paper}" />
   ${stairMarkup.defs || ""}
   ${
@@ -1747,6 +1781,11 @@ export function renderSectionSvg(
       roof_pitch_status: roofPitchInfo.status,
       roof_pitch_span_m: roofPitchInfo.spanM,
       roof_pitch_rise_m: roofPitchInfo.riseM,
+      vernacular_pack_id:
+        vernacularPack?.ukVernacularPackId || vernacularPack?.packId || null,
+      vernacular_pack_label:
+        vernacularPack?.packLabel || vernacularPack?.label || null,
+      vernacular_pack_parapet: packParapet,
       section_usefulness_score: usefulnessScore,
       section_candidate_quality:
         sectionProfile?.sectionCandidateQuality || null,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -6550,38 +6550,75 @@ export function buildProjectGraphRenderPrompt({
       : [];
     const parapet = provenance.parapet_default === true;
     const semiBasement = provenance.semi_basement_default === true;
+    // Phase D1 — when the brief asks for ≤2 above-grade storeys, scrub
+    // semi-basement language out of the descriptive narrative + facade
+    // language and replace the dedicated semi-basement bullet with a
+    // pavement-grade plinth statement. Negative clamps ("DO NOT add a third
+    // floor") didn't work in production — the LLM still rendered the
+    // basement because the narrative talked about it. Positive language
+    // ("EXACTLY 2 storeys, plinth at pavement only") works.
+    const targetStoreys = Number(brief?.target_storeys || 0);
+    const stripBasement =
+      semiBasement &&
+      Number.isFinite(targetStoreys) &&
+      targetStoreys > 0 &&
+      targetStoreys <= 2;
+    const sanitizeBasementText = (text) => {
+      if (!text || !stripBasement) return text;
+      return String(text)
+        .replace(
+          /\s*(?:and|with)?\s*(?:cast[-\s]?iron[^.,;]+|york\s*stone[^.,;]+|semi[-\s]?basement[^.,;]+)\s*[,.;]/gi,
+          ".",
+        )
+        .replace(/\s+over\s+a\s+semi[-\s]?basement[^.,;]*/gi, "")
+        .replace(/,\s*\./g, ".")
+        .replace(/\.\s*\./g, ".")
+        .replace(/\s+/g, " ")
+        .trim();
+    };
     if (packLabel || narrative || facadeLanguage || packMaterials.length) {
+      // Hard storey-count line up front. Positive constraint wins over
+      // negative clamps for LLM compliance.
+      if (Number.isFinite(targetStoreys) && targetStoreys > 0) {
+        vernacularLines.push(
+          `BUILDING STOREYS: EXACTLY ${targetStoreys} above-grade storey${targetStoreys === 1 ? "" : "s"}.${
+            stripBasement
+              ? " No semi-basement, no basement window band, no additional habitable floor below ground level."
+              : ""
+          }`,
+        );
+      }
       vernacularLines.push("REGIONAL VERNACULAR (UK pack):");
       if (packLabel)
         vernacularLines.push(
           `- Pack: ${packLabel}${period ? ` (${period})` : ""}`,
         );
-      if (narrative) vernacularLines.push(`- Narrative: ${narrative}`);
-      if (facadeLanguage)
-        vernacularLines.push(`- Facade language: ${facadeLanguage}`);
+      if (narrative) {
+        const cleaned = sanitizeBasementText(narrative);
+        if (cleaned) vernacularLines.push(`- Narrative: ${cleaned}`);
+      }
+      if (facadeLanguage) {
+        const cleaned = sanitizeBasementText(facadeLanguage);
+        if (cleaned) vernacularLines.push(`- Facade language: ${cleaned}`);
+      }
       if (roofLanguage)
         vernacularLines.push(`- Roof language: ${roofLanguage}`);
       if (windowLanguage)
         vernacularLines.push(`- Window language: ${windowLanguage}`);
-      if (packMaterials.length)
-        vernacularLines.push(`- Materials: ${packMaterials.join(", ")}`);
+      if (packMaterials.length) {
+        const filtered = stripBasement
+          ? packMaterials.filter((m) => !/railing/i.test(String(m)))
+          : packMaterials;
+        if (filtered.length) {
+          vernacularLines.push(`- Materials: ${filtered.join(", ")}`);
+        }
+      }
       if (parapet)
         vernacularLines.push("- Roofline: parapet concealing the roof.");
       if (semiBasement) {
-        // Phase B floor-count clamp — when the brief asks for ≤2 above-grade
-        // storeys but the pack implies a semi-basement, the LLM was rendering
-        // 3 visible storeys (basement + ground + first) and breaking parity
-        // with the deterministic 2D drawings (which only have target_storeys
-        // levels). Lock the storey count explicitly when the brief is in
-        // that band.
-        const targetStoreys = Number(brief?.target_storeys || 0);
-        if (
-          Number.isFinite(targetStoreys) &&
-          targetStoreys > 0 &&
-          targetStoreys <= 2
-        ) {
+        if (stripBasement) {
           vernacularLines.push(
-            `- Semi-basement: render as a STYLISTIC PLINTH at street level only — cast-iron front-area railings and York stone front steps are visible at the pavement, but the building has EXACTLY ${targetStoreys} above-grade storeys total. Do NOT add a third habitable floor or a basement window band that reads as a separate storey.`,
+            "- Plinth at pavement level only (stucco / render to ground), NO semi-basement, NO front-area railings, NO basement window band. Entrance is at pavement grade.",
           );
         } else {
           vernacularLines.push(


### PR DESCRIPTION
## Summary

Phase D fix branch — addresses the two issues the user reported on the post-PR-#93 W2 5SH production test:

1. **Photoreal panels still rendered 3 storeys** for a 2-storey brief (axonometric, exterior_render, hero_3d all showed semi-basement + raised ground + first = 3 visible levels). Phase B's negative clamp ("Do NOT add a third habitable floor") didn't override the LLM because the pack's descriptive narrative still talked about a semi-basement.
2. **Sections cut through a triangular gable** while elevations (Phase A parapet override) showed a flat parapet. Section/elevation parity was broken.

Single commit ([`1d269f7`](https://github.com/MOH131185/architect-ai-platform/commit/1d269f7)) on `fix/photoreal-storey-clamp-and-section-parapet`, off `main` at `9f1b365` (post-PR-#93 merge).

### D1 — scrub semi-basement language + hard storey-count statement

Replaces Phase B's negative clamp with a positive constraint approach:

- Prepend a **`BUILDING STOREYS: EXACTLY {N} above-grade storeys.`** statement at the top of the REGIONAL VERNACULAR block. Includes "No semi-basement, no basement window band, no additional habitable floor below ground level." when the brief is in the clamp band.
- When `pack.semi_basement_default && target_storeys ≤ 2`, **scrub** semi-basement language out of the descriptive narrative and facade language (regex strips "...over a semi-basement", "cast-iron front-area railings", "York stone front steps"), drop railings from the materials list, and replace the dedicated semi-basement bullet with: *"Plinth at pavement level only (stucco / render to ground), NO semi-basement, NO front-area railings, NO basement window band. Entrance is at pavement grade."*
- Applied in both `buildVernacularPackBlock` (panelPromptBuilders.js) and the slice's inline `buildProjectGraphRenderPrompt`.

### D2 — section renderer parapet awareness

Mirrors PR #92's elevation override on the section side:

- `renderSectionSvg` accepts `options.vernacularPack`, gates on `source === "ukVernacularPacks"` (Codex P1 pattern).
- When `pack.parapet_default === true`, override `roofLanguage` to include "parapet" so `renderRoof`'s flat-roof path emits a horizontal coping band instead of a gable triangle.
- `renderRoof`'s flat-detector now accepts both "flat" and "parapet" (mirrors elevation behaviour).
- SVG root carries `data-vernacular-pack` + `data-pack-parapet` attrs; `technical_quality_metadata` stamps `vernacular_pack_id/label/parapet`.
- `compiledProjectTechnicalPackBuilder` forwards `vernacularPack` from the slice's `buildDrawingSet` (already plumbed in PR #93).

### What this PR explicitly does NOT do (kept out of scope)

- D3 visual elevation upgrades (cast-iron railings glyphs, diminishing sash height scaling) — labelled "optional, lower priority" in the original Phase D plan and deferred.
- Any geometry change.
- Any Codex section work (the section renderer here only adds a flat-roof override; existing pitched-section behaviour is unchanged when no pack is supplied).

## Test plan
- [x] `npm run lint` — exit 0
- [x] D1 + D2 focused suite (`elevationAndPromptVernacularPack.test.js`): 16/16
- [x] Wider regression (9 suites, 91 tests): elevation/prompt vernacular, key-notes/material-palette pack-driven, localStylePack ukVernacular, ukVernacularPacks, drawingBlueprintRenderer, svgRendererPhase1, technicalDrawingPolish, technicalDrawingNormalization, projectGraphLayoutVariation
- [ ] Live W2 5SH generation on production after merge — confirm:
  - **Hero/Exterior/Axonometric photoreal panels render exactly 2 visible above-grade storeys** (no semi-basement, no railings, no third floor band)
  - **Section A-A and Section B-B show flat parapet + horizontal coping** matching the elevation parapet (no gable triangle)
  - Section SVG carries `data-vernacular-pack="london-stucco-terrace"` + `data-pack-parapet="true"`
  - Floor plans, material palette, key notes unchanged from PR #93
- [ ] Live EH8 (Edinburgh, `parapet_default: false`) generation — confirm sections still render pitched gable (override only fires when pack declares parapet)

## Files
**Modified:**
- `src/services/a1/panelPromptBuilders.js` — D1 scrub + storey statement in `buildVernacularPackBlock`
- `src/services/project/projectGraphVerticalSliceService.js` — D1 scrub + storey statement in inline `buildProjectGraphRenderPrompt`
- `src/services/drawing/svgSectionRenderer.js` — D2 vernacularPack option + parapet override + root data attrs + flat-detector accepts "parapet"
- `src/services/canonical/compiledProjectTechnicalPackBuilder.js` — forward `vernacularPack` to `renderSectionSvg`

**Tests:**
- `src/__tests__/services/elevationAndPromptVernacularPack.test.js` — D1 storey-count + basement-scrub regression; D2 four section-parapet tests (W2 forces flat coping, no-pack keeps gable, fallback ignored, EH8 parapet_default=false stays pitched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)