### PR TITLE
Enforce ProjectGraph A1 SVG and image-edit authority gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ APP_NAME=architecture-ai-riba-a1-platform
 APP_REGION=uk
 APP_TIMEZONE=Europe/London
 LOG_LEVEL=info
+PIPELINE_MODE=project_graph
+REACT_APP_PIPELINE_MODE=project_graph
+# Keep legacy /api/models project-generation endpoints disabled unless explicitly testing multi_panel/debug flows.
+ALLOW_LEGACY_GENERATION=false
 
 # Use base models now, then switch to hybrid or fine_tuned after training jobs exist.
 # base       = always use foundation models below

--- a/api/a1/compose.js
+++ b/api/a1/compose.js
@@ -2200,6 +2200,11 @@ async function handleComposeRequest(req, res, trace) {
     requestBody.materialPalette ||
     requestBody.metadata?.materialPalette ||
     null;
+  const sheetArtifactFromRequest =
+    requestBody.sheetArtifact ||
+    requestBody.a1Sheet ||
+    requestBody.metadata?.sheetArtifact ||
+    null;
   const openaiProviderFromRequest =
     requestBody.openaiProvider ||
     requestBody.metadata?.openaiProvider ||
@@ -2261,6 +2266,8 @@ async function handleComposeRequest(req, res, trace) {
     visualPanels: visualPanelsFromRequest,
     materialPalette: materialPaletteFromRequest,
     openaiProvider: openaiProviderFromRequest,
+    sheetArtifact: sheetArtifactFromRequest,
+    expectedGeometryHash: requestedHashes.geometryHash || null,
     strictPhotoreal,
     imageGenEnabled,
     scope: "compose_final",

--- a/api/models/generate-drawings.js
+++ b/api/models/generate-drawings.js
@@ -12,6 +12,7 @@
 import { generateTechnicalDrawings } from "../../src/services/drawing/technicalDrawingService.js";
 import { coerceToCanonicalProjectGeometry } from "../../src/services/cad/geometryFactory.js";
 import { isFeatureEnabled } from "../../src/config/featureFlags.js";
+import projectGraphProductionGuard from "../../server/utils/projectGraphProductionGuard.cjs";
 import {
   buildGenerateDrawingsResponse,
   validateGenerateDrawingsRequest,
@@ -29,6 +30,8 @@ import {
 
 export { config };
 
+const { rejectLegacyProjectGenerationIfDisabled } = projectGraphProductionGuard;
+
 export default async function handler(req, res) {
   if (handleOptions(req, res)) return;
   if (!setCors(req, res)) {
@@ -42,6 +45,15 @@ export default async function handler(req, res) {
     );
   }
   if (rejectInvalidMethod(req, res)) return;
+  if (
+    rejectLegacyProjectGenerationIfDisabled(
+      req,
+      res,
+      "/api/models/generate-drawings",
+    )
+  ) {
+    return;
+  }
   if (
     !ensureFeatureEnabled(
       res,

--- a/api/models/generate-project.js
+++ b/api/models/generate-project.js
@@ -5,6 +5,7 @@ import {
   validateGenerateProjectRequest,
 } from "../../src/services/models/architectureBackendContracts.js";
 import { getRecommendedModel } from "../../src/services/models/openSourceModelRouter.js";
+import projectGraphProductionGuard from "../../server/utils/projectGraphProductionGuard.cjs";
 import {
   config,
   ensureFeatureEnabled,
@@ -16,6 +17,8 @@ import {
 } from "./_shared.js";
 
 export { config };
+
+const { rejectLegacyProjectGenerationIfDisabled } = projectGraphProductionGuard;
 
 export default async function handler(req, res) {
   if (handleOptions(req, res)) return;
@@ -30,6 +33,15 @@ export default async function handler(req, res) {
     );
   }
   if (rejectInvalidMethod(req, res)) return;
+  if (
+    rejectLegacyProjectGenerationIfDisabled(
+      req,
+      res,
+      "/api/models/generate-project",
+    )
+  ) {
+    return;
+  }
   if (
     !ensureFeatureEnabled(
       res,

--- a/api/models/generate-visual-package.js
+++ b/api/models/generate-visual-package.js
@@ -1,6 +1,7 @@
 import { coerceToCanonicalProjectGeometry } from "../../src/services/cad/geometryFactory.js";
 import { isFeatureEnabled } from "../../src/config/featureFlags.js";
 import { buildVisualGenerationPackage } from "../../src/services/visual/geometryLockedVisualRouter.js";
+import projectGraphProductionGuard from "../../server/utils/projectGraphProductionGuard.cjs";
 import {
   buildGenerateVisualPackageResponse,
   validateGenerateVisualPackageRequest,
@@ -18,6 +19,8 @@ import {
 
 export { config };
 
+const { rejectLegacyProjectGenerationIfDisabled } = projectGraphProductionGuard;
+
 export default async function handler(req, res) {
   if (handleOptions(req, res)) return;
   if (!setCors(req, res)) {
@@ -31,6 +34,15 @@ export default async function handler(req, res) {
     );
   }
   if (rejectInvalidMethod(req, res)) return;
+  if (
+    rejectLegacyProjectGenerationIfDisabled(
+      req,
+      res,
+      "/api/models/generate-visual-package",
+    )
+  ) {
+    return;
+  }
   if (
     !ensureFeatureEnabled(
       res,

--- a/api/openai-image-stylize.js
+++ b/api/openai-image-stylize.js
@@ -97,12 +97,12 @@ export default async function handler(req, res) {
     });
   }
 
-  if (isGeometryLockedImagePanelType(normalizedPanelType) && !image) {
+  if (!image) {
     return res.status(422).json({
       error: MISSING_GEOMETRY_CONTROL_IMAGE_CODE,
       message:
-        "Geometry-locked architectural panels require a control image. Refusing text-to-image generation.",
-      panelType: normalizedPanelType,
+        "Image stylization requires a geometry control image. Text-only image generation is not allowed from this endpoint.",
+      panelType: normalizedPanelType || null,
     });
   }
 
@@ -118,36 +118,21 @@ export default async function handler(req, res) {
 
   const resolvedModel = getOpenAIImageModel(model);
   const resolvedSize = normalizeSize(size);
-  const useEdit = Boolean(image);
-
   try {
     console.log(
-      `[OpenAI] START image ${useEdit ? "edit" : "generation"} route=/api/openai-image-stylize panel=${normalizedPanelType || "unknown"} model=${resolvedModel} keySource=${keyInfo.keySource}`,
+      `[OpenAI] START image edit route=/api/openai-image-stylize panel=${normalizedPanelType || "unknown"} model=${resolvedModel} keySource=${keyInfo.keySource}`,
     );
-    const response = useEdit
-      ? await fetch("https://api.openai.com/v1/images/edits", {
-          method: "POST",
-          headers: buildOpenAIRequestHeaders(keyInfo, process.env),
-          body: createEditFormData({
-            image,
-            mask,
-            prompt,
-            size: resolvedSize,
-            model: resolvedModel,
-          }),
-        })
-      : await fetch("https://api.openai.com/v1/images/generations", {
-          method: "POST",
-          headers: buildOpenAIRequestHeaders(keyInfo, process.env, {
-            json: true,
-          }),
-          body: JSON.stringify({
-            model: resolvedModel,
-            prompt,
-            n: 1,
-            size: resolvedSize,
-          }),
-        });
+    const response = await fetch("https://api.openai.com/v1/images/edits", {
+      method: "POST",
+      headers: buildOpenAIRequestHeaders(keyInfo, process.env),
+      body: createEditFormData({
+        image,
+        mask,
+        prompt,
+        size: resolvedSize,
+        model: resolvedModel,
+      }),
+    });
 
     const requestId =
       response.headers?.get?.("x-request-id") ||
@@ -156,7 +141,7 @@ export default async function handler(req, res) {
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
       console.warn(
-        `[OpenAI] FAIL image ${useEdit ? "edit" : "generation"} route=/api/openai-image-stylize status=${response.status} requestId=${requestId || "none"}`,
+        `[OpenAI] FAIL image edit route=/api/openai-image-stylize status=${response.status} requestId=${requestId || "none"}`,
       );
       return res.status(response.status).json({
         error: "OPENAI_IMAGE_API_ERROR",
@@ -176,7 +161,7 @@ export default async function handler(req, res) {
     }
 
     console.log(
-      `[OpenAI] OK image ${useEdit ? "edit" : "generation"} route=/api/openai-image-stylize requestId=${requestId || "none"} usage=${JSON.stringify(data.usage || {})}`,
+      `[OpenAI] OK image edit route=/api/openai-image-stylize requestId=${requestId || "none"} usage=${JSON.stringify(data.usage || {})}`,
     );
     return res.status(200).json({
       images: [
@@ -189,8 +174,8 @@ export default async function handler(req, res) {
       provider: "openai",
       model: resolvedModel,
       size: resolvedSize,
-      mode: useEdit ? "edit" : "generation",
-      geometryPreserved: useEdit,
+      mode: "edit",
+      geometryPreserved: true,
       panelType: normalizedPanelType || null,
       requestId,
       usage: data.usage || null,

--- a/api/openai-image-stylize.js
+++ b/api/openai-image-stylize.js
@@ -8,8 +8,15 @@
  * models only for optional visual enhancement.
  */
 import openaiEnv from "../server/utils/openaiEnv.cjs";
+import projectGraphProductionGuard from "../server/utils/projectGraphProductionGuard.cjs";
 
 const { resolveOpenAIImageApiKeyInfo, buildOpenAIRequestHeaders } = openaiEnv;
+const {
+  GEOMETRY_LOCKED_IMAGE_PANEL_TYPES,
+  MISSING_GEOMETRY_CONTROL_IMAGE_CODE,
+  isGeometryLockedImagePanelType,
+  normalizePanelType,
+} = projectGraphProductionGuard;
 
 export const runtime = "nodejs";
 export const config = {
@@ -69,6 +76,7 @@ export default async function handler(req, res) {
     model,
     panelType,
   } = req.body || {};
+  const normalizedPanelType = normalizePanelType(panelType);
 
   if (!prompt || !String(prompt).trim()) {
     return res.status(400).json({
@@ -77,12 +85,24 @@ export default async function handler(req, res) {
     });
   }
 
-  const validPanelTypes = ["hero_3d", "interior_3d", "axonometric"];
-  if (panelType && !validPanelTypes.includes(panelType)) {
+  const validPanelTypes = GEOMETRY_LOCKED_IMAGE_PANEL_TYPES;
+  if (
+    normalizedPanelType &&
+    !isGeometryLockedImagePanelType(normalizedPanelType)
+  ) {
     return res.status(400).json({
       error: "INVALID_PANEL_TYPE",
       message: `Panel type must be one of: ${validPanelTypes.join(", ")}`,
       provided: panelType,
+    });
+  }
+
+  if (isGeometryLockedImagePanelType(normalizedPanelType) && !image) {
+    return res.status(422).json({
+      error: MISSING_GEOMETRY_CONTROL_IMAGE_CODE,
+      message:
+        "Geometry-locked architectural panels require a control image. Refusing text-to-image generation.",
+      panelType: normalizedPanelType,
     });
   }
 
@@ -102,7 +122,7 @@ export default async function handler(req, res) {
 
   try {
     console.log(
-      `[OpenAI] START image ${useEdit ? "edit" : "generation"} route=/api/openai-image-stylize panel=${panelType || "unknown"} model=${resolvedModel} keySource=${keyInfo.keySource}`,
+      `[OpenAI] START image ${useEdit ? "edit" : "generation"} route=/api/openai-image-stylize panel=${normalizedPanelType || "unknown"} model=${resolvedModel} keySource=${keyInfo.keySource}`,
     );
     const response = useEdit
       ? await fetch("https://api.openai.com/v1/images/edits", {
@@ -171,7 +191,7 @@ export default async function handler(req, res) {
       size: resolvedSize,
       mode: useEdit ? "edit" : "generation",
       geometryPreserved: useEdit,
-      panelType,
+      panelType: normalizedPanelType || null,
       requestId,
       usage: data.usage || null,
       keySource: keyInfo.keySource,

--- a/api/openai-images.js
+++ b/api/openai-images.js
@@ -9,8 +9,14 @@
 
 import { setCorsHeaders, handlePreflight } from "./_shared/cors.js";
 import openaiEnv from "../server/utils/openaiEnv.cjs";
+import projectGraphProductionGuard from "../server/utils/projectGraphProductionGuard.cjs";
 
 const { resolveOpenAIImageApiKeyInfo, buildOpenAIRequestHeaders } = openaiEnv;
+const {
+  PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK_CODE,
+  extractPanelType,
+  isProjectPanelType,
+} = projectGraphProductionGuard;
 
 function getOpenAIImageModel(requestModel) {
   return (
@@ -42,6 +48,23 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: "Method not allowed. Use POST." });
   }
 
+  const {
+    prompt,
+    size = "1024x1024",
+    model,
+    n = 1,
+    panelType = null,
+  } = req.body || {};
+  const normalizedPanelType = extractPanelType(req.body || {}) || panelType;
+  if (isProjectPanelType(normalizedPanelType)) {
+    return res.status(422).json({
+      error: PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK_CODE,
+      message:
+        "Project panels must be generated from ProjectGraph control images, not text-only image generation.",
+      panelType: normalizedPanelType,
+    });
+  }
+
   const keyInfo = resolveOpenAIImageApiKeyInfo(process.env);
   if (!keyInfo.hasKey) {
     return res.status(500).json({
@@ -52,7 +75,6 @@ export default async function handler(req, res) {
     });
   }
 
-  const { prompt, size = "1024x1024", model, n = 1 } = req.body || {};
   if (!prompt || !String(prompt).trim()) {
     return res.status(400).json({ error: "Prompt is required" });
   }
@@ -119,6 +141,7 @@ export default async function handler(req, res) {
       model: resolvedModel,
       size: resolvedSize,
       provider: "openai",
+      panelType: normalizedPanelType || null,
       requestId,
       usage: data.usage || null,
       keySource: keyInfo.keySource,

--- a/docs/implementation/a1-svg-image2-projectgraph-plan.md
+++ b/docs/implementation/a1-svg-image2-projectgraph-plan.md
@@ -1,0 +1,1028 @@
+# Architect AI Platform — A1 SVG + Image2 Implementation Plan
+
+Repository: `MOH131185/architect-ai-platform`  
+Target branch: create a new branch from `main`, for example `feature/projectgraph-svg-image2-a1-lock`  
+Primary goal: produce an A1 architecture sheet like the reference result: real SVG technical blueprint drawings plus axonometric, exterior perspective, and interior image2/OpenAI image-edit views that all belong to the same project.
+
+---
+
+## 1. Recommended implementation model
+
+### Best choice: Codex as the primary implementer
+
+Use **Codex** for the main implementation because this is a multi-file engineering task that needs patching, tests, and repeated repo-aware debugging. The work is not only prompt writing; it requires modifying routing, endpoints, feature gates, seed behaviour, validation, and A1 artifact composition.
+
+### Use Claude as reviewer/planner, not the primary implementer
+
+Claude can be useful to review architecture, check that the plan still makes sense, and critique the final pull request. But if you must choose one tool for implementation, choose **Codex** because the success criteria are code-level: patch files, run tests, inspect failures, and iterate.
+
+Recommended workflow:
+
+```text
+Codex: implement patches + tests + run build/test loop.
+Claude: review the plan or final PR for architectural consistency.
+```
+
+---
+
+## 2. Product target
+
+The platform should generate this type of output:
+
+```text
+A1 architecture sheet
+  ├── Site plan / boundary plan — deterministic SVG
+  ├── Ground floor plan — deterministic SVG
+  ├── First floor plan — deterministic SVG
+  ├── Elevations — deterministic SVG
+  ├── Section A-A / B-B — deterministic SVG
+  ├── Axonometric view — image2 edit from geometry control SVG/PNG
+  ├── Exterior perspective / hero view — image2 edit from geometry control SVG/PNG
+  ├── Interior view — image2 edit from geometry/interior control SVG/PNG
+  ├── Material / notes / scale / title block — deterministic SVG
+  └── QA metadata — same geometry hash and same visual identity hash
+```
+
+The core principle:
+
+```text
+ProjectGraph / compiled geometry = source of truth
+SVG = technical drawing source of truth
+image2 = presentation/rendering layer only
+A1 composer = deterministic assembly layer
+QA = hard export gate
+```
+
+Do **not** let an image model invent technical drawings or invent project geometry.
+
+---
+
+## 3. Current repo diagnosis
+
+The repo already contains many correct pieces, but they are not enforced tightly enough.
+
+### Good pieces already present
+
+- `src/config/pipelineMode.js` defaults to `project_graph`.
+- `api/project/generate-vertical-slice.js` exposes the ProjectGraph vertical-slice endpoint.
+- `src/services/render/projectGraphImageRenderer.js` rasterises deterministic control SVGs to PNG and calls OpenAI image edits.
+- `src/services/render/visualManifestService.js` builds a visual identity lock with `manifestHash`, `geometryHash`, storey count, materials, roof, glazing, entrance, climate, and style.
+- `src/services/canonical/compiledProjectTechnicalPackBuilder.js` builds deterministic technical panels from compiled geometry.
+- `src/services/drawing/svgPlanRenderer.js`, `svgElevationRenderer.js`, and `svgSectionRenderer.js` are the right path for technical SVG drawing.
+- `src/services/validation/drawingConsistencyChecks.js` already contains cross-view checks, but many are warning-level.
+
+### Main failure causes
+
+1. `PROJECT_GRAPH_IMAGE_GEN_ENABLED=false` by default, so image2 panels silently become deterministic fallback placeholders.
+2. `OPENAI_STRICT_IMAGE_GEN=false` allows fallback instead of making image failures visible.
+3. `/api/openai-images.js` is text-to-image generation and should not be used for project panels.
+4. `/api/openai-image-stylize.js` can fall back to image generation when `image` is missing.
+5. Legacy `multi_panel` and `/api/models/*` routes still exist and may produce prompt-only 2D/3D if the UI or env routes to them.
+6. Visual consistency is partly checked, but not always enforced as a hard export blocker.
+7. Repeated tests can look too similar because the new-project seed is not always varied, while same-project consistency should be preserved.
+
+---
+
+## 4. Required environment settings
+
+For production-like generation:
+
+```env
+PIPELINE_MODE=project_graph
+REACT_APP_PIPELINE_MODE=project_graph
+
+OPENAI_API_KEY=your_key_here
+OPENAI_IMAGES_API_KEY=your_key_here
+OPENAI_IMAGE_MODEL=gpt-image-2
+STEP_10_IMAGE_MODEL=gpt-image-2
+
+PROJECT_GRAPH_IMAGE_GEN_ENABLED=true
+OPENAI_STRICT_IMAGE_GEN=true
+
+PROJECT_GRAPH_REQUIRE_2D_3D_SAME_SOURCE=true
+PROJECT_GRAPH_STRICT_VALIDATION=true
+QA_FAIL_ON_2D_3D_MISMATCH=true
+QA_FAIL_ON_PROGRAMME_AREA_MISMATCH=true
+QA_FAIL_ON_SCHEMA_INVALID=true
+```
+
+Do not commit real keys.
+
+For local deterministic smoke tests that should not call image2:
+
+```env
+PROJECT_GRAPH_IMAGE_GEN_ENABLED=false
+OPENAI_STRICT_IMAGE_GEN=false
+```
+
+But the product path for the desired A1 result must run with image generation enabled and strict image generation enabled.
+
+---
+
+## 5. Desired pipeline architecture
+
+Implement and enforce this flow:
+
+```text
+User brief
+  ↓
+Programme / room schedule
+  ↓
+ProjectGraph / compiledProject
+  ↓
+Geometry hash generated
+  ↓
+Deterministic technical SVG pack
+  ├── site plan
+  ├── floor plans
+  ├── elevations
+  └── sections
+  ↓
+VisualManifest generated from the same compiledProject
+  ↓
+Deterministic 3D control SVGs generated from compiledProject
+  ├── hero_3d_control.svg
+  ├── exterior_render_control.svg
+  ├── axonometric_control.svg
+  └── interior_3d_control.svg
+  ↓
+Control SVGs rasterised to PNG
+  ↓
+OpenAI / image2 image-edit calls
+  ├── hero_3d.png
+  ├── exterior_render.png
+  ├── axonometric.png
+  └── interior_3d.png
+  ↓
+A1 composer embeds SVG technical panels + image2 PNG visual panels
+  ↓
+QA validates hash lock, panel presence, no placeholder/fallback, no text-only project panel generation
+  ↓
+Export final SVG / PNG / PDF
+```
+
+---
+
+## 6. Files to inspect and modify
+
+### Core project generation path
+
+```text
+api/project/generate-vertical-slice.js
+src/services/project/projectGraphVerticalSliceService.js
+src/hooks/useArchitectAIWorkflow.js
+src/config/pipelineMode.js
+```
+
+Ensure the UI and server always use `/api/project/generate-vertical-slice` for production A1 generation.
+
+### Technical SVG drawing path
+
+```text
+src/services/canonical/compiledProjectTechnicalPackBuilder.js
+src/services/drawing/svgPlanRenderer.js
+src/services/drawing/svgElevationRenderer.js
+src/services/drawing/svgSectionRenderer.js
+src/services/a1/composeCore.js
+src/services/a1/materialTexturePatterns.js
+src/services/project/compiledProjectExportService.js
+```
+
+Technical panels must remain deterministic SVG and must not route through image generation.
+
+### Image2 / OpenAI visual path
+
+```text
+src/services/render/projectGraphImageRenderer.js
+src/services/render/svgRasteriser.js
+src/services/render/visualManifestService.js
+api/openai-image-stylize.js
+api/openai-images.js
+src/services/ai/ImageStylerService.js
+```
+
+3D/perspective/interior/axonometric panels must use image edits with a control PNG, not text-only generations.
+
+### QA / consistency path
+
+```text
+src/services/validation/drawingConsistencyChecks.js
+src/services/validation/qaScorers/quantitativeScorer.js
+src/services/validation/qaScorers/qualitativeScorer.js
+scripts/smoke/runA1ConsistencySmoke.mjs
+src/__tests__/services/projectGraphVerticalSliceService.test.js
+src/__tests__/services/visualManifestService.test.js
+src/__tests__/services/svgRendererPhase2.test.js
+src/__tests__/services/axonometricCutawayPhase4.test.js
+```
+
+QA should block export when 2D and 3D do not share the same geometry authority.
+
+---
+
+## 7. Implementation changes
+
+## Change 1 — force production UI to ProjectGraph only
+
+Ensure production generation never falls back to legacy `multi_panel` or `/api/models/*` image-based drawing paths.
+
+### Expected behaviour
+
+```text
+Production A1 generation:
+  only /api/project/generate-vertical-slice
+
+Legacy/debug generation:
+  allowed only when explicitly enabled by env
+```
+
+### Suggested env flag
+
+Add or use:
+
+```env
+ALLOW_LEGACY_GENERATION=false
+```
+
+### Server-side guard concept
+
+In `server.cjs`, for legacy routes such as `/api/models/generate-project`, `/api/models/generate-drawings`, and `/api/models/generate-visual-package`, block them when production mode is ProjectGraph and legacy is disabled.
+
+Pseudo-code:
+
+```js
+function rejectLegacyProjectPanelRoute(req, res, next) {
+  const allowLegacy =
+    String(process.env.ALLOW_LEGACY_GENERATION || "")
+      .trim()
+      .toLowerCase() === "true";
+  const mode = getEffectivePipelineMode();
+
+  if (mode === "project_graph" && !allowLegacy) {
+    return res.status(410).json({
+      error: "LEGACY_GENERATION_DISABLED",
+      message:
+        "Production A1 generation must use /api/project/generate-vertical-slice so all 2D and 3D panels share ProjectGraph geometry authority.",
+    });
+  }
+
+  return next();
+}
+```
+
+Apply this guard only to production project-generation legacy routes, not unrelated health/auth/export routes.
+
+---
+
+## Change 2 — patch `/api/openai-image-stylize.js` to fail closed
+
+Current risk: if no `image` is supplied, the endpoint may call `/v1/images/generations`. For architectural panels, this creates unrelated 3D.
+
+### Required behaviour
+
+For these panel types, missing `image` must be a 422 error:
+
+```text
+hero_3d
+exterior_render
+interior_3d
+axonometric
+```
+
+Also add `exterior_render` to valid panel types.
+
+### Patch concept
+
+In `api/openai-image-stylize.js`, replace/extend panel validation:
+
+```js
+const GEOMETRY_LOCKED_PANEL_TYPES = new Set([
+  "hero_3d",
+  "exterior_render",
+  "interior_3d",
+  "axonometric",
+]);
+
+const validPanelTypes = [...GEOMETRY_LOCKED_PANEL_TYPES];
+
+if (panelType && !validPanelTypes.includes(panelType)) {
+  return res.status(400).json({
+    error: "INVALID_PANEL_TYPE",
+    message: `Panel type must be one of: ${validPanelTypes.join(", ")}`,
+    provided: panelType,
+  });
+}
+
+if (GEOMETRY_LOCKED_PANEL_TYPES.has(panelType) && !image) {
+  return res.status(422).json({
+    error: "MISSING_GEOMETRY_CONTROL_IMAGE",
+    message:
+      "Geometry-locked architectural panels require a control image. Refusing text-to-image generation.",
+    panelType,
+  });
+}
+```
+
+Then ensure:
+
+```js
+const useEdit = Boolean(image);
+```
+
+For geometry-locked panels, `useEdit` must always be true.
+
+---
+
+## Change 3 — block `/api/openai-images.js` for project panels
+
+`/api/openai-images.js` is text-to-image generation. It can be kept for mood images or non-project marketing visuals, but not for controlled architectural project panels.
+
+### Patch concept
+
+In `api/openai-images.js`, read `panelType` from the body:
+
+```js
+const {
+  prompt,
+  size = "1024x1024",
+  model,
+  n = 1,
+  panelType = null,
+} = req.body || {};
+```
+
+Add:
+
+```js
+const PROJECT_PANEL_TYPES = new Set([
+  "hero_3d",
+  "exterior_render",
+  "interior_3d",
+  "axonometric",
+  "floor_plan_ground",
+  "floor_plan_first",
+  "floor_plan_level2",
+  "elevation_north",
+  "elevation_south",
+  "elevation_east",
+  "elevation_west",
+  "section_AA",
+  "section_BB",
+]);
+
+if (PROJECT_PANEL_TYPES.has(panelType)) {
+  return res.status(422).json({
+    error: "PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK",
+    message:
+      "Project panels must be generated from ProjectGraph control images, not text-only image generation.",
+    panelType,
+  });
+}
+```
+
+This prevents accidental prompt-only generation for any project panel.
+
+---
+
+## Change 4 — enforce deterministic SVG for all technical panels
+
+Technical panels must not use image2, FLUX, Together, DALL-E, or any other image model.
+
+### Mandatory technical panel path
+
+```text
+compiledProject
+  → compiledProjectTechnicalPackBuilder
+  → svgPlanRenderer / svgElevationRenderer / svgSectionRenderer
+  → A1 composer
+```
+
+### Required metadata per technical panel
+
+Each technical panel should include:
+
+```js
+{
+  panelType: "floor_plan_ground",
+  source: "compiled_project",
+  renderer: "deterministic_svg",
+  geometryHash,
+  svgHash,
+  imageProviderUsed: "none",
+  technicalDrawing: true,
+  visualIdentityLocked: true
+}
+```
+
+### QA blocker
+
+Add a hard failure if any technical panel contains:
+
+```text
+providerUsed = openai / flux / together / image_model
+imageProviderUsed != none
+missing svgString
+missing geometryHash
+missing svgHash
+placeholder status
+```
+
+---
+
+## Change 5 — make all 3D visual panels use `renderProjectGraphPanelImage()`
+
+All visual panels must use the same geometry-aware path:
+
+```text
+compiled 3D control SVG
+  → rasteriseSvgToPng
+  → OpenAI image edit
+  → PNG artifact
+```
+
+### Panel types
+
+```text
+hero_3d
+exterior_render
+axonometric
+interior_3d
+```
+
+### Required metadata per visual panel
+
+Each visual panel should include:
+
+```js
+{
+  panelType,
+  provider: "openai",
+  providerUsed: "openai",
+  imageProviderUsed: "openai",
+  imageRenderFallback: false,
+  imageRenderFallbackReason: null,
+  geometryHash,
+  sourceGeometryHash: geometryHash,
+  visualManifestHash,
+  visualManifestId,
+  visualIdentityLocked: true,
+  referenceSource: "compiled_3d_control_svg",
+  controlSvgHash,
+  controlPngHash,
+  requestId,
+  model: "gpt-image-2"
+}
+```
+
+### QA blocker
+
+Block export if any required visual panel has:
+
+```text
+missing PNG
+missing controlSvgHash
+missing geometryHash
+missing visualManifestHash
+visualIdentityLocked !== true
+providerUsed !== openai when image generation was enabled
+imageRenderFallback === true when strict image generation is enabled
+different geometryHash from technical panels
+different visualManifestHash from sibling visual panels
+```
+
+---
+
+## Change 6 — strengthen VisualManifest as a hard contract
+
+`visualManifestService.js` is the right mechanism. Make it mandatory.
+
+### Required sequence
+
+```text
+compiledProject generated
+  → geometryHash generated
+  → visualManifest generated
+  → identity lock block prepended to every visual panel prompt
+  → visualManifestHash attached to every visual artifact
+```
+
+### Prompt rule
+
+Every 3D prompt should begin with:
+
+```text
+=== VISUAL IDENTITY LOCK ... ===
+...
+=== END IDENTITY LOCK ===
+```
+
+Then include the specific view instruction:
+
+```text
+View: front-left exterior perspective, eye level, overcast UK daylight
+```
+
+or:
+
+```text
+View: clean architectural axonometric from above, same roof, same footprint, same windows
+```
+
+or:
+
+```text
+View: interior kitchen/living view derived from the plan, same window positions and same material palette
+```
+
+### Negative constraints
+
+Keep these constraints in every visual prompt:
+
+```text
+Do not add extra floors.
+Do not move the entrance.
+Do not change roof form or pitch.
+Do not change facade material.
+Do not invent extra windows.
+Do not depict a different building.
+Do not add neighbouring buildings.
+Do not turn detached house into terrace/semi-detached/block.
+```
+
+---
+
+## Change 7 — convert visual consistency warnings to blocking errors
+
+`drawingConsistencyChecks.js` already detects some cross-view issues. Upgrade project-panel critical issues from warnings to errors.
+
+### Add helper
+
+Create a helper such as:
+
+```js
+function validateVisualPanelLocks({
+  panels = [],
+  expectedGeometryHash = null,
+}) {
+  const warnings = [];
+  const errors = [];
+
+  const required = ["hero_3d", "exterior_render", "axonometric", "interior_3d"];
+  const byType = new Map(
+    panels.map((panel) => [panel.panelType || panel.type, panel]),
+  );
+
+  for (const type of required) {
+    if (!byType.has(type)) {
+      errors.push(`VISUAL_PANEL_MISSING: ${type} is required.`);
+    }
+  }
+
+  const hashes = panels
+    .map((p) => p.metadata?.geometryHash || p.geometryHash)
+    .filter(Boolean);
+  const distinctGeometryHashes = [...new Set(hashes)];
+  if (
+    expectedGeometryHash &&
+    distinctGeometryHashes.some((h) => h !== expectedGeometryHash)
+  ) {
+    errors.push(
+      `VISUAL_GEOMETRY_HASH_MISMATCH: expected ${expectedGeometryHash}, got ${distinctGeometryHashes.join(", ")}.`,
+    );
+  }
+
+  const manifestHashes = panels
+    .map((p) => p.metadata?.visualManifestHash || p.visualManifestHash)
+    .filter(Boolean);
+  const distinctManifestHashes = [...new Set(manifestHashes)];
+  if (distinctManifestHashes.length > 1) {
+    errors.push(
+      `VISUAL_MANIFEST_HASH_MISMATCH: visual panels carry ${distinctManifestHashes.length} manifest hashes.`,
+    );
+  }
+
+  panels.forEach((panel) => {
+    const type = panel.panelType || panel.type || "unknown";
+    const meta = panel.metadata || panel.provenance || {};
+
+    if (
+      meta.visualIdentityLocked !== true &&
+      panel.visualIdentityLocked !== true
+    ) {
+      errors.push(
+        `VISUAL_IDENTITY_UNLOCKED: ${type} is not visualIdentityLocked.`,
+      );
+    }
+
+    if (
+      panel.imageRenderFallback === true ||
+      meta.imageRenderFallback === true
+    ) {
+      errors.push(
+        `VISUAL_IMAGE_FALLBACK: ${type} used fallback instead of image2 edit.`,
+      );
+    }
+
+    if ((panel.providerUsed || meta.providerUsed) === "deterministic") {
+      errors.push(
+        `VISUAL_PROVIDER_DETERMINISTIC: ${type} is placeholder/fallback.`,
+      );
+    }
+  });
+
+  return { warnings, errors };
+}
+```
+
+Call it inside the ProjectGraph vertical-slice QA path and/or `drawingConsistencyChecks.js`.
+
+---
+
+## Change 8 — final A1 composition must embed artifacts, not regenerate them
+
+The final board must not redraw empty frames or ask an image model to create the whole A1 sheet.
+
+### Correct final composition
+
+```text
+sheet SVG frame
+  + embedded technical SVGs
+  + embedded image2 PNGs
+  + deterministic labels
+  + deterministic title block
+```
+
+### Required export path
+
+```text
+sheetArtifact.svgString
+  → final .svg
+  → rasterised .png proof
+  → .pdf export embedding rendered full sheet
+```
+
+### QA metadata
+
+Attach render proof metadata:
+
+```js
+{
+  sheetSvgHash,
+  renderedPngHash,
+  nonBackgroundPixelRatio,
+  hasRequiredPanels: true,
+  pdfEmbedsRenderedSheet: true
+}
+```
+
+Block export if:
+
+```text
+sheetArtifact.svgString is missing
+rendered PNG is blank
+PDF contains only empty frames
+required panels are missing
+technical panel occupancy is too low
+```
+
+---
+
+## Change 9 — fix repeated test variation while preserving project consistency
+
+Do not remove consistency. Split variation into two levels:
+
+```text
+Across new tests/projects: vary seed.
+Within the same project: keep seed and geometry hash stable.
+```
+
+### Add new seed creation
+
+In the frontend request builder, add:
+
+```js
+function createRunSeed() {
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj?.getRandomValues) {
+    const arr = new Uint32Array(1);
+    cryptoObj.getRandomValues(arr);
+    return arr[0] % 2147483647;
+  }
+  return Math.floor(Math.random() * 2147483647);
+}
+```
+
+When starting a new project:
+
+```js
+const seed = params.seed ?? params.baseSeed ?? createRunSeed();
+
+request.baseSeed = seed;
+request.seed = seed;
+request.brief = {
+  ...request.brief,
+  generation_seed: seed,
+};
+```
+
+When regenerating one panel or modifying style only:
+
+```text
+reuse the original seed
+reuse the original compiledProject
+reuse the original geometryHash
+```
+
+When modifying layout/rooms:
+
+```text
+create a new compiledProject
+create a new geometryHash
+regenerate all 2D and 3D panels from the new geometry
+```
+
+---
+
+## Change 10 — add a golden A1 acceptance test
+
+Create a deterministic fixture:
+
+```text
+Project: Contemporary two-storey UK detached house
+Footprint: 8.4m × 7.2m
+Roof: gable roof, ridge east-west, charcoal standing seam
+Walls: buff brick
+Windows: white frames
+Entrance: timber entrance bay, front/north facade
+Ground floor: hall, living, kitchen/dining, WC, utility
+First floor: 3 bedrooms, bathroom, landing
+```
+
+### Test must assert
+
+```text
+A1 contains site plan
+A1 contains ground floor plan
+A1 contains first floor plan
+A1 contains at least two elevations
+A1 contains section A-A
+A1 contains axonometric panel
+A1 contains exterior perspective / hero panel
+A1 contains interior panel
+all technical panels are SVG
+no technical panel uses image model
+all visual panels use image edit, not text generation
+all panels share geometryHash
+all visual panels share visualManifestHash
+no visual panel uses fallback when strict image generation is enabled
+PDF/PNG export is not blank
+```
+
+---
+
+## 8. Suggested Codex implementation prompts
+
+Use these prompts one at a time. Do not ask Codex to do everything in a single pass unless the environment supports long-running multi-step coding.
+
+### Codex prompt 1 — lock project generation path
+
+```text
+You are working in MOH131185/architect-ai-platform on branch feature/projectgraph-svg-image2-a1-lock.
+
+Goal: make ProjectGraph vertical slice the only production path for A1 architecture generation.
+
+Inspect:
+- src/config/pipelineMode.js
+- src/services/workflowRouter.js
+- src/hooks/useArchitectAIWorkflow.js
+- server.cjs
+- api/project/generate-vertical-slice.js
+
+Implement:
+1. Ensure production A1 generation routes only through /api/project/generate-vertical-slice.
+2. Add or use ALLOW_LEGACY_GENERATION=false to block legacy /api/models generation routes when PIPELINE_MODE=project_graph.
+3. Keep legacy routes available only when ALLOW_LEGACY_GENERATION=true.
+4. Add tests or update existing tests to verify legacy project-generation routes are blocked in project_graph mode.
+
+Do not remove unrelated auth, billing, export, or health routes.
+Run relevant tests and report changed files.
+```
+
+### Codex prompt 2 — fail closed on image generation
+
+```text
+Goal: prevent text-only image generation from being used for architecture project panels.
+
+Inspect:
+- api/openai-image-stylize.js
+- api/openai-images.js
+- src/services/ai/ImageStylerService.js
+- src/services/render/projectGraphImageRenderer.js
+
+Implement:
+1. In api/openai-image-stylize.js, require a supplied image/control image for hero_3d, exterior_render, axonometric, and interior_3d.
+2. Add exterior_render to validPanelTypes.
+3. Return 422 MISSING_GEOMETRY_CONTROL_IMAGE if one of those panel types is requested without image.
+4. In api/openai-images.js, block project panel types from text-only image generation with 422 PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK.
+5. Add tests for both endpoints.
+
+The project panel types include all technical panel types and all 3D visual panel types.
+Run tests and report changed files.
+```
+
+### Codex prompt 3 — enforce visual manifest and geometry hash lock
+
+```text
+Goal: every visual panel must share the same geometryHash and visualManifestHash.
+
+Inspect:
+- src/services/render/visualManifestService.js
+- src/services/render/projectGraphImageRenderer.js
+- src/services/project/projectGraphVerticalSliceService.js
+- src/services/validation/drawingConsistencyChecks.js
+- src/__tests__/services/visualManifestService.test.js
+- src/__tests__/services/projectGraphVerticalSliceService.test.js
+
+Implement:
+1. Ensure the visual manifest is built once per compiledProject.
+2. Ensure every visual panel prompt includes buildVisualIdentityLockBlock(manifest).
+3. Attach visualManifestHash, visualManifestId, visualIdentityLocked=true, geometryHash, referenceSource, and controlSvgHash/controlPngHash to every visual panel artifact.
+4. Add a QA helper that fails export if visual panels have missing/different geometryHash or visualManifestHash.
+5. Make fallback visual panels blocking errors when OPENAI_STRICT_IMAGE_GEN=true.
+
+Run tests and report changed files.
+```
+
+### Codex prompt 4 — ensure technical panels are deterministic SVG only
+
+```text
+Goal: technical architecture drawings must never route through image models.
+
+Inspect:
+- src/services/canonical/compiledProjectTechnicalPackBuilder.js
+- src/services/drawing/svgPlanRenderer.js
+- src/services/drawing/svgElevationRenderer.js
+- src/services/drawing/svgSectionRenderer.js
+- src/services/validation/drawingConsistencyChecks.js
+- src/services/project/projectGraphVerticalSliceService.js
+
+Implement:
+1. Add metadata to technical panel artifacts: renderer=deterministic_svg, technicalDrawing=true, imageProviderUsed=none, geometryHash, svgHash.
+2. Add QA failure if a technical panel has no svgString, no svgHash, no geometryHash, or an image provider.
+3. Ensure A1 composition embeds these SVGs as final technical panels.
+4. Add tests that floor plans/elevations/sections are SVG-only and never image-generated.
+
+Run tests and report changed files.
+```
+
+### Codex prompt 5 — seed variation policy
+
+```text
+Goal: repeated new tests should vary, but same-project regeneration must remain consistent.
+
+Inspect:
+- src/hooks/useArchitectAIWorkflow.js
+- src/services/project/projectGraphVerticalSliceService.js
+- src/services/designHistoryRepository.js
+- tests related to project graph payloads
+
+Implement:
+1. Add a createRunSeed() helper in the frontend/request-building path.
+2. For new projects, create a new seed when params.seed/baseSeed is missing.
+3. Attach seed/baseSeed/brief.generation_seed to the ProjectGraph vertical-slice request.
+4. Preserve the original seed for same-project regeneration or style-only modification.
+5. Add tests proving two new runs without explicit seed get different seeds, while regenerate keeps the original seed.
+
+Run tests and report changed files.
+```
+
+### Codex prompt 6 — golden A1 acceptance test
+
+```text
+Goal: add a golden acceptance test for the target A1 result.
+
+Create or update tests under src/__tests__ or scripts/smoke.
+
+Fixture:
+- two-storey UK detached house
+- 8.4m x 7.2m footprint
+- gable roof
+- buff brick
+- charcoal standing seam roof
+- white frames
+- timber entrance bay
+- ground: hall, living, kitchen/dining, WC, utility
+- first: 3 bedrooms, bathroom, landing
+
+Assertions:
+- A1 sheet contains site plan, ground floor plan, first floor plan, elevations, section A-A, axonometric, exterior/hero, interior.
+- Technical panels are deterministic SVG only.
+- Visual panels use image-edit path or mocked image-edit path, never text-only generation.
+- All panels share geometryHash.
+- Visual panels share visualManifestHash.
+- No fallback visual panel is accepted when OPENAI_STRICT_IMAGE_GEN=true.
+- Exported sheet is not blank.
+
+Use mocks for OpenAI image edit calls where necessary. Do not require a real API key in CI.
+Run tests and report changed files.
+```
+
+---
+
+## 9. Suggested Claude review prompts
+
+Use Claude after Codex has produced a patch.
+
+### Claude prompt — architecture review
+
+```text
+Please review this PR for an architecture AI platform.
+
+Goal: deterministic ProjectGraph/SVG technical drawings plus image2/OpenAI image-edit visual panels on the same A1 sheet.
+
+Key rules:
+1. Technical panels must be deterministic SVG only.
+2. Visual 3D panels must use image-edit with a compiled geometry control image.
+3. Text-only image generation must be blocked for project panels.
+4. All panels must share geometryHash.
+5. All visual panels must share visualManifestHash.
+6. Fallback visual panels must block export when OPENAI_STRICT_IMAGE_GEN=true.
+7. New project runs should vary seed; same-project regeneration should preserve seed and geometryHash.
+
+Review for missed code paths, weak QA checks, and any route that could still produce bad 2D or unrelated 3D.
+```
+
+---
+
+## 10. Test and validation commands
+
+Run these after implementation:
+
+```bash
+npm run check:env
+npm run check:contracts
+npm run test:compose:routing
+npm run lint
+npm run build:active
+```
+
+Run focused tests:
+
+```bash
+npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath \
+  src/__tests__/services/projectGraphVerticalSliceService.test.js \
+  src/__tests__/services/visualManifestService.test.js \
+  src/__tests__/services/svgRendererPhase2.test.js \
+  src/__tests__/services/axonometricCutawayPhase4.test.js
+```
+
+Run smoke test if available:
+
+```bash
+node scripts/smoke/runA1ConsistencySmoke.mjs
+```
+
+---
+
+## 11. Acceptance criteria for final PR
+
+The PR is successful only when all of these are true:
+
+```text
+[ ] Production UI calls /api/project/generate-vertical-slice.
+[ ] Legacy generation routes are blocked in project_graph production mode unless explicitly enabled.
+[ ] /api/openai-images refuses project panel types.
+[ ] /api/openai-image-stylize refuses geometry-locked panels without a control image.
+[ ] exterior_render is supported as a geometry-locked visual panel type.
+[ ] Technical drawings are SVG-only and have geometryHash + svgHash.
+[ ] Visual panels use image edit from control SVG/PNG.
+[ ] Every visual panel has geometryHash + visualManifestHash + visualIdentityLocked=true.
+[ ] QA blocks geometry hash mismatch.
+[ ] QA blocks visual manifest mismatch.
+[ ] QA blocks placeholder/fallback 3D when strict image generation is enabled.
+[ ] A1 composer embeds finished artifacts, not prompt-generated fake board images.
+[ ] Exported SVG/PNG/PDF are not blank.
+[ ] New test runs vary seed.
+[ ] Same-project regeneration preserves seed and geometry hash.
+[ ] Golden A1 acceptance test passes.
+```
+
+---
+
+## 12. Final implementation principle
+
+The platform should never ask image2 to create the architecture from scratch.
+
+Correct:
+
+```text
+ProjectGraph → SVG/CAD geometry → control image → image2 edit → A1 composition
+```
+
+Incorrect:
+
+```text
+Prompt → image2 generation → hope it matches the plan
+```
+
+The first path produces a coherent A1 architecture sheet. The second path produces bad 2D and irrelevant 3D.

--- a/docs/implementation/a1-svg-image2-projectgraph-plan.md
+++ b/docs/implementation/a1-svg-image2-projectgraph-plan.md
@@ -117,6 +117,40 @@ OPENAI_STRICT_IMAGE_GEN=false
 
 But the product path for the desired A1 result must run with image generation enabled and strict image generation enabled.
 
+### OpenAI image-edit access preflight
+
+Before running strict ProjectGraph A1 generation, run the image-edit access preflight:
+
+```bash
+npm run smoke:openai-image-edit-access
+```
+
+The preflight sends one tiny deterministic PNG reference to `/v1/images/edits`
+using:
+
+```text
+OPENAI_IMAGES_API_KEY or OPENAI_API_KEY
+STEP_10_IMAGE_MODEL or OPENAI_IMAGE_MODEL
+```
+
+It does not change `PROJECT_GRAPH_IMAGE_GEN_ENABLED` or
+`OPENAI_STRICT_IMAGE_GEN`. It only checks whether the configured image-edit
+model can be used by the configured key before the strict A1 run starts.
+
+If OpenAI returns `401`, `403`, or model-access errors, the script exits
+non-zero and prints the configured model, HTTP status, request id when
+available, the exact provider message, and the suggested fix:
+
+```text
+Verify the OpenAI organization for this image model or choose an allowed
+image-edit model.
+```
+
+This preflight is diagnostic only. It must not weaken strict ProjectGraph image
+generation: with `OPENAI_STRICT_IMAGE_GEN=true`, missing access during the real
+A1 run must still fail visibly instead of returning deterministic fallback as
+fake OpenAI success.
+
 ---
 
 ## 5. Desired pipeline architecture

--- a/evals/golden/uk_house_svg_image2/manifest.json
+++ b/evals/golden/uk_house_svg_image2/manifest.json
@@ -1,0 +1,34 @@
+{
+  "description": "Phase 6 golden acceptance fixture: UK detached house A1 SVG technical panels plus image2 ProjectGraph visual panels.",
+  "brief": {
+    "project_name": "Golden UK Detached House",
+    "building_type": "detached-house",
+    "country": "UK",
+    "storeys": 2,
+    "footprint_m": {
+      "width": 8.4,
+      "depth": 7.2
+    },
+    "roof": {
+      "type": "gable",
+      "ridge_orientation": "east-west",
+      "material": "charcoal standing seam"
+    },
+    "walls": "buff brick",
+    "windows": "white frames",
+    "entrance": "timber entrance bay",
+    "programme": {
+      "ground": ["hall", "living room", "kitchen/dining", "WC", "utility"],
+      "first": ["3 bedrooms", "bathroom", "landing"]
+    }
+  },
+  "expected": {
+    "geometryHash": "golden-uk-house-geometry-hash",
+    "visualManifestHash": "golden-uk-house-visual-manifest-hash",
+    "layout": "presentation-v3",
+    "sheet": "A1 landscape",
+    "visualReferenceSource": "compiled_3d_control_svg",
+    "imageProviderUsed": "openai",
+    "imageRenderFallback": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eject": "react-scripts eject",
     "check:env": "node scripts/check-env.cjs",
     "smoke:openai": "node scripts/smoke/openai-provider-smoke.mjs",
+    "smoke:openai-image-edit-access": "node scripts/smoke/check-openai-image-edit-access.mjs",
     "smoke:a1-consistency": "node scripts/smoke/runA1ConsistencySmoke.mjs",
     "check:model-routes": "node scripts/check-model-routes.cjs",
     "check:contracts": "node scripts/check-contracts.cjs",

--- a/scripts/smoke/check-openai-image-edit-access.mjs
+++ b/scripts/smoke/check-openai-image-edit-access.mjs
@@ -1,0 +1,244 @@
+import path from "path";
+import sharp from "sharp";
+import openaiEnv from "../../src/services/openaiProviderEnv.cjs";
+
+async function loadDotenvIfAvailable() {
+  try {
+    const dotenv = await import("dotenv");
+    dotenv.config({ path: path.resolve(process.cwd(), ".env"), quiet: true });
+  } catch {
+    // dotenv is optional for this smoke script; process.env may already be set.
+  }
+}
+
+function jsonOut(payload) {
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+function fail(payload) {
+  jsonOut({ success: false, ...payload });
+  process.exitCode = 1;
+}
+
+function resolveImageApiKeyInfo(env = process.env) {
+  const sources = ["OPENAI_IMAGES_API_KEY", "OPENAI_API_KEY"];
+  for (const source of sources) {
+    const apiKey = openaiEnv.readEnv(env, source);
+    if (apiKey) {
+      return {
+        apiKey,
+        hasKey: true,
+        keySource: source,
+        keyLast4: openaiEnv.keyLast4(apiKey),
+      };
+    }
+  }
+  return {
+    apiKey: "",
+    hasKey: false,
+    keySource: null,
+    keyLast4: "",
+  };
+}
+
+function resolveImageModel(env = process.env) {
+  return (
+    openaiEnv.readEnv(env, "STEP_10_IMAGE_MODEL") ||
+    openaiEnv.readEnv(env, "OPENAI_IMAGE_MODEL") ||
+    "gpt-image-2"
+  ).trim();
+}
+
+function providerMessageFrom(data, rawText, status) {
+  return (
+    data?.error?.message ||
+    data?.message ||
+    rawText ||
+    `OpenAI images edit access check failed: ${status}`
+  );
+}
+
+function providerCodeFrom(data, status) {
+  return data?.error?.code || data?.error?.type || `HTTP_${status}`;
+}
+
+function isAccessDenied({ status, message = "", code = "" }) {
+  const combined = `${code} ${message}`.toLowerCase();
+  return (
+    status === 401 ||
+    status === 403 ||
+    combined.includes("model") ||
+    combined.includes("not verified") ||
+    combined.includes("organization must be verified") ||
+    combined.includes("not have access") ||
+    combined.includes("does not have access") ||
+    combined.includes("permission") ||
+    combined.includes("unauthorized")
+  );
+}
+
+async function buildTinyReferencePng() {
+  return sharp({
+    create: {
+      width: 32,
+      height: 32,
+      channels: 4,
+      background: { r: 245, g: 248, b: 252, alpha: 1 },
+    },
+  })
+    .composite([
+      {
+        input: Buffer.from(
+          '<svg width="32" height="32" xmlns="http://www.w3.org/2000/svg"><rect x="8" y="8" width="16" height="16" fill="#2563eb"/></svg>',
+        ),
+      },
+    ])
+    .png()
+    .toBuffer();
+}
+
+async function buildImageEditForm({ model }) {
+  if (typeof FormData === "undefined" || typeof Blob === "undefined") {
+    throw new Error(
+      "FormData/Blob unavailable in this runtime; use Node 18+ for the image edit access preflight.",
+    );
+  }
+
+  const referencePng = await buildTinyReferencePng();
+  const form = new FormData();
+  form.set("model", model);
+  form.set(
+    "prompt",
+    "Recreate this simple blue square test image on a plain light background.",
+  );
+  form.set("size", "1024x1024");
+  form.set("n", "1");
+  form.set(
+    "image",
+    new Blob([referencePng], { type: "image/png" }),
+    "openai-image-edit-access-preflight.png",
+  );
+  return form;
+}
+
+async function main() {
+  await loadDotenvIfAvailable();
+
+  if (typeof fetch === "undefined") {
+    const nodeFetch = await import("node-fetch");
+    global.fetch = nodeFetch.default;
+  }
+
+  const keyInfo = resolveImageApiKeyInfo(process.env);
+  const diagnostics = openaiEnv.getOpenAIOrgProjectDiagnostics(process.env);
+  const model = resolveImageModel(process.env);
+  const baseUrl =
+    openaiEnv.readEnv(process.env, "OPENAI_BASE_URL") ||
+    "https://api.openai.com/v1";
+
+  const basePayload = {
+    provider: "openai",
+    endpoint: "/v1/images/edits",
+    configuredModel: model,
+    keySource: keyInfo.keySource,
+    keyLast4: keyInfo.keyLast4,
+    projectGraphImageGenEnabled: openaiEnv.readEnv(
+      process.env,
+      "PROJECT_GRAPH_IMAGE_GEN_ENABLED",
+    ),
+    openaiStrictImageGen: openaiEnv.readEnv(
+      process.env,
+      "OPENAI_STRICT_IMAGE_GEN",
+    ),
+    ...diagnostics,
+  };
+
+  if (!keyInfo.hasKey) {
+    fail({
+      ...basePayload,
+      error: "OPENAI_IMAGE_EDIT_API_KEY_MISSING",
+      message:
+        "Set OPENAI_IMAGES_API_KEY or OPENAI_API_KEY before running this image-edit access preflight.",
+      suggestedFix:
+        "Configure OPENAI_IMAGES_API_KEY with image-edit access, or provide OPENAI_API_KEY for the preflight.",
+    });
+    return;
+  }
+
+  try {
+    const response = await fetch(`${baseUrl.replace(/\/$/, "")}/images/edits`, {
+      method: "POST",
+      headers: openaiEnv.buildOpenAIRequestHeaders(keyInfo, process.env),
+      body: await buildImageEditForm({ model }),
+    });
+    const requestId =
+      response.headers?.get?.("x-request-id") ||
+      response.headers?.get?.("openai-request-id") ||
+      null;
+    const rawText = await response.text().catch(() => "");
+    let data = null;
+    try {
+      data = rawText ? JSON.parse(rawText) : null;
+    } catch {
+      data = null;
+    }
+
+    if (!response.ok) {
+      const message = providerMessageFrom(data, rawText, response.status);
+      const error = providerCodeFrom(data, response.status);
+      const accessDenied = isAccessDenied({
+        status: response.status,
+        message,
+        code: error,
+      });
+      fail({
+        ...basePayload,
+        status: response.status,
+        requestId,
+        error,
+        accessDenied,
+        providerMessage: message,
+        suggestedFix: accessDenied
+          ? "Verify the OpenAI organization for this image model or choose an allowed image-edit model."
+          : "Review the provider message and retry with a neutral reference image/prompt or an allowed image-edit model.",
+      });
+      return;
+    }
+
+    const imageEntry = Array.isArray(data?.data) ? data.data[0] : null;
+    if (!imageEntry?.b64_json && !imageEntry?.url) {
+      fail({
+        ...basePayload,
+        status: response.status,
+        requestId,
+        error: "OPENAI_IMAGE_EDIT_EMPTY_RESPONSE",
+        providerMessage:
+          "OpenAI images edit access check returned success status but no image payload.",
+        suggestedFix:
+          "Retry the preflight or choose a known image-edit capable model.",
+      });
+      return;
+    }
+
+    jsonOut({
+      success: true,
+      ...basePayload,
+      status: response.status,
+      requestId,
+      imagePayloadReturned: true,
+      imagePayloadKind: imageEntry.b64_json ? "b64_json" : "url",
+      usage: data?.usage || null,
+      message: "Configured OpenAI image-edit model is accessible.",
+    });
+  } catch (error) {
+    fail({
+      ...basePayload,
+      error: "OPENAI_IMAGE_EDIT_PREFLIGHT_FAILED",
+      message: error?.message || String(error),
+      suggestedFix:
+        "Verify network access, organization/model access, or choose an allowed image-edit model.",
+    });
+  }
+}
+
+main();

--- a/server.cjs
+++ b/server.cjs
@@ -28,6 +28,9 @@ const {
   isLegacyProviderEnabled,
 } = require('./server/utils/legacyProviderGuard.cjs');
 const {
+  createLegacyProjectGenerationMiddleware,
+} = require('./server/utils/projectGraphProductionGuard.cjs');
+const {
   resolveOpenAIReasoningApiKey,
   resolveOpenAIImageApiKey,
   resolveOpenAIReasoningApiKeyInfo,
@@ -382,12 +385,21 @@ mountDynamicApiRoute('post', '/api/project/export/xlsx',    'api/project/export/
 // Phase 1/2 architecture backend routes (shared with api/models/* serverless handlers)
 mountDynamicApiRoute('post', '/api/models/generate-style', 'api/models/generate-style.js', [aiApiLimiter]);
 mountDynamicApiRoute('post', '/api/models/generate-floorplan', 'api/models/generate-floorplan.js', [aiApiLimiter]);
-mountDynamicApiRoute('post', '/api/models/generate-drawings', 'api/models/generate-drawings.js', [aiApiLimiter]);
-mountDynamicApiRoute('post', '/api/models/generate-project', 'api/models/generate-project.js', [aiApiLimiter]);
+mountDynamicApiRoute('post', '/api/models/generate-drawings', 'api/models/generate-drawings.js', [
+  aiApiLimiter,
+  createLegacyProjectGenerationMiddleware('/api/models/generate-drawings'),
+]);
+mountDynamicApiRoute('post', '/api/models/generate-project', 'api/models/generate-project.js', [
+  aiApiLimiter,
+  createLegacyProjectGenerationMiddleware('/api/models/generate-project'),
+]);
 mountDynamicApiRoute('post', '/api/models/regenerate-layer', 'api/models/regenerate-layer.js', [aiApiLimiter]);
 mountDynamicApiRoute('post', '/api/models/repair-project', 'api/models/repair-project.js', [aiApiLimiter]);
 mountDynamicApiRoute('post', '/api/models/generate-facade', 'api/models/generate-facade.js', [aiApiLimiter]);
-mountDynamicApiRoute('post', '/api/models/generate-visual-package', 'api/models/generate-visual-package.js', [aiApiLimiter]);
+mountDynamicApiRoute('post', '/api/models/generate-visual-package', 'api/models/generate-visual-package.js', [
+  aiApiLimiter,
+  createLegacyProjectGenerationMiddleware('/api/models/generate-visual-package'),
+]);
 mountDynamicApiRoute('post', '/api/models/validate-project', 'api/models/validate-project.js', [aiApiLimiter]);
 mountDynamicApiRoute('post', '/api/models/project-readiness', 'api/models/project-readiness.js', [aiApiLimiter]);
 mountDynamicApiRoute('post', '/api/models/plan-a1-panels', 'api/models/plan-a1-panels.js', [aiApiLimiter]);

--- a/server/utils/projectGraphProductionGuard.cjs
+++ b/server/utils/projectGraphProductionGuard.cjs
@@ -1,0 +1,177 @@
+const LEGACY_GENERATION_DISABLED_CODE = "LEGACY_GENERATION_DISABLED";
+const PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK_CODE =
+  "PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK";
+const MISSING_GEOMETRY_CONTROL_IMAGE_CODE = "MISSING_GEOMETRY_CONTROL_IMAGE";
+
+const GEOMETRY_LOCKED_IMAGE_PANEL_TYPES = Object.freeze([
+  "hero_3d",
+  "exterior_render",
+  "interior_3d",
+  "axonometric",
+]);
+
+const TECHNICAL_PROJECT_PANEL_TYPES = Object.freeze([
+  "site_plan",
+  "site_diagram",
+  "boundary_plan",
+  "floor_plan_ground",
+  "floor_plan_first",
+  "floor_plan_level2",
+  "floor_plan_level3",
+  "elevation_north",
+  "elevation_south",
+  "elevation_east",
+  "elevation_west",
+  "section_aa",
+  "section_bb",
+  "section_a_a",
+  "section_b_b",
+]);
+
+const PROJECT_PANEL_TYPES = Object.freeze([
+  ...GEOMETRY_LOCKED_IMAGE_PANEL_TYPES,
+  ...TECHNICAL_PROJECT_PANEL_TYPES,
+]);
+
+function normalizeToken(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]/g, "_");
+}
+
+function normalizePipelineMode(value) {
+  const mode = normalizeToken(value);
+  if (mode === "multipanel") {
+    return "multi_panel";
+  }
+  if (mode === "projectgraph" || mode === "riba_a1") {
+    return "project_graph";
+  }
+  return mode || "project_graph";
+}
+
+function normalizePanelType(value) {
+  return normalizeToken(value);
+}
+
+function isTruthy(value) {
+  return ["1", "true", "yes", "on"].includes(normalizeToken(value));
+}
+
+function getEffectivePipelineMode(env = process.env) {
+  return normalizePipelineMode(
+    env?.REACT_APP_PIPELINE_MODE || env?.PIPELINE_MODE || "project_graph",
+  );
+}
+
+function isLegacyGenerationAllowed(env = process.env) {
+  return (
+    isTruthy(env?.ALLOW_LEGACY_GENERATION) ||
+    getEffectivePipelineMode(env) === "multi_panel"
+  );
+}
+
+function shouldBlockLegacyProjectGeneration({ env = process.env } = {}) {
+  return (
+    getEffectivePipelineMode(env) === "project_graph" &&
+    !isLegacyGenerationAllowed(env)
+  );
+}
+
+function buildLegacyProjectGenerationDisabledPayload(route, env = process.env) {
+  return {
+    success: false,
+    error: LEGACY_GENERATION_DISABLED_CODE,
+    errorCode: LEGACY_GENERATION_DISABLED_CODE,
+    statusCode: 410,
+    message:
+      "Production A1 generation must use /api/project/generate-vertical-slice so all 2D and 3D panels share ProjectGraph geometry authority.",
+    details: {
+      route,
+      requiredRoute: "/api/project/generate-vertical-slice",
+      allowLegacyEnv: "ALLOW_LEGACY_GENERATION=true",
+    },
+    meta: {
+      pipelineMode: getEffectivePipelineMode(env),
+      legacyGenerationAllowed: isLegacyGenerationAllowed(env),
+    },
+  };
+}
+
+function rejectLegacyProjectGenerationIfDisabled(
+  req,
+  res,
+  route = "legacy_project_generation",
+  options = {},
+) {
+  const env = options.env || process.env;
+  if (!shouldBlockLegacyProjectGeneration({ env })) {
+    return false;
+  }
+
+  res.status(410).json(buildLegacyProjectGenerationDisabledPayload(route, env));
+  return true;
+}
+
+function createLegacyProjectGenerationMiddleware(route) {
+  return function rejectLegacyProjectGenerationMiddleware(req, res, next) {
+    if (rejectLegacyProjectGenerationIfDisabled(req, res, route)) {
+      return;
+    }
+    next();
+  };
+}
+
+function extractPanelType(body = {}) {
+  const candidates = [
+    body.panelType,
+    body.panel_type,
+    body.type,
+    body.viewType,
+    body.panel?.type,
+    body.panel?.panelType,
+    body.metadata?.panelType,
+    body.metadata?.panel_type,
+    body.metadata?.viewType,
+  ];
+
+  for (const candidate of candidates) {
+    const panelType = normalizePanelType(candidate);
+    if (panelType) {
+      return panelType;
+    }
+  }
+
+  return "";
+}
+
+function isGeometryLockedImagePanelType(panelType) {
+  return GEOMETRY_LOCKED_IMAGE_PANEL_TYPES.includes(
+    normalizePanelType(panelType),
+  );
+}
+
+function isProjectPanelType(panelType) {
+  return PROJECT_PANEL_TYPES.includes(normalizePanelType(panelType));
+}
+
+module.exports = {
+  GEOMETRY_LOCKED_IMAGE_PANEL_TYPES,
+  LEGACY_GENERATION_DISABLED_CODE,
+  MISSING_GEOMETRY_CONTROL_IMAGE_CODE,
+  PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK_CODE,
+  PROJECT_PANEL_TYPES,
+  TECHNICAL_PROJECT_PANEL_TYPES,
+  buildLegacyProjectGenerationDisabledPayload,
+  createLegacyProjectGenerationMiddleware,
+  extractPanelType,
+  getEffectivePipelineMode,
+  isGeometryLockedImagePanelType,
+  isLegacyGenerationAllowed,
+  isProjectPanelType,
+  normalizePanelType,
+  normalizePipelineMode,
+  rejectLegacyProjectGenerationIfDisabled,
+  shouldBlockLegacyProjectGeneration,
+};

--- a/src/__tests__/api/executeRegenerationPhase7.test.js
+++ b/src/__tests__/api/executeRegenerationPhase7.test.js
@@ -2,6 +2,16 @@ import generateProjectHandler from "../../../api/models/generate-project.js";
 import executeRegenerationHandler from "../../../api/models/execute-regeneration.js";
 import { resetFeatureFlags } from "../../config/featureFlags.js";
 
+const originalAllowLegacyGeneration = process.env.ALLOW_LEGACY_GENERATION;
+
+function restoreAllowLegacyGeneration() {
+  if (originalAllowLegacyGeneration === undefined) {
+    delete process.env.ALLOW_LEGACY_GENERATION;
+    return;
+  }
+  process.env.ALLOW_LEGACY_GENERATION = originalAllowLegacyGeneration;
+}
+
 function createMockResponse() {
   return {
     headers: {},
@@ -27,7 +37,12 @@ function createMockResponse() {
 }
 
 describe("Phase 7 execute-regeneration route", () => {
+  beforeEach(() => {
+    process.env.ALLOW_LEGACY_GENERATION = "true";
+  });
+
   afterEach(() => {
+    restoreAllowLegacyGeneration();
     resetFeatureFlags();
   });
 

--- a/src/__tests__/api/modelsHandlers.test.js
+++ b/src/__tests__/api/modelsHandlers.test.js
@@ -19,6 +19,16 @@ import {
   setFeatureFlag,
 } from "../../config/featureFlags.js";
 
+const originalAllowLegacyGeneration = process.env.ALLOW_LEGACY_GENERATION;
+
+function restoreAllowLegacyGeneration() {
+  if (originalAllowLegacyGeneration === undefined) {
+    delete process.env.ALLOW_LEGACY_GENERATION;
+    return;
+  }
+  process.env.ALLOW_LEGACY_GENERATION = originalAllowLegacyGeneration;
+}
+
 function createMockResponse() {
   return {
     headers: {},
@@ -44,7 +54,12 @@ function createMockResponse() {
 }
 
 describe("Phase 1 model route handlers", () => {
+  beforeEach(() => {
+    process.env.ALLOW_LEGACY_GENERATION = "true";
+  });
+
   afterEach(() => {
+    restoreAllowLegacyGeneration();
     resetFeatureFlags();
   });
 

--- a/src/__tests__/api/openaiImageRouteGuards.test.js
+++ b/src/__tests__/api/openaiImageRouteGuards.test.js
@@ -1,0 +1,146 @@
+import openaiImageStylizeHandler from "../../../api/openai-image-stylize.js";
+import openaiImagesHandler from "../../../api/openai-images.js";
+
+function createMockResponse() {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: null,
+    ended: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
+}
+
+describe("OpenAI image route project panel guards", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.OPENAI_IMAGES_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_REASONING_API_KEY;
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  test.each(["hero_3d", "exterior_render", "axonometric", "interior_3d"])(
+    "openai-image-stylize requires a control image for %s",
+    async (panelType) => {
+      const req = {
+        method: "POST",
+        body: {
+          prompt: "Render this ProjectGraph panel",
+          panelType,
+        },
+      };
+      const res = createMockResponse();
+
+      await openaiImageStylizeHandler(req, res);
+
+      expect(res.statusCode).toBe(422);
+      expect(res.body).toMatchObject({
+        error: "MISSING_GEOMETRY_CONTROL_IMAGE",
+        panelType,
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  test("openai-image-stylize rejects unsupported panel types", async () => {
+    const req = {
+      method: "POST",
+      body: {
+        prompt: "Render unsupported panel",
+        panelType: "site_plan",
+        image: "data:image/png;base64,ZmFrZQ==",
+      },
+    };
+    const res = createMockResponse();
+
+    await openaiImageStylizeHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe("INVALID_PANEL_TYPE");
+    expect(res.body.message).toContain("exterior_render");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test.each(["floor_plan_ground", "section_AA", "hero_3d"])(
+    "openai-images rejects text-only generation for project panel %s",
+    async (panelType) => {
+      const req = {
+        method: "POST",
+        headers: {},
+        body: {
+          prompt: "Generate an architectural project panel",
+          panelType,
+        },
+      };
+      const res = createMockResponse();
+
+      await openaiImagesHandler(req, res);
+
+      expect(res.statusCode).toBe(422);
+      expect(res.body).toMatchObject({
+        error: "PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK",
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  test("openai-images rejects nested project panel metadata", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: {
+        prompt: "Generate an architectural visual",
+        metadata: { panelType: "axonometric" },
+      },
+    };
+    const res = createMockResponse();
+
+    await openaiImagesHandler(req, res);
+
+    expect(res.statusCode).toBe(422);
+    expect(res.body.error).toBe("PROJECT_PANEL_REQUIRES_GEOMETRY_LOCK");
+    expect(res.body.panelType).toBe("axonometric");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("openai-images keeps non-project image generation on the normal key path", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: {
+        prompt: "Generate a generic material mood image",
+        panelType: "mood_image",
+      },
+    };
+    const res = createMockResponse();
+
+    await openaiImagesHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error).toBe("OPENAI_IMAGE_API_KEY_MISSING");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/api/openaiImageRouteGuards.test.js
+++ b/src/__tests__/api/openaiImageRouteGuards.test.js
@@ -65,6 +65,27 @@ describe("OpenAI image route project panel guards", () => {
     },
   );
 
+  test("openai-image-stylize rejects prompt-only requests without panelType", async () => {
+    const req = {
+      method: "POST",
+      body: {
+        prompt: "Render a presentation image without geometry",
+      },
+    };
+    const res = createMockResponse();
+
+    await openaiImageStylizeHandler(req, res);
+
+    expect(res.statusCode).toBe(422);
+    expect(res.body).toMatchObject({
+      error: "MISSING_GEOMETRY_CONTROL_IMAGE",
+      panelType: null,
+    });
+    expect(res.body.message).toMatch(/geometry control image/i);
+    expect(res.body.message).toMatch(/text-only image generation is not allowed/i);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   test("openai-image-stylize rejects unsupported panel types", async () => {
     const req = {
       method: "POST",
@@ -82,6 +103,45 @@ describe("OpenAI image route project panel guards", () => {
     expect(res.body.error).toBe("INVALID_PANEL_TYPE");
     expect(res.body.message).toContain("exterior_render");
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test("openai-image-stylize sends valid control-image requests to image edits only", async () => {
+    process.env.OPENAI_IMAGES_API_KEY = "sk-test-images";
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name) => (name === "x-request-id" ? "req_edit_123" : null),
+      },
+      json: async () => ({
+        data: [{ b64_json: "ZWRpdGVkLWltYWdl" }],
+        usage: { total_tokens: 1 },
+      }),
+    });
+    const req = {
+      method: "POST",
+      body: {
+        prompt: "Stylize this geometry-locked panel",
+        panelType: "hero_3d",
+        image: "data:image/png;base64,ZmFrZQ==",
+      },
+    };
+    const res = createMockResponse();
+
+    await openaiImageStylizeHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      mode: "edit",
+      geometryPreserved: true,
+      panelType: "hero_3d",
+      requestId: "req_edit_123",
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe(
+      "https://api.openai.com/v1/images/edits",
+    );
+    expect(global.fetch.mock.calls[0][0]).not.toContain("generations");
   });
 
   test.each(["floor_plan_ground", "section_AA", "hero_3d"])(

--- a/src/__tests__/api/projectGraphProductionRouteGuards.test.js
+++ b/src/__tests__/api/projectGraphProductionRouteGuards.test.js
@@ -1,0 +1,114 @@
+import generateDrawingsHandler from "../../../api/models/generate-drawings.js";
+import generateProjectHandler from "../../../api/models/generate-project.js";
+import generateVisualPackageHandler from "../../../api/models/generate-visual-package.js";
+import projectGraphProductionGuard from "../../../server/utils/projectGraphProductionGuard.cjs";
+
+const {
+  buildLegacyProjectGenerationDisabledPayload,
+  shouldBlockLegacyProjectGeneration,
+} = projectGraphProductionGuard;
+
+function createMockResponse() {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: null,
+    ended: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
+}
+
+describe("ProjectGraph production route guards", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.PIPELINE_MODE = "project_graph";
+    delete process.env.REACT_APP_PIPELINE_MODE;
+    delete process.env.ALLOW_LEGACY_GENERATION;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test.each([
+    ["/api/models/generate-project", generateProjectHandler],
+    ["/api/models/generate-drawings", generateDrawingsHandler],
+    ["/api/models/generate-visual-package", generateVisualPackageHandler],
+  ])(
+    "%s is blocked when ProjectGraph is the production mode",
+    async (route, handler) => {
+      const req = {
+        method: "POST",
+        headers: {},
+        body: {},
+      };
+      const res = createMockResponse();
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(410);
+      expect(res.body).toMatchObject({
+        success: false,
+        error: "LEGACY_GENERATION_DISABLED",
+        details: {
+          route,
+          requiredRoute: "/api/project/generate-vertical-slice",
+        },
+        meta: {
+          pipelineMode: "project_graph",
+          legacyGenerationAllowed: false,
+        },
+      });
+    },
+  );
+
+  test("legacy route lock can only be bypassed by explicit debug opt-in or multi_panel mode", () => {
+    expect(
+      shouldBlockLegacyProjectGeneration({
+        env: { PIPELINE_MODE: "project_graph" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockLegacyProjectGeneration({
+        env: {
+          PIPELINE_MODE: "project_graph",
+          ALLOW_LEGACY_GENERATION: "true",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockLegacyProjectGeneration({
+        env: { PIPELINE_MODE: "multi_panel" },
+      }),
+    ).toBe(false);
+
+    expect(
+      buildLegacyProjectGenerationDisabledPayload(
+        "/api/models/generate-project",
+        { PIPELINE_MODE: "project_graph" },
+      ),
+    ).toMatchObject({
+      error: "LEGACY_GENERATION_DISABLED",
+      statusCode: 410,
+      details: {
+        allowLegacyEnv: "ALLOW_LEGACY_GENERATION=true",
+      },
+    });
+  });
+});

--- a/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
+++ b/src/__tests__/hooks/useArchitectAIWorkflow.projectGraphPayload.test.js
@@ -1,5 +1,7 @@
 import {
   buildProjectGraphVerticalSliceRequest,
+  createProjectGraphGenerationSeed,
+  normalizeProjectGraphGenerationSeed,
   normalizeProjectGraphDrawingArtifacts,
   sanitizeProjectGraphPanelMap,
   sanitizeProjectGraphSvg,
@@ -126,6 +128,87 @@ describe("buildProjectGraphVerticalSliceRequest", () => {
     expect(request.projectDetails.baseSeed).toBe(1777895862);
     expect(request.brief.generation_seed).toBe(1777895862);
     expect(request.brief.baseSeed).toBe(1777895862);
+  });
+
+  test("generates fresh ProjectGraph seeds for new requests without an explicit seed", () => {
+    const first = buildProjectGraphVerticalSliceRequest({
+      designSpec: {
+        buildingCategory: "residential",
+        buildingSubType: "detached-house",
+        area: 180,
+        floorCount: 2,
+      },
+    });
+    const second = buildProjectGraphVerticalSliceRequest({
+      designSpec: {
+        buildingCategory: "residential",
+        buildingSubType: "detached-house",
+        area: 180,
+        floorCount: 2,
+      },
+    });
+
+    expect(first.generationSeed).toEqual(expect.any(Number));
+    expect(second.generationSeed).toEqual(expect.any(Number));
+    expect(second.generationSeed).not.toBe(first.generationSeed);
+    expect(first.seedSource).toBe("auto_new_project");
+    expect(first.variationMode).toBe("new_design");
+    expect(first.brief.generation_seed).toBe(first.generationSeed);
+    expect(first.brief.generation_lifecycle).toEqual({
+      generationSeed: first.generationSeed,
+      seedSource: "auto_new_project",
+      variationMode: "new_design",
+    });
+  });
+
+  test("reuses existing ProjectGraph seeds for same-geometry regeneration requests", () => {
+    const request = buildProjectGraphVerticalSliceRequest({
+      projectId: "project-123",
+      designHistoryId: "history-123",
+      designSpec: {
+        geometryHash: "geom-existing",
+        generationSeed: 424242,
+        buildingCategory: "residential",
+        buildingSubType: "detached-house",
+        area: 180,
+        floorCount: 2,
+      },
+    });
+
+    expect(request.generationSeed).toBe(424242);
+    expect(request.seedSource).toBe("reused_existing_project");
+    expect(request.variationMode).toBe("same_geometry_regen");
+  });
+
+  test("layout modifies do not reuse the previous ProjectGraph seed implicitly", () => {
+    const request = buildProjectGraphVerticalSliceRequest({
+      projectId: "project-123",
+      designHistoryId: "history-123",
+      modifyRequest: {
+        variationMode: "layout_modify",
+        customPrompt: "Add a larger first floor studio",
+      },
+      designSpec: {
+        geometryHash: "geom-existing",
+        generationSeed: 424242,
+        buildingCategory: "residential",
+        buildingSubType: "detached-house",
+        area: 220,
+        floorCount: 2,
+      },
+    });
+
+    expect(request.generationSeed).toEqual(expect.any(Number));
+    expect(request.generationSeed).not.toBe(424242);
+    expect(request.seedSource).toBe("auto_new_project");
+    expect(request.variationMode).toBe("layout_modify");
+  });
+
+  test("normalizes generated ProjectGraph seed values into provider-safe integers", () => {
+    const seed = createProjectGraphGenerationSeed();
+    expect(normalizeProjectGraphGenerationSeed(seed)).toBe(seed);
+    expect(seed).toBeGreaterThan(0);
+    expect(seed).toBeLessThan(2147483647);
   });
 
   test("raises unlocked 250 sqm detached-house payloads to two storeys", () => {

--- a/src/__tests__/services/a1/a1ExportGateTechnical.phase4.test.js
+++ b/src/__tests__/services/a1/a1ExportGateTechnical.phase4.test.js
@@ -1,18 +1,18 @@
-// Phase 4 — A1 export gate: promote technical content-empty + cross-view
-// inconsistency to blocking, keep visual-panel failures warning-only.
+// Phase 4/3 — A1 export gate: promote technical content-empty, cross-view
+// inconsistency, ProjectGraph visual authority, and sheet-source evidence to
+// blocking failures.
 //
 // Coverage:
 //   1. evaluateTechnicalPanelEvidence — floor plans now in technical set;
-//      schedules_notes excluded; per-panel blockedPanels detail; absent
-//      panels stay warning at every scope (stable gate contract).
+//      schedules_notes excluded; per-panel blockedPanels detail.
 //   2. evaluateCrossViewConsistencyEvidence — drawingConsistencyChecks errors
 //      become CROSS_VIEW_INCONSISTENT blockers; warnings stay warnings;
 //      drawings absent → silent pass.
-//   3. extractTechnicalGroupBlockers — filters to technical sources only.
+//   3. extractTechnicalGroupBlockers — extracts upstream export blockers.
 //   4. evaluateFinalA1ExportGate end-to-end — technical issues block;
-//      visual-only issues warn but never block from technical group.
+//      visual authority issues now block as Phase 3 hard gates.
 //   5. applyUpstreamGateTechnicalBlockersToQa — folds technical blockers
-//      into qa.status=fail with code A1_EXPORT_GATE_TECHNICAL_BLOCKED.
+//      and visual authority blockers into qa.status=fail.
 
 import {
   evaluateFinalA1ExportGate,
@@ -39,6 +39,7 @@ const TWO_STOREY_REQUIRED_REGISTRY = [
   "section_AA",
   "section_BB",
   "hero_3d",
+  "exterior_render",
   "interior_3d",
   "axonometric",
   "material_palette",
@@ -51,7 +52,24 @@ const TWO_STOREY_REQUIRED_REGISTRY = [
 // ---------------------------------------------------------------------------
 
 function readyPanel(type) {
-  return { type, status: "ready", hasSvg: true };
+  const isProjectPanel =
+    type.startsWith("floor_plan_") ||
+    type.startsWith("elevation_") ||
+    type.startsWith("section_") ||
+    ["hero_3d", "exterior_render", "axonometric", "interior_3d"].includes(type);
+  return {
+    type,
+    status: "ready",
+    hasSvg: true,
+    ...(isProjectPanel
+      ? {
+          geometryHash: "geometry-hash-1",
+          sourceGeometryHash: "geometry-hash-1",
+          providerUsed: "deterministic",
+          imageProviderUsed: "deterministic",
+        }
+      : {}),
+  };
 }
 
 function blankPanel(type) {
@@ -142,8 +160,26 @@ function gateInputs(overrides = {}) {
     targetStoreys: 2,
     visualManifest: {
       manifestHash: "manifest-hash-1",
+      geometryHash: "geometry-hash-1",
     },
-    visualPanels: [],
+    visualPanels: [
+      "hero_3d",
+      "exterior_render",
+      "axonometric",
+      "interior_3d",
+    ].map((type) => ({
+      type,
+      geometryHash: "geometry-hash-1",
+      sourceGeometryHash: "geometry-hash-1",
+      visualManifestHash: "manifest-hash-1",
+      visualIdentityLocked: true,
+      referenceSource: "compiled_3d_control_svg",
+      provider: "openai",
+      providerUsed: "openai",
+      imageProviderUsed: "openai",
+      imageRenderFallback: false,
+      controlSvgHash: `control-${type}`,
+    })),
     materialPalette: { cards: [{ name: "Brick" }] },
     openaiProvider: { ready: true },
     drawings: fullDrawingSet(),
@@ -188,32 +224,30 @@ describe("Phase 4 — evaluateTechnicalPanelEvidence (via gate)", () => {
     expect(gate.evidence.technicalPanelStatus.blank).toEqual([]);
   });
 
-  test("axonometric and site_diagram are listed for later phases — blank blocks today", () => {
+  test("axonometric is visual authority, not technical SVG authority", () => {
     const panels = fullPanelSet().map((panel) =>
       panel.type === "axonometric" ? blankPanel(panel.type) : panel,
     );
     const gate = evaluateFinalA1ExportGate(gateInputs({ panels }));
-    expect(gate.evidence.technicalPanelStatus.status).toBe("blocked");
-    expect(gate.evidence.technicalPanelStatus.blank).toContain("axonometric");
+    expect(gate.evidence.technicalPanelStatus.status).toBe("pass");
+    expect(gate.evidence.technicalPanelStatus.blank).not.toContain(
+      "axonometric",
+    );
   });
 
-  test("panels missing → warning at every scope (stable gate contract: absent evidence does not block)", () => {
-    // Phase 4 design rule: real content-empty enforcement fires via
-    // panelIsBlank only when panels ARE provided. Absent panels stays a
-    // warning at every scope so legacy compose callers that don't pass
-    // per-panel data continue to pass the gate (their hard failures come
-    // from PDF/OCR/glyph evidence, not technical panel presence).
+  test("panels missing blocks when required technical SVG registry is present", () => {
     const upstream = evaluateFinalA1ExportGate(
       gateInputs({ panels: [], scope: "upstream_partial" }),
     );
-    expect(upstream.evidence.technicalPanelStatus.status).toBe("warning");
-    expect(upstream.evidence.technicalPanelStatus.blockers).toEqual([]);
+    expect(upstream.evidence.technicalPanelStatus.status).toBe("blocked");
+    expect(upstream.evidence.technicalPanelStatus.codes).toContain(
+      "TECHNICAL_SVG_PANEL_MISSING",
+    );
 
     const composeFinal = evaluateFinalA1ExportGate(
       gateInputs({ panels: [], scope: "compose_final" }),
     );
-    expect(composeFinal.evidence.technicalPanelStatus.status).toBe("warning");
-    expect(composeFinal.evidence.technicalPanelStatus.blockers).toEqual([]);
+    expect(composeFinal.evidence.technicalPanelStatus.status).toBe("blocked");
   });
 
   test("all elevation panels OK → pass", () => {
@@ -267,9 +301,12 @@ describe("Phase 4 — evaluateCrossViewConsistencyEvidence (via gate)", () => {
     ).toBeGreaterThan(0);
   });
 
-  test("valid drawings → pass", () => {
+  test("valid drawings do not create cross-view blockers", () => {
     const gate = evaluateFinalA1ExportGate(gateInputs());
-    expect(gate.evidence.crossViewConsistencyStatus.status).toBe("pass");
+    expect(["pass", "warning"]).toContain(
+      gate.evidence.crossViewConsistencyStatus.status,
+    );
+    expect(gate.evidence.crossViewConsistencyStatus.blockers).toEqual([]);
   });
 
   test("drawings absent → silent pass (no opinion, no warning)", () => {
@@ -324,21 +361,18 @@ describe("Phase 4 — extractTechnicalGroupBlockers", () => {
     expect(summary.sources).toContain("crossViewConsistencyStatus");
   });
 
-  test("visual-panel manifest mismatch is NOT in technical group (warning-only)", () => {
-    const visualPanels = [
-      {
-        type: "hero_3d",
-        visualManifestHash: "different-hash",
-        visualIdentityLocked: true,
-      },
-    ];
+  test("visual-panel manifest mismatch is included in upstream authority blockers", () => {
+    const base = gateInputs();
+    const visualPanels = base.visualPanels.map((panel) =>
+      panel.type === "hero_3d"
+        ? { ...panel, visualManifestHash: "different-hash" }
+        : panel,
+    );
     const gate = evaluateFinalA1ExportGate(gateInputs({ visualPanels }));
     const summary = extractTechnicalGroupBlockers(gate);
-    // The visual manifest mismatch produces a gate-level blocker, but
-    // extractTechnicalGroupBlockers must NOT include it in the technical
-    // summary — visual concerns stay non-fatal at the slice level.
-    expect(summary.sources).not.toContain("visualPanelStatus");
-    expect(summary.sources).not.toContain("visualManifestStatus");
+    expect(summary.blocked).toBe(true);
+    expect(summary.sources).toContain("projectPanelAuthorityStatus");
+    expect(summary.codes).toContain("VISUAL_MANIFEST_HASH_MISMATCH");
   });
 
   test("not_applicable gate (preview, not final A1) → blocked=false", () => {
@@ -353,24 +387,22 @@ describe("Phase 4 — extractTechnicalGroupBlockers", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 4. evaluateFinalA1ExportGate — visual-only failures stay warning-only.
+// 4. evaluateFinalA1ExportGate — visual authority failures are hard gates.
 // ---------------------------------------------------------------------------
 
 describe("Phase 4 — gate-level visual vs technical separation", () => {
-  test("visual manifest mismatch blocks at gate level but is excluded from technical-group", () => {
-    const visualPanels = [
-      {
-        type: "hero_3d",
-        visualManifestHash: "different-hash",
-        visualIdentityLocked: true,
-      },
-    ];
+  test("visual manifest mismatch blocks at gate level and upstream summary", () => {
+    const base = gateInputs();
+    const visualPanels = base.visualPanels.map((panel) =>
+      panel.type === "hero_3d"
+        ? { ...panel, visualManifestHash: "different-hash" }
+        : panel,
+    );
     const gate = evaluateFinalA1ExportGate(gateInputs({ visualPanels }));
-    // Gate may report blocked overall (because visualPanelStatus blocks),
-    // but the technical-group filter must keep blocked=false so the slice
-    // does not 422 on visual-only issues.
     const summary = extractTechnicalGroupBlockers(gate);
-    expect(summary.blocked).toBe(false);
+    expect(gate.status).toBe("blocked");
+    expect(summary.blocked).toBe(true);
+    expect(summary.sources).toContain("projectPanelAuthorityStatus");
   });
 });
 
@@ -432,18 +464,20 @@ describe("Phase 4 — applyUpstreamGateTechnicalBlockersToQa", () => {
     expect(result.issues[0].details.codes).toContain("CROSS_VIEW_INCONSISTENT");
   });
 
-  test("visual-only failures → qa unchanged (warning-only at slice level)", () => {
-    const visualPanels = [
-      {
-        type: "hero_3d",
-        visualManifestHash: "different-hash",
-        visualIdentityLocked: true,
-      },
-    ];
+  test("visual authority failures → qa.status=fail", () => {
+    const base = gateInputs();
+    const visualPanels = base.visualPanels.map((panel) =>
+      panel.type === "hero_3d"
+        ? { ...panel, visualManifestHash: "different-hash" }
+        : panel,
+    );
     const gate = evaluateFinalA1ExportGate(gateInputs({ visualPanels }));
     const qa = passingQa();
     const result = applyUpstreamGateTechnicalBlockersToQa(qa, gate);
-    expect(result.status).toBe("pass");
-    expect(result.upstreamGateTechnicalBlocked).toBeUndefined();
+    expect(result.status).toBe("fail");
+    expect(result.upstreamGateTechnicalBlocked).toBe(true);
+    expect(result.issues[0].details.codes).toContain(
+      "VISUAL_MANIFEST_HASH_MISMATCH",
+    );
   });
 });

--- a/src/__tests__/services/a1FinalExportContract.test.js
+++ b/src/__tests__/services/a1FinalExportContract.test.js
@@ -40,6 +40,58 @@ function createMockComposeResponse() {
   };
 }
 
+function healthyProjectAuthorityEvidence() {
+  const panelTypes = [
+    "floor_plan_ground",
+    "floor_plan_first",
+    "elevation_north",
+    "elevation_south",
+    "elevation_east",
+    "elevation_west",
+    "section_AA",
+    "section_BB",
+    "hero_3d",
+    "exterior_render",
+    "axonometric",
+    "interior_3d",
+  ];
+  return {
+    panels: panelTypes.map((type) => ({
+      type,
+      status: "ready",
+      hasSvg: true,
+      geometryHash: "geometry-hash-OK",
+      sourceGeometryHash: "geometry-hash-OK",
+      providerUsed: "deterministic",
+      imageProviderUsed: "deterministic",
+    })),
+    panelRegistry: panelTypes,
+    visualManifest: {
+      manifestId: "visual-manifest-test-001",
+      manifestHash: "manifest-hash-OK",
+      geometryHash: "geometry-hash-OK",
+    },
+    visualPanels: [
+      "hero_3d",
+      "exterior_render",
+      "axonometric",
+      "interior_3d",
+    ].map((type) => ({
+      type,
+      geometryHash: "geometry-hash-OK",
+      sourceGeometryHash: "geometry-hash-OK",
+      visualManifestHash: "manifest-hash-OK",
+      visualIdentityLocked: true,
+      referenceSource: "compiled_3d_control_svg",
+      provider: "openai",
+      providerUsed: "openai",
+      imageProviderUsed: "openai",
+      imageRenderFallback: false,
+      controlSvgHash: `control-svg-${type}`,
+    })),
+  };
+}
+
 describe("a1FinalExportContract", () => {
   test("resolves explicit final A1 exports to print-master dimensions and gates", () => {
     const contract = resolveA1RenderContract({
@@ -206,11 +258,9 @@ describe("a1FinalExportContract", () => {
       },
       glyphIntegrity: { status: "pass", blockers: [] },
       sheetSetPlan: { required: false },
+      ...healthyProjectAuthorityEvidence(),
     });
 
-    // Phase F: legacy minimal inputs (no PDF metadata, no panels, no manifest,
-    // no material palette, no openai provider) → gate degrades to "warning"
-    // because evidence is absent; `allowed` stays true (no hard blocker).
     expect(gate.allowed).toBe(true);
     expect(gate.status).toBe("warning");
     expect(gate.blockers).toEqual([]);
@@ -249,6 +299,7 @@ describe("a1FinalExportContract", () => {
       },
       glyphIntegrity: { status: "pass", blockers: [] },
       sheetSetPlan: { required: false },
+      ...healthyProjectAuthorityEvidence(),
     });
 
     // Phase F: legacy success vocabulary updated; stable contract is `allowed`.
@@ -318,6 +369,7 @@ describe("a1FinalExportContract", () => {
           pdfUrl: "/api/a1/compose-output/a1-02.pdf",
         },
       },
+      ...healthyProjectAuthorityEvidence(),
     });
 
     // Phase F: with companion sheet generated the split-status evidence is
@@ -390,6 +442,7 @@ describe("a1FinalExportContract", () => {
 
     const HEALTHY_PANEL_REGISTRY = Object.freeze([
       "hero_3d",
+      "exterior_render",
       "interior_3d",
       "axonometric",
       "site_diagram",
@@ -407,25 +460,53 @@ describe("a1FinalExportContract", () => {
     ]);
 
     const buildHealthyPanels = () =>
-      HEALTHY_PANEL_REGISTRY.map((type) => ({
-        type,
-        status: "ready",
-        hasSvg: true,
-      }));
+      HEALTHY_PANEL_REGISTRY.map((type) => {
+        const isProjectPanel =
+          type.startsWith("floor_plan_") ||
+          type.startsWith("elevation_") ||
+          type.startsWith("section_") ||
+          ["hero_3d", "exterior_render", "axonometric", "interior_3d"].includes(
+            type,
+          );
+        return {
+          type,
+          status: "ready",
+          hasSvg: true,
+          ...(isProjectPanel
+            ? {
+                geometryHash: "geometry-hash-OK",
+                sourceGeometryHash: "geometry-hash-OK",
+                providerUsed: "deterministic",
+                imageProviderUsed: "deterministic",
+              }
+            : {}),
+        };
+      });
 
     const HEALTHY_VISUAL_MANIFEST = Object.freeze({
       version: "visual-manifest-v1",
       manifestId: "visual-manifest-test-001",
       manifestHash: "manifest-hash-OK",
+      geometryHash: "geometry-hash-OK",
       storeyCount: 2,
     });
 
     const buildHealthyVisualPanels = () =>
-      ["hero_3d", "interior_3d", "axonometric"].map((type) => ({
-        type,
-        visualManifestHash: "manifest-hash-OK",
-        visualIdentityLocked: true,
-      }));
+      ["hero_3d", "exterior_render", "interior_3d", "axonometric"].map(
+        (type) => ({
+          type,
+          geometryHash: "geometry-hash-OK",
+          sourceGeometryHash: "geometry-hash-OK",
+          visualManifestHash: "manifest-hash-OK",
+          visualIdentityLocked: true,
+          referenceSource: "compiled_3d_control_svg",
+          provider: "openai",
+          providerUsed: "openai",
+          imageProviderUsed: "openai",
+          imageRenderFallback: false,
+          controlSvgHash: `control-svg-${type}`,
+        }),
+      );
 
     const buildHealthyMaterialPalette = () => ({
       cards: [
@@ -452,6 +533,27 @@ describe("a1FinalExportContract", () => {
       openaiImageUsed: true,
       openaiRequestIds: ["req_abc123"],
       providerFallbacks: [],
+    });
+
+    const buildHealthyGateInputs = (overrides = {}) => ({
+      renderContract: baseRenderContract(),
+      pdfUrl: "/api/a1/compose-output/a1.pdf",
+      finalSheetRegression: okFinalSheetRegression(),
+      postComposeVerification: okPostCompose(),
+      glyphIntegrity: { status: "pass", blockers: [] },
+      sheetSetPlan: { required: false },
+      pdfMetadata: HEALTHY_PDF_METADATA,
+      rasterGlyphIntegrity: HEALTHY_RASTER_INTEGRITY,
+      panels: buildHealthyPanels(),
+      panelRegistry: HEALTHY_PANEL_REGISTRY,
+      targetStoreys: 2,
+      visualManifest: HEALTHY_VISUAL_MANIFEST,
+      visualPanels: buildHealthyVisualPanels(),
+      materialPalette: buildHealthyMaterialPalette(),
+      openaiProvider: HEALTHY_OPENAI_PROVIDER,
+      strictPhotoreal: false,
+      imageGenEnabled: true,
+      ...overrides,
     });
 
     test("valid final A1 passes", () => {
@@ -654,33 +756,18 @@ describe("a1FinalExportContract", () => {
 
     test("visualManifestHash mismatch blocks", () => {
       const gate = evaluateFinalA1ExportGate({
-        renderContract: baseRenderContract(),
-        pdfUrl: "/api/a1/compose-output/a1.pdf",
-        finalSheetRegression: okFinalSheetRegression(),
-        postComposeVerification: okPostCompose(),
-        glyphIntegrity: { status: "pass", blockers: [] },
-        sheetSetPlan: { required: false },
-        pdfMetadata: HEALTHY_PDF_METADATA,
-        rasterGlyphIntegrity: HEALTHY_RASTER_INTEGRITY,
-        panels: buildHealthyPanels(),
-        panelRegistry: HEALTHY_PANEL_REGISTRY,
-        targetStoreys: 2,
-        visualManifest: HEALTHY_VISUAL_MANIFEST,
+        ...buildHealthyGateInputs(),
         visualPanels: [
+          ...buildHealthyVisualPanels().filter(
+            (panel) => panel.type !== "interior_3d",
+          ),
           {
-            type: "hero_3d",
-            visualManifestHash: "manifest-hash-OK",
-            visualIdentityLocked: true,
-          },
-          {
-            type: "interior_3d",
+            ...buildHealthyVisualPanels().find(
+              (panel) => panel.type === "interior_3d",
+            ),
             visualManifestHash: "manifest-hash-DIFFERENT",
-            visualIdentityLocked: true,
           },
         ],
-        materialPalette: buildHealthyMaterialPalette(),
-        openaiProvider: HEALTHY_OPENAI_PROVIDER,
-        imageGenEnabled: true,
       });
 
       expect(gate.status).toBe("blocked");
@@ -688,6 +775,144 @@ describe("a1FinalExportContract", () => {
         "interior_3d",
       );
       expect(gate.blockers.join(" ")).toMatch(/visualManifestHash|manifest/);
+    });
+
+    test.each([
+      [
+        "missing technical SVG panel",
+        () => ({
+          panels: buildHealthyPanels().filter(
+            (panel) => panel.type !== "floor_plan_ground",
+          ),
+        }),
+        /TECHNICAL_SVG_PANEL_MISSING|floor_plan_ground/,
+      ],
+      [
+        "technical panel generated by image model",
+        () => ({
+          panels: buildHealthyPanels().map((panel) =>
+            panel.type === "floor_plan_ground"
+              ? {
+                  ...panel,
+                  providerUsed: "openai",
+                  imageProviderUsed: "openai",
+                  model: "gpt-image-1.5",
+                }
+              : panel,
+          ),
+        }),
+        /TECHNICAL_PANEL_IMAGE_MODEL_USED|floor_plan_ground/,
+      ],
+      [
+        "missing visual panel artifact",
+        () => ({
+          visualPanels: buildHealthyVisualPanels().filter(
+            (panel) => panel.type !== "exterior_render",
+          ),
+        }),
+        /VISUAL_PANEL_MISSING|exterior_render/,
+      ],
+      [
+        "visual panel text-only image generation",
+        () => ({
+          visualPanels: buildHealthyVisualPanels().map((panel) =>
+            panel.type === "hero_3d"
+              ? { ...panel, referenceSource: "text_prompt" }
+              : panel,
+          ),
+        }),
+        /VISUAL_PANEL_TEXT_ONLY_IMAGE_GENERATION|hero_3d/,
+      ],
+      [
+        "missing geometryHash on a project panel",
+        () => ({
+          panels: buildHealthyPanels().map((panel) =>
+            panel.type === "section_AA"
+              ? {
+                  ...panel,
+                  geometryHash: null,
+                  sourceGeometryHash: null,
+                }
+              : panel,
+          ),
+        }),
+        /PROJECT_PANEL_GEOMETRY_HASH_MISSING|section_AA/,
+      ],
+      [
+        "mismatched geometryHash across project panels",
+        () => ({
+          visualPanels: buildHealthyVisualPanels().map((panel) =>
+            panel.type === "axonometric"
+              ? { ...panel, geometryHash: "geometry-hash-DIFFERENT" }
+              : panel,
+          ),
+        }),
+        /PROJECT_PANEL_GEOMETRY_HASH_MISMATCH|geometry-hash-DIFFERENT/,
+      ],
+      [
+        "missing visualManifestHash",
+        () => ({
+          visualPanels: buildHealthyVisualPanels().map((panel) =>
+            panel.type === "hero_3d"
+              ? { ...panel, visualManifestHash: null }
+              : panel,
+          ),
+        }),
+        /VISUAL_MANIFEST_HASH_MISSING|hero_3d/,
+      ],
+      [
+        "visualIdentityLocked false",
+        () => ({
+          visualPanels: buildHealthyVisualPanels().map((panel) =>
+            panel.type === "interior_3d"
+              ? { ...panel, visualIdentityLocked: false }
+              : panel,
+          ),
+        }),
+        /VISUAL_IDENTITY_UNLOCKED|interior_3d/,
+      ],
+      [
+        "strict mode visual fallback",
+        () => ({
+          strictPhotoreal: true,
+          imageGenEnabled: true,
+          visualPanels: buildHealthyVisualPanels().map((panel) =>
+            panel.type === "hero_3d"
+              ? {
+                  ...panel,
+                  provider: "deterministic",
+                  providerUsed: "deterministic",
+                  imageProviderUsed: "deterministic",
+                  imageRenderFallback: true,
+                  imageRenderFallbackReason: "openai_error",
+                }
+              : panel,
+          ),
+        }),
+        /STRICT_IMAGE_RENDER_FALLBACK|hero_3d/,
+      ],
+      [
+        "PDF used empty frames instead of sheetArtifact.svgString",
+        () => ({
+          sheetArtifact: {
+            svgString: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+            svgHash: "sheet-svg-hash-OK",
+          },
+          pdfMetadata: {
+            ...HEALTHY_PDF_METADATA,
+            sourceSvgHash: "sheet-svg-hash-OK",
+            emptyFrameFallbackUsed: true,
+          },
+        }),
+        /A1_PDF_EMPTY_FRAMES_USED|sheetArtifact\.svgString/,
+      ],
+    ])("Phase 3 blocks %s", (_label, buildOverrides, blockerPattern) => {
+      const gate = evaluateFinalA1ExportGate(
+        buildHealthyGateInputs(buildOverrides()),
+      );
+      expect(gate.status).toBe("blocked");
+      expect(gate.allowed).toBe(false);
+      expect(gate.blockers.join(" ")).toMatch(blockerPattern);
     });
 
     test("missing material provenance warns", () => {

--- a/src/__tests__/services/projectGraphA1ComposerPhase4.test.js
+++ b/src/__tests__/services/projectGraphA1ComposerPhase4.test.js
@@ -1,0 +1,239 @@
+import {
+  buildTitleBlockPanelArtifact,
+  __projectGraphVerticalSliceInternals,
+} from "../../services/project/projectGraphVerticalSliceService.js";
+
+const {
+  buildA1PdfSourceMetadata,
+  buildPanelPlacements,
+  buildSheetSvg,
+  wrapPngAsSvgPanel,
+} = __projectGraphVerticalSliceInternals;
+
+const GEOMETRY_HASH = "geometry-hash-phase4";
+const VISUAL_MANIFEST = {
+  manifestId: "visual-manifest-phase4",
+  manifestHash: "visual-manifest-hash-phase4",
+  geometryHash: GEOMETRY_HASH,
+};
+
+function svgArtifact(panelType, body, metadata = {}) {
+  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="700" viewBox="0 0 1000 700"><rect width="1000" height="700" fill="#fff"/>${body}</svg>`;
+  return {
+    asset_id: `asset-${panelType}`,
+    asset_type: "compiled_project_panel_svg",
+    panel_type: panelType,
+    panelType,
+    source_model_hash: GEOMETRY_HASH,
+    geometryHash: GEOMETRY_HASH,
+    svgHash: `svg-hash-${panelType}`,
+    width: 1000,
+    height: 700,
+    svgString,
+    metadata: {
+      geometryHash: GEOMETRY_HASH,
+      sourceGeometryHash: GEOMETRY_HASH,
+      ...metadata,
+    },
+  };
+}
+
+function visualArtifact(panelType, { fallback = false } = {}) {
+  const pngPayload = Buffer.from(`phase4-${panelType}`).toString("base64");
+  const imageSvg = fallback
+    ? `<g id="deterministic-control-${panelType}"><path d="M100 520 L500 160 L900 520 Z" fill="#e9eef2" stroke="#223"/></g>`
+    : `<image href="data:image/png;base64,${pngPayload}" x="0" y="0" width="1000" height="700" preserveAspectRatio="xMidYMid meet" data-fit-mode="object-contain"/>`;
+  return svgArtifact(panelType, imageSvg, {
+    source: fallback
+      ? "compiled_project_render_inputs"
+      : "project_graph_image_renderer",
+    visualManifestHash: VISUAL_MANIFEST.manifestHash,
+    visualManifestId: VISUAL_MANIFEST.manifestId,
+    visualIdentityLocked: true,
+    referenceSource: "compiled_3d_control_svg",
+    imageRenderFallback: fallback,
+    imageRenderFallbackReason: fallback ? "gate_disabled" : null,
+    imageProviderUsed: fallback ? "deterministic" : "openai",
+    providerUsed: fallback ? "deterministic" : "openai",
+    controlSvgHash: `control-${panelType}`,
+  });
+}
+
+function dataArtifact(panelType, label) {
+  return svgArtifact(
+    panelType,
+    `<text x="80" y="120" font-size="48">${label}</text>`,
+    { source: "project_graph_data_panel" },
+  );
+}
+
+function buildFixtureArtifacts({ fallbackHero = false } = {}) {
+  const artifacts = [
+    svgArtifact(
+      "site_context",
+      '<g id="phase4-site-context"><text x="60" y="100">SITE / CONTEXT</text></g>',
+    ),
+    svgArtifact(
+      "floor_plan_ground",
+      '<g id="phase4-dimension-chain" class="dimension-chain"><text class="room-label">Living Room</text><path d="M80 80 H920 V620 H80 Z"/></g>',
+      {
+        drawingType: "plan",
+        technicalQualityMetadata: {
+          normalizedViewBox: "40 40 920 620",
+          contentBounds: {
+            x: 40,
+            y: 40,
+            width: 920,
+            height: 620,
+            occupancyRatio: 0.72,
+            widthRatio: 0.92,
+            heightRatio: 0.88,
+          },
+        },
+      },
+    ),
+    svgArtifact(
+      "floor_plan_first",
+      '<g id="phase4-first-plan"><text class="room-label">Bedroom</text><path d="M80 80 H920 V620 H80 Z"/></g>',
+    ),
+    svgArtifact("elevation_north", '<g id="phase4-north-elevation"/>'),
+    svgArtifact("elevation_south", '<g id="phase4-south-elevation"/>'),
+    svgArtifact("elevation_east", '<g id="phase4-east-elevation"/>'),
+    svgArtifact("elevation_west", '<g id="phase4-west-elevation"/>'),
+    svgArtifact("section_AA", '<g id="phase4-section-aa"/>'),
+    svgArtifact("section_BB", '<g id="phase4-section-bb"/>'),
+    visualArtifact("hero_3d", { fallback: fallbackHero }),
+    visualArtifact("axonometric"),
+    visualArtifact("interior_3d"),
+    dataArtifact("material_palette", "MATERIALS"),
+    dataArtifact("key_notes", "NOTES"),
+    dataArtifact("title_block", "TITLE"),
+  ];
+  return Object.fromEntries(artifacts.map((artifact) => [artifact.asset_id, artifact]));
+}
+
+function buildFixtureSheet({ fallbackHero = false } = {}) {
+  const panelArtifacts = buildFixtureArtifacts({ fallbackHero });
+  const panelPlacements = buildPanelPlacements({
+    drawingSet: { drawings: [] },
+    panelArtifacts,
+    targetStoreys: 2,
+    layoutTemplate: "presentation-v3",
+    geometryHash: GEOMETRY_HASH,
+    briefInputHash: "brief-hash-phase4",
+  });
+  return buildSheetSvg({
+    projectGraphId: "project-phase4",
+    brief: {
+      project_name: "Phase 4 Composer Test",
+      reference_match: false,
+      brief_input_hash: "brief-hash-phase4",
+    },
+    geometryHash: GEOMETRY_HASH,
+    panelPlacements,
+    panelArtifacts,
+    qaStatus: "pending",
+    sheetNumber: "A1-01",
+    sheetLabel: "Phase 4",
+    layoutTemplate: "presentation-v3",
+    visualManifest: VISUAL_MANIFEST,
+  });
+}
+
+describe("ProjectGraph A1 composer Phase 4", () => {
+  test("final sheet SVG embeds actual technical SVG content, not empty frames", () => {
+    const svg = buildFixtureSheet();
+
+    expect(svg).toContain("phase4-dimension-chain");
+    expect(svg).toContain("Living Room");
+    expect(svg).toContain("GROUND FLOOR PLAN");
+    expect(svg).toContain('data-panel-kind="technical"');
+    expect(svg).not.toContain('data-panel-missing="true"');
+  });
+
+  test("visual image panels are embedded when image2 artifacts are present", () => {
+    const svg = buildFixtureSheet();
+
+    expect(svg).toContain('data-panel-id="hero_3d"');
+    expect(svg).toContain('data-panel-id="axonometric"');
+    expect(svg).toContain('data-panel-id="interior_3d"');
+    expect(svg).toContain("EXTERIOR PERSPECTIVE");
+    expect(svg).toContain("AXONOMETRIC");
+    expect(svg).toContain("INTERIOR VIEW");
+    expect(svg).toContain("data:image/png;base64");
+    expect(svg).toContain("IMAGE2 / OPENAI EDIT");
+  });
+
+  test("embedded panels use object-contain preserveAspectRatio behavior", () => {
+    const svg = buildFixtureSheet();
+    const wrappedPng = wrapPngAsSvgPanel(
+      Buffer.from("phase4-png"),
+      "0 0 1000 700",
+      1000,
+      700,
+    );
+
+    expect(svg).toContain('preserveAspectRatio="xMidYMid meet"');
+    expect(svg).toContain('data-fit-mode="object-contain"');
+    expect(wrappedPng).toContain('preserveAspectRatio="xMidYMid meet"');
+    expect(wrappedPng).not.toContain("xMidYMid slice");
+  });
+
+  test("title block and provenance footer include geometry and visual manifest hashes", () => {
+    const titleBlock = buildTitleBlockPanelArtifact({
+      projectGraphId: "project-phase4",
+      brief: {
+        project_name: "Phase 4 Composer Test",
+        site_input: { address: "1 Test Street" },
+        target_gia_m2: 200,
+        target_storeys: 2,
+      },
+      geometryHash: GEOMETRY_HASH,
+      visualManifest: VISUAL_MANIFEST,
+      sheetPlan: {
+        sheet_number: "A1-01",
+        label: "RIBA Stage 2",
+        revision: "P02",
+        date: "2026-05-05",
+      },
+    });
+    const svg = buildFixtureSheet();
+
+    expect(titleBlock.svgString).toContain(`geometryHash ${GEOMETRY_HASH.slice(0, 18)}`);
+    expect(titleBlock.svgString).toContain(
+      `visualManifestHash ${VISUAL_MANIFEST.manifestHash.slice(0, 18)}`,
+    );
+    expect(svg).toContain('data-provenance-footer="true"');
+    expect(svg).toContain(GEOMETRY_HASH);
+    expect(svg).toContain(VISUAL_MANIFEST.manifestHash);
+    expect(svg).toContain("ProjectGraph authority");
+  });
+
+  test("PDF source metadata points at sheetArtifact.svgString", () => {
+    const metadata = buildA1PdfSourceMetadata({
+      asset_id: "asset-a1-svg",
+      svgHash: "sheet-svg-hash-phase4",
+      svgString: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+    });
+
+    expect(metadata).toEqual(
+      expect.objectContaining({
+        sourceSvgHash: "sheet-svg-hash-phase4",
+        sourceSvgAssetId: "asset-a1-svg",
+        sheetArtifactSvgStringUsed: true,
+        sourceSvgRole: "sheetArtifact.svgString",
+        emptyFrameFallbackUsed: false,
+      }),
+    );
+  });
+
+  test("fallback visual panels are labeled deterministic and do not claim OpenAI success", () => {
+    const svg = buildFixtureSheet({ fallbackHero: true });
+
+    expect(svg).toContain('data-panel-id="hero_3d"');
+    expect(svg).toContain('data-image-render-fallback="true"');
+    expect(svg).toContain('data-provider-used="deterministic"');
+    expect(svg).toContain("DETERMINISTIC FALLBACK");
+    expect(svg).toContain("fallback hero_3d");
+  });
+});

--- a/src/__tests__/services/projectGraphA1GoldenSvgImage2.test.js
+++ b/src/__tests__/services/projectGraphA1GoldenSvgImage2.test.js
@@ -1,0 +1,800 @@
+import fs from "fs";
+import path from "path";
+import {
+  buildRequiredA1PanelTypes,
+  buildTitleBlockPanelArtifact,
+  buildVisual3DPanelArtifacts,
+  __projectGraphVerticalSliceInternals,
+} from "../../services/project/projectGraphVerticalSliceService.js";
+import {
+  evaluateFinalA1ExportGate,
+  resolveA1RenderContract,
+} from "../../services/a1/a1FinalExportContract.js";
+import { computeCDSHashSync } from "../../services/validation/cdsHash.js";
+import { renderProjectGraphPanelImage } from "../../services/render/projectGraphImageRenderer.js";
+import { ensureCompiledProjectRenderInputs } from "../../services/compiler/compiledProjectRenderInputs.js";
+
+jest.mock("../../services/render/projectGraphImageRenderer.js", () => ({
+  renderProjectGraphPanelImage: jest.fn(),
+}));
+
+jest.mock("../../services/compiler/compiledProjectRenderInputs.js", () => ({
+  ensureCompiledProjectRenderInputs: jest.fn(),
+}));
+
+const { buildPanelPlacements, buildSheetSvg } =
+  __projectGraphVerticalSliceInternals;
+
+const fixture = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), "evals/golden/uk_house_svg_image2/manifest.json"),
+    "utf8",
+  ),
+);
+
+const GEOMETRY_HASH = fixture.expected.geometryHash;
+const VISUAL_MANIFEST = {
+  manifestId: "golden-uk-house-visual-manifest",
+  manifestHash: fixture.expected.visualManifestHash,
+  geometryHash: GEOMETRY_HASH,
+  buildingType: "detached-house",
+  storeyCount: 2,
+  roof: {
+    form: "gable",
+    ridgeOrientation: "east-west",
+    materialName: "charcoal standing seam",
+  },
+  primaryFacadeMaterial: {
+    name: "buff brick",
+    hex: "#c8ad7f",
+    application: "walls",
+  },
+  windowMaterial: "white frames",
+  doorMaterial: "timber entrance bay",
+  windowRhythm: "regular domestic openings",
+  entranceOrientation: "front-left timber bay",
+};
+
+const VISUAL_PANEL_TYPES = [
+  "hero_3d",
+  "exterior_render",
+  "axonometric",
+  "interior_3d",
+];
+
+function makeControlSvg(panelType) {
+  return [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">',
+    `<g id="golden-control-${panelType}" data-reference-source="compiled_3d_control_svg">`,
+    '<path class="massing-shell" d="M210 610 L210 330 L600 150 L990 330 L990 610 Z" fill="#f6f6f2" stroke="#111"/>',
+    '<path class="gable-roof" d="M210 330 L600 150 L990 330" fill="none" stroke="#111" stroke-width="8"/>',
+    '<rect class="opening window" x="315" y="390" width="110" height="120" fill="#dbeafe" stroke="#111"/>',
+    '<rect class="opening entrance" x="535" y="455" width="130" height="155" fill="#8b5a2b" stroke="#111"/>',
+    '<rect class="opening window" x="775" y="390" width="110" height="120" fill="#dbeafe" stroke="#111"/>',
+    "</g>",
+    "</svg>",
+  ].join("");
+}
+
+function makeRenderInputs() {
+  return Object.fromEntries(
+    VISUAL_PANEL_TYPES.map((panelType) => {
+      const svgString = makeControlSvg(panelType);
+      return [
+        panelType,
+        {
+          svgString,
+          svgHash: `golden-control-svg-hash-${panelType}`,
+          width: 1200,
+          height: 800,
+          metadata: {
+            width: 1200,
+            height: 800,
+            normalizedViewBox: "0 0 1200 800",
+            camera: { view: panelType },
+            primitiveCount: 9,
+            surfaceCount: 9,
+            geometryHash: GEOMETRY_HASH,
+          },
+        },
+      ];
+    }),
+  );
+}
+
+function technicalSvg(panelType, title, body) {
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800" data-golden-panel="${panelType}">`,
+    '<rect width="1200" height="800" fill="#ffffff"/>',
+    `<text class="drawing-title" x="60" y="72">${title}</text>`,
+    body,
+    '<g id="scale-bar" class="scale-marker"><line x1="60" y1="735" x2="260" y2="735" stroke="#111" stroke-width="4"/><text x="60" y="765">SCALE 1:100</text></g>',
+    "</svg>",
+  ].join("");
+}
+
+function technicalArtifact(panelType, drawingType, title, body) {
+  const svgString = technicalSvg(panelType, title, body);
+  return {
+    asset_id: `asset-golden-${panelType}`,
+    asset_type: "compiled_project_panel_svg",
+    panel_type: panelType,
+    panelType,
+    source_model_hash: GEOMETRY_HASH,
+    geometryHash: GEOMETRY_HASH,
+    sourceGeometryHash: GEOMETRY_HASH,
+    svgHash: computeCDSHashSync({ panelType, svgString, GEOMETRY_HASH }),
+    width: 1200,
+    height: 800,
+    svgString,
+    metadata: {
+      source: "compiled_project_technical_pack",
+      drawingType,
+      geometryHash: GEOMETRY_HASH,
+      sourceGeometryHash: GEOMETRY_HASH,
+      technicalDrawingFromImageModel: false,
+      imageModelGenerated: false,
+      technicalQualityMetadata: {
+        has_scale_bar: true,
+        has_overall_dimensions: true,
+        room_label_count: drawingType === "plan" ? 5 : 0,
+        contentBounds: {
+          x: 40,
+          y: 40,
+          width: 1120,
+          height: 720,
+          occupancyRatio: 0.78,
+          widthRatio: 0.93,
+          heightRatio: 0.9,
+        },
+      },
+    },
+  };
+}
+
+function planBody(level, rooms) {
+  return [
+    `<g id="${level}-blueprint" class="cad-layer-walls cad-lineweight-outline blueprint-linework">`,
+    '<g id="north-arrow" class="cad-layer-dimensions cad-lineweight-detail"><path d="M1090 105 L1115 175 L1090 158 L1065 175 Z" fill="#111"/><text x="1080" y="92">N</text></g>',
+    '<g id="title-block" class="cad-layer-dimensions cad-lineweight-detail"><text x="905" y="735">A1-GOLDEN / PROJECTGRAPH</text></g>',
+    '<rect x="170" y="140" width="840" height="520" fill="none" stroke="#0f172a" stroke-width="8"/>',
+    '<line class="cad-layer-walls cad-lineweight-primary" x1="480" y1="140" x2="480" y2="660" stroke="#0f172a" stroke-width="5"/>',
+    '<line class="cad-layer-walls cad-lineweight-primary" x1="170" y1="410" x2="1010" y2="410" stroke="#0f172a" stroke-width="5"/>',
+    '<g class="dimension-chain cad-layer-dimensions cad-lineweight-detail" id="overall-dimensions"><line x1="170" y1="105" x2="1010" y2="105" stroke="#1d4ed8"/><text x="550" y="95">8.4m</text><line x1="1045" y1="140" x2="1045" y2="660" stroke="#1d4ed8"/><text x="1065" y="410">7.2m</text></g>',
+    '<g class="opening-layer"><rect class="door-symbol" x="560" y="620" width="90" height="40"/><rect class="window-symbol" x="275" y="132" width="110" height="16"/><rect class="window-symbol" x="780" y="132" width="110" height="16"/></g>',
+    '<g id="plan-section-markers" class="cad-layer-dimensions"><line class="section-marker" data-section-label="A-A" x1="220" y1="235" x2="960" y2="235" stroke="#7c2d12" stroke-width="3"/><line class="section-marker" data-section-label="B-B" x1="390" y1="170" x2="390" y2="625" stroke="#7c2d12" stroke-width="3"/></g>',
+    rooms
+      .map(
+        (room, index) =>
+          `<g><text class="room-label" x="${230 + (index % 3) * 275}" y="${250 + Math.floor(index / 3) * 235}">${room}</text><text class="room-area-label" x="${230 + (index % 3) * 275}" y="${274 + Math.floor(index / 3) * 235}" data-room-area-m2="${12 + index}">${12 + index} m2</text></g>`,
+      )
+      .join(""),
+    "</g>",
+  ].join("");
+}
+
+function elevationBody() {
+  return [
+    '<g id="golden-north-elevation" class="cad-layer-walls cad-lineweight-outline elevation-linework">',
+    '<line id="ground-line" class="cad-layer-ground cad-lineweight-primary" x1="90" y1="650" x2="1110" y2="650" stroke="#111" stroke-width="5"/>',
+    '<line class="cad-layer-datums cad-lineweight-detail" data-datum-role="ffl-ground" x1="150" y1="650" x2="1080" y2="650" stroke="#1d4ed8"/><text x="155" y="638">FFL +0.000</text>',
+    '<line class="cad-layer-datums cad-lineweight-detail" data-datum-role="eaves" x1="205" y1="330" x2="995" y2="330" stroke="#1d4ed8"/><text x="155" y="324">EAVES +5.600</text>',
+    '<line class="cad-layer-datums cad-lineweight-detail" data-datum-role="ridge" x1="540" y1="155" x2="660" y2="155" stroke="#1d4ed8"/><text x="665" y="160">RIDGE +7.800</text>',
+    '<rect class="buff-brick-wall cad-lineweight-primary" x="220" y="330" width="760" height="320" fill="none" stroke="#111" stroke-width="6"/>',
+    '<path class="gable-roof-line charcoal-standing-seam cad-lineweight-primary" d="M220 330 L600 155 L980 330" fill="none" stroke="#111" stroke-width="8"/>',
+    '<rect class="white-frame-window" x="320" y="405" width="105" height="115" fill="none" stroke="#1d4ed8" stroke-width="4"/>',
+    '<rect class="timber-entrance-bay" x="540" y="470" width="125" height="180" fill="none" stroke="#92400e" stroke-width="5"/>',
+    '<rect class="white-frame-window" x="775" y="405" width="105" height="115" fill="none" stroke="#1d4ed8" stroke-width="4"/>',
+    '<text x="220" y="690">NORTH ELEVATION</text>',
+    "</g>",
+  ].join("");
+}
+
+function sectionBody() {
+  return [
+    '<g id="golden-section-aa" class="cad-layer-walls cad-lineweight-cut section-linework">',
+    '<line id="ground-line" class="cad-layer-ground cad-lineweight-primary" x1="120" y1="650" x2="1080" y2="650" stroke="#111" stroke-width="5"/>',
+    '<path class="section-cut-wall cad-lineweight-cut" d="M260 650 V320 H940 V650" fill="none" stroke="#111" stroke-width="8"/>',
+    '<path class="section-roof" d="M260 320 L600 145 L940 320" fill="none" stroke="#111" stroke-width="8"/>',
+    '<line class="floor-slab" x1="260" y1="485" x2="940" y2="485" stroke="#111" stroke-width="6"/>',
+    '<g class="cad-vertical-dimension-chain cad-layer-dimensions"><line x1="1015" y1="650" x2="1015" y2="145" stroke="#1d4ed8"/><text x="1030" y="405">7.8m ridge</text></g>',
+    '<text class="room-label" x="350" y="590">Kitchen / dining</text>',
+    '<text class="room-label" x="350" y="420">Bedroom</text>',
+    '<text x="120" y="705">SECTION A-A</text>',
+    "</g>",
+  ].join("");
+}
+
+function dataArtifact(panelType, label, body) {
+  return technicalArtifact(
+    panelType,
+    "data",
+    label,
+    `<g id="golden-${panelType}">${body}</g>`,
+  );
+}
+
+function buildTechnicalArtifacts() {
+  const artifacts = [
+    technicalArtifact(
+      "site_context",
+      "site",
+      "SITE / CONTEXT",
+      '<g id="golden-site-context"><rect class="site-boundary" x="220" y="150" width="760" height="500" fill="none" stroke="#111" stroke-width="6"/><path class="context-road" d="M120 690 H1080" stroke="#888" stroke-width="18"/><text x="250" y="230">UK detached house plot</text></g>',
+    ),
+    technicalArtifact(
+      "floor_plan_ground",
+      "plan",
+      "GROUND FLOOR PLAN",
+      planBody("ground", [
+        "Hall",
+        "Living room",
+        "Kitchen / dining",
+        "WC",
+        "Utility",
+      ]),
+    ),
+    technicalArtifact(
+      "floor_plan_first",
+      "plan",
+      "FIRST FLOOR PLAN",
+      planBody("first", [
+        "Bedroom 1",
+        "Bedroom 2",
+        "Bedroom 3",
+        "Bathroom",
+        "Landing",
+      ]),
+    ),
+    technicalArtifact(
+      "elevation_north",
+      "elevation",
+      "NORTH ELEVATION",
+      elevationBody(),
+    ),
+    technicalArtifact(
+      "elevation_south",
+      "elevation",
+      "SOUTH ELEVATION",
+      elevationBody(),
+    ),
+    technicalArtifact(
+      "elevation_east",
+      "elevation",
+      "EAST ELEVATION",
+      elevationBody(),
+    ),
+    technicalArtifact(
+      "elevation_west",
+      "elevation",
+      "WEST ELEVATION",
+      elevationBody(),
+    ),
+    technicalArtifact("section_AA", "section", "SECTION A-A", sectionBody()),
+    technicalArtifact("section_BB", "section", "SECTION B-B", sectionBody()),
+    dataArtifact(
+      "material_palette",
+      "MATERIALS",
+      '<rect x="90" y="150" width="160" height="90" fill="#c8ad7f"/><text x="280" y="200">Buff brick walls</text><rect x="90" y="280" width="160" height="90" fill="#30343b"/><text x="280" y="330">Charcoal standing seam roof</text><rect x="90" y="410" width="160" height="90" fill="#f8fafc" stroke="#111"/><text x="280" y="460">White window frames</text>',
+    ),
+    dataArtifact(
+      "key_notes",
+      "NOTES",
+      '<text x="80" y="160">ProjectGraph authority: compiled geometry controls all panels.</text><text x="80" y="230">Technical panels are deterministic SVG blueprint drawings.</text><text x="80" y="300">Visual panels are image2 edits from control SVG references.</text>',
+    ),
+  ];
+  const titleBlock = buildTitleBlockPanelArtifact({
+    projectGraphId: "golden-projectgraph-uk-house",
+    brief: {
+      project_name: fixture.brief.project_name,
+      site_input: { address: "Golden UK detached house test plot" },
+      target_gia_m2: 121,
+      target_storeys: 2,
+      brief_input_hash: "golden-brief-hash",
+    },
+    geometryHash: GEOMETRY_HASH,
+    visualManifest: VISUAL_MANIFEST,
+    sheetPlan: {
+      sheet_number: "A1-GOLDEN",
+      label: "SVG + IMAGE2 ACCEPTANCE",
+      revision: "P06",
+      date: "2026-05-05",
+    },
+  });
+  artifacts.push(titleBlock);
+  return Object.fromEntries(
+    artifacts.map((artifact) => [artifact.asset_id, artifact]),
+  );
+}
+
+async function buildGoldenArtifacts() {
+  const technicalArtifacts = buildTechnicalArtifacts();
+  const visualArtifacts = await buildVisual3DPanelArtifacts({
+    compiledProject: {
+      geometryHash: GEOMETRY_HASH,
+      levels: [{ id: "ground" }, { id: "first" }],
+      roof: { type: "gable", summary: { ridge_count: 1 } },
+      rooms: [],
+      openings: [],
+      walls: [],
+    },
+    geometryHash: GEOMETRY_HASH,
+    brief: {
+      project_name: fixture.brief.project_name,
+      building_type: "detached-house",
+      target_storeys: 2,
+      generation_seed: 260606,
+    },
+    visualManifest: VISUAL_MANIFEST,
+    programmeSummary: {
+      levels: [
+        { name: "Ground", rooms: fixture.brief.programme.ground },
+        { name: "First", rooms: fixture.brief.programme.first },
+      ],
+    },
+    region: "UK",
+    sheetDesignContext: {
+      contextHash: "golden-sheet-design-context",
+      visualManifestHash: VISUAL_MANIFEST.manifestHash,
+    },
+  });
+  return {
+    ...technicalArtifacts,
+    ...visualArtifacts,
+  };
+}
+
+function artifactsByPanelType(panelArtifacts) {
+  return Object.fromEntries(
+    Object.values(panelArtifacts).map((artifact) => [
+      artifact.panel_type,
+      artifact,
+    ]),
+  );
+}
+
+function panelEvidence(artifact) {
+  return {
+    type: artifact.panel_type,
+    panelType: artifact.panel_type,
+    status: "ready",
+    hasSvg: Boolean(artifact.svgString),
+    geometryHash: artifact.geometryHash || artifact.source_model_hash,
+    sourceGeometryHash:
+      artifact.sourceGeometryHash ||
+      artifact.metadata?.sourceGeometryHash ||
+      artifact.geometryHash ||
+      artifact.source_model_hash,
+    visualManifestHash:
+      artifact.visualManifestHash ||
+      artifact.metadata?.visualManifestHash ||
+      null,
+    visualIdentityLocked:
+      artifact.visualIdentityLocked === true ||
+      artifact.metadata?.visualIdentityLocked === true,
+    referenceSource:
+      artifact.referenceSource || artifact.metadata?.referenceSource || null,
+    provider: artifact.provider || artifact.metadata?.provider || null,
+    providerUsed:
+      artifact.providerUsed || artifact.metadata?.providerUsed || null,
+    imageProviderUsed:
+      artifact.imageProviderUsed ||
+      artifact.metadata?.imageProviderUsed ||
+      null,
+    imageRenderFallback:
+      artifact.imageRenderFallback ??
+      artifact.metadata?.imageRenderFallback ??
+      null,
+    imageRenderFallbackReason:
+      artifact.imageRenderFallbackReason ||
+      artifact.metadata?.imageRenderFallbackReason ||
+      null,
+    model: artifact.model || artifact.metadata?.model || null,
+    requestId: artifact.requestId || artifact.metadata?.requestId || null,
+    usage: artifact.usage || artifact.metadata?.usage || null,
+    controlSvgHash:
+      artifact.controlSvgHash || artifact.metadata?.controlSvgHash || null,
+    svgString: artifact.svgString,
+    metadata: artifact.metadata || {},
+  };
+}
+
+function buildDrawingsForGate(byPanel) {
+  return {
+    plan: [
+      {
+        level_id: "0",
+        svg: byPanel.floor_plan_ground.svgString,
+        sheet_mode: false,
+        window_count: 2,
+        door_count: 1,
+        room_label_count: 5,
+        area_label_count: 5,
+        dimension_chain_count: 1,
+        section_marker_count: 2,
+        section_marker_labels: ["A-A", "B-B"],
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-dimensions"],
+        cad_lineweight_classes: [
+          "cad-lineweight-outline",
+          "cad-lineweight-primary",
+        ],
+      },
+      {
+        level_id: "1",
+        svg: byPanel.floor_plan_first.svgString,
+        sheet_mode: false,
+        window_count: 2,
+        door_count: 0,
+        room_label_count: 5,
+        area_label_count: 5,
+        dimension_chain_count: 1,
+        section_marker_count: 2,
+        section_marker_labels: ["A-A", "B-B"],
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-dimensions"],
+        cad_lineweight_classes: [
+          "cad-lineweight-outline",
+          "cad-lineweight-primary",
+        ],
+      },
+    ],
+    elevation: [
+      {
+        svg: byPanel.elevation_north.svgString,
+        window_count: 1,
+        door_count: 1,
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-datums"],
+        cad_lineweight_classes: ["cad-lineweight-outline"],
+      },
+      {
+        svg: byPanel.elevation_south.svgString,
+        window_count: 1,
+        door_count: 0,
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-datums"],
+        cad_lineweight_classes: ["cad-lineweight-outline"],
+      },
+      {
+        svg: byPanel.elevation_east.svgString,
+        window_count: 1,
+        door_count: 0,
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-datums"],
+        cad_lineweight_classes: ["cad-lineweight-outline"],
+      },
+      {
+        svg: byPanel.elevation_west.svgString,
+        window_count: 1,
+        door_count: 0,
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-datums"],
+        cad_lineweight_classes: ["cad-lineweight-outline"],
+      },
+    ],
+    section: [
+      {
+        svg: byPanel.section_AA.svgString,
+        section_id: "AA",
+        floor_count: 2,
+        ground_line_count: 1,
+        stair_count: 0,
+        vertical_dimension_chain_count: 1,
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-dimensions"],
+        cad_lineweight_classes: ["cad-lineweight-cut"],
+      },
+      {
+        svg: byPanel.section_BB.svgString,
+        section_id: "BB",
+        floor_count: 2,
+        ground_line_count: 1,
+        stair_count: 0,
+        vertical_dimension_chain_count: 1,
+        cad_layer_classes: ["cad-layer-walls", "cad-layer-dimensions"],
+        cad_lineweight_classes: ["cad-lineweight-cut"],
+      },
+    ],
+  };
+}
+
+function buildGoldenSheet(panelArtifacts) {
+  const panelPlacements = buildPanelPlacements({
+    drawingSet: { drawings: [] },
+    panelArtifacts,
+    targetStoreys: 2,
+    layoutTemplate: fixture.expected.layout,
+    geometryHash: GEOMETRY_HASH,
+    briefInputHash: "golden-brief-hash",
+  });
+  const svgString = buildSheetSvg({
+    projectGraphId: "golden-projectgraph-uk-house",
+    brief: {
+      project_name: fixture.brief.project_name,
+      reference_match: false,
+      brief_input_hash: "golden-brief-hash",
+    },
+    geometryHash: GEOMETRY_HASH,
+    panelPlacements,
+    panelArtifacts,
+    qaStatus: "pass",
+    sheetNumber: "A1-GOLDEN",
+    sheetLabel: "SVG + IMAGE2 ACCEPTANCE",
+    layoutTemplate: fixture.expected.layout,
+    visualManifest: VISUAL_MANIFEST,
+  });
+  return {
+    svgString,
+    svgHash: computeCDSHashSync({ svgString }),
+    panelPlacements,
+  };
+}
+
+function buildGoldenGateInputs({
+  panelArtifacts,
+  sheetArtifact,
+  visualPanels,
+}) {
+  const byPanel = artifactsByPanelType(panelArtifacts);
+  const panelRegistry = [
+    ...buildRequiredA1PanelTypes(2, fixture.expected.layout),
+    "exterior_render",
+  ];
+  return {
+    renderContract: resolveA1RenderContract({ renderIntent: "final_a1" }),
+    pdfUrl: "data:application/pdf;base64,Z29sZGVu",
+    finalSheetRegression: {
+      finalSheetRegressionReady: true,
+      hardBlockers: [],
+    },
+    postComposeVerification: {
+      publishability: { status: "pass", blockers: [] },
+      renderedTextZone: {
+        status: "pass",
+        blockers: [],
+        ocr: { available: true },
+        ocrEvidenceQuality: "verified",
+      },
+    },
+    glyphIntegrity: { status: "pass", blockers: [] },
+    rasterGlyphIntegrity: { status: "pass", warnings: [], suspectZones: [] },
+    pdfMetadata: {
+      dpi: 300,
+      pdfRenderMode: "raster_textpaths_300dpi",
+      textRenderMode: "font_paths",
+      rasterIntegrityStatus: "pass",
+      sourceSvgHash: sheetArtifact.svgHash,
+      emptyFrameFallbackUsed: false,
+    },
+    sheetArtifact,
+    panels: Object.values(panelArtifacts).map(panelEvidence),
+    panelRegistry,
+    targetStoreys: 2,
+    visualManifest: VISUAL_MANIFEST,
+    visualPanels,
+    materialPalette: {
+      cards: [
+        {
+          name: "Buff brick",
+          label: "Buff brick",
+          materialSignature: "buff_brick",
+          textureKind: "procedural_svg_pattern",
+          source: "procedural_svg_pattern",
+        },
+      ],
+    },
+    openaiProvider: {
+      openaiConfigured: true,
+      openaiReasoningUsed: false,
+      openaiImageUsed: true,
+      openaiRequestIds: VISUAL_PANEL_TYPES.map((type) => `req-golden-${type}`),
+      providerFallbacks: [],
+    },
+    presentationSummary: {
+      presentationMode: "geometry_locked_image_render",
+      fallbackPanels: [],
+      renderedPanels: VISUAL_PANEL_TYPES,
+    },
+    expectedGeometryHash: GEOMETRY_HASH,
+    strictPhotoreal: true,
+    imageGenEnabled: true,
+    scope: "compose_final",
+    drawings: buildDrawingsForGate(byPanel),
+    projectGeometry: {
+      levels: [{ id: "ground" }, { id: "first" }],
+      windows: [{ id: "w1" }, { id: "w2" }, { id: "w3" }, { id: "w4" }],
+      doors: [{ id: "d1" }],
+      stairs: [],
+    },
+    sheetSetPlan: { required: false, generated: true },
+  };
+}
+
+describe("Phase 6 golden A1 SVG + image2 ProjectGraph acceptance", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "true";
+    process.env.OPENAI_STRICT_IMAGE_GEN = "true";
+    process.env.OPENAI_IMAGES_API_KEY = "sk-test-golden-images";
+    ensureCompiledProjectRenderInputs.mockReturnValue(makeRenderInputs());
+    renderProjectGraphPanelImage.mockImplementation(async ({ panelType }) => ({
+      pngBuffer: Buffer.from(`golden-image2-edit-${panelType}`),
+      provider: "openai",
+      providerUsed: "openai",
+      imageProviderUsed: "openai",
+      imageRenderFallback: false,
+      imageRenderFallbackReason: null,
+      openaiConfigured: true,
+      provenance: {
+        panelType,
+        provider: "openai",
+        providerUsed: "openai",
+        imageProviderUsed: "openai",
+        imageRenderFallback: false,
+        imageRenderFallbackReason: null,
+        model: "gpt-image-2",
+        size: "1536x1024",
+        requestId: `req-golden-${panelType}`,
+        usage: { total_tokens: 42 },
+        sourceGeometryHash: GEOMETRY_HASH,
+        referenceSource: "compiled_3d_control_svg",
+      },
+    }));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  test("golden UK detached A1 sheet embeds SVG technical panels and image2 visual panels from one ProjectGraph authority", async () => {
+    const panelArtifacts = await buildGoldenArtifacts();
+    const byPanel = artifactsByPanelType(panelArtifacts);
+    const visualPanels = VISUAL_PANEL_TYPES.map((type) =>
+      panelEvidence(byPanel[type]),
+    );
+    const sheetArtifact = buildGoldenSheet(panelArtifacts);
+    const gate = evaluateFinalA1ExportGate(
+      buildGoldenGateInputs({
+        panelArtifacts,
+        sheetArtifact,
+        visualPanels,
+      }),
+    );
+
+    expect(renderProjectGraphPanelImage).toHaveBeenCalledTimes(4);
+    expect(renderProjectGraphPanelImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        panelType: "axonometric",
+        deterministicSvg: expect.stringContaining(
+          'data-reference-source="compiled_3d_control_svg"',
+        ),
+        geometryHash: GEOMETRY_HASH,
+      }),
+    );
+
+    expect(byPanel.floor_plan_ground.svgString).toContain("<svg");
+    expect(byPanel.floor_plan_first.svgString).toContain("<svg");
+    expect(
+      Object.keys(byPanel).filter((type) => type.startsWith("elevation_"))
+        .length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      Object.keys(byPanel).filter((type) => type.startsWith("section_")).length,
+    ).toBeGreaterThanOrEqual(1);
+
+    expect(byPanel.hero_3d || byPanel.exterior_render).toBeTruthy();
+    expect(byPanel.axonometric).toBeTruthy();
+    expect(byPanel.interior_3d).toBeTruthy();
+
+    for (const panelType of ["floor_plan_ground", "floor_plan_first"]) {
+      expect(byPanel[panelType].svgString).toContain("room-label");
+      expect(byPanel[panelType].svgString).toContain("dimension-chain");
+      expect(byPanel[panelType].svgString).toContain("scale-marker");
+      expect(byPanel[panelType].svgString).toContain("cad-layer");
+      expect(byPanel[panelType].metadata.technicalDrawingFromImageModel).toBe(
+        false,
+      );
+      expect(byPanel[panelType].metadata.imageModelGenerated).toBe(false);
+    }
+
+    for (const panel of visualPanels) {
+      expect(panel.referenceSource).toBe("compiled_3d_control_svg");
+      expect(panel.imageProviderUsed).toBe("openai");
+      expect(panel.imageRenderFallback).toBe(false);
+      expect(panel.visualIdentityLocked).toBe(true);
+      expect(panel.visualManifestHash).toBe(VISUAL_MANIFEST.manifestHash);
+      expect(panel.geometryHash).toBe(GEOMETRY_HASH);
+    }
+
+    const projectPanelHashes = new Set(
+      Object.values(byPanel)
+        .filter(
+          (artifact) =>
+            artifact.panel_type?.startsWith("floor_plan_") ||
+            artifact.panel_type?.startsWith("elevation_") ||
+            artifact.panel_type?.startsWith("section_") ||
+            VISUAL_PANEL_TYPES.includes(artifact.panel_type),
+        )
+        .map((artifact) => artifact.geometryHash || artifact.source_model_hash),
+    );
+    expect([...projectPanelHashes]).toEqual([GEOMETRY_HASH]);
+    expect(
+      new Set(visualPanels.map((panel) => panel.visualManifestHash)),
+    ).toEqual(new Set([VISUAL_MANIFEST.manifestHash]));
+
+    expect(sheetArtifact.svgString).toContain("<svg");
+    expect(sheetArtifact.svgString).toContain("GROUND FLOOR PLAN");
+    expect(sheetArtifact.svgString).toContain("FIRST FLOOR PLAN");
+    expect(sheetArtifact.svgString).toContain("room-label");
+    expect(sheetArtifact.svgString).toContain("data:image/png;base64");
+    expect(sheetArtifact.svgString).toContain("IMAGE2 / OPENAI EDIT");
+    expect(sheetArtifact.svgString).toContain("TITLE BLOCK");
+    expect(sheetArtifact.svgString).toContain(GEOMETRY_HASH);
+    expect(sheetArtifact.svgString).toContain(VISUAL_MANIFEST.manifestHash);
+    expect(sheetArtifact.svgString).not.toContain('data-panel-missing="true"');
+
+    expect(gate.status).toBe("pass");
+    expect(gate.allowed).toBe(true);
+    expect(gate.blockers).toEqual([]);
+    expect(gate.evidence.projectPanelAuthorityStatus.codes).toEqual([]);
+    expect(gate.evidence.sheetArtifactStatus.hasSheetSvgString).toBe(true);
+  });
+
+  test("golden export gate fails when axonometric drifts from the shared manifest or geometry hash", async () => {
+    const panelArtifacts = await buildGoldenArtifacts();
+    const baseSheet = buildGoldenSheet(panelArtifacts);
+    const byPanel = artifactsByPanelType(panelArtifacts);
+    const baseVisualPanels = VISUAL_PANEL_TYPES.map((type) =>
+      panelEvidence(byPanel[type]),
+    );
+
+    const manifestDriftPanels = baseVisualPanels.map((panel) =>
+      panel.type === "axonometric"
+        ? {
+            ...panel,
+            visualManifestHash: "different-golden-manifest",
+            metadata: {
+              ...panel.metadata,
+              visualManifestHash: "different-golden-manifest",
+            },
+          }
+        : panel,
+    );
+    const manifestGate = evaluateFinalA1ExportGate(
+      buildGoldenGateInputs({
+        panelArtifacts,
+        sheetArtifact: baseSheet,
+        visualPanels: manifestDriftPanels,
+      }),
+    );
+
+    expect(manifestGate.allowed).toBe(false);
+    expect(manifestGate.evidence.projectPanelAuthorityStatus.codes).toContain(
+      "VISUAL_MANIFEST_HASH_MISMATCH",
+    );
+
+    const geometryDriftPanels = baseVisualPanels.map((panel) =>
+      panel.type === "axonometric"
+        ? {
+            ...panel,
+            geometryHash: "different-golden-geometry",
+            sourceGeometryHash: "different-golden-geometry",
+            metadata: {
+              ...panel.metadata,
+              geometryHash: "different-golden-geometry",
+              sourceGeometryHash: "different-golden-geometry",
+            },
+          }
+        : panel,
+    );
+    const geometryGate = evaluateFinalA1ExportGate(
+      buildGoldenGateInputs({
+        panelArtifacts,
+        sheetArtifact: baseSheet,
+        visualPanels: geometryDriftPanels,
+      }),
+    );
+
+    expect(geometryGate.allowed).toBe(false);
+    expect(geometryGate.evidence.projectPanelAuthorityStatus.codes).toContain(
+      "PROJECT_PANEL_GEOMETRY_HASH_MISMATCH",
+    );
+  });
+});

--- a/src/__tests__/services/projectGraphGenerationSeedLifecycle.test.js
+++ b/src/__tests__/services/projectGraphGenerationSeedLifecycle.test.js
@@ -1,0 +1,232 @@
+import {
+  stampGenerationLifecycleOnArtifacts,
+  __projectGraphVerticalSliceInternals,
+} from "../../services/project/projectGraphVerticalSliceService.js";
+
+jest.setTimeout(240000);
+
+const {
+  normalizeBrief,
+  buildSiteContext,
+  buildClimatePack,
+  buildLocalStylePack,
+  buildProgramme,
+  buildProjectGeometryFromProgramme,
+  compileProject,
+} = __projectGraphVerticalSliceInternals;
+
+function createSeedLifecycleInput(overrides = {}) {
+  const briefOverrides = overrides.brief || {};
+  const input = {
+    brief: {
+      project_name: "Seed Lifecycle House",
+      building_type: "residential",
+      target_gia_m2: 180,
+      target_storeys: 2,
+      site_input: {
+        postcode: "N1 1AA",
+        lat: 51.5416,
+        lon: -0.1022,
+      },
+      style_keywords: ["contextual brick", "calm modern"],
+      ...briefOverrides,
+    },
+    sitePolygon: [
+      { lat: 51.54175, lng: -0.1024 },
+      { lat: 51.54175, lng: -0.10195 },
+      { lat: 51.54145, lng: -0.10195 },
+      { lat: 51.54145, lng: -0.1024 },
+    ],
+    siteMetrics: {
+      areaM2: 1040,
+      orientationDeg: 8,
+    },
+    contextProviders: { useDefaultFetch: false },
+    ...overrides,
+  };
+  if (overrides.brief) {
+    input.brief = {
+      ...input.brief,
+      ...briefOverrides,
+    };
+  }
+  return input;
+}
+
+function buildCompiledGeometryHash(input) {
+  const brief = normalizeBrief(input);
+  const site = buildSiteContext({
+    brief,
+    sitePolygon: input.sitePolygon,
+    siteMetrics: input.siteMetrics,
+  });
+  const climate = buildClimatePack(brief, site);
+  const localStyle = buildLocalStylePack(brief, site, climate);
+  const programme = buildProgramme({
+    brief,
+    programSpaces: input.programSpaces || [],
+  });
+  const projectGeometry = buildProjectGeometryFromProgramme({
+    brief,
+    site,
+    programme,
+    localStyle,
+    climate,
+  });
+  const compiledProject = compileProject({
+    projectGeometry,
+    masterDNA: {
+      projectName: brief.project_name,
+      projectID: projectGeometry.project_id,
+      styleDNA: projectGeometry.metadata.style_dna,
+      rooms: programme.spaces,
+    },
+    locationData: {
+      address: brief.site_input.address,
+      coordinates: { lat: site.lat, lng: site.lon },
+      climate: { type: climate.weather_source },
+      localMaterials: localStyle.material_palette,
+    },
+  });
+  return {
+    brief,
+    compiledProject,
+    geometryHash: compiledProject.geometryHash,
+  };
+}
+
+describe("ProjectGraph generation seed lifecycle", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "false";
+    process.env.OPENAI_STRICT_IMAGE_GEN = "false";
+    process.env.OPENAI_API_KEY = "sk-test-openai-base";
+    process.env.OPENAI_IMAGES_API_KEY = "sk-test-openai-images";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("new ProjectGraph requests without explicit seeds receive different generation seeds", () => {
+    const first = normalizeBrief(createSeedLifecycleInput());
+    const second = normalizeBrief(createSeedLifecycleInput());
+
+    expect(first.generation_seed).toEqual(expect.any(Number));
+    expect(second.generation_seed).toEqual(expect.any(Number));
+    expect(second.generation_seed).not.toBe(first.generation_seed);
+    expect(first.seedSource).toBe("auto_new_project");
+    expect(first.variationMode).toBe("new_design");
+  });
+
+  test("same-project regeneration reuses the previous generation seed", () => {
+    const brief = normalizeBrief(
+      createSeedLifecycleInput({
+        projectId: "project-existing",
+        existingGeometryHash: "geom-existing",
+        existingGenerationSeed: 918273,
+      }),
+    );
+
+    expect(brief.generation_seed).toBe(918273);
+    expect(brief.seedSource).toBe("reused_existing_project");
+    expect(brief.variationMode).toBe("same_geometry_regen");
+  });
+
+  test("style-only modify keeps the compiled geometry hash stable", () => {
+    const base = buildCompiledGeometryHash(
+      createSeedLifecycleInput({ seed: 7001 }),
+    );
+    const styleOnly = buildCompiledGeometryHash(
+      createSeedLifecycleInput({
+        seed: 7001,
+        projectId: "project-existing",
+        existingGeometryHash: base.geometryHash,
+        variationMode: "style_modify",
+        modifyRequest: {
+          customPrompt: "Use a warmer material palette",
+          variationMode: "style_modify",
+        },
+      }),
+    );
+
+    expect(styleOnly.brief.variationMode).toBe("style_modify");
+    expect(styleOnly.geometryHash).toBe(base.geometryHash);
+  });
+
+  test("layout modify creates a different compiled geometry hash", () => {
+    const base = buildCompiledGeometryHash(
+      createSeedLifecycleInput({ seed: 7101 }),
+    );
+    const layoutModified = buildCompiledGeometryHash(
+      createSeedLifecycleInput({
+        seed: 7101,
+        projectId: "project-existing",
+        existingGeometryHash: base.geometryHash,
+        variationMode: "layout_modify",
+        brief: {
+          target_gia_m2: 240,
+        },
+      }),
+    );
+
+    expect(layoutModified.brief.variationMode).toBe("layout_modify");
+    expect(layoutModified.geometryHash).not.toBe(base.geometryHash);
+  });
+
+  test("all panel artifacts in one result can be stamped with the same generation seed metadata", () => {
+    const panelsByAsset = {
+      "asset-floor": {
+        asset_id: "asset-floor",
+        panel_type: "floor_plan_ground",
+        geometryHash: "geom-seed",
+        metadata: {},
+      },
+      "asset-hero": {
+        asset_id: "asset-hero",
+        panel_type: "hero_3d",
+        geometryHash: "geom-seed",
+        metadata: { providerUsed: "deterministic" },
+      },
+    };
+    const stamped = stampGenerationLifecycleOnArtifacts(panelsByAsset, {
+      generationSeed: 812345,
+      seedSource: "user",
+      variationMode: "new_design",
+    });
+
+    const panels = Object.values(stamped);
+    expect(panels.length).toBeGreaterThan(0);
+    for (const panel of panels) {
+      expect(panel.generationSeed).toBe(812345);
+      expect(panel.metadata.generationSeed).toBe(812345);
+      expect(panel.seedSource).toBe("user");
+      expect(panel.variationMode).toBe("new_design");
+      expect(panel.metadata.generationLifecycle).toEqual({
+        generationSeed: 812345,
+        seedSource: "user",
+        variationMode: "new_design",
+      });
+    }
+  });
+
+  test("repeated same-geometry panel regeneration does not create a different building", () => {
+    const base = buildCompiledGeometryHash(
+      createSeedLifecycleInput({ seed: 9001 }),
+    );
+    const regenerated = buildCompiledGeometryHash(
+      createSeedLifecycleInput({
+        projectId: "project-existing",
+        existingGeometryHash: base.geometryHash,
+        existingGenerationSeed: 9001,
+        variationMode: "same_geometry_regen",
+      }),
+    );
+
+    expect(regenerated.brief.generation_seed).toBe(9001);
+    expect(regenerated.brief.seedSource).toBe("reused_existing_project");
+    expect(regenerated.geometryHash).toBe(base.geometryHash);
+  });
+});

--- a/src/__tests__/services/projectGraphImageRenderer.test.js
+++ b/src/__tests__/services/projectGraphImageRenderer.test.js
@@ -53,6 +53,27 @@ describe("projectGraphImageRenderer OpenAI provider behavior", () => {
     expect(rasteriseSvgToPng).not.toHaveBeenCalled();
   });
 
+  test("PROJECT_GRAPH_IMAGE_GEN_ENABLED=false fails closed in strict mode", async () => {
+    process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "false";
+    process.env.OPENAI_STRICT_IMAGE_GEN = "true";
+    process.env.OPENAI_IMAGES_API_KEY = "sk-image-1234";
+
+    await expect(
+      renderProjectGraphPanelImage({
+        panelType: "hero_3d",
+        deterministicSvg: "<svg><rect width='10' height='10'/></svg>",
+        prompt: "Render a building",
+        geometryHash: "geo-hash",
+      }),
+    ).rejects.toMatchObject({
+      code: "OPENAI_STRICT_IMAGE_GEN_FAILED",
+      fallbackReason: "gate_disabled",
+      strictImageGeneration: true,
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(rasteriseSvgToPng).not.toHaveBeenCalled();
+  });
+
   test("image generation enabled without a server-side key records missing_api_key fallback", async () => {
     process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "true";
     process.env.REACT_APP_OPENAI_API_KEY = "sk-browser-only";

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -781,6 +781,22 @@ describe("projectGraphVerticalSliceService", () => {
       "PRESENTATION_RENDER_FALLBACK_USED",
     );
     for (const artifact of Object.values(result.artifacts.drawings)) {
+      expect(artifact.geometryHash).toBe(result.geometryHash);
+      expect(artifact.sourceGeometryHash).toBe(result.geometryHash);
+      expect(artifact.renderer).toBe("deterministic_svg");
+      expect(artifact.providerUsed).toBe("deterministic_svg");
+      expect(artifact.imageProviderUsed).toBe("none");
+      expect(artifact.technicalDrawing).toBe(true);
+      expect(artifact.metadata).toEqual(
+        expect.objectContaining({
+          geometryHash: result.geometryHash,
+          sourceGeometryHash: result.geometryHash,
+          renderer: "deterministic_svg",
+          providerUsed: "deterministic_svg",
+          imageProviderUsed: "none",
+          technicalDrawing: true,
+        }),
+      );
       expect(artifact.contentBounds).toEqual(
         expect.objectContaining({
           occupancyRatio: expect.any(Number),
@@ -1783,6 +1799,86 @@ describe("projectGraphVerticalSliceService", () => {
       expect(keyNotes.svgString).toContain(`Programme: ${programmeLabel}.`);
     },
   );
+
+  test("buildDrawingSet stamps deterministic technical SVG provenance", () => {
+    const briefInput = createReadingRoomBrief();
+    const brief = __projectGraphVerticalSliceInternals.normalizeBrief(briefInput);
+    const programme = __projectGraphVerticalSliceInternals.buildProgramme({
+      brief,
+    });
+    const site = __projectGraphVerticalSliceInternals.buildSiteContext({
+      brief,
+      sitePolygon: briefInput.sitePolygon,
+      siteMetrics: briefInput.siteMetrics,
+    });
+    const climate = __projectGraphVerticalSliceInternals.buildClimatePack(
+      brief,
+      site,
+    );
+    const localStyle = __projectGraphVerticalSliceInternals.buildLocalStylePack(
+      brief,
+      site,
+      climate,
+    );
+    const projectGeometry =
+      __projectGraphVerticalSliceInternals.buildProjectGeometryFromProgramme({
+        brief,
+        site,
+        programme,
+        localStyle,
+        climate,
+      });
+    const placedProgramme =
+      __projectGraphVerticalSliceInternals.syncProgrammeActuals(
+        programme,
+        projectGeometry,
+      );
+    const compiledProject = __projectGraphVerticalSliceInternals.compileProject({
+      projectGeometry,
+      masterDNA: {
+        projectName: brief.project_name,
+        projectID: projectGeometry.project_id,
+        styleDNA: projectGeometry.metadata.style_dna,
+        rooms: placedProgramme.spaces,
+      },
+      locationData: {
+        address: brief.site_input.address,
+        coordinates: { lat: site.lat, lng: site.lon },
+        climate: { type: climate.weather_source },
+        localMaterials: localStyle.material_palette,
+      },
+    });
+
+    const { drawingArtifacts } =
+      __projectGraphVerticalSliceInternals.buildDrawingSet(compiledProject, {
+        layoutTemplate: "presentation-v3",
+        vernacularPack: localStyle?.style_provenance || null,
+      });
+    const groundPlan = Object.values(drawingArtifacts).find(
+      (artifact) => artifact.panel_type === "floor_plan_ground",
+    );
+
+    expect(groundPlan).toEqual(
+      expect.objectContaining({
+        geometryHash: compiledProject.geometryHash,
+        sourceGeometryHash: compiledProject.geometryHash,
+        renderer: "deterministic_svg",
+        providerUsed: "deterministic_svg",
+        imageProviderUsed: "none",
+        technicalDrawing: true,
+      }),
+    );
+    expect(groundPlan.metadata).toEqual(
+      expect.objectContaining({
+        geometryHash: compiledProject.geometryHash,
+        sourceGeometryHash: compiledProject.geometryHash,
+        renderer: "deterministic_svg",
+        providerUsed: "deterministic_svg",
+        imageProviderUsed: "none",
+        technicalDrawing: true,
+      }),
+    );
+  });
 
   test("respects manual target_storeys=4 and emits one floor plan panel per level", async () => {
     const briefInput = createReadingRoomBrief();

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -2398,12 +2398,13 @@ describe("projectGraphVerticalSliceService", () => {
 
   test("ProjectGraph export hashes are deterministic for identical inputs", async () => {
     const first = await buildArchitectureProjectVerticalSlice(
-      createReadingRoomBrief(),
+      { ...createReadingRoomBrief(), seed: 246810 },
     );
     const second = await buildArchitectureProjectVerticalSlice(
-      createReadingRoomBrief(),
+      { ...createReadingRoomBrief(), seed: 246810 },
     );
 
+    expect(second.generationSeed).toBe(first.generationSeed);
     expect(second.geometryHash).toBe(first.geometryHash);
     expect(second.architectReasoningManifest.manifestHash).toBe(
       first.architectReasoningManifest.manifestHash,

--- a/src/__tests__/services/projectGraphVisualImage2Phase2.test.js
+++ b/src/__tests__/services/projectGraphVisualImage2Phase2.test.js
@@ -1,0 +1,303 @@
+import fs from "fs";
+import path from "path";
+import { buildVisual3DPanelArtifacts } from "../../services/project/projectGraphVerticalSliceService.js";
+import { renderProjectGraphPanelImage } from "../../services/render/projectGraphImageRenderer.js";
+import { ensureCompiledProjectRenderInputs } from "../../services/compiler/compiledProjectRenderInputs.js";
+
+jest.mock("../../services/render/projectGraphImageRenderer.js", () => ({
+  renderProjectGraphPanelImage: jest.fn(),
+}));
+
+jest.mock("../../services/compiler/compiledProjectRenderInputs.js", () => ({
+  ensureCompiledProjectRenderInputs: jest.fn(),
+}));
+
+const PANEL_TYPES = [
+  "hero_3d",
+  "exterior_render",
+  "axonometric",
+  "interior_3d",
+];
+
+const GEOMETRY_HASH = "geom-phase2-123";
+const VISUAL_MANIFEST = {
+  manifestId: "visual-manifest-phase2",
+  manifestHash: "visual-manifest-hash-phase2",
+  geometryHash: GEOMETRY_HASH,
+  buildingType: "house",
+  storeyCount: 2,
+  roof: { form: "concealed parapet", materialName: "slate" },
+  primaryFacadeMaterial: {
+    name: "London stock brick",
+    hex: "#b89b72",
+    application: "primary facade",
+  },
+  secondaryFacadeMaterial: {
+    name: "Portland stone",
+    hex: "#d8d2c3",
+    application: "trim",
+  },
+  windowMaterial: "painted timber",
+  doorMaterial: "painted timber",
+  windowRhythm: "regular three-bay",
+  entranceOrientation: "front-left approach",
+};
+
+function makeRenderInputs(overrides = {}) {
+  return Object.fromEntries(
+    PANEL_TYPES.map((panelType) => [
+      panelType,
+      {
+        svgString: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 80"><rect width="100" height="80"/><text>${panelType}</text></svg>`,
+        svgHash: `control-svg-hash-${panelType}`,
+        width: 100,
+        height: 80,
+        metadata: {
+          width: 100,
+          height: 80,
+          normalizedViewBox: "0 0 100 80",
+          camera: { view: panelType },
+          primitiveCount: 6,
+          surfaceCount: 6,
+        },
+        ...(overrides[panelType] || {}),
+      },
+    ]),
+  );
+}
+
+function makeBaseArgs() {
+  return {
+    compiledProject: {
+      geometryHash: GEOMETRY_HASH,
+      levels: [{ id: "ground", height_m: 3.2 }],
+      roof: { type: "concealed_parapet" },
+    },
+    geometryHash: GEOMETRY_HASH,
+    brief: {
+      project_name: "Phase 2 Visual Test",
+      building_type: "house",
+      target_storeys: 2,
+    },
+    visualManifest: VISUAL_MANIFEST,
+    programmeSummary: { totalAreaM2: 120 },
+    region: "London",
+    sheetDesignContext: {
+      contextHash: "sheet-design-context-hash",
+      programSpaces: [
+        { level: "Ground", name: "Living" },
+        { level: "Ground", name: "Kitchen" },
+      ],
+    },
+  };
+}
+
+async function buildVisuals(args = {}) {
+  return buildVisual3DPanelArtifacts({
+    ...makeBaseArgs(),
+    ...args,
+  });
+}
+
+describe("ProjectGraph visual image2 Phase 2", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "true";
+    process.env.OPENAI_STRICT_IMAGE_GEN = "false";
+    jest.clearAllMocks();
+    ensureCompiledProjectRenderInputs.mockReturnValue(makeRenderInputs());
+    renderProjectGraphPanelImage.mockImplementation(async ({ panelType }) => ({
+      pngBuffer: Buffer.from(`png-${panelType}`),
+      provider: "openai",
+      providerUsed: "openai",
+      imageProviderUsed: "openai",
+      imageRenderFallback: false,
+      imageRenderFallbackReason: null,
+      openaiConfigured: true,
+      provenance: {
+        panelType,
+        provider: "openai",
+        providerUsed: "openai",
+        imageProviderUsed: "openai",
+        imageRenderFallback: false,
+        imageRenderFallbackReason: null,
+        model: "gpt-image-2",
+        size: "1536x1024",
+        requestId: `req-${panelType}`,
+        usage: { total_tokens: 10 },
+        sourceGeometryHash: GEOMETRY_HASH,
+        referenceSource: "compiled_3d_control_svg",
+      },
+    }));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("calls renderProjectGraphPanelImage for every required visual panel", async () => {
+    await buildVisuals();
+
+    expect(renderProjectGraphPanelImage).toHaveBeenCalledTimes(4);
+    for (const panelType of PANEL_TYPES) {
+      expect(renderProjectGraphPanelImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          panelType,
+          deterministicSvg: expect.stringContaining(panelType),
+          geometryHash: GEOMETRY_HASH,
+          prompt: expect.stringContaining("=== VISUAL IDENTITY LOCK"),
+        }),
+      );
+    }
+
+    const promptsByPanel = Object.fromEntries(
+      renderProjectGraphPanelImage.mock.calls.map(([call]) => [
+        call.panelType,
+        call.prompt,
+      ]),
+    );
+    expect(promptsByPanel.hero_3d).toMatch(
+      /front-left architectural exterior/i,
+    );
+    expect(promptsByPanel.exterior_render).toMatch(
+      /front-left architectural exterior/i,
+    );
+    expect(promptsByPanel.axonometric).toMatch(
+      /technical axonometric\/isometric/i,
+    );
+    expect(promptsByPanel.interior_3d).toMatch(
+      /derived from the same project programme/i,
+    );
+    for (const prompt of Object.values(promptsByPanel)) {
+      expect(prompt).toContain(`geometryHash: ${GEOMETRY_HASH}`);
+      expect(prompt).toContain(
+        `visualManifestHash: ${VISUAL_MANIFEST.manifestHash}`,
+      );
+    }
+  });
+
+  test("visual panel artifacts carry shared geometry, manifest, provider, control, and prompt metadata", async () => {
+    const visualsByAsset = await buildVisuals();
+    const visuals = Object.fromEntries(
+      Object.values(visualsByAsset).map((artifact) => [
+        artifact.panel_type,
+        artifact,
+      ]),
+    );
+
+    expect(Object.keys(visuals).sort()).toEqual(PANEL_TYPES.slice().sort());
+    for (const panelType of PANEL_TYPES) {
+      const artifact = visuals[panelType];
+      expect(artifact).toMatchObject({
+        panel_type: panelType,
+        geometryHash: GEOMETRY_HASH,
+        sourceGeometryHash: GEOMETRY_HASH,
+        visualManifestHash: VISUAL_MANIFEST.manifestHash,
+        visualManifestId: VISUAL_MANIFEST.manifestId,
+        visualIdentityLocked: true,
+        referenceSource: "compiled_3d_control_svg",
+        provider: "openai",
+        providerUsed: "openai",
+        imageProviderUsed: "openai",
+        imageRenderFallback: false,
+        imageRenderFallbackReason: null,
+        model: "gpt-image-2",
+        requestId: `req-${panelType}`,
+        usage: { total_tokens: 10 },
+        controlSvgHash: `control-svg-hash-${panelType}`,
+      });
+      expect(artifact.promptHash).toEqual(expect.any(String));
+      expect(artifact.metadata).toMatchObject({
+        geometryHash: GEOMETRY_HASH,
+        sourceGeometryHash: GEOMETRY_HASH,
+        visualManifestHash: VISUAL_MANIFEST.manifestHash,
+        visualManifestId: VISUAL_MANIFEST.manifestId,
+        visualIdentityLocked: true,
+        referenceSource: "compiled_3d_control_svg",
+        providerUsed: "openai",
+        imageProviderUsed: "openai",
+        imageRenderFallback: false,
+        imageRenderFallbackReason: null,
+        openaiImageUsed: true,
+        openaiRequestId: `req-${panelType}`,
+        openaiUsage: { total_tokens: 10 },
+        controlSvgHash: `control-svg-hash-${panelType}`,
+        promptHash: artifact.promptHash,
+      });
+    }
+  });
+
+  test("strict image generation fails when a required control SVG is missing", async () => {
+    process.env.OPENAI_STRICT_IMAGE_GEN = "true";
+    ensureCompiledProjectRenderInputs.mockReturnValue({
+      ...makeRenderInputs(),
+      axonometric: {
+        ...makeRenderInputs().axonometric,
+        svgString: "",
+        svgHash: null,
+      },
+    });
+
+    await expect(buildVisuals()).rejects.toMatchObject({
+      code: "OPENAI_STRICT_IMAGE_GEN_FAILED",
+      panelType: "axonometric",
+      fallbackReason: "missing_control_svg",
+      strictImageGeneration: true,
+    });
+  });
+
+  test("fallback mode marks deterministic panels without claiming OpenAI success", async () => {
+    process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "false";
+    renderProjectGraphPanelImage.mockImplementation(async ({ panelType }) => ({
+      pngBuffer: null,
+      provider: "openai",
+      providerUsed: "deterministic",
+      imageProviderUsed: "deterministic",
+      imageRenderFallback: true,
+      imageRenderFallbackReason: "gate_disabled",
+      openaiConfigured: true,
+      model: "gpt-image-2",
+      provenance: {
+        panelType,
+        provider: "openai",
+        providerUsed: "deterministic",
+        imageProviderUsed: "deterministic",
+        imageRenderFallback: true,
+        imageRenderFallbackReason: "gate_disabled",
+        sourceGeometryHash: GEOMETRY_HASH,
+        referenceSource: "compiled_3d_control_svg",
+        model: "gpt-image-2",
+        requestId: null,
+        usage: null,
+      },
+    }));
+
+    const visuals = await buildVisuals();
+
+    expect(renderProjectGraphPanelImage).toHaveBeenCalledTimes(4);
+    for (const artifact of Object.values(visuals)) {
+      expect(artifact.providerUsed).toBe("deterministic");
+      expect(artifact.imageProviderUsed).toBe("deterministic");
+      expect(artifact.imageRenderFallback).toBe(true);
+      expect(artifact.imageRenderFallbackReason).toBe("gate_disabled");
+      expect(artifact.metadata.openaiImageUsed).toBe(false);
+      expect(artifact.metadata.visualRenderMode).toBe("deterministic_fallback");
+    }
+  });
+
+  test("ProjectGraph visual path does not use text-only image generation", () => {
+    const root = process.cwd();
+    const files = [
+      "src/services/project/projectGraphVerticalSliceService.js",
+      "src/services/render/projectGraphImageRenderer.js",
+    ];
+
+    for (const file of files) {
+      const text = fs.readFileSync(path.join(root, file), "utf8");
+      expect(text).not.toMatch(/\/api\/openai-images/);
+      expect(text).not.toMatch(/\/v1\/images\/generations/);
+    }
+  });
+});

--- a/src/__tests__/services/visualManifestService.test.js
+++ b/src/__tests__/services/visualManifestService.test.js
@@ -362,6 +362,7 @@ describe("buildProjectGraphRenderPrompt — Phase D injection", () => {
     expect(prompt).not.toMatch(/VISUAL CONTINUITY CONSTRAINTS/);
     // But the rest of the prompt (intent + reasoning + style) must still be
     // present.
-    expect(prompt).toContain("Photoreal hero exterior 3D perspective");
+    expect(prompt).toContain("GEOMETRY AND VISUAL AUTHORITY");
+    expect(prompt).toContain("Realistic front-left architectural exterior");
   });
 });

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -2436,7 +2436,7 @@ const ArchitectAIWizardContainer = () => {
         designSpec,
         siteSnapshot,
         featureFlags: {},
-        seed: Date.now(),
+        seed: isProjectGraphMode ? undefined : Date.now(),
         sheetType: "ARCH",
         overlays: [],
       });

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -52,8 +52,240 @@ const STAGES = Object.freeze([
 ]);
 const PROJECT_GRAPH_REQUEST_SOFT_LIMIT_CHARS = 750_000;
 const PROJECT_GRAPH_SITE_SNAPSHOT_DATA_URL_MAX_CHARS = 600_000;
+const PROJECT_GRAPH_GENERATION_SEED_MAX = 2_147_483_647;
 const SITE_SNAPSHOT_IMAGE_DATA_URL_RE =
   /^data:image\/(?:png|jpe?g|webp);base64,[a-z0-9+/=\s]+$/i;
+let projectGraphAutoSeedCounter = 0;
+
+export function normalizeProjectGraphGenerationSeed(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.abs(Math.trunc(numeric)) % PROJECT_GRAPH_GENERATION_SEED_MAX;
+}
+
+function randomProjectGraphSeedComponent() {
+  const cryptoObj =
+    typeof window !== "undefined" ? window.crypto : null;
+  if (cryptoObj?.getRandomValues) {
+    const buffer = new Uint32Array(1);
+    cryptoObj.getRandomValues(buffer);
+    return buffer[0];
+  }
+  return Math.floor(Math.random() * PROJECT_GRAPH_GENERATION_SEED_MAX);
+}
+
+export function createProjectGraphGenerationSeed() {
+  projectGraphAutoSeedCounter =
+    (projectGraphAutoSeedCounter + 1) % PROJECT_GRAPH_GENERATION_SEED_MAX;
+  const seed = normalizeProjectGraphGenerationSeed(
+    Date.now() + randomProjectGraphSeedComponent() + projectGraphAutoSeedCounter,
+  );
+  return seed === null || seed === 0 ? 1 : seed;
+}
+
+function firstProjectGraphSeedCandidate(candidates = []) {
+  for (const candidate of candidates) {
+    const normalized = normalizeProjectGraphGenerationSeed(candidate);
+    if (normalized !== null) return normalized;
+  }
+  return null;
+}
+
+function normalizeProjectGraphVariationMode(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (
+    [
+      "new_design",
+      "same_geometry_regen",
+      "style_modify",
+      "layout_modify",
+    ].includes(normalized)
+  ) {
+    return normalized;
+  }
+  if (["regenerate", "panel_regen", "same_geometry"].includes(normalized)) {
+    return "same_geometry_regen";
+  }
+  if (["style", "materials", "material_modify"].includes(normalized)) {
+    return "style_modify";
+  }
+  if (["layout", "programme", "program", "geometry"].includes(normalized)) {
+    return "layout_modify";
+  }
+  return null;
+}
+
+function hasProjectGraphExistingIdentity(params = {}, designSpec = {}) {
+  const projectDetails =
+    designSpec.projectDetails ||
+    designSpec.specifications ||
+    designSpec.project ||
+    {};
+  return Boolean(
+    params.projectId ||
+      params.designId ||
+      params.designHistoryId ||
+      params.compiledProject ||
+      params.geometryHash ||
+      designSpec.projectId ||
+      designSpec.designId ||
+      designSpec.designHistoryId ||
+      designSpec.compiledProject ||
+      designSpec.geometryHash ||
+      designSpec.v2Bundle?.compiledProject ||
+      designSpec.v2Bundle?.geometryHash ||
+      projectDetails.projectId ||
+      projectDetails.designId ||
+      projectDetails.designHistoryId ||
+      projectDetails.geometryHash,
+  );
+}
+
+function requestLooksLayoutAffecting(params = {}, designSpec = {}) {
+  const modifyRequest = params.modifyRequest || designSpec.modifyRequest || {};
+  const changeText = [
+    params.changeType,
+    params.modifyType,
+    modifyRequest.changeType,
+    modifyRequest.scope,
+    modifyRequest.mode,
+    modifyRequest.customPrompt,
+    ...(Array.isArray(modifyRequest.quickToggles)
+      ? modifyRequest.quickToggles
+      : []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    /\b(layout|programme|program|room|space|area|floor|storey|story|massing|footprint|opening|window|door|stair)\b/.test(
+      changeText,
+    ) ||
+    Boolean(
+      params.programSpaces ||
+        designSpec.programSpaces ||
+        designSpec.programme?.spaces ||
+        designSpec.program?.spaces,
+    )
+  );
+}
+
+function requestLooksStyleOnly(params = {}, designSpec = {}) {
+  const modifyRequest = params.modifyRequest || designSpec.modifyRequest || {};
+  const changeText = [
+    params.changeType,
+    params.modifyType,
+    modifyRequest.changeType,
+    modifyRequest.scope,
+    modifyRequest.mode,
+    modifyRequest.customPrompt,
+    ...(Array.isArray(modifyRequest.quickToggles)
+      ? modifyRequest.quickToggles
+      : []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    /\b(style|material|materials|palette|facade|facade|colour|color|finish|tone)\b/.test(
+      changeText,
+    ) && !requestLooksLayoutAffecting(params, designSpec)
+  );
+}
+
+function resolveProjectGraphVariationMode(params = {}, designSpec = {}) {
+  const hasExistingProject = hasProjectGraphExistingIdentity(params, designSpec);
+  const explicit = normalizeProjectGraphVariationMode(
+    params.variationMode ||
+      params.projectVariationMode ||
+      designSpec.variationMode ||
+      designSpec.projectVariationMode ||
+      params.modifyRequest?.variationMode ||
+      designSpec.modifyRequest?.variationMode,
+  );
+  if (explicit) return explicit;
+  if (hasExistingProject && requestLooksLayoutAffecting(params, designSpec)) {
+    return "layout_modify";
+  }
+  if (hasExistingProject && requestLooksStyleOnly(params, designSpec)) {
+    return "style_modify";
+  }
+  if (hasExistingProject) {
+    return "same_geometry_regen";
+  }
+  return "new_design";
+}
+
+function resolveProjectGraphGenerationLifecycle(params = {}) {
+  const designSpec = params.designSpec || {};
+  const projectDetails =
+    designSpec.projectDetails ||
+    designSpec.specifications ||
+    designSpec.project ||
+    designSpec;
+  const sourceBrief = designSpec.brief || designSpec.projectBrief || {};
+  const variationMode = resolveProjectGraphVariationMode(params, designSpec);
+  const hasExistingProject = hasProjectGraphExistingIdentity(params, designSpec);
+  const directSeed = firstProjectGraphSeedCandidate([
+    params.seed,
+    params.baseSeed,
+    params.generationSeed,
+  ]);
+  if (directSeed !== null) {
+    return {
+      generationSeed: directSeed,
+      seedSource: "user",
+      variationMode,
+    };
+  }
+
+  const projectSeed = firstProjectGraphSeedCandidate([
+    designSpec.seed,
+    designSpec.baseSeed,
+    designSpec.generationSeed,
+    projectDetails.seed,
+    projectDetails.baseSeed,
+    projectDetails.generationSeed,
+    sourceBrief.generation_seed,
+    sourceBrief.generationSeed,
+    sourceBrief.baseSeed,
+    designSpec.metadata?.generationSeed,
+    designSpec.a1Sheet?.metadata?.generationSeed,
+    designSpec.compiledProject?.metadata?.generationSeed,
+    designSpec.v2Bundle?.compiledProject?.metadata?.generationSeed,
+  ]);
+
+  if (
+    projectSeed !== null &&
+    hasExistingProject &&
+    variationMode !== "layout_modify"
+  ) {
+    return {
+      generationSeed: projectSeed,
+      seedSource: "reused_existing_project",
+      variationMode,
+    };
+  }
+
+  if (projectSeed !== null && !hasExistingProject) {
+    return {
+      generationSeed: projectSeed,
+      seedSource: "user",
+      variationMode,
+    };
+  }
+
+  return {
+    generationSeed: createProjectGraphGenerationSeed(),
+    seedSource: "auto_new_project",
+    variationMode,
+  };
+}
 
 function isTruthyRequestFlag(value) {
   if (value === true) return true;
@@ -565,18 +797,8 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
     String(params.qualityTarget || designSpec.qualityTarget || "")
       .trim()
       .toLowerCase() === "reference_match";
-  const rawGenerationSeed =
-    params.seed ??
-    params.baseSeed ??
-    designSpec.seed ??
-    designSpec.baseSeed ??
-    projectDetails.seed ??
-    projectDetails.baseSeed ??
-    null;
-  const numericGenerationSeed = Number(rawGenerationSeed);
-  const generationSeed = Number.isFinite(numericGenerationSeed)
-    ? Math.abs(Math.trunc(numericGenerationSeed))
-    : null;
+  const generationLifecycle = resolveProjectGraphGenerationLifecycle(params);
+  const { generationSeed, seedSource, variationMode } = generationLifecycle;
   const resolvedBrief = sourceProjectBrief
     ? {
         ...sourceProjectBrief,
@@ -612,7 +834,11 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
         target_storeys: resolvedFloorCount,
         targetStoreys: resolvedFloorCount,
         generation_seed: generationSeed,
+        generationSeed,
         baseSeed: generationSeed,
+        seedSource,
+        variationMode,
+        generation_lifecycle: generationLifecycle,
         referenceMatch,
         reference_match: referenceMatch,
         renderIntent: referenceMatch
@@ -634,7 +860,11 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
         target_storeys: resolvedFloorCount,
         targetStoreys: resolvedFloorCount,
         generation_seed: generationSeed,
+        generationSeed,
         baseSeed: generationSeed,
+        seedSource,
+        variationMode,
+        generation_lifecycle: generationLifecycle,
         building_type: canonicalBuildingType || "dwelling",
         canonical_building_type: canonicalBuildingType || "dwelling",
         original_category: originalCategory,
@@ -687,6 +917,19 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
   return {
     baseSeed: generationSeed,
     seed: generationSeed,
+    generationSeed,
+    seedSource,
+    variationMode,
+    generationLifecycle,
+    projectId: params.projectId || designSpec.projectId || null,
+    designHistoryId:
+      params.designHistoryId || designSpec.designHistoryId || null,
+    existingGeometryHash:
+      params.geometryHash ||
+      designSpec.geometryHash ||
+      designSpec.compiledProject?.geometryHash ||
+      designSpec.v2Bundle?.compiledProject?.geometryHash ||
+      null,
     referenceMatch,
     reference_match: referenceMatch,
     renderIntent: referenceMatch
@@ -720,6 +963,9 @@ export function buildProjectGraphVerticalSliceRequest(params = {}) {
       ),
       generationSeed,
       baseSeed: generationSeed,
+      seedSource,
+      variationMode,
+      generationLifecycle,
       customNotes: projectDetails.customNotes || designSpec.buildingNotes || "",
       entranceDirection:
         projectDetails.entranceDirection ||
@@ -976,6 +1222,10 @@ async function runProjectGraphVerticalSliceWorkflow({
       verticalSlice.projectGraph?.project_id ||
       null,
     geometryHash: verticalSlice.geometryHash,
+    seed: verticalSlice.generationSeed || verticalSlice.seed || null,
+    generationSeed: verticalSlice.generationSeed || verticalSlice.seed || null,
+    seedSource: verticalSlice.seedSource || null,
+    variationMode: verticalSlice.variationMode || null,
     compiledProject: verticalSlice.artifacts?.compiledProject || null,
     projectGeometry: verticalSlice.artifacts?.projectGeometry || null,
     panels: panelMap,
@@ -987,6 +1237,10 @@ async function runProjectGraphVerticalSliceWorkflow({
     metadata: {
       workflow: PIPELINE_MODE.PROJECT_GRAPH,
       pipelineVersion: verticalSlice.pipelineVersion,
+      generationSeed: verticalSlice.generationSeed || verticalSlice.seed || null,
+      seedSource: verticalSlice.seedSource || null,
+      variationMode: verticalSlice.variationMode || null,
+      generationLifecycle: verticalSlice.generationLifecycle || null,
       projectGraphId:
         verticalSlice.projectGraph?.project_graph_id ||
         verticalSlice.projectGraph?.project_id ||

--- a/src/services/a1/a1FinalExportContract.js
+++ b/src/services/a1/a1FinalExportContract.js
@@ -591,8 +591,15 @@ const PHASE_F_GATE_SCOPES = Object.freeze({
   UPSTREAM_PARTIAL: "upstream_partial",
 });
 
+const VISUAL_PROJECT_PANEL_TYPES_FOR_GATE = Object.freeze([
+  "hero_3d",
+  "exterior_render",
+  "axonometric",
+  "interior_3d",
+]);
+
 function panelTypeOf(panel) {
-  return panel?.type || panel?.panelType || null;
+  return panel?.type || panel?.panelType || panel?.panel_type || null;
 }
 
 function panelIsBlank(panel) {
@@ -602,6 +609,134 @@ function panelIsBlank(panel) {
   }
   if (panel.hasSvg === false) return true;
   return false;
+}
+
+function panelMetadataOf(panel) {
+  return panel?.metadata && typeof panel.metadata === "object"
+    ? panel.metadata
+    : {};
+}
+
+function readPanelField(panel, field) {
+  const metadata = panelMetadataOf(panel);
+  if (panel && Object.prototype.hasOwnProperty.call(panel, field)) {
+    return panel[field];
+  }
+  if (metadata && Object.prototype.hasOwnProperty.call(metadata, field)) {
+    return metadata[field];
+  }
+  if (panel?.meta && Object.prototype.hasOwnProperty.call(panel.meta, field)) {
+    return panel.meta[field];
+  }
+  return null;
+}
+
+function readAnyPanelField(panel, fields = []) {
+  for (const field of fields) {
+    const value = readPanelField(panel, field);
+    if (value !== null && value !== undefined && value !== "") return value;
+  }
+  return null;
+}
+
+function readPanelGeometryHash(panel) {
+  return readAnyPanelField(panel, [
+    "geometryHash",
+    "sourceGeometryHash",
+    "source_model_hash",
+    "sourceModelHash",
+    "geometry_hash",
+  ]);
+}
+
+function readPanelVisualManifestHash(panel) {
+  return readAnyPanelField(panel, [
+    "visualManifestHash",
+    "visual_manifest_hash",
+  ]);
+}
+
+function normalizeAuthorityToken(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
+}
+
+function panelHasTruthyField(panel, field) {
+  return readPanelField(panel, field) === true;
+}
+
+function isVisualProjectPanelType(type) {
+  return VISUAL_PROJECT_PANEL_TYPES_FOR_GATE.includes(type);
+}
+
+function isImageModelToken(value) {
+  const token = normalizeAuthorityToken(value);
+  if (!token || token === "deterministic" || token === "none") return false;
+  return (
+    token.includes("openai") ||
+    token.includes("gpt-image") ||
+    token.includes("dall-e") ||
+    token.includes("dalle") ||
+    token.includes("flux") ||
+    token.includes("stability") ||
+    token.includes("midjourney") ||
+    token === "image_model" ||
+    token === "text_to_image"
+  );
+}
+
+function panelUsesImageModel(panel) {
+  return [
+    readPanelField(panel, "provider"),
+    readPanelField(panel, "providerUsed"),
+    readPanelField(panel, "imageProviderUsed"),
+    readPanelField(panel, "model"),
+    readPanelField(panel, "imageRenderModel"),
+    readPanelField(panel, "generationProvider"),
+  ].some(isImageModelToken);
+}
+
+function technicalPanelUsesImageModel(panel) {
+  if (panelHasTruthyField(panel, "technicalDrawingFromImageModel")) {
+    return true;
+  }
+  if (panelHasTruthyField(panel, "imageModelGenerated")) {
+    return true;
+  }
+  if (panelHasTruthyField(panel, "openaiImageUsed")) {
+    return true;
+  }
+  return panelUsesImageModel(panel);
+}
+
+function visualPanelUsesTextOnlyGeneration(panel) {
+  if (!panelUsesImageModel(panel)) return false;
+  const referenceSource = normalizeAuthorityToken(
+    readPanelField(panel, "referenceSource"),
+  );
+  const generationMode = normalizeAuthorityToken(
+    readAnyPanelField(panel, [
+      "generationMode",
+      "imageGenerationMode",
+      "renderMode",
+      "visualRenderMode",
+      "source",
+    ]),
+  );
+  if (
+    referenceSource === "compiled_3d_control_svg" ||
+    generationMode === "geometry_locked_image_render"
+  ) {
+    return false;
+  }
+  return (
+    !referenceSource ||
+    referenceSource.includes("text") ||
+    referenceSource.includes("prompt") ||
+    generationMode.includes("text_to_image") ||
+    generationMode.includes("prompt")
+  );
 }
 
 function evaluatePdfMetadataEvidence({
@@ -824,14 +959,10 @@ function evaluateRequiredPanelEvidence({
   };
 }
 
-// Phase 4: technical panel set is the deterministic-SVG drawings the A1
-// export depends on for geometry communication. Floor plans were missing
-// from the prior set — that's the gap the failing PDF exposed. axonometric
-// and site_diagram are listed here so that *once* later phases re-classify
-// them as compiled-technical-svg renderers, the content-empty gate covers
-// them automatically. Today they still route through the visual fallback,
-// so panelIsBlank only fires if the placement status is non-ready (i.e.
-// even the deterministic_fallback SVG is missing).
+// Phase 4/3: technical panel set is the deterministic-SVG drawing group the
+// A1 export depends on for geometry communication. Visual 3D panels are
+// validated separately because they must route through geometry-locked image
+// edits, not through the deterministic technical drawing contract.
 const TECHNICAL_PANEL_TYPES_FOR_GATE = Object.freeze([
   "floor_plan_ground",
   "floor_plan_first",
@@ -847,9 +978,6 @@ const TECHNICAL_PANEL_TYPES_FOR_GATE = Object.freeze([
   "elevation_west",
   "section_AA",
   "section_BB",
-  // Effective once later phases re-classify these as technical:
-  "axonometric",
-  "site_diagram",
 ]);
 
 function isTechnicalPanelType(type) {
@@ -865,18 +993,45 @@ function isTechnicalPanelType(type) {
   return false;
 }
 
-function evaluateTechnicalPanelEvidence({ panels } = {}) {
+function isProjectAuthorityPanelType(type) {
+  return isTechnicalPanelType(type) || isVisualProjectPanelType(type);
+}
+
+function evaluateTechnicalPanelEvidence({ panels, panelRegistry } = {}) {
   const blockers = [];
   const warnings = [];
   const blank = [];
+  const missing = [];
+  const imageModelPanels = [];
   const blockedPanels = [];
+  const requiredTechnicalTypes = Array.isArray(panelRegistry)
+    ? panelRegistry.filter(isTechnicalPanelType)
+    : [];
 
   if (!Array.isArray(panels) || panels.length === 0) {
-    // Stable gate contract: absent evidence degrades to warning, not block.
-    // Real content-empty enforcement fires via panelIsBlank when panels ARE
-    // provided. This keeps legacy compose flows that don't pass per-panel
-    // data passing the gate (their hard failures come from PDF/OCR/glyph
-    // evidence, not technical panel presence).
+    if (requiredTechnicalTypes.length) {
+      blockers.push(
+        `TECHNICAL_SVG_PANEL_MISSING: Required technical SVG panel evidence missing for: ${requiredTechnicalTypes.join(", ")}.`,
+      );
+      for (const type of requiredTechnicalTypes) {
+        blockedPanels.push({
+          type,
+          code: "TECHNICAL_SVG_PANEL_MISSING",
+          status: null,
+          hasSvg: false,
+        });
+      }
+      return {
+        status: "blocked",
+        blockers: unique(blockers),
+        warnings,
+        blank: [],
+        missing: requiredTechnicalTypes,
+        imageModelPanels,
+        blockedPanels,
+        codes: ["TECHNICAL_SVG_PANEL_MISSING"],
+      };
+    }
     return {
       status: "warning",
       blockers,
@@ -884,9 +1039,26 @@ function evaluateTechnicalPanelEvidence({ panels } = {}) {
         "Technical panel evidence not provided to gate; per-panel render status unknown.",
       ],
       blank: [],
+      missing: [],
+      imageModelPanels,
       blockedPanels: [],
       codes: [],
     };
+  }
+
+  const providedTypes = new Set(
+    panels.map((panel) => panelTypeOf(panel)).filter(Boolean),
+  );
+  for (const type of requiredTechnicalTypes) {
+    if (!providedTypes.has(type)) {
+      missing.push(type);
+      blockedPanels.push({
+        type,
+        code: "TECHNICAL_SVG_PANEL_MISSING",
+        status: null,
+        hasSvg: false,
+      });
+    }
   }
 
   for (const panel of panels) {
@@ -901,13 +1073,38 @@ function evaluateTechnicalPanelEvidence({ panels } = {}) {
         hasSvg: panel?.hasSvg === true,
       });
     }
+    if (technicalPanelUsesImageModel(panel)) {
+      imageModelPanels.push(type);
+      blockedPanels.push({
+        type,
+        code: "TECHNICAL_PANEL_IMAGE_MODEL_USED",
+        provider: readPanelField(panel, "provider"),
+        providerUsed: readPanelField(panel, "providerUsed"),
+        imageProviderUsed: readPanelField(panel, "imageProviderUsed"),
+      });
+    }
   }
 
-  const codes = blockedPanels.length ? ["PANEL_CONTENT_EMPTY"] : [];
+  const codes = unique([
+    missing.length ? "TECHNICAL_SVG_PANEL_MISSING" : null,
+    blank.length ? "PANEL_CONTENT_EMPTY" : null,
+    imageModelPanels.length ? "TECHNICAL_PANEL_IMAGE_MODEL_USED" : null,
+  ]);
+
+  if (missing.length) {
+    blockers.push(
+      `TECHNICAL_SVG_PANEL_MISSING: Required technical SVG panel(s) missing: ${missing.join(", ")}.`,
+    );
+  }
 
   if (blank.length) {
     blockers.push(
       `PANEL_CONTENT_EMPTY: Required technical panel(s) missing or blank: ${blank.join(", ")}.`,
+    );
+  }
+  if (imageModelPanels.length) {
+    blockers.push(
+      `TECHNICAL_PANEL_IMAGE_MODEL_USED: Technical SVG panel(s) were generated by an image model: ${imageModelPanels.join(", ")}.`,
     );
   }
 
@@ -920,6 +1117,8 @@ function evaluateTechnicalPanelEvidence({ panels } = {}) {
     blockers: unique(blockers),
     warnings: unique(warnings),
     blank,
+    missing,
+    imageModelPanels,
     blockedPanels,
     codes,
   };
@@ -1031,7 +1230,7 @@ function evaluateVisualManifestEvidence({
         panel?.metadata?.visualManifestHash ||
         null;
       if (!panelHash) {
-        warnings.push(
+        blockers.push(
           `Visual panel "${type}" has no visualManifestHash; identity lock evidence is incomplete.`,
         );
         continue;
@@ -1052,7 +1251,7 @@ function evaluateVisualManifestEvidence({
       );
     }
     if (unlocked.length) {
-      warnings.push(
+      blockers.push(
         `Visual panel(s) ${unlocked.join(", ")} are missing visualIdentityLocked=true.`,
       );
     }
@@ -1070,6 +1269,259 @@ function evaluateVisualManifestEvidence({
     manifestHash: expectedHash,
     mismatched,
     unlocked,
+  };
+}
+
+function buildProjectAuthorityPanelMap({ panels, visualPanels }) {
+  const byType = new Map();
+  for (const panel of Array.isArray(panels) ? panels : []) {
+    const type = panelTypeOf(panel);
+    if (!type || !isProjectAuthorityPanelType(type)) continue;
+    byType.set(type, panel);
+  }
+  // Prefer the richer visual artifact list when provided. Sheet placements can
+  // be reduced to layout/status fields, while visualPanels carries image2
+  // provenance and manifest-lock metadata.
+  for (const panel of Array.isArray(visualPanels) ? visualPanels : []) {
+    const type = panelTypeOf(panel);
+    if (!type || !isVisualProjectPanelType(type)) continue;
+    byType.set(type, panel);
+  }
+  return byType;
+}
+
+function evaluateProjectPanelAuthorityEvidence({
+  panels,
+  visualPanels,
+  visualManifest,
+  strictPhotoreal,
+  imageGenEnabled,
+  expectedGeometryHash,
+} = {}) {
+  const blockers = [];
+  const warnings = [];
+  const codes = [];
+  const panelMap = buildProjectAuthorityPanelMap({ panels, visualPanels });
+  const missingVisualPanels = [];
+  const missingGeometryHashPanels = [];
+  const geometryHashByPanel = {};
+  const visualManifestHashByPanel = {};
+  const missingVisualManifestHashPanels = [];
+  const mismatchedVisualManifestHashPanels = [];
+  const unlockedVisualPanels = [];
+  const textOnlyVisualPanels = [];
+  const strictFallbackPanels = [];
+  const visualEvidenceTypes = new Set(
+    (Array.isArray(visualPanels) ? visualPanels : [])
+      .map((panel) => panelTypeOf(panel))
+      .filter(isVisualProjectPanelType),
+  );
+
+  for (const type of VISUAL_PROJECT_PANEL_TYPES_FOR_GATE) {
+    if (!visualEvidenceTypes.has(type)) {
+      missingVisualPanels.push(type);
+    }
+  }
+
+  const expectedManifestHash = visualManifest?.manifestHash || null;
+  const expectedPanelGeometryHash =
+    expectedGeometryHash || visualManifest?.geometryHash || null;
+
+  for (const [type, panel] of panelMap.entries()) {
+    const geometryHash = readPanelGeometryHash(panel);
+    if (!geometryHash) {
+      missingGeometryHashPanels.push(type);
+    } else {
+      geometryHashByPanel[type] = geometryHash;
+    }
+
+    if (!isVisualProjectPanelType(type)) continue;
+
+    const manifestHash = readPanelVisualManifestHash(panel);
+    if (!manifestHash) {
+      missingVisualManifestHashPanels.push(type);
+    } else {
+      visualManifestHashByPanel[type] = manifestHash;
+      if (expectedManifestHash && manifestHash !== expectedManifestHash) {
+        mismatchedVisualManifestHashPanels.push(type);
+      }
+    }
+
+    if (readPanelField(panel, "visualIdentityLocked") !== true) {
+      unlockedVisualPanels.push(type);
+    }
+
+    if (visualPanelUsesTextOnlyGeneration(panel)) {
+      textOnlyVisualPanels.push(type);
+    }
+
+    if (
+      imageGenEnabled === true &&
+      strictPhotoreal === true &&
+      readPanelField(panel, "imageRenderFallback") === true
+    ) {
+      strictFallbackPanels.push(type);
+    }
+  }
+
+  const geometryHashes = unique(Object.values(geometryHashByPanel));
+  const visualManifestHashes = unique(Object.values(visualManifestHashByPanel));
+  const geometryMismatchPanels = [];
+  if (expectedPanelGeometryHash) {
+    for (const [type, hash] of Object.entries(geometryHashByPanel)) {
+      if (hash !== expectedPanelGeometryHash) geometryMismatchPanels.push(type);
+    }
+  }
+
+  if (missingVisualPanels.length) {
+    codes.push("VISUAL_PANEL_MISSING");
+    blockers.push(
+      `VISUAL_PANEL_MISSING: Required visual project panel(s) missing: ${missingVisualPanels.join(", ")}.`,
+    );
+  }
+  if (missingGeometryHashPanels.length) {
+    codes.push("PROJECT_PANEL_GEOMETRY_HASH_MISSING");
+    blockers.push(
+      `PROJECT_PANEL_GEOMETRY_HASH_MISSING: Project panel(s) missing geometryHash: ${missingGeometryHashPanels.join(", ")}.`,
+    );
+  }
+  if (geometryHashes.length > 1 || geometryMismatchPanels.length) {
+    codes.push("PROJECT_PANEL_GEOMETRY_HASH_MISMATCH");
+    blockers.push(
+      `PROJECT_PANEL_GEOMETRY_HASH_MISMATCH: Technical and visual project panels do not share one geometryHash (${geometryHashes.join(", ")}).`,
+    );
+  }
+  if (missingVisualManifestHashPanels.length) {
+    codes.push("VISUAL_MANIFEST_HASH_MISSING");
+    blockers.push(
+      `VISUAL_MANIFEST_HASH_MISSING: Visual panel(s) missing visualManifestHash: ${missingVisualManifestHashPanels.join(", ")}.`,
+    );
+  }
+  if (
+    visualManifestHashes.length > 1 ||
+    mismatchedVisualManifestHashPanels.length
+  ) {
+    codes.push("VISUAL_MANIFEST_HASH_MISMATCH");
+    blockers.push(
+      `VISUAL_MANIFEST_HASH_MISMATCH: Visual panels do not share one visualManifestHash (${visualManifestHashes.join(", ")}).`,
+    );
+  }
+  if (unlockedVisualPanels.length) {
+    codes.push("VISUAL_IDENTITY_UNLOCKED");
+    blockers.push(
+      `VISUAL_IDENTITY_UNLOCKED: Visual panel(s) are missing visualIdentityLocked=true: ${unlockedVisualPanels.join(", ")}.`,
+    );
+  }
+  if (textOnlyVisualPanels.length) {
+    codes.push("VISUAL_PANEL_TEXT_ONLY_IMAGE_GENERATION");
+    blockers.push(
+      `VISUAL_PANEL_TEXT_ONLY_IMAGE_GENERATION: Visual project panel(s) used text-only image generation instead of compiled_3d_control_svg references: ${textOnlyVisualPanels.join(", ")}.`,
+    );
+  }
+  if (strictFallbackPanels.length) {
+    codes.push("STRICT_IMAGE_RENDER_FALLBACK");
+    blockers.push(
+      `STRICT_IMAGE_RENDER_FALLBACK: imageRenderFallback=true under strict OpenAI image generation for panel(s): ${strictFallbackPanels.join(", ")}.`,
+    );
+  }
+
+  let status = "pass";
+  if (blockers.length) status = "blocked";
+  else if (warnings.length) status = "warning";
+
+  return {
+    status,
+    blockers: unique(blockers),
+    warnings: unique(warnings),
+    codes: unique(codes),
+    evaluatedPanelCount: panelMap.size,
+    requiredVisualPanelTypes: VISUAL_PROJECT_PANEL_TYPES_FOR_GATE.slice(),
+    missingVisualPanels,
+    missingGeometryHashPanels,
+    geometryHashes,
+    geometryHashByPanel,
+    geometryMismatchPanels,
+    expectedGeometryHash: expectedPanelGeometryHash,
+    visualManifestHashes,
+    visualManifestHashByPanel,
+    expectedVisualManifestHash: expectedManifestHash,
+    missingVisualManifestHashPanels,
+    mismatchedVisualManifestHashPanels,
+    unlockedVisualPanels,
+    textOnlyVisualPanels,
+    strictFallbackPanels,
+  };
+}
+
+function evaluateSheetArtifactEvidence({ sheetArtifact, pdfMetadata } = {}) {
+  const blockers = [];
+  const warnings = [];
+  const codes = [];
+
+  if (!sheetArtifact) {
+    return {
+      status: "pass",
+      blockers,
+      warnings,
+      codes,
+      evaluated: false,
+      sourceSvgHash: null,
+      sheetSvgHash: null,
+    };
+  }
+
+  const svgString =
+    sheetArtifact.svgString || sheetArtifact.metadata?.svgString;
+  const sheetSvgHash =
+    sheetArtifact.svgHash ||
+    sheetArtifact.source_svg_hash ||
+    sheetArtifact.metadata?.svgHash ||
+    null;
+  const sourceSvgHash =
+    pdfMetadata?.sourceSvgHash ||
+    pdfMetadata?.source_svg_hash ||
+    pdfMetadata?.sourceSheetSvgHash ||
+    null;
+
+  if (typeof svgString !== "string" || !/<svg[\s>]/i.test(svgString)) {
+    codes.push("A1_SHEET_SOURCE_SVG_MISSING");
+    blockers.push(
+      "A1_SHEET_SOURCE_SVG_MISSING: Final A1 export requires sheetArtifact.svgString as the source SVG.",
+    );
+  }
+
+  if (
+    pdfMetadata?.emptyFrameFallbackUsed === true ||
+    pdfMetadata?.usesEmptyFrames === true ||
+    normalizeAuthorityToken(pdfMetadata?.source) === "empty_frames"
+  ) {
+    codes.push("A1_PDF_EMPTY_FRAMES_USED");
+    blockers.push(
+      "A1_PDF_EMPTY_FRAMES_USED: PDF/A1 export used empty frames instead of sheetArtifact.svgString.",
+    );
+  }
+
+  if (sourceSvgHash && sheetSvgHash && sourceSvgHash !== sheetSvgHash) {
+    codes.push("A1_PDF_SOURCE_SVG_HASH_MISMATCH");
+    blockers.push(
+      `A1_PDF_SOURCE_SVG_HASH_MISMATCH: PDF source SVG hash ${sourceSvgHash} does not match sheetArtifact.svgHash ${sheetSvgHash}.`,
+    );
+  }
+
+  let status = "pass";
+  if (blockers.length) status = "blocked";
+  else if (warnings.length) status = "warning";
+
+  return {
+    status,
+    blockers: unique(blockers),
+    warnings: unique(warnings),
+    codes: unique(codes),
+    evaluated: true,
+    sourceSvgHash,
+    sheetSvgHash,
+    hasSheetSvgString:
+      typeof svgString === "string" && /<svg[\s>]/i.test(svgString),
   };
 }
 
@@ -1297,6 +1749,8 @@ export function evaluateFinalA1ExportGate({
   materialPalette = null,
   openaiProvider = null,
   presentationSummary = null,
+  sheetArtifact = null,
+  expectedGeometryHash = null,
   strictPhotoreal = false,
   imageGenEnabled = false,
   scope = PHASE_F_GATE_SCOPES.COMPOSE_FINAL,
@@ -1393,7 +1847,10 @@ export function evaluateFinalA1ExportGate({
     panelRegistry,
     targetStoreys,
   });
-  const technicalPanelStatus = evaluateTechnicalPanelEvidence({ panels });
+  const technicalPanelStatus = evaluateTechnicalPanelEvidence({
+    panels,
+    panelRegistry,
+  });
   const crossViewConsistencyStatus = evaluateCrossViewConsistencyEvidence({
     drawings,
     projectGeometry,
@@ -1403,24 +1860,40 @@ export function evaluateFinalA1ExportGate({
     visualPanels,
     scope,
   });
+  const projectPanelAuthorityStatus = evaluateProjectPanelAuthorityEvidence({
+    panels,
+    visualPanels,
+    visualManifest,
+    strictPhotoreal,
+    imageGenEnabled,
+    expectedGeometryHash,
+  });
+  const projectAuthorityVisualBlockers =
+    projectPanelAuthorityStatus.blockers.filter((blocker) =>
+      /VISUAL_|STRICT_IMAGE_RENDER_FALLBACK/.test(blocker),
+    );
   const visualPanelStatus = {
-    status: visualManifestStatus.mismatched.length
+    status: projectAuthorityVisualBlockers.length
       ? "blocked"
-      : visualManifestStatus.unlocked.length
-        ? "warning"
+      : visualManifestStatus.status === "blocked"
+        ? "blocked"
         : "pass",
-    blockers: visualManifestStatus.mismatched.length
-      ? [
-          `Visual panel(s) ${visualManifestStatus.mismatched.join(", ")} did not match the sheet visual manifest hash.`,
-        ]
-      : [],
-    warnings: visualManifestStatus.unlocked.length
-      ? [
-          `Visual panel(s) ${visualManifestStatus.unlocked.join(", ")} are not visualIdentityLocked.`,
-        ]
-      : [],
-    mismatched: visualManifestStatus.mismatched,
-    unlocked: visualManifestStatus.unlocked,
+    blockers: unique([
+      ...projectAuthorityVisualBlockers,
+      ...(visualManifestStatus.blockers || []),
+    ]),
+    warnings: [],
+    mismatched: unique([
+      ...visualManifestStatus.mismatched,
+      ...projectPanelAuthorityStatus.mismatchedVisualManifestHashPanels,
+    ]),
+    unlocked: unique([
+      ...visualManifestStatus.unlocked,
+      ...projectPanelAuthorityStatus.unlockedVisualPanels,
+    ]),
+    missing: projectPanelAuthorityStatus.missingVisualPanels,
+    textOnly: projectPanelAuthorityStatus.textOnlyVisualPanels,
+    strictFallback: projectPanelAuthorityStatus.strictFallbackPanels,
   };
   const materialPaletteStatus = evaluateMaterialPaletteEvidence({
     materialPalette,
@@ -1433,6 +1906,10 @@ export function evaluateFinalA1ExportGate({
     imageGenEnabled,
     scope,
   });
+  const sheetArtifactStatus = evaluateSheetArtifactEvidence({
+    sheetArtifact,
+    pdfMetadata,
+  });
   const layoutStatus = evaluateLayoutEvidence({ presentationSummary });
   const sheetSplitStatus = evaluateSheetSplitEvidence({ sheetSetPlan });
 
@@ -1443,8 +1920,10 @@ export function evaluateFinalA1ExportGate({
     technicalPanelStatus,
     crossViewConsistencyStatus,
     visualManifestStatus,
+    projectPanelAuthorityStatus,
     materialPaletteStatus,
     openaiProviderStatus,
+    sheetArtifactStatus,
     layoutStatus,
     sheetSplitStatus,
   ]) {
@@ -1475,32 +1954,31 @@ export function evaluateFinalA1ExportGate({
       requiredPanelStatus,
       technicalPanelStatus,
       crossViewConsistencyStatus,
+      projectPanelAuthorityStatus,
       visualPanelStatus,
       visualManifestStatus,
       materialPaletteStatus,
       openaiProviderStatus,
+      sheetArtifactStatus,
       layoutStatus,
       sheetSplitStatus,
     },
   };
 }
 
-// Phase 4: technical-group blocker extraction. The gate aggregates evidence
-// from both technical-drawing concerns and visual/photoreal concerns. The
-// slice service must fail-closed only on the *technical* group — visual
-// failures stay warning-only per Phase 4 scope. This helper isolates that
-// subset so callers don't have to know which evidence keys are technical.
+// Phase 4/3: upstream blocker extraction. The slice service must fail closed
+// when the A1 export gate proves that deterministic technical SVGs, visual
+// image2 panels, or the final sheet source SVG no longer share one
+// ProjectGraph authority.
 //
 // Technical sources:
 //   - technicalPanelStatus      → PANEL_CONTENT_EMPTY
 //   - crossViewConsistencyStatus → CROSS_VIEW_INCONSISTENT
 //   - requiredPanelStatus       → A1_REQUIRED_PANEL_MISSING (panel registry)
+//   - projectPanelAuthorityStatus → geometry/manifest/image2 authority
+//   - sheetArtifactStatus       → sheetArtifact.svgString/PDF source evidence
 //   - layoutStatus              → A1_LAYOUT_BROKEN
 //   - sheetSplitStatus          → A1_SHEET_SPLIT_REQUIRED
-//
-// Visual sources (intentionally excluded):
-//   - visualPanelStatus, visualManifestStatus, materialPaletteStatus,
-//     openaiProviderStatus, pdfMetadata, rasterGlyphIntegrity
 export function extractTechnicalGroupBlockers(gateResult) {
   const empty = {
     blocked: false,
@@ -1519,6 +1997,11 @@ export function extractTechnicalGroupBlockers(gateResult) {
       ev: evidence.crossViewConsistencyStatus,
     },
     { key: "requiredPanelStatus", ev: evidence.requiredPanelStatus },
+    {
+      key: "projectPanelAuthorityStatus",
+      ev: evidence.projectPanelAuthorityStatus,
+    },
+    { key: "sheetArtifactStatus", ev: evidence.sheetArtifactStatus },
     { key: "layoutStatus", ev: evidence.layoutStatus },
     { key: "sheetSplitStatus", ev: evidence.sheetSplitStatus },
   ];

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -5165,13 +5165,17 @@ function formatPanelTitle(panelType) {
   return raw
     .replace(/^floor_plan_ground$/, "Ground floor plan")
     .replace(/^floor_plan_first$/, "First floor plan")
+    .replace(/^elevation_north$/, "North elevation")
+    .replace(/^elevation_south$/, "South elevation")
+    .replace(/^elevation_east$/, "East elevation")
+    .replace(/^elevation_west$/, "West elevation")
     .replace(/^section_AA$/, "Section A-A")
     .replace(/^section_BB$/, "Section B-B")
-    .replace(/^site_context$/, "Site plan")
+    .replace(/^site_context$/, "Site / Context")
     .replace(/^hero_3d$/, "Exterior perspective")
-    .replace(/^exterior_render$/, "Exterior render")
-    .replace(/^axonometric$/, "Axonometric view")
-    .replace(/^interior_3d$/, "Interior perspective")
+    .replace(/^exterior_render$/, "Exterior perspective")
+    .replace(/^axonometric$/, "Axonometric")
+    .replace(/^interior_3d$/, "Interior view")
     .replace(/^material_palette$/, "Material palette")
     .replace(/^key_notes$/, "Key notes")
     .replace(/^title_block$/, "Title block")
@@ -6534,6 +6538,7 @@ export function buildTitleBlockPanelArtifact({
   geometryHash,
   sheetPlan,
   sheetDesignContext = null,
+  visualManifest = null,
 }) {
   const width = 620;
   const height = 900;
@@ -6575,6 +6580,10 @@ export function buildTitleBlockPanelArtifact({
       sheetDesignContext?.studio_footer ||
       "Architecture | Design | Planning",
   ).trim();
+  const visualManifestHash =
+    visualManifest?.manifestHash ||
+    sheetDesignContext?.visualManifestHash ||
+    null;
   const disclaimerLines = splitNoteLines(PROFESSIONAL_REVIEW_DISCLAIMER, 64, 3);
   // Phase 2 — broader RIBA-style metadata. The first 5 rows preserve the
   // existing data source (so existing tests and downstream readers continue
@@ -6638,7 +6647,8 @@ export function buildTitleBlockPanelArtifact({
   ${disclaimerSvg}
   <text x="34" y="808" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#222222">${escapeXml(architectName.toUpperCase())}</text>
   <text x="34" y="828" font-family="Arial, sans-serif" font-size="12" fill="#555555">${escapeXml(studioFooter)}</text>
-  <text x="34" y="862" font-family="Arial, sans-serif" font-size="11" fill="#888888">source_model_hash ${escapeXml(String(geometryHash || "").slice(0, 16))}</text>
+  <text x="34" y="846" font-family="Arial, sans-serif" font-size="10" fill="#666666">geometryHash ${escapeXml(String(geometryHash || "").slice(0, 18))}</text>
+  <text x="34" y="862" font-family="Arial, sans-serif" font-size="10" fill="#666666">visualManifestHash ${escapeXml(String(visualManifestHash || "n/a").slice(0, 18))}</text>
   <text x="586" y="862" font-family="Arial, sans-serif" font-size="11" text-anchor="end" fill="#888888">${escapeXml(`${ribaStageLabel} • Rev ${revision}`)}</text>
 </svg>`;
   const svgHash = computeCDSHashSync({
@@ -6690,6 +6700,7 @@ export function buildTitleBlockPanelArtifact({
       date: dateLabel,
       architect: architectName,
       studioFooter,
+      visualManifestHash,
       rowKeys: rows.map((r) => r[0]),
       sheetDesignContextHash: sheetDesignContext?.contextHash || null,
       sourceContext: sheetDesignContext
@@ -6971,7 +6982,7 @@ export function buildProjectGraphRenderPrompt({
 function wrapPngAsSvgPanel(pngBuffer, viewBox, width, height) {
   const dataUrl = `data:image/png;base64,${pngBuffer.toString("base64")}`;
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="${viewBox}" preserveAspectRatio="xMidYMid meet">
-  <image href="${dataUrl}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="xMidYMid slice"/>
+  <image href="${dataUrl}" x="0" y="0" width="${width}" height="${height}" preserveAspectRatio="xMidYMid meet" data-fit-mode="object-contain"/>
 </svg>`;
 }
 
@@ -7310,6 +7321,7 @@ async function buildSheetPanelArtifacts({
     geometryHash,
     sheetPlan,
     sheetDesignContext,
+    visualManifest,
   });
   const visual3d = await buildVisual3DPanelArtifacts({
     compiledProject,
@@ -8361,6 +8373,53 @@ export function computePanelSlotFitMetrics({
   };
 }
 
+function artifactMetadataValue(artifact = null, key) {
+  if (!artifact) return null;
+  if (artifact[key] !== undefined && artifact[key] !== null) return artifact[key];
+  if (
+    artifact.metadata &&
+    artifact.metadata[key] !== undefined &&
+    artifact.metadata[key] !== null
+  ) {
+    return artifact.metadata[key];
+  }
+  return null;
+}
+
+function panelKindForSheet(panelType = "") {
+  if (REQUIRED_3D_A1_PANEL_TYPES.includes(panelType)) return "visual";
+  if (
+    String(panelType).startsWith("floor_plan_") ||
+    String(panelType).startsWith("elevation_") ||
+    String(panelType).startsWith("section_")
+  ) {
+    return "technical";
+  }
+  return "data";
+}
+
+function buildVisualPanelStatusBadge(artifact = null) {
+  const panelType = artifact?.panel_type || artifact?.panelType || "";
+  if (!REQUIRED_3D_A1_PANEL_TYPES.includes(panelType)) return null;
+  const fallback = artifactMetadataValue(artifact, "imageRenderFallback") !== false;
+  if (fallback) {
+    return {
+      label: "DETERMINISTIC FALLBACK",
+      providerUsed: "deterministic",
+      fallback: true,
+      fallbackReason:
+        artifactMetadataValue(artifact, "imageRenderFallbackReason") ||
+        "image_generation_disabled_or_unavailable",
+    };
+  }
+  return {
+    label: "IMAGE2 / OPENAI EDIT",
+    providerUsed: artifactMetadataValue(artifact, "imageProviderUsed") || "openai",
+    fallback: false,
+    fallbackReason: null,
+  };
+}
+
 function renderSheetPanel({
   placement,
   artifact,
@@ -8387,14 +8446,22 @@ function renderSheetPanel({
   });
   const content =
     placement.status === "ready"
-      ? `<svg x="${contentX}" y="${contentY}" width="${contentWidth}" height="${contentHeight}" viewBox="${escapeXml(viewBox)}" preserveAspectRatio="xMidYMid meet" overflow="hidden" data-inlined-panel="true">${svgBody}</svg>`
+      ? `<svg x="${contentX}" y="${contentY}" width="${contentWidth}" height="${contentHeight}" viewBox="${escapeXml(viewBox)}" preserveAspectRatio="xMidYMid meet" overflow="hidden" data-inlined-panel="true" data-fit-mode="object-contain">${svgBody}</svg>`
       : `<g data-panel-missing="true"><rect x="${contentX}" y="${contentY}" width="${contentWidth}" height="${contentHeight}" fill="#fff3f0" stroke="#a43f2a" stroke-dasharray="4 3"/><text x="${contentX + 8}" y="${contentY + 22}" font-size="7" fill="#a43f2a">Missing source panel</text></g>`;
+  const panelKind = panelKindForSheet(placement.panelType);
+  const visualBadge = buildVisualPanelStatusBadge(artifact);
+  const badgeSvg = visualBadge
+    ? `<g data-visual-provider-badge="true">
+  <rect x="${placement.x + placement.width - 70}" y="${placement.y + 2.2}" width="66" height="6.8" fill="${visualBadge.fallback ? "#fff4df" : "#eef8ff"}" stroke="${visualBadge.fallback ? "#b26b00" : "#0b5d7d"}" stroke-width="0.35"/>
+  <text x="${placement.x + placement.width - 37}" y="${placement.y + 7.4}" font-size="3.2" font-family="${EMBEDDED_FONT_STACK}" text-anchor="middle" fill="${visualBadge.fallback ? "#8a4b00" : "#0b5d7d"}">${escapeXml(visualBadge.label)}</text>
+</g>`
+    : "";
 
   // Phase B caption cleanup: show only title (left) + scale (right). The
   // geometry hash and source-model-hash were colliding with the title and
   // adding visual clutter; they remain available on the wrapping <g>
   // (data-source-model-hash) and on sheet metadata for downstream QA.
-  return `<g data-panel-id="${escapeXml(placement.panelType)}" data-source-panel-asset-id="${escapeXml(placement.sourcePanelAssetId || "")}" data-source-model-hash="${escapeXml(placement.source_model_hash || "")}" data-caption-layout="${caption.layout}">
+  return `<g data-panel-id="${escapeXml(placement.panelType)}" data-panel-kind="${panelKind}" data-source-panel-asset-id="${escapeXml(placement.sourcePanelAssetId || "")}" data-source-model-hash="${escapeXml(placement.source_model_hash || "")}" data-caption-layout="${caption.layout}" data-preserve-aspect-ratio="xMidYMid meet" data-fit-mode="object-contain" data-provider-used="${escapeXml(visualBadge?.providerUsed || artifactMetadataValue(artifact, "providerUsed") || "")}" data-image-render-fallback="${visualBadge ? String(visualBadge.fallback) : ""}" data-image-render-fallback-reason="${escapeXml(visualBadge?.fallbackReason || "")}">
   <rect x="${placement.x}" y="${placement.y}" width="${placement.width}" height="${placement.height}" rx="0.4" fill="#ffffff" stroke="#111111" stroke-width="0.45"/>
   <text x="${placement.x + caption.titleX}" y="${placement.y + caption.titleY}" font-size="${CAPTION_TITLE_FONT_SIZE}" font-family="${EMBEDDED_FONT_STACK}" font-weight="700" fill="#111111">${titleText}</text>
   ${
@@ -8402,7 +8469,43 @@ function renderSheetPanel({
       ? `<text x="${placement.x + caption.scaleX}" y="${placement.y + caption.scaleY}" font-size="${caption.scaleFontSize}" font-family="${EMBEDDED_FONT_STACK}" text-anchor="end" fill="#444444">${scaleText}</text>`
       : ""
   }
+  ${badgeSvg}
   ${content}
+</g>`;
+}
+
+function buildSheetProvenanceFooter({
+  geometryHash,
+  visualManifest,
+  panelArtifacts,
+} = {}) {
+  const visualArtifacts = normalizeArtifactCollection(panelArtifacts).filter(
+    (artifact) => REQUIRED_3D_A1_PANEL_TYPES.includes(artifact?.panel_type),
+  );
+  const providerValues = [
+    ...new Set(
+      visualArtifacts
+        .map((artifact) => artifactMetadataValue(artifact, "imageProviderUsed"))
+        .filter(Boolean),
+    ),
+  ];
+  const fallbackPanels = visualArtifacts
+    .filter((artifact) => artifactMetadataValue(artifact, "imageRenderFallback") !== false)
+    .map((artifact) => artifact.panel_type);
+  const providerSummary =
+    providerValues.length > 0 ? providerValues.join("+") : "deterministic";
+  const fallbackStatus = fallbackPanels.length
+    ? `fallback ${fallbackPanels.join(",")}`
+    : "fallback none";
+  const visualManifestHash = visualManifest?.manifestHash || null;
+  return `<g data-provenance-footer="true" data-geometry-hash="${escapeXml(geometryHash || "")}" data-visual-manifest-hash="${escapeXml(visualManifestHash || "")}" data-provider-summary="${escapeXml(providerSummary)}" data-image-render-fallback-status="${escapeXml(fallbackStatus)}" data-authority-source="ProjectGraph compiled geometry" data-export-source="sheetArtifact.svgString">
+  <rect x="6" y="582" width="829" height="7" fill="#ffffff" opacity="0.96"/>
+  <line x1="6" y1="582" x2="835" y2="582" stroke="#111111" stroke-width="0.25"/>
+  <text x="10" y="587" font-size="3.4" font-family="${EMBEDDED_FONT_STACK}" fill="#222222">ProjectGraph authority: compiled geometry / deterministic technical SVGs / geometry-locked visual edits</text>
+  <text x="382" y="587" font-size="3.4" font-family="${EMBEDDED_FONT_STACK}" fill="#444444">geometryHash ${escapeXml(String(geometryHash || "").slice(0, 16))}</text>
+  <text x="535" y="587" font-size="3.4" font-family="${EMBEDDED_FONT_STACK}" fill="#444444">visualManifestHash ${escapeXml(String(visualManifestHash || "n/a").slice(0, 16))}</text>
+  <text x="735" y="587" font-size="3.4" font-family="${EMBEDDED_FONT_STACK}" text-anchor="end" fill="#444444">providers ${escapeXml(providerSummary)}</text>
+  <text x="831" y="587" font-size="3.4" font-family="${EMBEDDED_FONT_STACK}" text-anchor="end" fill="${fallbackPanels.length ? "#8a4b00" : "#444444"}">${escapeXml(fallbackStatus)}</text>
 </g>`;
 }
 
@@ -8416,6 +8519,7 @@ function buildSheetSvg({
   sheetNumber = "A1-00",
   sheetLabel = "RIBA Stage 2 Master",
   layoutTemplate = "board-v2",
+  visualManifest = null,
 }) {
   const artifactIndex = buildPanelArtifactIndex(panelArtifacts);
   const panelGroups = panelPlacements
@@ -8430,12 +8534,18 @@ function buildSheetSvg({
   const sourcePanelAssetIds = panelPlacements
     .map((placement) => placement.sourcePanelAssetId)
     .filter(Boolean);
+  const provenanceFooter = buildSheetProvenanceFooter({
+    geometryHash,
+    visualManifest,
+    panelArtifacts,
+  });
 
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="${A1_SHEET_SIZE_MM.width}mm" height="${A1_SHEET_SIZE_MM.height}mm" viewBox="0 0 ${A1_SHEET_SIZE_MM.width} ${A1_SHEET_SIZE_MM.height}" data-layout-version="${A1_SHEET_LAYOUT_VERSION}" data-layout-template="${escapeXml(layoutTemplate)}" data-placeholder-only="false" data-reference-match="${brief?.reference_match === true ? "true" : "false"}" data-brief-input-hash="${escapeXml(brief?.brief_input_hash || "")}" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-sheet-number="${escapeXml(sheetNumber)}" data-sheet-label="${escapeXml(sheetLabel)}" data-qa-status="${escapeXml(qaStatus || "pending")}">
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${A1_SHEET_SIZE_MM.width}mm" height="${A1_SHEET_SIZE_MM.height}mm" viewBox="0 0 ${A1_SHEET_SIZE_MM.width} ${A1_SHEET_SIZE_MM.height}" data-layout-version="${A1_SHEET_LAYOUT_VERSION}" data-layout-template="${escapeXml(layoutTemplate)}" data-placeholder-only="false" data-reference-match="${brief?.reference_match === true ? "true" : "false"}" data-brief-input-hash="${escapeXml(brief?.brief_input_hash || "")}" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-visual-manifest-hash="${escapeXml(visualManifest?.manifestHash || "")}" data-sheet-number="${escapeXml(sheetNumber)}" data-sheet-label="${escapeXml(sheetLabel)}" data-qa-status="${escapeXml(qaStatus || "pending")}" data-export-source="sheetArtifact.svgString">
   <rect width="${A1_SHEET_SIZE_MM.width}" height="${A1_SHEET_SIZE_MM.height}" fill="#ffffff"/>
   <rect x="5" y="5" width="831" height="584" fill="none" stroke="#111111" stroke-width="0.7"/>
   <desc>Reference board A1 package for ${escapeXml(brief.project_name)}. Panels ${sourcePanelAssetIds.length}. Geometry hash ${escapeXml(geometryHash)}.</desc>
   ${panelGroups}
+  ${provenanceFooter}
 </svg>`;
 }
 
@@ -8599,6 +8709,7 @@ async function buildA1Sheet({
     sheetNumber: drawingNumber,
     sheetLabel,
     layoutTemplate,
+    visualManifest,
   });
   __a1mark = __a1sheetLog(
     "build_sheet_svg",
@@ -8915,6 +9026,18 @@ const FINAL_A1_RASTER_DPI = 300;
 const PREVIEW_A1_RASTER_DPI = 144;
 const FINAL_A1_RASTER_MIN_RATIO = 0.95; // tolerance vs expected pixel size
 
+function buildA1PdfSourceMetadata(sheetArtifact = {}) {
+  return {
+    sourceSvgHash: sheetArtifact?.svgHash || null,
+    sourceSvgAssetId: sheetArtifact?.asset_id || null,
+    sheetArtifactSvgStringUsed:
+      typeof sheetArtifact?.svgString === "string" &&
+      sheetArtifact.svgString.length > 0,
+    sourceSvgRole: "sheetArtifact.svgString",
+    emptyFrameFallbackUsed: false,
+  };
+}
+
 async function buildA1PdfArtifact({
   projectGraphId,
   brief,
@@ -9198,10 +9321,7 @@ async function buildA1PdfArtifact({
     textRenderMode: "font_paths",
     rasterIntegrityStatus: rasterGlyphIntegrity?.status || "not_run",
     hybridVectorPdfFollowUp: true,
-    sourceSvgHash: sheetArtifact.svgHash,
-    sourceSvgAssetId: sheetArtifact.asset_id,
-    sheetArtifactSvgStringUsed: true,
-    emptyFrameFallbackUsed: false,
+    ...buildA1PdfSourceMetadata(sheetArtifact),
   };
 
   // Phase 5D: optional vector PDF as an *additional* artifact behind a
@@ -12263,6 +12383,12 @@ export const __projectGraphVerticalSliceInternals = Object.freeze({
   syncProgrammeActuals,
   compileProject,
   buildArchitectReasoningManifest,
+  buildPanelPlacements,
+  buildSheetSvg,
+  buildSheetProvenanceFooter,
+  buildA1PdfSourceMetadata,
+  renderSheetPanel,
+  wrapPngAsSvgPanel,
   // Phase 4: exposed for unit testing the upstream-gate technical-blocker fold.
   applyUpstreamGateTechnicalBlockersToQa,
 });

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -228,6 +228,17 @@ function isTruthyFlag(value) {
   ].includes(String(value).trim().toLowerCase());
 }
 
+function createStrictVisualImageError({ panelType, reason, message }) {
+  const error = new Error(
+    `[OpenAI] strict image generation failed panel=${panelType} reason=${reason}: ${message || reason}`,
+  );
+  error.code = "OPENAI_STRICT_IMAGE_GEN_FAILED";
+  error.panelType = panelType;
+  error.fallbackReason = reason;
+  error.strictImageGeneration = true;
+  return error;
+}
+
 function isReferenceMatchRequested(input = {}, sourceBrief = {}) {
   return (
     isTruthyFlag(input.referenceMatch) ||
@@ -6790,13 +6801,13 @@ export function buildProjectGraphRenderPrompt({
   const baseIntent =
     {
       hero_3d:
-        "Photoreal hero exterior 3D perspective — magazine-cover quality. Match the silhouette of the reference image exactly (same massing, same roof shape, same opening positions, same storey count). Apply the materials, lighting, and detailing from the reasoning chain below.",
+        "Realistic front-left architectural exterior perspective for the hero_3d panel — magazine-cover quality. Match the silhouette of the control image exactly (same massing, same roof shape, same opening positions, same storey count). Apply the materials, lighting, and detailing from the reasoning chain below.",
       exterior_render:
-        "Photoreal front-elevation hero render — slight 12° angle, head-on composition. Match the reference silhouette exactly. Render with golden-hour lighting and physically-based materials.",
+        "Realistic front-left architectural exterior perspective for the exterior_render panel — slight 12° angle, composed from the main approach. Match the control silhouette exactly. Render with golden-hour lighting and physically-based materials.",
       axonometric:
-        "Photoreal axonometric 3D projection (30° isometric) showing roof form and four facades. Match the reference massing, roof, and opening layout exactly. Material textures legible.",
+        "Technical axonometric/isometric view matching the same massing, roof, storeys, openings, and facade rhythm as the control geometry. Material textures legible without changing the building logic.",
       interior_3d:
-        "Photoreal interior perspective — main living/kitchen space. Use the SAME materials and palette as the exterior. Match the reference interior volume.",
+        "Interior view derived from the same project programme — main living/kitchen or primary public space. Use the SAME materials and palette as the exterior, and do not alter shell, opening, stair, or room-adjacency logic.",
     }[panelType] || "Photoreal architectural render.";
   const intent = cutawayActive
     ? buildAxonometricCutawayIntent({ sheetDesignContext, brief })
@@ -6808,6 +6819,18 @@ export function buildProjectGraphRenderPrompt({
   // interior_3d) describe the same building. The block is identical across
   // panels for the same manifest, so OpenAI image generation cannot drift.
   const identityLock = buildVisualIdentityLockBlock(visualManifest);
+  const geometryHash =
+    compiledProject?.geometryHash ||
+    compiledProject?.geometry_hash ||
+    visualManifest?.geometryHash ||
+    "n/a";
+  const visualManifestHash = visualManifest?.manifestHash || "n/a";
+  const authorityLine = [
+    "GEOMETRY AND VISUAL AUTHORITY:",
+    `geometryHash: ${geometryHash}`,
+    `visualManifestHash: ${visualManifestHash}`,
+    "Use the supplied control image as the geometry reference; do not use text-only generation and do not invent project geometry.",
+  ].join("\n");
   const visualContinuity =
     buildProjectGraphVisualContinuityBlock(visualManifest);
   // Regional vernacular block — when the slice resolved a UK pack
@@ -6933,6 +6956,7 @@ export function buildProjectGraphRenderPrompt({
     : null;
   return [
     identityLock,
+    authorityLine,
     visualContinuity,
     `Project: ${projectName} — ${buildingType}.`,
     intent,
@@ -6951,7 +6975,7 @@ function wrapPngAsSvgPanel(pngBuffer, viewBox, width, height) {
 </svg>`;
 }
 
-async function buildVisual3DPanelArtifacts({
+export async function buildVisual3DPanelArtifacts({
   compiledProject,
   geometryHash,
   brief = null,
@@ -6978,6 +7002,12 @@ async function buildVisual3DPanelArtifacts({
     cutawayEnvOverride === "true" ||
     cutawayEnvOverride === "1" ||
     isFeatureEnabled("axonometricCutawayEnabled");
+  const strictImageGeneration =
+    isTruthyFlag(
+      typeof process !== "undefined"
+        ? process.env?.OPENAI_STRICT_IMAGE_GEN
+        : false,
+    ) === true;
   const renderInputs = ensureCompiledProjectRenderInputs(compiledProject, {
     geometryHash,
     views: REQUIRED_3D_A1_PANEL_TYPES,
@@ -6990,6 +7020,17 @@ async function buildVisual3DPanelArtifacts({
       const height = renderInput.height || renderInput.metadata?.height || 1050;
       const viewBox =
         renderInput.metadata?.normalizedViewBox || `0 0 ${width} ${height}`;
+      const controlSvgHash = deterministicSvgString
+        ? renderInput.svgHash ||
+          computeCDSHashSync({
+            panelType,
+            geometryHash,
+            referenceSource: "compiled_3d_control_svg",
+            svgString: deterministicSvgString,
+          })
+        : null;
+      let prompt = "";
+      let promptHash = null;
 
       // Phase 4: when PROJECT_GRAPH_IMAGE_GEN_ENABLED=true, anchor a
       // gpt-image call on the deterministic SVG silhouette and replace
@@ -7002,7 +7043,7 @@ async function buildVisual3DPanelArtifacts({
       let imageRenderFallbackReason = "gate_disabled";
       let renderResult = null;
       if (deterministicSvgString) {
-        const prompt = buildProjectGraphRenderPrompt({
+        prompt = buildProjectGraphRenderPrompt({
           panelType,
           brief,
           compiledProject,
@@ -7014,6 +7055,12 @@ async function buildVisual3DPanelArtifacts({
           visualManifest,
           sheetDesignContext,
           axonometricCutawayEnabled,
+        });
+        promptHash = computeCDSHashSync({
+          panelType,
+          geometryHash,
+          visualManifestHash: visualManifest?.manifestHash || null,
+          prompt,
         });
         try {
           renderResult = await renderProjectGraphPanelImage({
@@ -7047,10 +7094,27 @@ async function buildVisual3DPanelArtifacts({
           renderProvenance = renderResult.provenance;
           imageRenderFallbackReason = null;
         } else if (renderResult?.imageRenderFallbackReason) {
+          if (strictImageGeneration) {
+            throw createStrictVisualImageError({
+              panelType,
+              reason: renderResult.imageRenderFallbackReason,
+              message:
+                renderResult.error ||
+                "OpenAI image generation returned fallback metadata under strict image generation.",
+            });
+          }
           imageRenderFallbackReason = renderResult.imageRenderFallbackReason;
         }
       } else {
-        imageRenderFallbackReason = "empty_response";
+        imageRenderFallbackReason = "missing_control_svg";
+        if (strictImageGeneration) {
+          throw createStrictVisualImageError({
+            panelType,
+            reason: "missing_control_svg",
+            message:
+              "ProjectGraph visual panels require a deterministic compiled-geometry control SVG before image editing.",
+          });
+        }
       }
       const presentationMode = renderProvenance
         ? "geometry_locked_image_render"
@@ -7061,6 +7125,15 @@ async function buildVisual3DPanelArtifacts({
       const visualRenderMode = renderProvenance
         ? "photoreal_image_gen"
         : "deterministic_fallback";
+      const provider = renderProvenance ? "openai" : "deterministic";
+      const providerUsed = renderProvenance ? "openai" : "deterministic";
+      const imageProviderUsed = renderProvenance ? "openai" : "deterministic";
+      const imageRenderFallback = renderProvenance === null;
+      const renderModel =
+        renderProvenance?.model || renderResult?.model || null;
+      const requestId =
+        renderProvenance?.requestId || renderResult?.requestId || null;
+      const usage = renderProvenance?.usage || renderResult?.usage || null;
 
       const svgHash =
         renderInput.svgHash ||
@@ -7082,6 +7155,21 @@ async function buildVisual3DPanelArtifacts({
           panelType,
           source_model_hash: geometryHash,
           geometryHash,
+          sourceGeometryHash: geometryHash,
+          visualManifestId: visualManifest?.manifestId || null,
+          visualManifestHash: visualManifest?.manifestHash || null,
+          visualIdentityLocked: Boolean(visualManifest?.manifestHash),
+          referenceSource: "compiled_3d_control_svg",
+          provider,
+          providerUsed,
+          imageProviderUsed,
+          imageRenderFallback,
+          imageRenderFallbackReason,
+          model: renderModel,
+          requestId,
+          usage,
+          controlSvgHash,
+          promptHash,
           authoritySource: "project_graph_compiled_geometry",
           svgHash,
           width,
@@ -7099,19 +7187,26 @@ async function buildVisual3DPanelArtifacts({
             svgHash,
             sourceGeometryHash: geometryHash,
             referenceSource: "compiled_3d_control_svg",
-            imageRenderFallback: renderProvenance === null,
+            controlSvgHash,
+            promptHash,
+            provider,
+            providerUsed,
+            imageRenderFallback,
             imageRenderFallbackReason,
-            imageRenderModel: renderProvenance?.model || null,
+            imageRenderModel: renderModel,
+            model: renderModel,
             imageRenderSize: renderProvenance?.size || null,
             imageRenderByteLength,
-            imageProviderUsed: renderProvenance ? "openai" : "deterministic",
+            imageProviderUsed,
             openaiConfigured:
               renderResult?.openaiConfigured ??
               renderResult?.provenance?.openaiConfigured ??
               false,
             openaiImageUsed: Boolean(renderProvenance),
-            openaiRequestId: renderProvenance?.requestId || null,
-            openaiUsage: renderProvenance?.usage || null,
+            openaiRequestId: requestId,
+            requestId,
+            openaiUsage: usage,
+            usage,
             openaiKeySource:
               renderProvenance?.keySource ||
               renderResult?.keySource ||

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -5286,13 +5286,20 @@ function buildDrawingSet(compiledProject, options = {}) {
     drawingArtifacts: Object.fromEntries(
       Object.entries(technicalPanels).map(([panelType, panel]) => {
         const assetId = createStableId("asset-svg", panelType, panel.svgHash);
+        const geometryHash = compiledProject.geometryHash;
         return [
           assetId,
           {
             asset_id: assetId,
             asset_type: "drawing_svg",
             panel_type: panelType,
-            source_model_hash: compiledProject.geometryHash,
+            source_model_hash: geometryHash,
+            geometryHash,
+            sourceGeometryHash: geometryHash,
+            renderer: "deterministic_svg",
+            providerUsed: "deterministic_svg",
+            imageProviderUsed: "none",
+            technicalDrawing: true,
             svgHash: panel.svgHash,
             width: panel.width,
             height: panel.height,
@@ -5304,6 +5311,12 @@ function buildDrawingSet(compiledProject, options = {}) {
             technicalQualityMetadata: panel.technicalQualityMetadata || null,
             metadata: {
               source: "compiled_project_technical_panel",
+              renderer: "deterministic_svg",
+              providerUsed: "deterministic_svg",
+              imageProviderUsed: "none",
+              technicalDrawing: true,
+              geometryHash,
+              sourceGeometryHash: geometryHash,
               panelType,
               expectedPanelType: panelType,
               drawingType: panel.drawingType || drawingTypeForPanel(panelType),
@@ -12706,6 +12719,7 @@ export const __projectGraphVerticalSliceInternals = Object.freeze({
   compileProject,
   buildArchitectReasoningManifest,
   buildPanelPlacements,
+  buildDrawingSet,
   buildSheetSvg,
   buildSheetProvenanceFooter,
   buildA1PdfSourceMetadata,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -9198,6 +9198,10 @@ async function buildA1PdfArtifact({
     textRenderMode: "font_paths",
     rasterIntegrityStatus: rasterGlyphIntegrity?.status || "not_run",
     hybridVectorPdfFollowUp: true,
+    sourceSvgHash: sheetArtifact.svgHash,
+    sourceSvgAssetId: sheetArtifact.asset_id,
+    sheetArtifactSvgStringUsed: true,
+    emptyFrameFallbackUsed: false,
   };
 
   // Phase 5D: optional vector PDF as an *additional* artifact behind a
@@ -11685,21 +11689,73 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       targetStoreysForGate,
       sheetArtifact.layoutTemplate || resolvePresentationLayoutTemplate(brief),
     );
-    const visualPanelArtifacts = Object.values(primaryPanelArtifacts).filter(
-      (artifact) =>
-        REQUIRED_3D_A1_PANEL_TYPES.includes(artifact?.panel_type) ||
-        artifact?.metadata?.visualManifestHash,
+    const artifactByPanelType = new Map(
+      Object.values(primaryPanelArtifacts)
+        .filter((artifact) => artifact?.panel_type)
+        .map((artifact) => [artifact.panel_type, artifact]),
     );
-    const visualPanelsForGate = visualPanelArtifacts.map((artifact) => ({
-      type: artifact.panel_type,
-      visualManifestHash:
-        artifact.metadata?.visualManifestHash ||
-        artifact.visualManifestHash ||
-        null,
-      visualIdentityLocked:
-        artifact.metadata?.visualIdentityLocked === true ||
-        artifact.visualIdentityLocked === true,
-    }));
+    const buildGatePanelEvidence = (panelType, placement = null) => {
+      const artifact = artifactByPanelType.get(panelType) || {};
+      const metadata = artifact.metadata || {};
+      return {
+        type: panelType,
+        panelType,
+        status:
+          placement?.status ||
+          artifact.status ||
+          (artifact.svgString ? "ready" : null),
+        hasSvg: Boolean(
+          artifact.svgString || placement?.svgString || placement?.hasSvg,
+        ),
+        geometryHash:
+          artifact.geometryHash ||
+          metadata.geometryHash ||
+          artifact.sourceGeometryHash ||
+          metadata.sourceGeometryHash ||
+          artifact.source_model_hash ||
+          null,
+        sourceGeometryHash:
+          artifact.sourceGeometryHash ||
+          metadata.sourceGeometryHash ||
+          artifact.geometryHash ||
+          metadata.geometryHash ||
+          artifact.source_model_hash ||
+          null,
+        visualManifestId:
+          artifact.visualManifestId || metadata.visualManifestId || null,
+        visualManifestHash:
+          artifact.visualManifestHash || metadata.visualManifestHash || null,
+        visualIdentityLocked:
+          artifact.visualIdentityLocked === true ||
+          metadata.visualIdentityLocked === true,
+        referenceSource:
+          artifact.referenceSource || metadata.referenceSource || null,
+        provider: artifact.provider || metadata.provider || null,
+        providerUsed: artifact.providerUsed || metadata.providerUsed || null,
+        imageProviderUsed:
+          artifact.imageProviderUsed || metadata.imageProviderUsed || null,
+        imageRenderFallback:
+          artifact.imageRenderFallback ?? metadata.imageRenderFallback ?? null,
+        imageRenderFallbackReason:
+          artifact.imageRenderFallbackReason ||
+          metadata.imageRenderFallbackReason ||
+          null,
+        model: artifact.model || metadata.model || null,
+        requestId: artifact.requestId || metadata.requestId || null,
+        usage: artifact.usage || metadata.usage || null,
+        controlSvgHash:
+          artifact.controlSvgHash || metadata.controlSvgHash || null,
+        promptHash: artifact.promptHash || metadata.promptHash || null,
+        svgHash: artifact.svgHash || metadata.svgHash || null,
+        svgString: artifact.svgString || placement?.svgString || null,
+        metadata,
+      };
+    };
+    const visualPanelsForGate = REQUIRED_3D_A1_PANEL_TYPES.map((panelType) =>
+      artifactByPanelType.has(panelType)
+        ? buildGatePanelEvidence(panelType)
+        : null,
+    ).filter(Boolean);
     const materialPaletteArtifact = Object.values(primaryPanelArtifacts).find(
       (artifact) => artifact?.panel_type === "material_palette",
     );
@@ -11712,11 +11768,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
         }
       : null;
     const panelsForGate = (sheetArtifact.panelPlacements || []).map(
-      (placement) => ({
-        type: placement.panelType,
-        status: placement.status,
-        hasSvg: placement.status === "ready",
-      }),
+      (placement) => buildGatePanelEvidence(placement.panelType, placement),
     );
     // Phase 4: bucket the deterministic drawing SVGs by drawing type so the
     // gate's cross-view evidence evaluator (drawingConsistencyChecks) can
@@ -11794,6 +11846,16 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     const upstreamGate = evaluateFinalA1ExportGate({
       renderContract: upstreamRenderContract,
       // PDF/raster/post-compose evidence is owned by the compose route.
+      pdfMetadata: pdfArtifact?.pdfMetadata
+        ? {
+            ...pdfArtifact.pdfMetadata,
+            sourceSvgHash:
+              pdfArtifact.pdfMetadata.sourceSvgHash ||
+              pdfArtifact.source_svg_hash ||
+              null,
+          }
+        : null,
+      sheetArtifact,
       panels: panelsForGate,
       panelRegistry: phaseFRequiredPanels,
       targetStoreys: targetStoreysForGate,
@@ -11805,6 +11867,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
         brief?.reference_match === true ||
         process.env.OPENAI_STRICT_IMAGE_GEN === "true",
       imageGenEnabled: process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED === "true",
+      expectedGeometryHash: compiledProject.geometryHash,
       scope: "upstream_partial",
       // Phase 4: cross-view consistency evidence inputs.
       drawings: drawingsForGate,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -121,6 +121,7 @@ const PROFESSIONAL_REVIEW_DISCLAIMER =
   "AI-generated early-stage architecture package. Regulation checks are preliminary design flags and require professional review.";
 const A1_SHEET_LAYOUT_VERSION = "projectgraph-a1-reference-board-v1";
 const A1_SHEET_SIZE_MM = { width: 841, height: 594 };
+const PROJECT_GRAPH_GENERATION_SEED_MAX = 2_147_483_647;
 const MAX_TARGET_STOREYS = Math.max(
   1,
   Number.parseInt(process.env.MAX_TARGET_STOREYS, 10) || 8,
@@ -164,6 +165,7 @@ const TECHNICAL_A1_PANEL_TYPES_BASE = [
   "section_AA",
   "section_BB",
 ];
+let projectGraphAutoSeedCounter = 0;
 
 export function buildRequiredA1PanelTypes(
   targetStoreys = 1,
@@ -283,7 +285,7 @@ function round(value, precision = 3) {
 function normalizeGenerationSeed(value) {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return null;
-  return Math.abs(Math.trunc(numeric)) % 2147483647;
+  return Math.abs(Math.trunc(numeric)) % PROJECT_GRAPH_GENERATION_SEED_MAX;
 }
 
 function resolveGenerationSeed(input = {}, sourceBrief = {}) {
@@ -298,6 +300,228 @@ function resolveGenerationSeed(input = {}, sourceBrief = {}) {
       sourceBrief.generationSeed ??
       sourceBrief.seed,
   );
+}
+
+function createAutoGenerationSeed() {
+  projectGraphAutoSeedCounter =
+    (projectGraphAutoSeedCounter + 1) % PROJECT_GRAPH_GENERATION_SEED_MAX;
+  const seed = normalizeGenerationSeed(
+    Date.now() +
+      Math.floor(Math.random() * PROJECT_GRAPH_GENERATION_SEED_MAX) +
+      projectGraphAutoSeedCounter,
+  );
+  return seed === null || seed === 0 ? 1 : seed;
+}
+
+function firstGenerationSeedCandidate(candidates = []) {
+  for (const candidate of candidates) {
+    const normalized = normalizeGenerationSeed(candidate);
+    if (normalized !== null) return normalized;
+  }
+  return null;
+}
+
+function normalizeVariationMode(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (
+    [
+      "new_design",
+      "same_geometry_regen",
+      "style_modify",
+      "layout_modify",
+    ].includes(normalized)
+  ) {
+    return normalized;
+  }
+  if (["regenerate", "panel_regen", "same_geometry"].includes(normalized)) {
+    return "same_geometry_regen";
+  }
+  if (["style", "materials", "material_modify"].includes(normalized)) {
+    return "style_modify";
+  }
+  if (["layout", "programme", "program", "geometry"].includes(normalized)) {
+    return "layout_modify";
+  }
+  return null;
+}
+
+function normalizeSeedSource(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return ["user", "auto_new_project", "reused_existing_project"].includes(
+    normalized,
+  )
+    ? normalized
+    : null;
+}
+
+function hasExistingProjectIdentity(input = {}) {
+  return Boolean(
+    input.projectId ||
+      input.project_id ||
+      input.designId ||
+      input.design_id ||
+      input.designHistoryId ||
+      input.design_history_id ||
+      input.compiledProject ||
+      input.artifacts?.compiledProject ||
+      input.projectDetails?.compiledProject ||
+      input.geometryHash ||
+      input.geometry_hash ||
+      input.existingGeometryHash ||
+      input.projectDetails?.geometryHash ||
+      input.projectDetails?.existingGeometryHash,
+  );
+}
+
+function requestLooksLayoutAffecting(input = {}) {
+  const modifyRequest = input.modifyRequest || {};
+  const changeText = [
+    input.changeType,
+    input.modifyType,
+    modifyRequest.changeType,
+    modifyRequest.scope,
+    modifyRequest.mode,
+    modifyRequest.customPrompt,
+    ...(Array.isArray(modifyRequest.quickToggles)
+      ? modifyRequest.quickToggles
+      : []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    /\b(layout|programme|program|room|space|area|floor|storey|story|massing|footprint|opening|window|door|stair)\b/.test(
+      changeText,
+    ) ||
+    Boolean(
+      input.programSpaces ||
+        input.programme?.spaces ||
+        input.program?.spaces ||
+        input.projectDetails?.programSpaces,
+    )
+  );
+}
+
+function requestLooksStyleOnly(input = {}) {
+  const modifyRequest = input.modifyRequest || {};
+  const changeText = [
+    input.changeType,
+    input.modifyType,
+    modifyRequest.changeType,
+    modifyRequest.scope,
+    modifyRequest.mode,
+    modifyRequest.customPrompt,
+    ...(Array.isArray(modifyRequest.quickToggles)
+      ? modifyRequest.quickToggles
+      : []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return (
+    /\b(style|material|materials|palette|facade|colour|color|finish|tone)\b/.test(
+      changeText,
+    ) && !requestLooksLayoutAffecting(input)
+  );
+}
+
+function resolveVariationMode(input = {}) {
+  const hasExistingProject = hasExistingProjectIdentity(input);
+  const explicit = normalizeVariationMode(
+    input.variationMode ||
+      input.projectVariationMode ||
+      input.modifyRequest?.variationMode ||
+      input.brief?.variationMode ||
+      input.projectBrief?.variationMode,
+  );
+  if (explicit) return explicit;
+  if (hasExistingProject && requestLooksLayoutAffecting(input)) {
+    return "layout_modify";
+  }
+  if (hasExistingProject && requestLooksStyleOnly(input)) {
+    return "style_modify";
+  }
+  if (hasExistingProject) return "same_geometry_regen";
+  return "new_design";
+}
+
+function resolveExistingProjectSeed(input = {}, sourceBrief = {}) {
+  return firstGenerationSeedCandidate([
+    input.existingGenerationSeed,
+    input.previousGenerationSeed,
+    input.projectDetails?.existingGenerationSeed,
+    input.projectDetails?.generationSeed,
+    input.designHistory?.generationSeed,
+    input.designHistory?.seed,
+    input.designHistoryEntry?.generationSeed,
+    input.designHistoryEntry?.seed,
+    input.metadata?.generationSeed,
+    input.generationLifecycle?.generationSeed,
+    input.seedLifecycle?.generationSeed,
+    input.artifacts?.generationSeed,
+    input.artifacts?.compiledProject?.metadata?.generationSeed,
+    input.compiledProject?.metadata?.generationSeed,
+    input.compiledProject?.generationSeed,
+    sourceBrief.generation_lifecycle?.generationSeed,
+    sourceBrief.seedLifecycle?.generationSeed,
+  ]);
+}
+
+function resolveGenerationSeedLifecycle(input = {}, sourceBrief = {}) {
+  const variationMode = resolveVariationMode(input);
+  const explicitSeed = firstGenerationSeedCandidate([
+    input.seed,
+    input.baseSeed,
+    input.generationSeed,
+    input.projectDetails?.seed,
+    input.projectDetails?.baseSeed,
+  ]);
+  if (explicitSeed !== null) {
+    return {
+      generationSeed: explicitSeed,
+      seedSource: normalizeSeedSource(input.seedSource) || "user",
+      variationMode,
+    };
+  }
+
+  const briefSeed = firstGenerationSeedCandidate([
+    sourceBrief.baseSeed,
+    sourceBrief.generation_seed,
+    sourceBrief.generationSeed,
+    sourceBrief.seed,
+  ]);
+  const existingSeed =
+    resolveExistingProjectSeed(input, sourceBrief) ?? briefSeed;
+  if (
+    existingSeed !== null &&
+    hasExistingProjectIdentity(input) &&
+    variationMode !== "layout_modify"
+  ) {
+    return {
+      generationSeed: existingSeed,
+      seedSource: "reused_existing_project",
+      variationMode,
+    };
+  }
+
+  if (briefSeed !== null) {
+    return {
+      generationSeed: briefSeed,
+      seedSource: "user",
+      variationMode,
+    };
+  }
+
+  return {
+    generationSeed: createAutoGenerationSeed(),
+    seedSource: "auto_new_project",
+    variationMode,
+  };
 }
 
 function seededIndex(seed, length, salt = "design-option") {
@@ -810,7 +1034,11 @@ function detectProgrammeGroundCollapse({
 
 function normalizeBrief(input = {}) {
   const sourceBrief = input.brief || input.projectBrief || input;
-  const generationSeed = resolveGenerationSeed(input, sourceBrief);
+  const generationLifecycle = resolveGenerationSeedLifecycle(
+    input,
+    sourceBrief,
+  );
+  const { generationSeed, seedSource, variationMode } = generationLifecycle;
   const projectDetails = input.projectDetails || {};
   const locationData = input.locationData || {};
   const referenceMatch = isReferenceMatchRequested(input, sourceBrief);
@@ -1047,6 +1275,10 @@ function normalizeBrief(input = {}) {
     generation_seed: generationSeed,
     design_variant_seed: generationSeed,
     generation_variation_enabled: generationSeed !== null,
+    generationSeed,
+    seedSource,
+    variationMode,
+    generation_lifecycle: generationLifecycle,
     referenceMatch,
     reference_match: referenceMatch,
     brief_input_hash: briefInputHash,
@@ -7145,6 +7377,9 @@ export async function buildVisual3DPanelArtifacts({
       const requestId =
         renderProvenance?.requestId || renderResult?.requestId || null;
       const usage = renderProvenance?.usage || renderResult?.usage || null;
+      const generationSeed = normalizeGenerationSeed(brief?.generation_seed);
+      const seedSource = brief?.seedSource || null;
+      const variationMode = brief?.variationMode || null;
 
       const svgHash =
         renderInput.svgHash ||
@@ -7167,6 +7402,9 @@ export async function buildVisual3DPanelArtifacts({
           source_model_hash: geometryHash,
           geometryHash,
           sourceGeometryHash: geometryHash,
+          generationSeed,
+          seedSource,
+          variationMode,
           visualManifestId: visualManifest?.manifestId || null,
           visualManifestHash: visualManifest?.manifestHash || null,
           visualIdentityLocked: Boolean(visualManifest?.manifestHash),
@@ -7197,6 +7435,10 @@ export async function buildVisual3DPanelArtifacts({
             geometryHash,
             svgHash,
             sourceGeometryHash: geometryHash,
+            generationSeed,
+            seedSource,
+            variationMode,
+            generationLifecycle: brief?.generation_lifecycle || null,
             referenceSource: "compiled_3d_control_svg",
             controlSvgHash,
             promptHash,
@@ -9009,6 +9251,9 @@ function buildResultPanelMap(panelArtifacts = {}) {
             authoritySource:
               artifact.authoritySource || "project_graph_compiled_geometry",
             geometryHash: artifact.geometryHash || artifact.source_model_hash,
+            generationSeed: artifact.generationSeed || null,
+            seedSource: artifact.seedSource || null,
+            variationMode: artifact.variationMode || null,
             source_model_hash: artifact.source_model_hash || null,
             svgHash: artifact.svgHash || null,
             metadata: cloneData(artifact.metadata || {}),
@@ -9449,6 +9694,33 @@ function artifactArray(artifacts = {}) {
   if (Array.isArray(artifacts)) return artifacts.filter(Boolean);
   if (!artifacts || typeof artifacts !== "object") return [];
   return Object.values(artifacts).filter(Boolean);
+}
+
+export function stampGenerationLifecycleOnArtifacts(
+  artifacts = {},
+  lifecycle = {},
+) {
+  const generationSeed = normalizeGenerationSeed(lifecycle.generationSeed);
+  const seedSource = lifecycle.seedSource || null;
+  const variationMode = lifecycle.variationMode || null;
+  for (const artifact of artifactArray(artifacts)) {
+    if (!artifact || typeof artifact !== "object") continue;
+    artifact.generationSeed = generationSeed;
+    artifact.seedSource = seedSource;
+    artifact.variationMode = variationMode;
+    artifact.metadata = {
+      ...(artifact.metadata || {}),
+      generationSeed,
+      seedSource,
+      variationMode,
+      generationLifecycle: {
+        generationSeed,
+        seedSource,
+        variationMode,
+      },
+    };
+  }
+  return artifacts;
 }
 
 function findPanelArtifact(artifacts = {}, panelType) {
@@ -11452,6 +11724,16 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       localMaterials: localStyle.material_palette,
     },
   });
+  compiledProject.generationSeed = brief.generation_seed;
+  compiledProject.seedSource = brief.seedSource || null;
+  compiledProject.variationMode = brief.variationMode || null;
+  compiledProject.metadata = {
+    ...(compiledProject.metadata || {}),
+    generationSeed: brief.generation_seed,
+    seedSource: brief.seedSource || null,
+    variationMode: brief.variationMode || null,
+    generationLifecycle: brief.generation_lifecycle || null,
+  };
   __vsMark = __vsLog("compile_project", __vsMark);
   // Compiled-project QA. Catches geometry layers losing a level (e.g. the
   // 3-level brief silently producing a 2-level model). The level-count
@@ -11684,6 +11966,27 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
   const sheetArtifact = primary.sheetArtifact;
   const pdfArtifact = primary.pdf;
   const primaryPanelArtifacts = primary.sheetPanelArtifacts || {};
+  const generationLifecycle = {
+    generationSeed: brief.generation_seed,
+    seedSource: brief.seedSource || null,
+    variationMode: brief.variationMode || null,
+  };
+  stampGenerationLifecycleOnArtifacts(drawingArtifacts, generationLifecycle);
+  stampGenerationLifecycleOnArtifacts(primary.panelArtifacts, generationLifecycle);
+  stampGenerationLifecycleOnArtifacts(
+    primary.sheetPanelArtifacts,
+    generationLifecycle,
+  );
+  sheetArtifact.generationSeed = generationLifecycle.generationSeed;
+  sheetArtifact.seedSource = generationLifecycle.seedSource;
+  sheetArtifact.variationMode = generationLifecycle.variationMode;
+  sheetArtifact.metadata = {
+    ...(sheetArtifact.metadata || {}),
+    generationSeed: generationLifecycle.generationSeed,
+    seedSource: generationLifecycle.seedSource,
+    variationMode: generationLifecycle.variationMode,
+    generationLifecycle,
+  };
   const siteMapArtifact =
     Object.values(primaryPanelArtifacts).find(
       (artifact) => artifact.panel_type === "site_context",
@@ -12104,6 +12407,10 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     visuals3d,
     renderedProof: pdfArtifact.renderedProof,
     textRenderStatus: pdfArtifact.renderedProof?.textRenderStatus,
+    generationSeed: generationLifecycle.generationSeed,
+    seedSource: generationLifecycle.seedSource,
+    variationMode: generationLifecycle.variationMode,
+    generationLifecycle,
     presentationMode: sheetArtifact.presentationMode,
     visualFidelityStatus: sheetArtifact.visualFidelityStatus,
     referenceMatch: brief?.reference_match === true,
@@ -12323,6 +12630,19 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     success: qa.status === "pass",
     pipelineVersion: PROJECT_GRAPH_VERTICAL_SLICE_VERSION,
     geometryHash: compiledProject.geometryHash,
+    seed: generationLifecycle.generationSeed,
+    generationSeed: generationLifecycle.generationSeed,
+    seedSource: generationLifecycle.seedSource,
+    variationMode: generationLifecycle.variationMode,
+    generationLifecycle,
+    metadata: {
+      generationSeed: generationLifecycle.generationSeed,
+      seedSource: generationLifecycle.seedSource,
+      variationMode: generationLifecycle.variationMode,
+      generationLifecycle,
+      geometryHash: compiledProject.geometryHash,
+      visualManifestHash: visualManifest.manifestHash,
+    },
     projectTypeSupport: brief.project_type_support || null,
     projectGraph: finalGraph,
     provenanceManifest,
@@ -12371,6 +12691,8 @@ export async function buildArchitectureProjectVerticalSliceWithRepair(
 export const __projectGraphVerticalSliceInternals = Object.freeze({
   normalizeBrief,
   normalizeGenerationSeed,
+  resolveGenerationSeedLifecycle,
+  createAutoGenerationSeed,
   selectDesignOptionForRun,
   seededFraction,
   seededRotation,

--- a/src/services/render/projectGraphImageRenderer.js
+++ b/src/services/render/projectGraphImageRenderer.js
@@ -325,7 +325,7 @@ export async function renderProjectGraphPanelImage({
         keySource: config.keySource,
       },
     );
-    return createFallbackResult({
+    return handleFallback({
       panelType,
       geometryHash,
       reason: "gate_disabled",


### PR DESCRIPTION
## Summary

Enforces the ProjectGraph A1 SVG + image-edit authority pipeline.

This PR makes deterministic SVG technical drawings the source of truth, blocks text-only image generation for ProjectGraph visual panels, routes hero/exterior/axonometric/interior panels through geometry-locked OpenAI image edits, adds strict A1 export authority gates, adds ProjectGraph seed lifecycle handling, adds a golden SVG+image2 acceptance test, and adds an OpenAI image-edit model-access preflight.

## Core checks pass

- lint
- check:env
- check:contracts
- build:active

## Image2 smoke notes

Clean-worktree strict smoke at `df1dbaf` with `gpt-image-1.5` passed the ProjectGraph image-edit authority checks:

- `hero_3d` reached `/v1/images/edits`
- `exterior_render` reached `/v1/images/edits`
- `axonometric` reached `/v1/images/edits`
- `interior_3d` reached `/v1/images/edits`
- all visual panels used `referenceSource=compiled_3d_control_svg`
- all project panels shared `geometryHash=2577b252db1a1235`
- all visual panels shared `visualManifestHash=017541dc12b9ce67`
- `imageRenderFallback=false` for all visual panels
- A1 sheet SVG and PDF were exported

The older RIBA fixture acceptance script still reports `qaStatus=fail` / legacy `qa.score=82` while the scorecard total is `100`; the targeted image-edit authority smoke passed.

Full real-image smoke with `gpt-image-2` is blocked by OpenAI org/model access:
`gpt-image-2` returns 403 organization verification required.

This is expected fail-closed behavior, not a ProjectGraph routing failure.

Only merge to main after the PR is reviewed and CI passes.

## Production caution

For production, use the allowed image-edit model until `gpt-image-2` access is solved:

```env
PROJECT_GRAPH_IMAGE_GEN_ENABLED=true
OPENAI_STRICT_IMAGE_GEN=true
OPENAI_IMAGE_MODEL=gpt-image-1.5
STEP_10_IMAGE_MODEL=gpt-image-1.5
```

Do not enable this combination until the preflight passes:

```env
PROJECT_GRAPH_IMAGE_GEN_ENABLED=true
OPENAI_STRICT_IMAGE_GEN=true
OPENAI_IMAGE_MODEL=gpt-image-2
STEP_10_IMAGE_MODEL=gpt-image-2
```

Either verify the OpenAI org for `gpt-image-2`, or use an allowed image-edit model.

## Validation

- `npm run lint`
- `git diff --check`
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`
- `npm run smoke:openai-image-edit-access`
- clean-worktree strict ProjectGraph image-edit authority smoke with `gpt-image-1.5`