### PR TITLE
feat(a1): blueprint-grade deterministic technical renderer

### DIFF
--- a/src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js
+++ b/src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js
@@ -15,6 +15,7 @@ import {
   buildKeyNoteItems,
   buildKeyNotesPanelArtifact,
   buildMaterialPalettePanelArtifact,
+  __projectGraphVerticalSliceInternals,
 } from "../../services/project/projectGraphVerticalSliceService.js";
 import { resolveUKVernacular } from "../../services/style/ukVernacularPacks.js";
 
@@ -124,6 +125,111 @@ describe("buildKeyNoteItems — QA summary group", () => {
     });
     const qaGroup = groups.find((g) => g.id === "qa_summary");
     expect(qaGroup).toBeUndefined();
+  });
+});
+
+describe("ArchitectReasoningManifest — Key Notes design rationale", () => {
+  test("builds a deterministic compact sidecar manifest and Key Notes group", () => {
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    const localStyle = makeLocalStyleWithPack(pack);
+    const compiledProject = {
+      geometryHash: "geometry-hash-w2",
+      levels: [{ id: "ground" }, { id: "first" }],
+      rooms: [
+        { id: "living", name: "Living Room", zone: "day" },
+        { id: "kitchen", name: "Kitchen", zone: "service" },
+        { id: "landing", name: "Landing", zone: "circulation" },
+      ],
+      windows: [
+        { id: "w1", orientation: "south" },
+        { id: "w2", orientation: "west" },
+      ],
+      stairs: [{ id: "main-stair" }],
+      sectionCuts: {
+        candidates: [
+          { sectionType: "longitudinal", strategyName: "stair/daylight cut" },
+          { sectionType: "transverse", strategyName: "front-to-back cut" },
+        ],
+      },
+    };
+    const manifest =
+      __projectGraphVerticalSliceInternals.buildArchitectReasoningManifest({
+        projectGraphId: "pg-w2",
+        brief: {
+          ...baseBrief,
+          site_input: { postcode: "W2 5SH" },
+        },
+        site: {
+          postcode: "W2 5SH",
+          north_angle_degrees: 8,
+          boundary_source: "manual_verified",
+          main_entry: { orientation: "south", source: "manual" },
+        },
+        climate: { source: "deterministic", zone: "UK temperate" },
+        regulations: { parts: [{ part: "Part L" }, { part: "Part M" }] },
+        localStyle,
+        programmeSummary: {
+          rooms_per_level: {
+            ground: ["Living Room", "Kitchen", "WC"],
+            first: ["Bedroom", "Bathroom"],
+          },
+        },
+        compiledProject,
+        technicalBuild: { technicalPanelTypes: ["section_AA", "section_BB"] },
+        sheetDesignContext: {
+          materials: [
+            { name: "white stucco render" },
+            { name: "natural slate" },
+          ],
+        },
+      });
+
+    expect(manifest).toEqual(
+      expect.objectContaining({
+        asset_type: "architect_reasoning_manifest_json",
+        schema_version: "architect-reasoning-manifest-v1",
+        source_model_hash: "geometry-hash-w2",
+        geometryHash: "geometry-hash-w2",
+        authoritySource: "project_graph_compiled_geometry",
+        deterministic: true,
+        manifestHash: expect.any(String),
+      }),
+    );
+    expect(manifest.prompt_splice_lines.length).toBeGreaterThanOrEqual(6);
+    expect(manifest.prompt_splice_lines.length).toBeLessThanOrEqual(8);
+    expect(manifest.design_rationale).toEqual(
+      expect.objectContaining({
+        site_orientation: expect.stringMatching(/Site\/orientation/i),
+        zoning: expect.stringMatching(/Zoning/i),
+        circulation: expect.stringMatching(/Circulation/i),
+        daylight: expect.stringMatching(/Daylight/i),
+        facade_vernacular: expect.stringMatching(/London stucco terrace/i),
+        section_cut: expect.stringMatching(/Section cuts/i),
+        material: expect.stringMatching(/stucco|slate/i),
+        qa_caveats: expect.stringMatching(/QA caveats/i),
+      }),
+    );
+    expect(manifest.qa_caveats.join(" ")).toMatch(/warning-only/i);
+
+    const groups = buildKeyNoteItems({
+      brief: baseBrief,
+      site: baseSite,
+      climate: baseClimate,
+      regulations: baseRegulations,
+      localStyle,
+      architectReasoningManifest: manifest,
+    });
+    const rationaleGroup = groups.find((g) => g.id === "design_rationale");
+    expect(rationaleGroup).toEqual(
+      expect.objectContaining({
+        heading: "Design rationale",
+        lines: manifest.key_note_lines,
+      }),
+    );
+    expect(rationaleGroup.lines.length).toBeGreaterThanOrEqual(3);
+    expect(rationaleGroup.lines.join(" ")).toMatch(
+      /Site\/orientation|Circulation|Section cuts/i,
+    );
   });
 });
 

--- a/src/__tests__/services/drawing/svgPlanRendererFidelity.test.js
+++ b/src/__tests__/services/drawing/svgPlanRendererFidelity.test.js
@@ -156,7 +156,13 @@ function fixture(extra = {}) {
         head_height_m: 2.1,
       },
     ],
-    stairs: [],
+    stairs: [
+      {
+        id: "main-stair",
+        level_id: "ground",
+        bbox: { min_x: 16.3, min_y: 8.4, max_x: 18.6, max_y: 15.4 },
+      },
+    ],
     sections: [
       {
         id: "section-long",
@@ -316,6 +322,40 @@ describe("renderPlanSvg — Phase 1 fidelity features", () => {
     expect(result.svg).toContain('class="furniture-garage"');
     expect(result.svg).toContain('class="furniture-utility"');
     expect(result.svg).toContain('class="furniture-wardrobe"');
+  });
+
+  test("emits blueprint-grade CAD layers, line weights, tags and dimensions", () => {
+    const result = renderPlanSvg(fixture(), { width: 1200, height: 900 });
+    const meta = result.technical_quality_metadata;
+
+    expect(result.svg).toContain('data-blueprint-grade="true"');
+    expect(result.svg).toContain("cad-layer-walls");
+    expect(result.svg).toContain("cad-wall-poche");
+    expect(result.svg).toContain("cad-lineweight-cut");
+    expect(result.svg).toContain("cad-lineweight-primary");
+    expect(result.svg).toContain("room-area-label");
+    expect(result.svg).toContain("data-room-area-m2");
+    expect(result.svg).toContain("cad-window-tag");
+    expect(result.svg).toContain("cad-door-tag");
+    expect(result.svg).toContain("cad-stair-arrow");
+    expect(result.svg).toContain("cad-stair-label");
+    expect(result.svg).toContain(
+      'data-dimension-chain-types="overall bay opening internal"',
+    );
+    expect(result.svg).toContain("cad-dimension-chain-bay");
+    expect(result.svg).toContain("cad-dimension-chain-opening");
+    expect(result.svg).toContain("cad-section-marker");
+    expect(result.svg).toContain('data-section-label="A-A"');
+    expect(meta.cad_grade_renderer).toBe(true);
+    expect(meta.has_room_area_labels).toBe(true);
+    expect(meta.has_cad_layer_classes).toBe(true);
+    expect(meta.has_cad_lineweight_classes).toBe(true);
+    expect(meta.cad_layer_classes).toEqual(
+      expect.arrayContaining(["cad-layer-walls", "cad-layer-dimensions"]),
+    );
+    expect(meta.dimension_chain_types).toEqual(
+      expect.arrayContaining(["overall", "bay", "opening", "internal"]),
+    );
   });
 });
 

--- a/src/__tests__/services/drawing/technicalDrawingPolishPhase3.test.js
+++ b/src/__tests__/services/drawing/technicalDrawingPolishPhase3.test.js
@@ -8,6 +8,7 @@ import {
   FURNITURE_SYMBOL_VERSION,
 } from "../../../services/drawing/furnitureSymbolService.js";
 import { getBlueprintTheme } from "../../../services/drawing/drawingBounds.js";
+import { resolveUKVernacular } from "../../../services/style/ukVernacularPacks.js";
 
 function rectangle(minX, minY, maxX, maxY) {
   return [
@@ -236,7 +237,45 @@ function createPolishFixture() {
         head_height_m: 2.1,
       },
     ],
-    stairs: [],
+    stairs: [
+      {
+        id: "main-stair",
+        level_id: "ground",
+        bbox: { min_x: 14, min_y: 12, max_x: 18, max_y: 16 },
+        depth_m: 3.2,
+      },
+    ],
+  };
+}
+
+function createW2FacadeGrammar(pack) {
+  return {
+    orientations: [
+      {
+        side: "south",
+        roofline_language: pack.roof_language,
+        parapet_mode: pack.parapet_default ? "continuous parapet" : "none",
+        material_zones: [
+          {
+            material: "white stucco render",
+            application: "primary facade",
+            start_m: 0,
+            end_m: 8,
+          },
+          {
+            material: "natural slate",
+            application: "roof parapet",
+            start_m: 8,
+            end_m: 12,
+          },
+        ],
+        components: {
+          bays: [{ center_m: 3 }, { center_m: 6 }, { center_m: 9 }],
+          parapets: [{ type: "parapet" }],
+          sills: [{ type: "sill band" }],
+        },
+      },
+    ],
   };
 }
 
@@ -346,6 +385,65 @@ describe("Phase 3 — elevation datums", () => {
     expect(typeof result.svg).toBe("string");
     expect(result.svg.length).toBeGreaterThan(500);
   });
+
+  test("blueprint-grade elevation carries CAD material hatches, datums and opening cues", () => {
+    const fixture = createPolishFixture();
+    const result = renderElevationSvg(fixture, {}, { orientation: "south" });
+    const meta = result.technical_quality_metadata;
+
+    expect(result.svg).toContain('data-blueprint-grade="true"');
+    expect(result.svg).toContain("cad-layer-material-hatches");
+    expect(result.svg).toContain("cad-material-hatch");
+    expect(result.svg).toContain('data-datum-role="ffl-ground"');
+    expect(result.svg).toContain('data-datum-role="eaves"');
+    expect(result.svg).toContain('data-datum-role="ridge"');
+    expect(result.svg).toContain("cad-window-head-line");
+    expect(result.svg).toContain("cad-window-sill-line");
+    expect(result.svg).toContain("cad-opening-tag");
+    expect(result.svg).toContain("cad-facade-rhythm-cue");
+    expect(meta.has_cad_layer_classes).toBe(true);
+    expect(meta.has_cad_lineweight_classes).toBe(true);
+    expect(meta.has_eaves_datum).toBe(true);
+    expect(meta.has_ridge_datum).toBe(true);
+    expect(meta.has_opening_tags).toBe(true);
+  });
+
+  test("W2 London stucco pack still drives elevation material and parapet cues", () => {
+    const fixture = createPolishFixture();
+    const pack = resolveUKVernacular({ postcode: "W2 5SH" });
+    expect(pack.packId).toBe("london-stucco-terrace");
+    const result = renderElevationSvg(
+      fixture,
+      {
+        materials: pack.materials.map((name) => ({
+          name,
+          application: /slate/i.test(name) ? "roof parapet" : "primary facade",
+          source: "ukVernacularPacks",
+        })),
+        facade_language: pack.facade_language,
+        roof_language: pack.roof_language,
+      },
+      {
+        orientation: "south",
+        vernacularPack: { ...pack, source: "ukVernacularPacks" },
+        facadeGrammar: createW2FacadeGrammar(pack),
+      },
+    );
+
+    expect(result.svg).toContain(
+      'data-vernacular-pack="london-stucco-terrace"',
+    );
+    expect(result.svg).toContain('data-pack-parapet="true"');
+    expect(result.svg).toContain('data-pack-facade-stucco="true"');
+    expect(result.svg).toContain('data-material-hatch="render"');
+    expect(result.svg).toMatch(/parapet|stucco|render/i);
+    expect(result.technical_quality_metadata.vernacular_pack_parapet).toBe(
+      true,
+    );
+    expect(result.technical_quality_metadata.vernacular_pack_has_stucco).toBe(
+      true,
+    );
+  });
 });
 
 describe("Phase 3 — section ground hatch and cut rooms", () => {
@@ -379,6 +477,33 @@ describe("Phase 3 — section ground hatch and cut rooms", () => {
     expect(
       result.technical_quality_metadata.cut_room_count,
     ).toBeGreaterThanOrEqual(0);
+  });
+
+  test("blueprint-grade section carries cut poche, ground hatch, datums and vertical dimensions", () => {
+    const fixture = createPolishFixture();
+    const result = renderSectionSvg(
+      fixture,
+      {},
+      { sectionType: "longitudinal" },
+    );
+    const meta = result.technical_quality_metadata;
+
+    expect(result.svg).toContain('data-blueprint-grade="true"');
+    expect(result.svg).toContain("cad-section-cut-poche");
+    expect(result.svg).toContain("cad-lineweight-cut");
+    expect(result.svg).toContain("cad-ground-hatch");
+    expect(result.svg).toContain("cad-foundation-build-up");
+    expect(result.svg).toContain("cad-slab-build-up");
+    expect(result.svg).toContain("cad-roof-build-up");
+    expect(result.svg).toContain("cad-vertical-dimension-chain");
+    expect(result.svg).toContain('data-datum-role="ffl"');
+    expect(result.svg).toContain('data-datum-role="eaves"');
+    expect(result.svg).toContain('data-datum-role="ridge"');
+    expect(meta.has_cad_layer_classes).toBe(true);
+    expect(meta.has_cad_lineweight_classes).toBe(true);
+    expect(meta.has_vertical_dimension_chain).toBe(true);
+    expect(meta.eaves_datum_count).toBeGreaterThan(0);
+    expect(meta.ridge_datum_count).toBeGreaterThan(0);
   });
 });
 

--- a/src/__tests__/services/drawingConsistencyChecks.test.js
+++ b/src/__tests__/services/drawingConsistencyChecks.test.js
@@ -12,31 +12,57 @@ function planSvg({
   scaleBar = true,
   roomLabel = true,
   dimensionChain = true,
+  roomArea = true,
+  sectionMarker = true,
 } = {}) {
   return [
     SVG_HEADER,
     northArrow ? '<g id="north-arrow"/>' : "",
     titleBlock ? '<g id="title-block"/>' : "",
     scaleBar ? '<g id="scale-bar"/>' : "",
+    '<g class="cad-layer-walls cad-lineweight-cut"/>',
     roomLabel ? '<text class="room-label">Living Room</text>' : "",
+    roomArea
+      ? '<text class="room-area-label" data-room-area-m2="24.0">24.0 m2</text>'
+      : "",
     dimensionChain ? '<g class="dimension-chain"/>' : "",
+    sectionMarker
+      ? '<g id="plan-section-markers"><g class="section-marker cad-section-marker" data-section-label="A-A"/></g>'
+      : "",
     SVG_FOOTER,
   ].join("");
 }
 
-function elevationSvg({ groundLine = true, fflMarker = true } = {}) {
+function elevationSvg({
+  groundLine = true,
+  fflMarker = true,
+  eavesDatum = true,
+  ridgeDatum = true,
+} = {}) {
   return [
     SVG_HEADER,
+    '<g class="cad-layer-material-hatches cad-lineweight-outline"/>',
     groundLine ? '<line id="ground-line"/>' : "",
-    fflMarker ? "<text>FFL +0.000</text>" : "",
+    fflMarker ? '<text data-datum-role="ffl-ground">FFL +0.000</text>' : "",
+    eavesDatum ? '<text data-datum-role="eaves">EAVES +6.200</text>' : "",
+    ridgeDatum ? '<text data-datum-role="ridge">RIDGE +7.200</text>' : "",
     SVG_FOOTER,
   ].join("");
 }
 
-function sectionSvg({ groundLine = true, sectionId = true } = {}) {
+function sectionSvg({
+  groundLine = true,
+  sectionId = true,
+  verticalDimension = true,
+} = {}) {
   return [
     SVG_HEADER,
-    groundLine ? '<line id="ground-line"/>' : "",
+    groundLine
+      ? '<g id="phase3-section-ground-hatch" class="cad-layer-ground cad-lineweight-cut"><line id="ground-line"/></g>'
+      : "",
+    verticalDimension
+      ? '<g class="cad-layer-dimensions cad-vertical-dimension-chain cad-lineweight-detail"/>'
+      : "",
     sectionId ? "<text>Section A-A</text>" : "",
     SVG_FOOTER,
   ].join("");
@@ -48,8 +74,10 @@ function productionPlanSvg() {
     '<g id="north-arrow"/>',
     '<g id="title-block"/>',
     '<g id="blueprint-scale-bar"/>',
-    '<g id="plan-room-labels"><g class="plan-room-label"><text>Reading Room</text></g></g>',
-    '<g class="dimension-chain horizontal"/>',
+    '<g class="cad-layer-walls cad-lineweight-cut"/>',
+    '<g id="plan-room-labels"><g class="plan-room-label" data-room-area-m2="32.0"><text>Reading Room</text><text class="room-area-label">32.0 m2</text></g></g>',
+    '<g class="dimension-chain horizontal cad-dimension-chain"/>',
+    '<g id="plan-section-markers"><g class="section-marker cad-section-marker" data-section-label="A-A"/></g>',
     SVG_FOOTER,
   ].join("");
 }
@@ -57,9 +85,12 @@ function productionPlanSvg() {
 function productionElevationSvg() {
   return [
     SVG_HEADER,
-    '<g id="phase8-ground-line"/>',
+    '<g id="phase8-ground-line" class="cad-layer-site-ground cad-lineweight-outline"/>',
+    '<g class="cad-layer-material-hatches"/>',
     '<g class="phase8-window"/>',
-    "<text>FFL +0.000</text>",
+    '<text data-datum-role="ffl-ground">FFL +0.000</text>',
+    '<text data-datum-role="eaves">EAVES +6.200</text>',
+    '<text data-datum-role="ridge">RIDGE +7.200</text>',
     SVG_FOOTER,
   ].join("");
 }
@@ -67,7 +98,8 @@ function productionElevationSvg() {
 function productionSectionSvg() {
   return [
     SVG_HEADER,
-    '<g id="phase3-section-ground-hatch"/>',
+    '<g id="phase3-section-ground-hatch" class="cad-layer-ground cad-lineweight-cut"/>',
+    '<g class="cad-layer-dimensions cad-vertical-dimension-chain cad-lineweight-detail"/>',
     '<g id="phase8-section-stair-cuts"/>',
     SVG_FOOTER,
   ].join("");
@@ -199,6 +231,98 @@ describe("runDrawingConsistencyChecks — per-view reliability", () => {
     expect(result.valid).toBe(true);
     expect(result.errors).toEqual([]);
     expect(result.warnings).toEqual([]);
+  });
+
+  test("CAD-grade QA warnings are non-blocking export warnings only", () => {
+    const result = runDrawingConsistencyChecks({
+      projectGeometry: {
+        levels: [{ id: 0 }],
+        windows: [{ id: "w1" }],
+        doors: [{ id: "d1" }],
+      },
+      drawings: {
+        plan: [
+          {
+            level_id: "0",
+            svg: planSvg({
+              roomLabel: false,
+              roomArea: false,
+              dimensionChain: false,
+              sectionMarker: false,
+            }),
+            window_count: 1,
+            door_count: 1,
+          },
+        ],
+        elevation: [
+          {
+            svg: elevationSvg({
+              fflMarker: false,
+              eavesDatum: false,
+              ridgeDatum: false,
+            }),
+            window_count: 1,
+            door_count: 1,
+          },
+        ],
+        section: [
+          {
+            svg: sectionSvg({
+              groundLine: false,
+              verticalDimension: false,
+            }),
+            section_id: "SECTION A-A",
+          },
+        ],
+      },
+      enableCrossViewChecks: false,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.checks.cadGradeTechnicalQa).toBe(true);
+    expect(result.checks.cadGradeTechnicalQaBlocking).toBe(false);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("CAD_QA_PLAN_ROOM_LABELS"),
+        expect.stringContaining("CAD_QA_PLAN_ROOM_AREAS"),
+        expect.stringContaining("CAD_QA_PLAN_DIMENSIONS"),
+        expect.stringContaining("CAD_QA_SECTION_MARKERS_MISSING"),
+        expect.stringContaining("CAD_QA_ELEVATION_FFL_DATUM"),
+        expect.stringContaining("CAD_QA_ELEVATION_EAVES_DATUM"),
+        expect.stringContaining("CAD_QA_ELEVATION_RIDGE_DATUM"),
+        expect.stringContaining("CAD_QA_SECTION_GROUND_LINE"),
+        expect.stringContaining("CAD_QA_SECTION_VERTICAL_DIMENSION"),
+      ]),
+    );
+  });
+
+  test("CAD-grade QA aligns compact section ids with plan markers", () => {
+    const matching = runDrawingConsistencyChecks({
+      projectGeometry: { levels: [{ id: 0 }] },
+      drawings: {
+        plan: [{ level_id: "0", svg: planSvg() }],
+        elevation: [{ svg: elevationSvg() }],
+        section: [{ svg: sectionSvg(), panel_type: "section_AA" }],
+      },
+      enableCrossViewChecks: false,
+    });
+    expect(matching.warnings.join("\n")).not.toContain(
+      "CAD_QA_SECTION_MARKER_ALIGNMENT",
+    );
+
+    const mismatched = runDrawingConsistencyChecks({
+      projectGeometry: { levels: [{ id: 0 }] },
+      drawings: {
+        plan: [{ level_id: "0", svg: planSvg() }],
+        elevation: [{ svg: elevationSvg() }],
+        section: [{ svg: sectionSvg(), panel_type: "section_BB" }],
+      },
+      enableCrossViewChecks: false,
+    });
+    expect(mismatched.warnings.join("\n")).toContain(
+      "CAD_QA_SECTION_MARKER_ALIGNMENT",
+    );
   });
 
   // Hotfix coverage: in the A1 sheet, the global title-block + north arrow

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -587,6 +587,44 @@ describe("projectGraphVerticalSliceService", () => {
         (q) => q.code === "CONTEXT_PROVIDERS_OFFLINE",
       ),
     ).toBe(true);
+    expect(result.architectReasoningManifest).toEqual(
+      expect.objectContaining({
+        asset_type: "architect_reasoning_manifest_json",
+        schema_version: "architect-reasoning-manifest-v1",
+        source_model_hash: result.geometryHash,
+        geometryHash: result.geometryHash,
+        authoritySource: "project_graph_compiled_geometry",
+        deterministic: true,
+        manifestHash: expect.any(String),
+      }),
+    );
+    expect(
+      result.architectReasoningManifest.prompt_splice_lines.length,
+    ).toBeGreaterThanOrEqual(6);
+    expect(
+      result.architectReasoningManifest.prompt_splice_lines.length,
+    ).toBeLessThanOrEqual(8);
+    expect(result.architectReasoningManifest.design_rationale).toEqual(
+      expect.objectContaining({
+        site_orientation: expect.any(String),
+        zoning: expect.any(String),
+        circulation: expect.any(String),
+        daylight: expect.any(String),
+        facade_vernacular: expect.any(String),
+        section_cut: expect.any(String),
+        material: expect.any(String),
+        qa_caveats: expect.any(String),
+      }),
+    );
+    expect(result.artifacts.architectReasoningManifest).toEqual(
+      result.architectReasoningManifest,
+    );
+    expect(result.artifacts.architectReasoningManifestHash).toBe(
+      result.architectReasoningManifest.manifestHash,
+    );
+    expect(result.artifacts.panelMap.key_notes.svgString).toContain(
+      "Design rationale",
+    );
     // Phase 5B — visual identity validation report attached to artifacts
     // and to sheet metadata. Deterministic-fallback path must not fail.
     // The validator is report-only; it never modifies the export gate
@@ -2366,6 +2404,10 @@ describe("projectGraphVerticalSliceService", () => {
       createReadingRoomBrief(),
     );
 
+    expect(second.geometryHash).toBe(first.geometryHash);
+    expect(second.architectReasoningManifest.manifestHash).toBe(
+      first.architectReasoningManifest.manifestHash,
+    );
     expect(second.artifacts.a1Pdf.renderedPngHash).toBe(
       first.artifacts.a1Pdf.renderedPngHash,
     );

--- a/src/config/featureFlags.js
+++ b/src/config/featureFlags.js
@@ -1447,6 +1447,62 @@ export const FEATURE_FLAGS = {
   dualQaQuantitativeScoring: true,
 
   /**
+   * Blueprint-grade deterministic technical renderer.
+   *
+   * When enabled, deterministic SVG technical panels emit CAD-grade layer
+   * classes, line-weight metadata, datums, dimension markers, and drafting
+   * annotations. This remains SVG / ProjectGraph authority only.
+   *
+   * @type {boolean}
+   * @default true
+   */
+  blueprintGradeTechnicalRenderer: true,
+
+  /**
+   * Architect reasoning manifest.
+   *
+   * When enabled, the ProjectGraph vertical slice emits a compact deterministic
+   * reasoning sidecar and a concise Design rationale group on Key Notes.
+   *
+   * @type {boolean}
+   * @default true
+   */
+  architectReasoningManifest: true,
+
+  /**
+   * CAD-grade technical QA.
+   *
+   * When enabled, deterministic drawing QA reports drafting-grade completeness
+   * gaps as warnings. It does not use qualitative LLM scoring.
+   *
+   * @type {boolean}
+   * @default true
+   */
+  cadGradeTechnicalQa: true,
+
+  /**
+   * CAD-grade technical QA blocking mode.
+   *
+   * Kept off for this PR: CAD-grade issues are warnings only and must not
+   * become export blockers.
+   *
+   * @type {boolean}
+   * @default false
+   */
+  cadGradeTechnicalQaBlocking: false,
+
+  /**
+   * Architect critique pass.
+   *
+   * Reserved for a future qualitative critique pass. Off by default and not
+   * used by technical SVG generation.
+   *
+   * @type {boolean}
+   * @default false
+   */
+  architectCritiquePass: false,
+
+  /**
    * Dual-scored QA report — qualitative LLM-rubric block (paper §4.6).
    *
    * When enabled, runs a fixed RIBA-rubric LLM evaluator and attaches a

--- a/src/services/drawing/svgElevationRenderer.js
+++ b/src/services/drawing/svgElevationRenderer.js
@@ -317,12 +317,14 @@ function renderRoof(
     roofLanguage.includes("flat") || roofLanguage.includes("parapet");
   if (flatRoof) {
     return `
-      <g id="phase14-section-roof" ${renderRoofPitchDataAttributes({
-        ...roofPitchInfo,
-        status: "flat",
-        pitchDeg: null,
-        riseM: null,
-      })}>
+      <g id="phase14-section-roof" class="cad-layer-roof cad-lineweight-outline" ${renderRoofPitchDataAttributes(
+        {
+          ...roofPitchInfo,
+          status: "flat",
+          pitchDeg: null,
+          riseM: null,
+        },
+      )}>
         <rect x="${formatNumber(baseX)}" y="${formatNumber(
           topY - 18,
         )}" width="${formatNumber(widthPx)}" height="4" fill="${theme.paper}" stroke="${theme.line}" stroke-width="1.2" />
@@ -359,7 +361,7 @@ function renderRoof(
     polish,
   );
   return `
-    <g id="phase14-section-roof" ${renderRoofPitchDataAttributes(roofPitchInfo)}>
+      <g id="phase14-section-roof" class="cad-layer-roof cad-lineweight-outline" ${renderRoofPitchDataAttributes(roofPitchInfo)}>
       <path d="M ${formatNumber(baseX - 6)} ${formatNumber(
         topY,
       )} L ${formatNumber(baseX + widthPx / 2)} ${formatNumber(
@@ -504,6 +506,26 @@ function renderLevelDatums(
   // Phase 3 — optional RIDGE datum. Caller passes `{ y, heightM }` when the
   // ridge height is known so the elevation matches the goal sheet's
   // "RIDGE +X.XXm" label band.
+  let eavesDatumCount = 0;
+  const lastLevel = levelProfiles[levelProfiles.length - 1] || null;
+  if (lastLevel && Number.isFinite(Number(lastLevel.top_m))) {
+    const eavesY = baseY - Number(lastLevel.top_m) * scale;
+    const eavesFont = polishSize(9, fontScale);
+    labels.push(`
+      <line class="cad-eaves-datum cad-lineweight-detail" x1="${formatNumber(baseX + widthPx + 6)}" y1="${formatNumber(
+        eavesY,
+      )}" x2="${formatNumber(baseX + widthPx + 44)}" y2="${formatNumber(
+        eavesY,
+      )}" stroke="${theme.lineMuted}" stroke-width="${guideStroke}" />
+      <text class="cad-eaves-datum-label" x="${formatNumber(
+        baseX + widthPx + 50,
+      )}" y="${formatNumber(eavesY + 4)}" font-size="${eavesFont}" font-family="Arial, sans-serif" font-weight="700" data-datum-role="eaves">${escapeXml(
+        `EAVES +${Number(lastLevel.top_m).toFixed(2)}m`,
+      )}</text>
+    `);
+    eavesDatumCount = 1;
+  }
+
   let ridgeDatumCount = 0;
   if (
     ridgeInfo &&
@@ -528,8 +550,10 @@ function renderLevelDatums(
   }
 
   return {
-    markup: `<g id="phase8-elevation-datums">${lines.join("")}${labels.join("")}</g>`,
-    count: levelProfiles.length + 1 + ridgeDatumCount,
+    markup: `<g id="phase8-elevation-datums" class="cad-layer-datums cad-elevation-datums">${lines.join("")}${labels.join("")}</g>`,
+    count: levelProfiles.length + 1 + eavesDatumCount + ridgeDatumCount,
+    hasEaves: eavesDatumCount > 0,
+    hasRidge: ridgeDatumCount > 0,
   };
 }
 
@@ -548,7 +572,7 @@ function renderProjectedOpenings(
     .sort(
       (left, right) => Number(left.center_m || 0) - Number(right.center_m || 0),
     )
-    .map((windowElement) => {
+    .map((windowElement, index) => {
       const level = levelProfiles.find(
         (entry) => entry.id === windowElement.levelId,
       );
@@ -571,6 +595,7 @@ function renderProjectedOpenings(
               sillY - 2,
             )}" stroke="${theme.lineLight}" stroke-width="1" />`
           : "";
+      const tag = `W${String(index + 1).padStart(2, "0")}`;
       return `
         <g class="phase8-window">
           <rect x="${formatNumber(x)}" y="${formatNumber(headY)}" width="${formatNumber(
@@ -586,12 +611,12 @@ function renderProjectedOpenings(
           )}" x2="${formatNumber(x + widthPx)}" y2="${formatNumber(
             sillY,
           )}" stroke="${theme.guide}" stroke-width="0.9" />
-          <line x1="${formatNumber(x)}" y1="${formatNumber(
+          <line class="cad-window-sill-line" x1="${formatNumber(x)}" y1="${formatNumber(
             sillY,
           )}" x2="${formatNumber(x + widthPx)}" y2="${formatNumber(
             sillY,
           )}" stroke="${theme.lineMuted}" stroke-width="1.05" />
-          <line x1="${formatNumber(x)}" y1="${formatNumber(
+          <line class="cad-window-head-line" x1="${formatNumber(x)}" y1="${formatNumber(
             headY,
           )}" x2="${formatNumber(x + widthPx)}" y2="${formatNumber(
             headY,
@@ -607,6 +632,7 @@ function renderProjectedOpenings(
             headY + 4,
           )}" stroke="${theme.guide}" stroke-width="0.8" />
           ${mullionMarkup}
+          <text class="cad-opening-tag cad-window-tag" x="${formatNumber(x + widthPx / 2)}" y="${formatNumber(headY - 4)}" font-size="8" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" fill="${theme.lineMuted}">${escapeXml(tag)}</text>
         </g>
       `;
     })
@@ -616,13 +642,14 @@ function renderProjectedOpenings(
     .sort(
       (left, right) => Number(left.center_m || 0) - Number(right.center_m || 0),
     )
-    .map((door) => {
+    .map((door, index) => {
       const level = levelProfiles.find((entry) => entry.id === door.levelId);
       if (!level) return "";
       const widthPx = Math.max(24, Number(door.width_m || 1.1) * scale);
       const x = baseX + Number(door.center_m || 0) * scale - widthPx / 2;
       const headY = projectY(level, door.head_height_m || 2.2);
       const heightPx = Math.max(26, baseY - headY);
+      const tag = `D${String(index + 1).padStart(2, "0")}`;
       return `
         <g class="phase8-door">
           <rect x="${formatNumber(x)}" y="${formatNumber(headY)}" width="${formatNumber(
@@ -638,6 +665,7 @@ function renderProjectedOpenings(
           )}" x2="${formatNumber(x + widthPx)}" y2="${formatNumber(
             baseY,
           )}" stroke="${theme.guide}" stroke-width="0.9" />
+          <text class="cad-opening-tag cad-door-tag" x="${formatNumber(x + widthPx / 2)}" y="${formatNumber(headY - 4)}" font-size="8" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" fill="${theme.lineMuted}">${escapeXml(tag)}</text>
           <line x1="${formatNumber(x)}" y1="${formatNumber(
             headY,
           )}" x2="${formatNumber(x + widthPx)}" y2="${formatNumber(
@@ -659,7 +687,7 @@ function renderProjectedOpenings(
     .join("");
 
   return {
-    markup: `<g id="phase9-elevation-openings">${windowMarkup}${doorMarkup}</g>`,
+    markup: `<g id="phase9-elevation-openings" class="cad-layer-openings cad-lineweight-secondary">${windowMarkup}${doorMarkup}</g>`,
     windowCount: (sideFacade.projectedWindows || []).length,
     doorCount: (sideFacade.projectedDoors || []).length,
   };
@@ -706,7 +734,7 @@ function renderRhythmGuides(
       ].map((centerM) => baseX + centerM * scale);
   const guides = guidePositions
     .map((x) => {
-      return `<line x1="${formatNumber(x)}" y1="${formatNumber(
+      return `<line class="cad-facade-rhythm-cue cad-lineweight-detail" x1="${formatNumber(x)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(x)}" y2="${formatNumber(
         baseY,
@@ -715,7 +743,7 @@ function renderRhythmGuides(
     .join("");
 
   return {
-    markup: `<g id="phase8-elevation-rhythm">${guides}</g>`,
+    markup: `<g id="phase8-elevation-rhythm" class="cad-layer-rhythm">${guides}</g>`,
     count: guidePositions.length,
   };
 }
@@ -784,7 +812,7 @@ function renderMaterialZones(
       );
       const labelX = x + zoneWidthPx / 2;
       return `
-        <g class="phase8-elevation-material-zone" data-zone-index="${index}">
+        <g class="phase8-elevation-material-zone cad-material-hatch" data-zone-index="${index}" data-material-hatch="${escapeXml(String(materialKey || ""))}">
           <rect x="${formatNumber(x)}" y="${formatNumber(
             baseY - heightPx,
           )}" width="${formatNumber(zoneWidthPx)}" height="${formatNumber(
@@ -814,7 +842,7 @@ function renderMaterialZones(
 
   return {
     markup: `
-      <g id="phase8-elevation-material-zones">
+      <g id="phase8-elevation-material-zones" class="cad-layer-material-hatches">
         ${markup}
         <rect x="${formatNumber(baseX)}" y="${formatNumber(
           baseY - heightPx,
@@ -1137,7 +1165,7 @@ function renderFacadeFeatures(
 
 function renderGroundLine(baseX, baseY, widthPx, theme) {
   return `
-    <g id="phase8-ground-line">
+    <g id="phase8-ground-line" class="cad-layer-site-ground cad-lineweight-outline">
       <rect x="${formatNumber(baseX - 18)}" y="${formatNumber(
         baseY,
       )}" width="${formatNumber(widthPx + 36)}" height="24" fill="url(#phase8-elev-ground)" />
@@ -1167,7 +1195,7 @@ function renderOverallDimensions(
   const guideStroke = polishSize(0.9, polish.strokeScale || 1);
   const primaryStroke = polishSize(1, polish.strokeScale || 1);
   return `
-    <g id="phase8-elevation-dimensions">
+    <g id="phase8-elevation-dimensions" class="cad-layer-dimensions cad-dimension-chain-overall cad-vertical-dimension-chain cad-lineweight-detail">
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(baseX)}" y2="${formatNumber(
@@ -1399,6 +1427,7 @@ export function renderElevationSvg(
   const width = options.width || 1200;
   const height = options.height || 760;
   const sheetMode = options.sheetMode === true;
+  const blueprintGrade = isFeatureEnabled("blueprintGradeTechnicalRenderer");
   const sheetPolish = resolveElevationPolish(sheetMode);
   const showInternalTitleBlock =
     !sheetMode || options.showInternalTitleBlock === true;
@@ -1694,7 +1723,7 @@ export function renderElevationSvg(
   const semiBasementMarkup =
     packSemiBasement && semiBasementHeightPx > 0
       ? `
-  <g data-vernacular-feature="semi_basement">
+  <g data-vernacular-feature="semi_basement" class="cad-plinth-base cad-semi-basement-cue">
     <rect x="${formatNumber(baseX)}" y="${formatNumber(baseY)}" width="${formatNumber(
       widthPx,
     )}" height="${formatNumber(semiBasementHeightPx)}" fill="${theme.paperMuted || theme.paper}" stroke="${theme.line}" stroke-width="0.7" stroke-dasharray="4 2" />
@@ -1713,9 +1742,10 @@ export function renderElevationSvg(
     : "";
 
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${theme.name}" data-bounds-source="${envelope.source}"${packDataAttrs}>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${theme.name}" data-bounds-source="${envelope.source}" data-blueprint-grade="${blueprintGrade ? "true" : "false"}"${packDataAttrs}>
   ${buildMaterialPatternDefs(theme)}
   <rect width="${width}" height="${height}" fill="${theme.paper}" />
+  ${blueprintGrade ? '<g class="cad-lineweight-registry cad-lineweight-outline cad-lineweight-projection cad-lineweight-detail" data-cad-layer="lineweight-registry"/>' : ""}
   ${
     sheetMode
       ? ""
@@ -1784,6 +1814,8 @@ export function renderElevationSvg(
       shading_count: facadeOrientation?.shading_elements?.length || 0,
       material_zone_count: materialZones.count,
       ffl_marker_count: datums.count,
+      eaves_datum_count: datums.hasEaves ? 1 : 0,
+      ridge_datum_count: datums.hasRidge ? 1 : 0,
       sill_lintel_count: openings.windowCount * 2 + openings.doorCount,
       feature_count: featureMarkup.count,
       facade_richness_score: facadeRichnessScore,
@@ -1821,6 +1853,24 @@ export function renderElevationSvg(
       vernacular_pack_semi_basement: packSemiBasement,
       vernacular_pack_window_language: packWindowLanguageRaw || null,
       vernacular_pack_has_stucco: packHasStucco,
+      cad_grade_renderer: blueprintGrade,
+      cad_layer_classes: [
+        "cad-layer-material-hatches",
+        "cad-layer-datums",
+        "cad-layer-openings",
+        "cad-layer-rhythm",
+        "cad-layer-dimensions",
+      ],
+      cad_lineweight_classes: [
+        "cad-lineweight-outline",
+        "cad-lineweight-projection",
+        "cad-lineweight-detail",
+      ],
+      has_cad_layer_classes: blueprintGrade,
+      has_cad_lineweight_classes: blueprintGrade,
+      has_eaves_datum: datums.hasEaves,
+      has_ridge_datum: datums.hasRidge,
+      has_opening_tags: openings.windowCount + openings.doorCount > 0,
     },
   };
 }

--- a/src/services/drawing/svgPlanRenderer.js
+++ b/src/services/drawing/svgPlanRenderer.js
@@ -343,16 +343,16 @@ function renderRoomLabel(room = {}, project, theme) {
   );
 
   return `
-    <g class="plan-room-label">
+    <g class="plan-room-label" data-room-id="${escapeXml(room.id || room.name || "")}" data-room-area-m2="${formatNumber(areaValue, 1)}">
       <rect x="${formatNumber(labelPoint.x - labelWidth / 2)}" y="${formatNumber(
         labelPoint.y - 22,
-      )}" width="${formatNumber(labelWidth)}" height="38" fill="${theme.paper}" fill-opacity="0.95" stroke="${theme.guide}" stroke-width="0.95" rx="4" ry="4"/>
+      )}" width="${formatNumber(labelWidth)}" height="38" fill="${theme.paper}" fill-opacity="0.95" stroke="${theme.guide}" stroke-width="0.95" rx="4" ry="4" class="cad-room-label-backplate cad-lineweight-detail"/>
       <text x="${formatNumber(labelPoint.x)}" y="${formatNumber(
         labelPoint.y - 6,
-      )}" font-size="13" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" class="sheet-critical-label" data-text-role="critical">${name}</text>
+      )}" font-size="13" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" class="sheet-critical-label cad-room-name-label" data-text-role="critical">${name}</text>
       <text x="${formatNumber(labelPoint.x)}" y="${formatNumber(
         labelPoint.y + 10,
-      )}" font-size="10" font-family="Arial, sans-serif" text-anchor="middle" class="sheet-critical-label" data-text-role="critical">${escapeXml(
+      )}" font-size="10" font-family="Arial, sans-serif" text-anchor="middle" class="sheet-critical-label room-area-label cad-text-room-area" data-text-role="critical">${escapeXml(
         secondaryLine,
       )}</text>
     </g>
@@ -455,7 +455,7 @@ function renderWallMarkup(walls = [], project, theme) {
       const fill = wall.exterior ? theme.poche : theme.pocheSoft;
       const stroke = wall.exterior ? theme.line : theme.lineMuted;
       const strokeWidth = wall.exterior ? 2.05 : 1.28;
-      return `<path d="${path}" fill="${fill}" fill-opacity="${wall.exterior ? "0.98" : "0.76"}" stroke="${stroke}" stroke-width="${strokeWidth}" stroke-linejoin="miter" data-wall-role="${wall.exterior ? "exterior" : "interior"}"/>`;
+      return `<path class="cad-wall-poche ${wall.exterior ? "cad-lineweight-cut cad-wall-exterior" : "cad-lineweight-primary cad-wall-interior"}" d="${path}" fill="${fill}" fill-opacity="${wall.exterior ? "0.98" : "0.76"}" stroke="${stroke}" stroke-width="${strokeWidth}" stroke-linejoin="miter" data-wall-role="${wall.exterior ? "exterior" : "interior"}"/>`;
     })
     .join("");
 }
@@ -472,7 +472,7 @@ function renderWindowMarkup(
     (entry) =>
       `${entry.wall_id || ""}:${entry.position_m?.x || 0}:${entry.position_m?.y || 0}:${entry.id || ""}`,
   )
-    .map((windowElement) => {
+    .map((windowElement, index) => {
       const wall = wallMap.get(windowElement.wall_id);
       const vectors = wallVectors(wall);
       if (!vectors) {
@@ -542,6 +542,11 @@ function renderWindowMarkup(
         x: gapB.x - jambNxPx * jambHalfPx,
         y: gapB.y - jambNyPx * jambHalfPx,
       };
+      const tagPoint = project({
+        x: center.x + vectors.normal.x * (thicknessM + 0.28),
+        y: center.y + vectors.normal.y * (thicknessM + 0.28),
+      });
+      const tag = `W${String(index + 1).padStart(2, "0")}`;
 
       return `
         <g class="plan-window" data-window-id="${escapeXml(windowElement.id || "")}">
@@ -577,6 +582,7 @@ function renderWindowMarkup(
           )}" x2="${formatNumber(jambEndFace2.x)}" y2="${formatNumber(
             jambEndFace2.y,
           )}" stroke="${theme.line}" stroke-width="1.05" stroke-linecap="square"/>
+          <text class="cad-opening-tag cad-window-tag" x="${formatNumber(tagPoint.x)}" y="${formatNumber(tagPoint.y)}" font-size="8" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" fill="${theme.lineMuted}">${escapeXml(tag)}</text>
         </g>
       `;
     })
@@ -595,7 +601,7 @@ function renderDoorMarkup(
     (entry) =>
       `${entry.wall_id || ""}:${entry.position_m?.x || 0}:${entry.position_m?.y || 0}:${entry.id || ""}`,
   )
-    .map((door) => {
+    .map((door, index) => {
       const wall = wallMap.get(door.wall_id);
       const vectors = wallVectors(wall);
       if (!vectors) {
@@ -665,6 +671,11 @@ function renderDoorMarkup(
         closedVector.x * openVector.y - closedVector.y * openVector.x >= 0
           ? 1
           : 0;
+      const tagPoint = {
+        x: (hingePx.x + closedPx.x + openPx.x) / 3,
+        y: (hingePx.y + closedPx.y + openPx.y) / 3,
+      };
+      const tag = `D${String(index + 1).padStart(2, "0")}`;
 
       return `
         <g class="plan-door" data-door-id="${escapeXml(door.id || "")}">
@@ -691,10 +702,11 @@ function renderDoorMarkup(
             radiusPx,
           )} 0 0 ${sweepFlag} ${formatNumber(openPx.x)} ${formatNumber(
             openPx.y,
-          )}" fill="none" stroke="${theme.lineMuted}" stroke-width="1.15"/>
+          )}" fill="none" stroke="${theme.lineMuted}" stroke-width="1.15" class="cad-door-swing-arc cad-lineweight-detail"/>
           <circle cx="${formatNumber(hingePx.x)}" cy="${formatNumber(
             hingePx.y,
           )}" r="1.8" fill="${theme.line}"/>
+          <text class="cad-opening-tag cad-door-tag" x="${formatNumber(tagPoint.x)}" y="${formatNumber(tagPoint.y)}" font-size="8" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" fill="${theme.lineMuted}">${escapeXml(tag)}</text>
         </g>
       `;
     })
@@ -793,15 +805,15 @@ function renderStairMarkup(stairs = [], project, theme) {
           )}" x2="${formatNumber(topRight.x - 6)}" y2="${formatNumber(
             topLeft.y + 6,
           )}" stroke="${theme.guide}" stroke-width="0.85" stroke-dasharray="4 3"/>
-          <line x1="${formatNumber(arrowStart.x)}" y1="${formatNumber(
+          <line class="plan-stair-arrow cad-stair-arrow cad-lineweight-primary" x1="${formatNumber(arrowStart.x)}" y1="${formatNumber(
             arrowStart.y,
           )}" x2="${formatNumber(arrowEnd.x)}" y2="${formatNumber(
             arrowEnd.y,
           )}" stroke="${theme.line}" stroke-width="1.35"/>
-          <path d="${arrowHead}" fill="${theme.line}"/>
+          <path class="plan-stair-arrow-head cad-stair-arrow" d="${arrowHead}" fill="${theme.line}"/>
           <text x="${formatNumber(
             (topLeft.x + topRight.x) / 2,
-          )}" y="${formatNumber(bottomLeft.y - 6)}" font-size="10" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" class="sheet-critical-label" data-text-role="critical">UP</text>
+          )}" y="${formatNumber(bottomLeft.y - 6)}" font-size="10" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" class="sheet-critical-label cad-stair-label" data-text-role="critical">UP</text>
         </g>
       `;
     })
@@ -983,7 +995,7 @@ function renderExternalDimensions(
   });
 
   const markup = `
-    <g id="external-dimensions">
+    <g id="external-dimensions" class="cad-layer-dimensions cad-dimension-chain-overall cad-lineweight-detail" data-dimension-chain-types="overall bay opening internal">
       <line x1="${formatNumber(topLeft.x)}" y1="${formatNumber(
         topLeft.y,
       )}" x2="${formatNumber(topLeft.x)}" y2="${formatNumber(
@@ -1047,8 +1059,8 @@ function renderExternalDimensions(
       )} ${formatNumber(
         (topRight.y + bottomRight.y) / 2,
       )})" text-anchor="middle">${escapeXml(formatMeters(bounds.height))}</text>
-      ${horizontalChain.markup ? `<g class="dimension-chain horizontal">${horizontalChain.markup}</g>` : ""}
-      ${verticalChain.markup ? `<g class="dimension-chain vertical">${verticalChain.markup}</g>` : ""}
+      ${horizontalChain.markup ? `<g class="dimension-chain horizontal"><g class="cad-dimension-chain cad-dimension-chain-bay cad-dimension-chain-internal">${horizontalChain.markup}</g></g>` : ""}
+      ${verticalChain.markup ? `<g class="dimension-chain vertical"><g class="cad-dimension-chain cad-dimension-chain-opening cad-dimension-chain-internal">${verticalChain.markup}</g></g>` : ""}
     </g>
   `;
 
@@ -1181,7 +1193,7 @@ function renderSectionMarkers(sections, project, theme) {
     const py = ux;
     const tickLen = 8;
     labels.push(`${letter}-${letter}`);
-    return `<g class="section-marker" data-section-id="${escapeXml(section.id || "")}" data-section-type="${escapeXml(section.sectionType || "")}" data-section-letter="${letter}">
+    return `<g class="section-marker cad-section-marker cad-lineweight-primary" data-section-id="${escapeXml(section.id || "")}" data-section-type="${escapeXml(section.sectionType || "")}" data-section-letter="${letter}" data-section-label="${letter}-${letter}">
       <line x1="${formatNumber(from.x)}" y1="${formatNumber(from.y)}" x2="${formatNumber(to.x)}" y2="${formatNumber(to.y)}" stroke="${theme.line}" stroke-width="1.4" stroke-dasharray="10 4 2 4"/>
       <circle cx="${formatNumber(from.x)}" cy="${formatNumber(from.y)}" r="9" fill="${theme.paper}" stroke="${theme.line}" stroke-width="1.3"/>
       <circle cx="${formatNumber(to.x)}" cy="${formatNumber(to.y)}" r="9" fill="${theme.paper}" stroke="${theme.line}" stroke-width="1.3"/>
@@ -1237,6 +1249,7 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
   const width = options.width || 1200;
   const height = options.height || 900;
   const sheetMode = options.sheetMode === true;
+  const blueprintGrade = isFeatureEnabled("blueprintGradeTechnicalRenderer");
   const showInternalTitleBlock =
     !sheetMode || options.showInternalTitleBlock === true;
   const includeSiteContext = options.includeSiteContext === true && !sheetMode;
@@ -1410,8 +1423,9 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
   );
 
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${theme.name}" data-bounds-source="${boundsSource}">
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${theme.name}" data-bounds-source="${boundsSource}" data-blueprint-grade="${blueprintGrade ? "true" : "false"}">
   <rect width="${width}" height="${height}" fill="${theme.paper}"/>
+  ${blueprintGrade ? '<g class="cad-lineweight-registry cad-lineweight-cut cad-lineweight-primary cad-lineweight-secondary cad-lineweight-detail" data-cad-layer="lineweight-registry"/>' : ""}
   ${
     siteOutline
       ? `<path d="${siteOutline}" fill="none" stroke="${theme.guide}" stroke-width="1" stroke-dasharray="8 5"/>`
@@ -1422,14 +1436,14 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
       ? `<path d="${buildableOutline}" fill="none" stroke="${theme.lineLight}" stroke-width="1" stroke-dasharray="4 4"/>`
       : ""
   }
-  ${footprintPath ? `<path d="${footprintPath}" fill="none" stroke="${theme.lineMuted}" stroke-width="1.1"/>` : ""}
-  ${roomFillMarkup}
+  ${footprintPath ? `<path class="cad-building-footprint cad-lineweight-primary" d="${footprintPath}" fill="none" stroke="${theme.lineMuted}" stroke-width="1.1"/>` : ""}
+  ${roomFillMarkup ? `<g class="cad-layer-rooms cad-lineweight-secondary">${roomFillMarkup}</g>` : ""}
   ${furnitureHints.markup}
-  <g id="plan-walls">${wallMarkup}</g>
-  <g id="plan-openings">${windowMarkup}${doorMarkup}</g>
+  <g id="plan-walls" class="cad-layer-walls">${wallMarkup}</g>
+  <g id="plan-openings" class="cad-layer-openings cad-lineweight-secondary">${windowMarkup}${doorMarkup}</g>
   ${circulationMarkup ? `<g id="plan-circulation">${circulationMarkup}</g>` : ""}
-  ${stairMarkup ? `<g id="plan-stairs">${stairMarkup}</g>` : ""}
-  ${roomLabelMarkup ? `<g id="plan-room-labels">${roomLabelMarkup}</g>` : ""}
+  ${stairMarkup ? `<g id="plan-stairs" class="cad-layer-stairs">${stairMarkup}</g>` : ""}
+  ${roomLabelMarkup ? `<g id="plan-room-labels" class="cad-layer-annotations">${roomLabelMarkup}</g>` : ""}
   ${sectionMarkers.markup}
   ${dimensionMarkup}
   ${!sheetMode ? renderNorthArrow(width, layout, theme, geometry.site?.north_orientation_deg || 0) : ""}
@@ -1478,6 +1492,25 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
         dimensionResult.chain.horizontalSegmentCount,
       dimension_chain_vertical_segments:
         dimensionResult.chain.verticalSegmentCount,
+      cad_grade_renderer: blueprintGrade,
+      cad_layer_classes: [
+        "cad-layer-rooms",
+        "cad-layer-walls",
+        "cad-layer-openings",
+        "cad-layer-stairs",
+        "cad-layer-annotations",
+        "cad-layer-dimensions",
+      ],
+      cad_lineweight_classes: [
+        "cad-lineweight-cut",
+        "cad-lineweight-primary",
+        "cad-lineweight-secondary",
+        "cad-lineweight-detail",
+      ],
+      dimension_chain_types: ["overall", "bay", "opening", "internal"],
+      has_room_area_labels: !options.hideRoomLabels && levelRooms.length > 0,
+      has_cad_layer_classes: blueprintGrade,
+      has_cad_lineweight_classes: blueprintGrade,
       line_hierarchy: {
         exterior_wall: 2.05,
         interior_wall: 1.28,

--- a/src/services/drawing/svgSectionRenderer.js
+++ b/src/services/drawing/svgSectionRenderer.js
@@ -439,7 +439,7 @@ function renderGroundHatch(
     );
   }
   return {
-    markup: `<g id="phase3-section-ground-hatch" data-grade-band="true">
+    markup: `<g id="phase3-section-ground-hatch" class="cad-layer-ground cad-ground-hatch" data-grade-band="true">
       <rect x="${formatNumber(startX)}" y="${formatNumber(startY)}" width="${formatNumber(bandWidth)}" height="${formatNumber(bandHeight)}" fill="${fill}" fill-opacity="${fillOpacity}"/>
       ${lines.join("")}
       <line id="ground-line" x1="${formatNumber(startX)}" y1="${formatNumber(startY)}" x2="${formatNumber(startX + bandWidth)}" y2="${formatNumber(startY)}" stroke="${SECTION_THEME.line}" stroke-width="1.1"/>
@@ -521,7 +521,7 @@ function renderOverallSectionDimensions(
   const guideStroke = polishSize(0.9, polish.strokeScale || 1);
   const primaryStroke = polishSize(1, polish.strokeScale || 1);
   return `
-    <g id="phase8-section-dimensions">
+    <g id="phase8-section-dimensions" class="cad-layer-dimensions cad-vertical-dimension-chain cad-dimension-chain-overall cad-lineweight-detail">
       <line x1="${formatNumber(baseX)}" y1="${formatNumber(
         baseY - heightPx,
       )}" x2="${formatNumber(baseX)}" y2="${formatNumber(
@@ -597,6 +597,7 @@ function renderLevelDatums(
   scale,
   lineweights = {},
   polish = {},
+  options = {},
 ) {
   const lines = [];
   const labels = [];
@@ -612,7 +613,7 @@ function renderLevelDatums(
     const midY =
       baseY - (level.bottom_m + Number(level.height_m || 3.2) / 2) * scale;
     lines.push(
-      `<line x1="${baseX}" y1="${topY}" x2="${baseX + widthPx}" y2="${topY}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${datumWeight}" stroke-dasharray="10 6" />`,
+      `<line class="cad-section-ceiling-datum cad-lineweight-detail" x1="${baseX}" y1="${topY}" x2="${baseX + widthPx}" y2="${topY}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${datumWeight}" stroke-dasharray="10 6" data-datum-role="ceiling" />`,
     );
     labels.push(`
       <g class="phase8-section-level-label">
@@ -630,14 +631,38 @@ function renderLevelDatums(
   });
 
   labels.push(`
-    <line x1="${baseX - 52}" y1="${baseY}" x2="${baseX - 6}" y2="${baseY}" stroke="${SECTION_THEME.line}" stroke-width="${secondaryStroke}" />
+    <line class="cad-section-ffl-datum" x1="${baseX - 52}" y1="${baseY}" x2="${baseX - 6}" y2="${baseY}" stroke="${SECTION_THEME.line}" stroke-width="${secondaryStroke}" data-datum-role="ffl" />
     <rect x="${baseX - 144}" y="${baseY - 11}" width="86" height="16" rx="3" ry="3" fill="${SECTION_THEME.paper}" fill-opacity="0.94" stroke="${SECTION_THEME.guide}" stroke-width="${labelStroke}" />
-    <text x="${baseX - 134}" y="${baseY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical">FFL +0.00m</text>
+    <text x="${baseX - 134}" y="${baseY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical" data-datum-role="ffl">FFL +0.00m</text>
   `);
 
+  let eavesDatumCount = 0;
+  const eavesHeightM = Number(options.eavesHeightM);
+  if (Number.isFinite(eavesHeightM) && eavesHeightM > 0) {
+    const eavesY = baseY - eavesHeightM * scale;
+    labels.push(`
+      <line class="cad-section-eaves-datum cad-lineweight-detail" x1="${baseX + widthPx + 6}" y1="${eavesY}" x2="${baseX + widthPx + 48}" y2="${eavesY}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${secondaryStroke}" data-datum-role="eaves" />
+      <text class="cad-section-eaves-datum-label" x="${baseX + widthPx + 54}" y="${eavesY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" data-datum-role="eaves">EAVES +${eavesHeightM.toFixed(2)}m</text>
+    `);
+    eavesDatumCount = 1;
+  }
+
+  let ridgeDatumCount = 0;
+  const ridgeHeightM = Number(options.ridgeHeightM);
+  if (Number.isFinite(ridgeHeightM) && ridgeHeightM > eavesHeightM) {
+    const ridgeY = baseY - ridgeHeightM * scale;
+    labels.push(`
+      <line class="cad-section-ridge-datum cad-lineweight-detail" x1="${baseX + widthPx + 6}" y1="${ridgeY}" x2="${baseX + widthPx + 48}" y2="${ridgeY}" stroke="${SECTION_THEME.line}" stroke-width="${secondaryStroke}" data-datum-role="ridge" />
+      <text class="cad-section-ridge-datum-label" x="${baseX + widthPx + 54}" y="${ridgeY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" data-datum-role="ridge">RIDGE +${ridgeHeightM.toFixed(2)}m</text>
+    `);
+    ridgeDatumCount = 1;
+  }
+
   return {
-    markup: `<g id="phase8-section-datums">${lines.join("")}${labels.join("")}</g>`,
-    count: levelProfiles.length + 1,
+    markup: `<g id="phase8-section-datums" class="cad-layer-datums cad-section-datums">${lines.join("")}${labels.join("")}</g>`,
+    count: levelProfiles.length + 1 + eavesDatumCount + ridgeDatumCount,
+    hasEaves: eavesDatumCount > 0,
+    hasRidge: ridgeDatumCount > 0,
   };
 }
 
@@ -732,7 +757,7 @@ function renderFoundation(
     return `<path d="M ${startX} ${y} L ${startX + 8} ${y + 4} L ${startX + 16} ${y} L ${startX + 24} ${y + 4}" fill="none" stroke="${SECTION_THEME.guide}" stroke-width="${lineweights.guide || 0.72}" />`;
   }).join("");
   return `
-    <g id="phase8-section-foundation" data-truth="${quality}" data-truth-mode="${truthMode}" data-truth-state="${truthState}">
+    <g id="phase8-section-foundation" class="cad-layer-foundation cad-foundation-build-up" data-truth="${quality}" data-truth-mode="${truthMode}" data-truth-state="${truthState}">
       <rect x="${baseX - 10}" y="${baseY}" width="${widthPx + 20}" height="42" fill="${SECTION_THEME.paper}" fill-opacity="${fillOpacity}" />
       <rect x="${baseX - 14}" y="${baseY + 12}" width="${widthPx + 28}" height="18" fill="${SECTION_THEME.fillSoft}" fill-opacity="0.24" />
       ${bandMarkup}
@@ -863,7 +888,7 @@ function renderRoof(
     .join("");
   if (flat) {
     return `
-      <g id="phase14-section-roof" data-truth="${quality}" data-truth-mode="${truthMode}" data-truth-state="${truthState}" ${renderRoofPitchDataAttributes(
+      <g id="phase14-section-roof" class="cad-layer-roof cad-roof-build-up cad-lineweight-outline" data-truth="${quality}" data-truth-mode="${truthMode}" data-truth-state="${truthState}" ${renderRoofPitchDataAttributes(
         {
           ...roofPitchInfo,
           status: "flat",
@@ -911,7 +936,7 @@ function renderRoof(
     roofPitchInfo,
   );
   return `
-    <g id="phase14-section-roof" data-truth="${quality}" data-truth-mode="${truthMode}" data-truth-state="${truthState}" ${renderRoofPitchDataAttributes(roofPitchInfo)}>
+    <g id="phase14-section-roof" class="cad-layer-roof cad-roof-build-up cad-lineweight-outline" data-truth="${quality}" data-truth-mode="${truthMode}" data-truth-state="${truthState}" ${renderRoofPitchDataAttributes(roofPitchInfo)}>
     <path d="M ${roofX - 4} ${topY} L ${roofX + roofWidth / 2} ${ridgeY} L ${roofX + roofWidth + 4} ${topY} L ${roofX + roofWidth - 12} ${topY} L ${roofX + roofWidth / 2} ${undersideY} L ${roofX + 12} ${topY} Z" fill="${SECTION_THEME.fillSoft}" fill-opacity="${quality === "blocked" ? 0.42 : quality === "weak" ? 0.66 : 0.92}" stroke="${SECTION_THEME.lineMuted}" stroke-opacity="${strokeOpacity}" stroke-width="${lineweights.primary || 1.4}"${dasharray} />
     <path d="M ${roofX} ${topY} L ${roofX + roofWidth / 2} ${ridgeY} L ${roofX + roofWidth} ${topY}" fill="none" stroke="${SECTION_THEME.line}" stroke-opacity="${strokeOpacity}" stroke-width="${lineweights.cutOutline || 2}"${dasharray} />
     <path d="M ${roofX + 12} ${topY} L ${roofX + roofWidth / 2} ${undersideY} L ${roofX + roofWidth - 12} ${topY}" fill="none" stroke="${SECTION_THEME.lineMuted}" stroke-opacity="${strokeOpacity}" stroke-width="${lineweights.primary || 1.2}"${dasharray} />
@@ -987,7 +1012,7 @@ function renderCutRooms(
       const areaY = y + heightPx / 2 + (nameLines.length > 1 ? 18 : 11);
 
       return `
-        <g class="phase8-cut-room">
+        <g class="phase8-cut-room cad-section-room-label">
           <rect x="${x}" y="${y}" width="${widthPx}" height="${heightPx}" fill="${SECTION_THEME.paper}" stroke="${SECTION_THEME.line}" stroke-width="${roomStroke}" />
           <line x1="${x}" y1="${y + heightPx}" x2="${x + widthPx}" y2="${y + heightPx}" stroke="${SECTION_THEME.line}" stroke-width="${roomCutStroke}" />
           <line x1="${x}" y1="${y}" x2="${x}" y2="${y + heightPx}" stroke="${SECTION_THEME.line}" stroke-width="${roomCutStroke}" />
@@ -999,7 +1024,7 @@ function renderCutRooms(
     .join("");
 
   return {
-    markup: `<g id="phase8-section-cut-rooms">${markup}</g>`,
+    markup: `<g id="phase8-section-cut-rooms" class="cad-layer-room-cuts">${markup}</g>`,
     count: cutRooms.length,
   };
 }
@@ -1074,11 +1099,11 @@ function renderStairCut(
       )} L ${formatNumber(arrowEnd.x + 4)} ${formatNumber(arrowEnd.y + 2)} Z`;
 
       return `
-        <g id="phase8-section-stair-${escapeXml(stair.id || "stair")}" data-truth-state="${truthState}">
+        <g id="phase8-section-stair-${escapeXml(stair.id || "stair")}" class="cad-section-stair-cut" data-truth-state="${truthState}">
           <rect x="${x}" y="${y}" width="${widthPx}" height="${heightPx}" fill="${SECTION_THEME.paper}" fill-opacity="${fillOpacity}" stroke="${SECTION_THEME.line}" stroke-width="1.6"${strokeDash} />
           <line x1="${x + 3}" y1="${y + 4}" x2="${x + 3}" y2="${y + heightPx - 4}" stroke="${SECTION_THEME.line}" stroke-width="1.15"${strokeDash} />
           ${treads}
-          <line x1="${formatNumber(arrowStart.x)}" y1="${formatNumber(
+          <line class="cad-stair-section-arrow" x1="${formatNumber(arrowStart.x)}" y1="${formatNumber(
             arrowStart.y,
           )}" x2="${formatNumber(arrowEnd.x)}" y2="${formatNumber(
             arrowEnd.y,
@@ -1096,7 +1121,7 @@ function renderStairCut(
     .join("");
 
   return {
-    markup: `<g id="phase8-section-stair-cuts">${markup}</g>`,
+    markup: `<g id="phase8-section-stair-cuts" class="cad-layer-stair-cuts">${markup}</g>`,
     count: (stairs || []).length,
     treadCount: (stairs || []).reduce(
       (sum, stair) => sum + Number(stair.treadCount || 7),
@@ -1132,7 +1157,7 @@ function renderSlabCuts(
       );
       const edgeInset = Math.min(6, Math.max(3, slab.width * 0.04));
       return `
-        <g id="phase14-section-slab-${escapeXml(slab.level?.id || slab.id)}" data-truth="${quality}" data-truth-state="${truthState}">
+        <g id="phase14-section-slab-${escapeXml(slab.level?.id || slab.id)}" class="cad-layer-slab cad-slab-build-up" data-truth="${quality}" data-truth-state="${truthState}">
           <rect x="${slab.x || 0}" y="${slab.y}" width="${slab.width}" height="${buildUpDepth}" fill="${SECTION_THEME.fillSoft}" fill-opacity="${fillOpacity}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.primary || 1.2}"${dasharray} />
           <line x1="${slab.x || 0}" y1="${slab.y}" x2="${(slab.x || 0) + slab.width}" y2="${slab.y}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.cutOutline || 1.8}"${dasharray} />
           <line x1="${slab.x || 0}" y1="${slab.y}" x2="${slab.x || 0}" y2="${slab.y + buildUpDepth}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.secondary || 1}" />
@@ -1143,7 +1168,7 @@ function renderSlabCuts(
     })
     .join("");
   return {
-    markup: `<g id="phase14-section-slabs">${markup}</g>`,
+    markup: `<g id="phase14-section-slabs" class="cad-layer-slab-build-up">${markup}</g>`,
     count: (slabs || []).length,
   };
 }
@@ -1189,7 +1214,7 @@ function renderCutWalls(
         truthState === "direct" ? "" : ' stroke-dasharray="7 4"';
 
       return `
-        <g id="phase13-section-cut-wall-${escapeXml(wall.id || index)}" data-truth-state="${truthState}">
+        <g id="phase13-section-cut-wall-${escapeXml(wall.id || index)}" class="cad-section-cut-poche cad-lineweight-cut" data-truth-state="${truthState}">
           <rect x="${x}" y="${y}" width="${widthPx}" height="${heightPx}" fill="${SECTION_THEME.poche}" fill-opacity="${fillOpacity}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.cutOutline || 1.8}"${strokeDash} />
           <line x1="${x}" y1="${y + 3}" x2="${x}" y2="${y + heightPx - 3}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.primary || 1.2}"${strokeDash} />
           <line x1="${x + widthPx}" y1="${y + 3}" x2="${x + widthPx}" y2="${y + heightPx - 3}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.primary || 1.2}"${strokeDash} />
@@ -1204,7 +1229,7 @@ function renderCutWalls(
     .join("");
 
   return {
-    markup: `<g id="phase13-section-cut-walls">${markup}</g>`,
+    markup: `<g id="phase13-section-cut-walls" class="cad-layer-cut-poche">${markup}</g>`,
     count: (walls || []).length,
   };
 }
@@ -1283,6 +1308,7 @@ export function renderSectionSvg(
   const width = options.width || 1200;
   const height = options.height || 760;
   const sheetMode = options.sheetMode === true;
+  const blueprintGrade = isFeatureEnabled("blueprintGradeTechnicalRenderer");
   const sheetPolish = resolveSectionPolish(sheetMode);
   const showInternalTitleBlock =
     !sheetMode || options.showInternalTitleBlock === true;
@@ -1492,6 +1518,14 @@ export function renderSectionSvg(
     };
   }
 
+  const sectionEavesHeightM = totalHeight;
+  const sectionRidgeHeightM =
+    Number.isFinite(Number(roofPitchInfoBase.riseM)) &&
+    Number(roofPitchInfoBase.riseM) > 0
+      ? totalHeight + Number(roofPitchInfoBase.riseM)
+      : packParapet
+        ? totalHeight + 0.45
+        : null;
   const datums = renderLevelDatums(
     baseX,
     baseY,
@@ -1500,6 +1534,10 @@ export function renderSectionSvg(
     scale,
     lineweights,
     sheetPolish,
+    {
+      eavesHeightM: sectionEavesHeightM,
+      ridgeHeightM: sectionRidgeHeightM,
+    },
   );
   const foundation = renderFoundation(
     baseX,
@@ -1708,8 +1746,9 @@ export function renderSectionSvg(
       )}" data-pack-parapet="${packParapet}"`
     : "";
   const svg = `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${SECTION_THEME.name}" data-bounds-source="${envelopeBounds.source}" data-a1-quality-polish="${sheetMode ? "section_datums_dimensions_v2" : "section_standard"}" data-section-edge-clearance-status="${sectionVisualMetrics.edgeClearanceStatus}" data-section-body-occupancy="${sectionVisualMetrics.bodyOccupancyRatio}"${packDataAttrs}>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-theme="${SECTION_THEME.name}" data-bounds-source="${envelopeBounds.source}" data-a1-quality-polish="${sheetMode ? "section_datums_dimensions_v2" : "section_standard"}" data-section-edge-clearance-status="${sectionVisualMetrics.edgeClearanceStatus}" data-section-body-occupancy="${sectionVisualMetrics.bodyOccupancyRatio}" data-blueprint-grade="${blueprintGrade ? "true" : "false"}"${packDataAttrs}>
   <rect width="${width}" height="${height}" fill="${SECTION_THEME.paper}" />
+  ${blueprintGrade ? '<g class="cad-lineweight-registry cad-lineweight-cut cad-lineweight-projection cad-lineweight-detail" data-cad-layer="lineweight-registry"/>' : ""}
   ${stairMarkup.defs || ""}
   ${
     sheetMode
@@ -1729,9 +1768,13 @@ export function renderSectionSvg(
   ${datums.markup}
   ${slabMarkup.markup}
   ${cutRoomMarkup.markup}
-  ${wallMarkup.markup}
-  ${openingMarkup.markup}
-  ${stairMarkup.markup}
+  ${
+    wallMarkup.markup
+      ? `<g class="cad-layer-cut-poche cad-section-cut-poche cad-lineweight-cut">${wallMarkup.markup}</g>`
+      : ""
+  }
+  ${openingMarkup.markup ? `<g class="cad-layer-openings">${openingMarkup.markup}</g>` : ""}
+  ${stairMarkup.markup ? `<g class="cad-layer-stair-cuts">${stairMarkup.markup}</g>` : ""}
   ${renderOverallSectionDimensions(
     baseX,
     baseY,
@@ -1774,6 +1817,9 @@ export function renderSectionSvg(
       foundation_marker_count: 1,
       ground_hatch_band_lines: groundHatch.count,
       ground_hatch_visible: groundHatch.count > 0,
+      vertical_dimension_chain_count: 1,
+      eaves_datum_count: datums.hasEaves ? 1 : 0,
+      ridge_datum_count: datums.hasRidge ? 1 : 0,
       stair_tread_count: stairMarkup.treadCount,
       roof_profile_visible: true,
       roof_pitch_degrees: roofPitchInfo.pitchDeg,
@@ -1813,6 +1859,25 @@ export function renderSectionSvg(
       section_edge_clearance_status: sectionVisualMetrics.edgeClearanceStatus,
       section_edge_clearances_px: sectionVisualMetrics.edgeClearancesPx,
       section_min_edge_clearance_px: sectionVisualMetrics.minEdgeClearancePx,
+      cad_grade_renderer: blueprintGrade,
+      cad_layer_classes: [
+        "cad-layer-ground",
+        "cad-layer-foundation",
+        "cad-layer-slab-build-up",
+        "cad-layer-cut-poche",
+        "cad-layer-room-cuts",
+        "cad-layer-stair-cuts",
+        "cad-layer-datums",
+        "cad-layer-dimensions",
+      ],
+      cad_lineweight_classes: [
+        "cad-lineweight-cut",
+        "cad-lineweight-projection",
+        "cad-lineweight-detail",
+      ],
+      has_cad_layer_classes: blueprintGrade,
+      has_cad_lineweight_classes: blueprintGrade,
+      has_vertical_dimension_chain: true,
       slot_occupancy_ratio: slotOccupancyRatio,
       scale_bar_meters: scaleBar.barMeters,
       section_evidence_quality:

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -114,6 +114,8 @@ import { resolveMainEntryDirection } from "../site/mainEntryDirectionService.js"
 export const PROJECT_GRAPH_SCHEMA_VERSION = "project-graph-v1";
 export const PROJECT_GRAPH_VERTICAL_SLICE_VERSION =
   "project-graph-vertical-slice-v1";
+export const ARCHITECT_REASONING_MANIFEST_VERSION =
+  "architect-reasoning-manifest-v1";
 
 const PROFESSIONAL_REVIEW_DISCLAIMER =
   "AI-generated early-stage architecture package. Regulation checks are preliminary design flags and require professional review.";
@@ -5791,6 +5793,7 @@ function splitNoteLines(note = "", maxChars = 36, maxLines = 3) {
 // across runs so the panel order is deterministic regardless of input.
 const KEY_NOTE_GROUP_ORDER = Object.freeze([
   "style_provenance",
+  "design_rationale",
   "external_walls",
   "roof",
   "windows_doors",
@@ -5820,6 +5823,287 @@ function describeMaterial(material) {
   return tail.length ? `${name} (${tail.join(" / ")})` : name;
 }
 
+function compactManifestText(value, fallback = "", maxLength = 180) {
+  const raw = String(value || fallback || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!raw) return "";
+  if (raw.length <= maxLength) return raw;
+  return `${raw.slice(0, Math.max(0, maxLength - 1)).trimEnd()}.`;
+}
+
+function summarizeProgrammeZones(
+  programmeSummary = null,
+  compiledProject = {},
+) {
+  const roomsPerLevel =
+    programmeSummary && typeof programmeSummary === "object"
+      ? programmeSummary.rooms_per_level || {}
+      : {};
+  const levelSummaries = Object.entries(roomsPerLevel)
+    .map(([level, rooms]) => {
+      const roomList = Array.isArray(rooms) ? rooms : [];
+      if (!roomList.length) return "";
+      return `${level}: ${roomList.slice(0, 4).join(", ")}`;
+    })
+    .filter(Boolean);
+  if (levelSummaries.length) {
+    return levelSummaries.slice(0, 2).join("; ");
+  }
+
+  const zones = [
+    ...new Set(
+      (compiledProject.rooms || [])
+        .map((room) => room.zone || room.programme_zone || room.function)
+        .filter(Boolean)
+        .map((entry) => String(entry).trim()),
+    ),
+  ];
+  return zones.length ? zones.slice(0, 4).join(", ") : "programme zones";
+}
+
+function summarizeCirculationStrategy(compiledProject = {}) {
+  const circulationRooms = (compiledProject.rooms || []).filter((room) =>
+    /circulation|hall|landing|lobby|stair/i.test(
+      `${room.name || ""} ${room.function || ""} ${room.zone || ""}`,
+    ),
+  );
+  const stairCount = (compiledProject.stairs || []).length;
+  const levelCount = (compiledProject.levels || []).length;
+  const circulationNames = circulationRooms
+    .map((room) => room.name || room.function || room.id)
+    .filter(Boolean)
+    .slice(0, 3);
+  const names = circulationNames.length
+    ? ` via ${circulationNames.join(", ")}`
+    : "";
+  const stairText = stairCount
+    ? `${stairCount} stair core${stairCount === 1 ? "" : "s"}`
+    : "direct horizontal circulation";
+  return `${stairText}${names}; ${Math.max(1, levelCount || 1)} level stack.`;
+}
+
+function summarizeDaylightStrategy(compiledProject = {}, climate = {}) {
+  const windowCount = (compiledProject.windows || []).length;
+  const southOrWestWindows = (compiledProject.windows || []).filter((window) =>
+    /south|west/i.test(
+      `${window.orientation || ""} ${window.side || ""} ${window.wall_side || ""}`,
+    ),
+  ).length;
+  const climateCue =
+    climate?.design_strategy ||
+    climate?.strategy ||
+    climate?.zone ||
+    climate?.koppen ||
+    "UK temperate default";
+  return `${windowCount} external opening${windowCount === 1 ? "" : "s"} coordinate daylight; ${southOrWestWindows} south/west aperture cue${southOrWestWindows === 1 ? "" : "s"}; ${climateCue}.`;
+}
+
+function summarizeVernacularStrategy(localStyle = {}) {
+  const provenance =
+    localStyle?.style_provenance &&
+    typeof localStyle.style_provenance === "object"
+      ? localStyle.style_provenance
+      : {};
+  const packLabel = provenance.packLabel || provenance.label || null;
+  const facade =
+    provenance.facade_language ||
+    localStyle?.styleDNA?.facade_language ||
+    localStyle?.facade_language ||
+    "local facade grammar";
+  const windows =
+    provenance.window_language ||
+    localStyle?.styleDNA?.window_language ||
+    localStyle?.window_language ||
+    "coordinated openings";
+  const roof =
+    provenance.roof_language ||
+    localStyle?.styleDNA?.roof_language ||
+    localStyle?.roof_language ||
+    "contextual roofline";
+  return packLabel
+    ? `${packLabel}: ${facade}; ${windows}; ${roof}.`
+    : `${facade}; ${windows}; ${roof}.`;
+}
+
+function summarizeMaterialRationale(
+  localStyle = {},
+  sheetDesignContext = null,
+) {
+  const provenanceMaterials = Array.isArray(
+    localStyle?.style_provenance?.materials,
+  )
+    ? localStyle.style_provenance.materials
+    : [];
+  const contextMaterials = Array.isArray(sheetDesignContext?.materials)
+    ? sheetDesignContext.materials.map((entry) =>
+        typeof entry === "string" ? entry : entry?.name || entry?.material,
+      )
+    : [];
+  const paletteMaterials = Array.isArray(localStyle?.material_palette)
+    ? localStyle.material_palette.map((entry) =>
+        typeof entry === "string" ? entry : entry?.name || entry?.material,
+      )
+    : [];
+  const materials = [
+    ...new Set(
+      [...provenanceMaterials, ...contextMaterials, ...paletteMaterials]
+        .filter(Boolean)
+        .map((entry) => String(entry).trim()),
+    ),
+  ];
+  return materials.length
+    ? `Material logic follows ${materials.slice(0, 4).join(", ")}.`
+    : "Material logic follows local style palette and canonical facade/roof defaults.";
+}
+
+function summarizeSectionCutRationale(
+  compiledProject = {},
+  technicalBuild = {},
+) {
+  const sectionCandidates = Array.isArray(
+    compiledProject.sectionCuts?.candidates,
+  )
+    ? compiledProject.sectionCuts.candidates
+    : [];
+  const renderedSections = (technicalBuild.technicalPanelTypes || []).filter(
+    (type) => String(type).startsWith("section_"),
+  );
+  const candidateText = sectionCandidates.length
+    ? sectionCandidates
+        .slice(0, 2)
+        .map(
+          (entry) =>
+            entry.strategyName ||
+            entry.strategyId ||
+            entry.sectionType ||
+            entry.id,
+        )
+        .filter(Boolean)
+        .join(", ")
+    : "longitudinal and transverse building cuts";
+  return `${renderedSections.length || 2} coordinated section view${(renderedSections.length || 2) === 1 ? "" : "s"} use ${candidateText}.`;
+}
+
+function buildArchitectReasoningManifest({
+  projectGraphId,
+  brief,
+  site,
+  climate,
+  regulations,
+  localStyle,
+  programmeSummary,
+  compiledProject,
+  technicalBuild,
+  sheetDesignContext = null,
+}) {
+  if (!isFeatureEnabled("architectReasoningManifest")) return null;
+
+  const geometryHash = compiledProject?.geometryHash || null;
+  const siteOrientation = compactManifestText(
+    `Site/orientation: main entry ${site?.main_entry?.orientation || "north"} (${site?.main_entry?.source || "fallback"}), north ${Number(site?.north_angle_degrees || 0).toFixed(0)} deg, boundary ${site?.boundary_source || "site geometry"}.`,
+  );
+  const zoning = compactManifestText(
+    `Zoning: ${summarizeProgrammeZones(programmeSummary, compiledProject)}.`,
+  );
+  const circulation = compactManifestText(
+    `Circulation: ${summarizeCirculationStrategy(compiledProject)}.`,
+  );
+  const daylight = compactManifestText(
+    `Daylight: ${summarizeDaylightStrategy(compiledProject, climate)}.`,
+  );
+  const facadeVernacular = compactManifestText(
+    `Facade/vernacular: ${summarizeVernacularStrategy(localStyle)}`,
+  );
+  const sectionCut = compactManifestText(
+    `Section cuts: ${summarizeSectionCutRationale(compiledProject, technicalBuild)}`,
+  );
+  const material = compactManifestText(
+    `Materials: ${summarizeMaterialRationale(localStyle, sheetDesignContext)}`,
+  );
+  const qaCaveat = compactManifestText(
+    `QA caveats: deterministic concept package; ${PROFESSIONAL_REVIEW_DISCLAIMER}`,
+  );
+  const promptSpliceLines = [
+    siteOrientation,
+    zoning,
+    circulation,
+    daylight,
+    facadeVernacular,
+    sectionCut,
+    material,
+    qaCaveat,
+  ].filter(Boolean);
+  const keyNoteLines = [
+    `${siteOrientation} ${zoning}`,
+    `${circulation} ${daylight}`,
+    `${facadeVernacular} ${material}`,
+    `${sectionCut} ${qaCaveat}`,
+  ].map((line) => compactManifestText(line, "", 220));
+
+  const manifestBody = {
+    asset_type: "architect_reasoning_manifest_json",
+    schema_version: ARCHITECT_REASONING_MANIFEST_VERSION,
+    source_model_hash: geometryHash,
+    geometryHash,
+    projectGraphId,
+    generated_by: PROJECT_GRAPH_VERTICAL_SLICE_VERSION,
+    deterministic: true,
+    authoritySource: "project_graph_compiled_geometry",
+    prompt_splice_lines: promptSpliceLines.slice(0, 8),
+    key_note_lines: keyNoteLines.filter(Boolean).slice(0, 4),
+    design_rationale: {
+      site_orientation: siteOrientation,
+      zoning,
+      circulation,
+      daylight,
+      facade_vernacular: facadeVernacular,
+      section_cut: sectionCut,
+      material,
+      qa_caveats: qaCaveat,
+    },
+    inputs: {
+      building_type: brief?.building_type || null,
+      canonical_building_type: brief?.canonical_building_type || null,
+      target_storeys: brief?.target_storeys || null,
+      target_gia_m2: brief?.target_gia_m2 || null,
+      postcode: brief?.site_input?.postcode || site?.postcode || null,
+      climate_source: climate?.weather_source || climate?.source || null,
+      regulation_parts: Array.isArray(regulations?.parts)
+        ? regulations.parts
+            .map((part) => part.part || part.id || part.name)
+            .filter(Boolean)
+        : [],
+      vernacular_pack_id:
+        localStyle?.style_provenance?.ukVernacularPackId ||
+        localStyle?.style_provenance?.packId ||
+        null,
+    },
+    qa_caveats: [
+      "CAD-grade checks are warning-only in this PR.",
+      "Regulatory checks are preliminary concept-stage flags.",
+      "Verify dimensions, structure, planning, and buildability with qualified professionals.",
+    ],
+  };
+  const manifestHash = computeCDSHashSync({
+    schema_version: manifestBody.schema_version,
+    source_model_hash: geometryHash,
+    prompt_splice_lines: manifestBody.prompt_splice_lines,
+    design_rationale: manifestBody.design_rationale,
+    inputs: manifestBody.inputs,
+  });
+  return {
+    asset_id: createStableId(
+      "asset-architect-reasoning",
+      projectGraphId,
+      geometryHash,
+      manifestHash,
+    ),
+    manifestHash,
+    ...manifestBody,
+  };
+}
+
 export function buildKeyNoteItems({
   brief,
   site,
@@ -5828,6 +6112,7 @@ export function buildKeyNoteItems({
   localStyle,
   sheetDesignContext = null,
   qaSummary = null,
+  architectReasoningManifest = null,
 }) {
   const ctxMaterials =
     Array.isArray(sheetDesignContext?.materials) &&
@@ -5943,6 +6228,12 @@ export function buildKeyNoteItems({
     }
   }
 
+  const designRationaleLines =
+    architectReasoningManifest &&
+    Array.isArray(architectReasoningManifest.key_note_lines)
+      ? architectReasoningManifest.key_note_lines.slice(0, 4)
+      : [];
+
   // QA summary — paper §4.6 dual-track assessment. Optional; when the caller
   // hasn't supplied a qaSummary (panel built before QA computed), the group
   // emits no lines and is filtered out. When supplied, surfaces the
@@ -5982,6 +6273,10 @@ export function buildKeyNoteItems({
     style_provenance: {
       heading: "Style provenance",
       lines: styleProvenanceLines,
+    },
+    design_rationale: {
+      heading: "Design rationale",
+      lines: designRationaleLines,
     },
     qa_summary: {
       heading: "QA summary",
@@ -6093,6 +6388,7 @@ export function buildKeyNotesPanelArtifact({
   geometryHash,
   sheetDesignContext = null,
   qaSummary = null,
+  architectReasoningManifest = null,
 }) {
   const width = 560;
   const height = 900;
@@ -6104,6 +6400,7 @@ export function buildKeyNotesPanelArtifact({
     localStyle,
     sheetDesignContext,
     qaSummary,
+    architectReasoningManifest,
   });
   let cursorY = 102;
   const groupSvg = groups
@@ -6875,6 +7172,7 @@ async function buildSheetPanelArtifacts({
   // consumers; not consumed by the existing data-panel builders yet.
   // eslint-disable-next-line no-unused-vars
   sheetDesignContext = null,
+  architectReasoningManifest = null,
   // Optional partial QA summary precomputed before panels (programme
   // adjacency + quantitative metrics — both pure functions of compiledProject
   // and projectGraph and therefore safe to compute pre-panel). Surfaces on
@@ -6909,6 +7207,7 @@ async function buildSheetPanelArtifacts({
     geometryHash,
     sheetDesignContext,
     qaSummary,
+    architectReasoningManifest,
   });
   const titleBlock = buildTitleBlockPanelArtifact({
     projectGraphId,
@@ -8066,6 +8365,7 @@ async function buildA1Sheet({
   // Phase 1: optional SheetDesignContext. Existing callers may omit it; the
   // function does not yet hard-depend on it.
   sheetDesignContext = null,
+  architectReasoningManifest = null,
 }) {
   const __a1sheetStart = Date.now();
   const __a1sheetLog = (step, sinceMs, extra = "") => {
@@ -8160,6 +8460,7 @@ async function buildA1Sheet({
     },
     visualManifest,
     sheetDesignContext,
+    architectReasoningManifest,
     qaSummary: panelQaSummary,
   });
   __a1mark = __a1sheetLog("build_panel_artifacts", __a1mark);
@@ -11085,6 +11386,25 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     __vsMark,
     `hash=${sheetDesignContext.contextHash} ok=${sheetDesignContextReport.ok} gaps=${sheetDesignContextReport.gaps.length}`,
   );
+  const architectReasoningManifest = buildArchitectReasoningManifest({
+    projectGraphId,
+    brief,
+    site,
+    climate,
+    regulations,
+    localStyle,
+    programmeSummary,
+    compiledProject,
+    technicalBuild,
+    sheetDesignContext,
+  });
+  if (architectReasoningManifest) {
+    __vsMark = __vsLog(
+      "architect_reasoning_manifest",
+      __vsMark,
+      `lines=${architectReasoningManifest.prompt_splice_lines.length}`,
+    );
+  }
   const renderedSheets = [];
   for (const sheetPlan of splitDecision.sheets) {
     const sheetIndex = renderedSheets.length;
@@ -11109,6 +11429,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       sheetPlan,
       visualManifest,
       sheetDesignContext,
+      architectReasoningManifest,
     });
     __vsMark = __vsLog(`build_a1_sheet[${sheetTag}]`, __vsMark);
     const pdfStart = Date.now();
@@ -11543,6 +11864,9 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     sheetDesignContext,
     sheetDesignContextHash: sheetDesignContext.contextHash,
     sheetDesignContextReport,
+    architectReasoningManifest,
+    architectReasoningManifestHash:
+      architectReasoningManifest?.manifestHash || null,
     // Phase 5B — post-render visual identity validation report. Warning-
     // only by default; opt-in strict mode lets a downstream export gate
     // demote on visual-identity drift. The validator reads what panel
@@ -11724,8 +12048,10 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     projectTypeSupport: brief.project_type_support || null,
     projectGraph: finalGraph,
     provenanceManifest,
+    architectReasoningManifest,
     artifacts: {
       ...artifacts,
+      ...(architectReasoningManifest ? { architectReasoningManifest } : {}),
       qaReport: {
         asset_id: createStableId(
           "asset-qa",
@@ -11778,6 +12104,7 @@ export const __projectGraphVerticalSliceInternals = Object.freeze({
   buildProjectGeometryFromProgramme,
   syncProgrammeActuals,
   compileProject,
+  buildArchitectReasoningManifest,
   // Phase 4: exposed for unit testing the upstream-gate technical-blocker fold.
   applyUpstreamGateTechnicalBlockersToQa,
 });
@@ -11785,6 +12112,7 @@ export const __projectGraphVerticalSliceInternals = Object.freeze({
 export default {
   PROJECT_GRAPH_SCHEMA_VERSION,
   PROJECT_GRAPH_VERTICAL_SLICE_VERSION,
+  ARCHITECT_REASONING_MANIFEST_VERSION,
   buildArchitectureProjectVerticalSlice,
   buildArchitectureProjectVerticalSliceWithRepair,
   validateProjectGraphVerticalSlice,

--- a/src/services/validation/drawingConsistencyChecks.js
+++ b/src/services/validation/drawingConsistencyChecks.js
@@ -1,3 +1,5 @@
+import { isFeatureEnabled } from "../../config/featureFlags.js";
+
 function hasSvgPayload(entry) {
   return Boolean(entry?.svg && String(entry.svg).includes("<svg"));
 }
@@ -29,6 +31,130 @@ function numberFromEntry(entry, keys = []) {
     }
   }
   return 0;
+}
+
+function valueFromEntry(entry, keys = []) {
+  for (const key of keys) {
+    const value =
+      entry?.[key] ??
+      entry?.metadata?.[key] ??
+      entry?.technicalQualityMetadata?.[key] ??
+      entry?.technical_quality_metadata?.[key] ??
+      entry?.metadata?.technicalQualityMetadata?.[key] ??
+      entry?.metadata?.technical_quality_metadata?.[key];
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function hasAnyClassToken(svg, tokens = []) {
+  return tokens.some((token) => svgHasClassToken(svg, token));
+}
+
+function hasCadLineweightClasses(entry, svg) {
+  const classes = valueFromEntry(entry, ["cad_lineweight_classes"]);
+  return (
+    (Array.isArray(classes) && classes.length > 0) ||
+    hasAnyClassToken(svg, [
+      "cad-lineweight-cut",
+      "cad-lineweight-outline",
+      "cad-lineweight-primary",
+      "cad-lineweight-secondary",
+      "cad-lineweight-projection",
+      "cad-lineweight-detail",
+    ])
+  );
+}
+
+function hasCadLayerClasses(entry, svg) {
+  const classes = valueFromEntry(entry, ["cad_layer_classes"]);
+  return (
+    (Array.isArray(classes) && classes.length > 0) ||
+    hasAnyClassToken(svg, [
+      "cad-layer-walls",
+      "cad-layer-material-hatches",
+      "cad-layer-ground",
+      "cad-layer-dimensions",
+      "cad-layer-datums",
+    ])
+  );
+}
+
+function hasPlanRoomAreas(entry, svg) {
+  return (
+    numberFromEntry(entry, ["area_label_count"]) > 0 ||
+    valueFromEntry(entry, ["has_room_area_labels"]) === true ||
+    svgHasClassToken(svg, "room-area-label") ||
+    /data-room-area-m2=/i.test(String(svg || ""))
+  );
+}
+
+function hasPlanSectionMarkers(entry, svg) {
+  return (
+    numberFromEntry(entry, ["section_marker_count"]) > 0 ||
+    svgHasId(svg, "plan-section-markers") ||
+    svgHasClassToken(svg, "section-marker")
+  );
+}
+
+function hasElevationDatum(entry, svg, datumRole) {
+  const normalized = String(datumRole || "").toLowerCase();
+  if (normalized === "eaves") {
+    return (
+      numberFromEntry(entry, ["eaves_datum_count"]) > 0 ||
+      /data-datum-role=["']eaves["']/i.test(String(svg || ""))
+    );
+  }
+  if (normalized === "ridge") {
+    return (
+      numberFromEntry(entry, ["ridge_datum_count"]) > 0 ||
+      /data-datum-role=["']ridge["']/i.test(String(svg || ""))
+    );
+  }
+  return /data-datum-role=["']ffl(?:-ground)?["']|FFL/i.test(String(svg || ""));
+}
+
+function hasSectionVerticalDimension(entry, svg) {
+  return (
+    numberFromEntry(entry, ["vertical_dimension_chain_count"]) > 0 ||
+    valueFromEntry(entry, ["has_vertical_dimension_chain"]) === true ||
+    svgHasClassToken(svg, "cad-vertical-dimension-chain")
+  );
+}
+
+function collectPlanSectionLabels(entries = []) {
+  const labels = new Set();
+  for (const entry of entries || []) {
+    const metaLabels = valueFromEntry(entry, ["section_marker_labels"]);
+    if (Array.isArray(metaLabels)) {
+      metaLabels.forEach((label) => labels.add(String(label).toUpperCase()));
+    }
+    const svg = String(entry?.svg || "");
+    const matches = svg.matchAll(/data-section-label=["']([^"']+)["']/gi);
+    for (const match of matches) {
+      labels.add(String(match[1] || "").toUpperCase());
+    }
+  }
+  return labels;
+}
+
+function normalizeSectionLabel(entry = {}) {
+  const normalized = String(entry.section_id || entry.panel_type || "")
+    .replace(/^SECTION[_ -]?/i, "")
+    .replace(/^section[_ -]?/i, "")
+    .replace(/_/g, "-")
+    .toUpperCase();
+  const compact = normalized.replace(/[^A-Z]/g, "");
+  if (
+    compact.length === 2 &&
+    compact[0] === compact[1] &&
+    !normalized.includes("-")
+  ) {
+    return `${compact[0]}-${compact[1]}`;
+  }
+  return normalized;
 }
 
 function hasPlanScaleBar(entry, svg) {
@@ -364,6 +490,135 @@ function validateCrossViewConsistency({ drawings = {}, projectGeometry = {} }) {
   return warnings;
 }
 
+function validateCadGradeTechnicalQa({ drawings = {}, projectGeometry = {} }) {
+  const warnings = [];
+  const planEntries = drawings.plan || [];
+  const elevationEntries = drawings.elevation || [];
+  const sectionEntries = drawings.section || [];
+
+  planEntries.forEach((entry, index) => {
+    const svg = String(entry?.svg || "");
+    if (svg && !hasPlanRoomLabels(entry, svg)) {
+      warnings.push(
+        `CAD_QA_PLAN_ROOM_LABELS: drawings.plan[${index}] has no room labels.`,
+      );
+    }
+    if (svg && !hasPlanRoomAreas(entry, svg)) {
+      warnings.push(
+        `CAD_QA_PLAN_ROOM_AREAS: drawings.plan[${index}] has no room area labels.`,
+      );
+    }
+    if (svg && !hasDimensionChain(entry, svg)) {
+      warnings.push(
+        `CAD_QA_PLAN_DIMENSIONS: drawings.plan[${index}] has no dimension chain.`,
+      );
+    }
+    if (svg && !hasPlanSectionMarkers(entry, svg)) {
+      warnings.push(
+        `CAD_QA_SECTION_MARKERS_MISSING: drawings.plan[${index}] has no coordinated section markers.`,
+      );
+    }
+    if (
+      svg &&
+      (!hasCadLayerClasses(entry, svg) || !hasCadLineweightClasses(entry, svg))
+    ) {
+      warnings.push(
+        `CAD_QA_LINEWEIGHT_CLASSES: drawings.plan[${index}] is missing CAD layer or line-weight classes.`,
+      );
+    }
+  });
+
+  elevationEntries.forEach((entry, index) => {
+    const svg = String(entry?.svg || "");
+    if (svg && !hasElevationDatum(entry, svg, "ffl")) {
+      warnings.push(
+        `CAD_QA_ELEVATION_FFL_DATUM: drawings.elevation[${index}] has no FFL datum.`,
+      );
+    }
+    if (svg && !hasElevationDatum(entry, svg, "eaves")) {
+      warnings.push(
+        `CAD_QA_ELEVATION_EAVES_DATUM: drawings.elevation[${index}] has no eaves datum.`,
+      );
+    }
+    if (svg && !hasElevationDatum(entry, svg, "ridge")) {
+      warnings.push(
+        `CAD_QA_ELEVATION_RIDGE_DATUM: drawings.elevation[${index}] has no ridge/parapet datum.`,
+      );
+    }
+    if (
+      svg &&
+      (!hasCadLayerClasses(entry, svg) || !hasCadLineweightClasses(entry, svg))
+    ) {
+      warnings.push(
+        `CAD_QA_LINEWEIGHT_CLASSES: drawings.elevation[${index}] is missing CAD layer or line-weight classes.`,
+      );
+    }
+  });
+
+  sectionEntries.forEach((entry, index) => {
+    const svg = String(entry?.svg || "");
+    if (svg && !hasGroundLine(entry, svg)) {
+      warnings.push(
+        `CAD_QA_SECTION_GROUND_LINE: drawings.section[${index}] has no ground line or hatch.`,
+      );
+    }
+    if (svg && !hasSectionVerticalDimension(entry, svg)) {
+      warnings.push(
+        `CAD_QA_SECTION_VERTICAL_DIMENSION: drawings.section[${index}] has no vertical dimension chain.`,
+      );
+    }
+    if (
+      svg &&
+      (!hasCadLayerClasses(entry, svg) || !hasCadLineweightClasses(entry, svg))
+    ) {
+      warnings.push(
+        `CAD_QA_LINEWEIGHT_CLASSES: drawings.section[${index}] is missing CAD layer or line-weight classes.`,
+      );
+    }
+  });
+
+  const expectedOpenings =
+    (projectGeometry.windows || []).length +
+    (projectGeometry.doors || []).length;
+  const planOpenings = planEntries.reduce(
+    (sum, entry) =>
+      sum +
+      Number(entry?.window_count || 0) +
+      numberFromEntry(entry, ["door_count"]),
+    0,
+  );
+  const elevationOpenings = elevationEntries.reduce(
+    (sum, entry) =>
+      sum +
+      Number(entry?.window_count || 0) +
+      numberFromEntry(entry, ["door_count"]),
+    0,
+  );
+  if (
+    expectedOpenings > 0 &&
+    ((planOpenings > 0 && planOpenings !== expectedOpenings) ||
+      (elevationOpenings > 0 && elevationOpenings !== expectedOpenings))
+  ) {
+    warnings.push(
+      `CAD_QA_OPENING_COUNT_ALIGNMENT: ProjectGraph has ${expectedOpenings} openings, plans report ${planOpenings}, elevations report ${elevationOpenings}.`,
+    );
+  }
+
+  const planSectionLabels = collectPlanSectionLabels(planEntries);
+  if (sectionEntries.length && planSectionLabels.size) {
+    sectionEntries.forEach((entry, index) => {
+      const label = normalizeSectionLabel(entry);
+      if (label && !planSectionLabels.has(label)) {
+        warnings.push(
+          `CAD_QA_SECTION_MARKER_ALIGNMENT: drawings.section[${index}] (${label}) has no matching plan section marker.`,
+        );
+      }
+    });
+  }
+
+  return warnings;
+}
+
 export function runDrawingConsistencyChecks({
   projectGeometry,
   drawings = {},
@@ -406,6 +661,16 @@ export function runDrawingConsistencyChecks({
     warnings.push(...crossViewWarnings);
   }
 
+  const cadGradeTechnicalQa = isFeatureEnabled("cadGradeTechnicalQa");
+  if (cadGradeTechnicalQa) {
+    warnings.push(
+      ...validateCadGradeTechnicalQa({
+        drawings,
+        projectGeometry,
+      }),
+    );
+  }
+
   return {
     valid: errors.length === 0,
     warnings,
@@ -414,6 +679,8 @@ export function runDrawingConsistencyChecks({
       requestedTypes: drawingTypes,
       levelCount,
       crossViewChecks: enableCrossViewChecks,
+      cadGradeTechnicalQa,
+      cadGradeTechnicalQaBlocking: false,
       counts: {
         plan: (drawings.plan || []).length,
         elevation: (drawings.elevation || []).length,


### PR DESCRIPTION
## Summary
- Adds blueprint-grade CAD metadata/classes to deterministic ProjectGraph SVG floor plans, elevations, and sections without using image generation for technical panels.
- Adds ArchitectReasoningManifest sidecar output with 8-line prompt splice and a compact Key Notes "Design rationale" group.
- Adds warning-only CAD-grade technical QA for room labels/areas, dimensions, datums, line-weight classes, opening counts, and section marker alignment.

## Renderer Notes
- Plan SVG now carries CAD layer/lineweight classes, wall poche, room area labels, opening tags, refined door swing classing, stair arrow labels, dimension-chain types, and section marker labels.
- Elevation SVG now carries material hatch classes, FFL/eaves/ridge datums, head/sill cue lines, opening tags, facade rhythm cues, and W2 stucco/parapet pack cues.
- Section SVG now carries ground hatch, cut poche wrapper, slab/foundation/roof build-up classes, room labels, vertical dimensions, and FFL/eaves/ridge datums.

## Validation
- PASS: `npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/drawing/svgPlanRendererFidelity.test.js src/__tests__/services/drawing/technicalDrawingPolishPhase3.test.js src/__tests__/services/drawingConsistencyChecks.test.js src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js`
- PASS: `npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/a1FinalExportContract.test.js`
- PASS: `npm run check:env`
- PASS: `npm run check:contracts`
- PASS: `npm run test:compose:routing`
- PASS: `npm run lint`
- PASS: `npm run build:active`
- PASS: `npm run smoke:a1-consistency`

## Caveat
- The broad `projectGraphVerticalSliceService.test.js` file was started but stopped after repeated full A1 raster/PDF builds; the focused manifest tests and requested validation suite above passed.
