### PR TITLE
Restore site boundary measurements and numeric editing

### DIFF
--- a/src/__tests__/components/SiteBoundaryEditorV2.boundaryMeasurements.test.js
+++ b/src/__tests__/components/SiteBoundaryEditorV2.boundaryMeasurements.test.js
@@ -1,0 +1,275 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+
+jest.mock("framer-motion", () => {
+  const React = require("react");
+  const passthrough = React.forwardRef(
+    (
+      {
+        children,
+        initial,
+        animate,
+        exit,
+        transition,
+        whileHover,
+        whileTap,
+        layout,
+        ...props
+      },
+      ref,
+    ) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    ),
+  );
+  passthrough.displayName = "MotionDivMock";
+  return {
+    motion: { div: passthrough },
+    AnimatePresence: ({ children }) => <>{children}</>,
+  };
+});
+
+jest.mock("../../components/map/useGoogleMap.js", () => ({
+  useGoogleMap: () => ({
+    map: null,
+    google: null,
+    isLoaded: true,
+    isLoading: false,
+    error: null,
+    geocodeAddress: jest.fn(),
+  }),
+}));
+
+import { SiteBoundaryEditorV2 } from "../../components/map/SiteBoundaryEditorV2.jsx";
+import { BoundaryNumericEditor } from "../../components/map/BoundaryNumericEditor.jsx";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const LAT_LNG_BOUNDARY = [
+  { lat: 51.5, lng: -0.1 },
+  { lat: 51.5, lng: -0.099 },
+  { lat: 51.501, lng: -0.099 },
+  { lat: 51.501, lng: -0.1 },
+];
+
+const VERTICES = LAT_LNG_BOUNDARY.map((point) => [point.lng, point.lat]);
+
+function renderComponent(ui) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function click(element) {
+  act(() => {
+    element.click();
+  });
+}
+
+function changeInput(input, value) {
+  act(() => {
+    const valueSetter = Object.getOwnPropertyDescriptor(input, "value")?.set;
+    const prototypeValueSetter = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(input),
+      "value",
+    )?.set;
+    if (prototypeValueSetter && valueSetter !== prototypeValueSetter) {
+      prototypeValueSetter.call(input, value);
+    } else if (valueSetter) {
+      valueSetter.call(input, value);
+    } else {
+      input.value = value;
+    }
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+function buttonByText(container, text) {
+  return [...container.querySelectorAll("button")].find((button) =>
+    button.textContent.includes(text),
+  );
+}
+
+function renderBoundaryEditor(props = {}) {
+  return renderComponent(
+    <SiteBoundaryEditorV2
+      initialBoundaryPolygon={LAT_LNG_BOUNDARY}
+      autoDetectEnabled={false}
+      autoDetectOnLoad={false}
+      onBoundaryChange={jest.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe("SiteBoundaryEditorV2 boundary measurements", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  test("renders BoundaryDiagnostics by default when boundary has at least 3 vertices", () => {
+    const { container, unmount } = renderBoundaryEditor();
+
+    expect(container.textContent).toContain("Boundary Measurements");
+    expect(container.textContent).toContain("Drag corners, draw a new polygon");
+    expect(container.textContent).toContain("Area");
+    expect(container.textContent).toContain("Perimeter");
+    expect(container.textContent).toContain("Vertices");
+    expect(container.textContent).toContain("Status");
+
+    unmount();
+  });
+
+  test("diagnostics include segment details and interior angles", () => {
+    const { container, unmount } = renderBoundaryEditor();
+
+    expect(container.textContent).toContain("Segment Details");
+    expect(container.textContent).toContain("Interior Angles");
+
+    unmount();
+  });
+
+  test("Diagnostics toggle hides detailed tables but keeps summary cards", () => {
+    const { container, unmount } = renderBoundaryEditor();
+
+    click(buttonByText(container, "Diagnostics"));
+
+    expect(container.textContent).toContain("Area");
+    expect(container.textContent).toContain("Perimeter");
+    expect(container.textContent).toContain("Vertices");
+    expect(container.textContent).toContain("Status");
+    expect(container.textContent).not.toContain("Segment Details");
+    expect(container.textContent).not.toContain("Interior Angles");
+
+    click(buttonByText(container, "Diagnostics"));
+    expect(container.textContent).toContain("Segment Details");
+    expect(container.textContent).toContain("Interior Angles");
+
+    unmount();
+  });
+
+  test("Edit mode instructions are visible", () => {
+    const { container, unmount } = renderBoundaryEditor();
+
+    click(buttonByText(container, "Edit"));
+
+    expect(container.textContent).toContain(
+      "Drag blue corner points to adjust the boundary",
+    );
+    expect(container.textContent).toContain(
+      "Click midpoint dots to add a corner",
+    );
+    expect(container.textContent).toContain(
+      "Select a corner and press Delete/Backspace to remove it",
+    );
+
+    unmount();
+  });
+
+  test("Draw mode instructions are visible", () => {
+    const { container, unmount } = renderBoundaryEditor();
+
+    click(buttonByText(container, "Draw"));
+
+    expect(container.textContent).toContain("Click to place corners");
+    expect(container.textContent).toContain("Double-click or Enter to finish");
+    expect(container.textContent).toContain("Esc/Backspace to undo last point");
+    expect(container.textContent).toContain("Shift = 45° snap");
+
+    unmount();
+  });
+
+  test("clearing boundary emits invalid manual boundary clear payload", async () => {
+    const onBoundaryChange = jest.fn();
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+    const { container, unmount } = renderBoundaryEditor({ onBoundaryChange });
+
+    click(buttonByText(container, "Clear"));
+    await act(async () => {});
+    expect(window.confirm).toHaveBeenCalled();
+
+    const lastPayload =
+      onBoundaryChange.mock.calls[onBoundaryChange.mock.calls.length - 1][0];
+    expect(lastPayload).toEqual(
+      expect.objectContaining({
+        invalid: true,
+        manualVerified: false,
+        clearManualVerified: true,
+        boundarySource: "manual_invalid",
+        source: "manual_invalid",
+      }),
+    );
+
+    unmount();
+  });
+});
+
+describe("BoundaryNumericEditor dimensions", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("renders segment length and bearing inputs", () => {
+    const { container, unmount } = renderComponent(
+      <BoundaryNumericEditor
+        vertices={VERTICES}
+        onVerticesChange={jest.fn()}
+      />,
+    );
+
+    click(buttonByText(container, "Dimensions"));
+
+    expect(
+      container.querySelector('input[aria-label="Segment 1 length metres"]'),
+    ).toBeTruthy();
+    expect(
+      container.querySelector('input[aria-label="Segment 1 bearing degrees"]'),
+    ).toBeTruthy();
+    expect(container.textContent).toContain("Interior angle");
+
+    unmount();
+  });
+
+  test("applying a numeric length change calls onVerticesChange with an updated polygon", () => {
+    const onVerticesChange = jest.fn();
+    const { container, unmount } = renderComponent(
+      <BoundaryNumericEditor
+        vertices={VERTICES}
+        onVerticesChange={onVerticesChange}
+      />,
+    );
+
+    click(buttonByText(container, "Dimensions"));
+    const lengthInput = container.querySelector(
+      'input[aria-label="Segment 1 length metres"]',
+    );
+    changeInput(lengthInput, "25");
+    click(
+      container.querySelector(
+        'button[aria-label="Apply segment 1 dimensions"]',
+      ),
+    );
+
+    expect(onVerticesChange).toHaveBeenCalledTimes(1);
+    const updated = onVerticesChange.mock.calls[0][0];
+    expect(updated).toHaveLength(VERTICES.length);
+    expect(updated[1]).not.toEqual(VERTICES[1]);
+
+    unmount();
+  });
+});

--- a/src/components/map/BoundaryNumericEditor.jsx
+++ b/src/components/map/BoundaryNumericEditor.jsx
@@ -1,0 +1,311 @@
+/**
+ * BoundaryNumericEditor.jsx
+ *
+ * Two-tab manual boundary editor:
+ * - Coordinates: existing lat/lng table and import/export tools.
+ * - Dimensions: segment length/bearing edits for simple numeric refinement.
+ *
+ * @module BoundaryNumericEditor
+ */
+
+import React, { useEffect, useState, useCallback } from "react";
+import { VertexTableEditor } from "./VertexTableEditor.jsx";
+import {
+  calculateAngles,
+  calculateSegments,
+  closeRing,
+  roundCoord,
+  validatePolygon,
+} from "./boundaryGeometry.js";
+
+const EARTH_RADIUS_METERS = 6371000;
+
+function toRadians(value) {
+  return (Number(value) * Math.PI) / 180;
+}
+
+function toDegrees(value) {
+  return (Number(value) * 180) / Math.PI;
+}
+
+function normalizeBearing(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return ((numeric % 360) + 360) % 360;
+}
+
+function destinationFromBearing(start, lengthM, bearingDeg) {
+  const distance = Number(lengthM);
+  const bearing = normalizeBearing(bearingDeg);
+  if (!Array.isArray(start) || !Number.isFinite(distance) || bearing === null) {
+    return null;
+  }
+
+  const lng1 = toRadians(start[0]);
+  const lat1 = toRadians(start[1]);
+  const theta = toRadians(bearing);
+  const delta = distance / EARTH_RADIUS_METERS;
+
+  const sinLat1 = Math.sin(lat1);
+  const cosLat1 = Math.cos(lat1);
+  const sinDelta = Math.sin(delta);
+  const cosDelta = Math.cos(delta);
+
+  const lat2 = Math.asin(
+    sinLat1 * cosDelta + cosLat1 * sinDelta * Math.cos(theta),
+  );
+  const lng2 =
+    lng1 +
+    Math.atan2(
+      Math.sin(theta) * sinDelta * cosLat1,
+      cosDelta - sinLat1 * Math.sin(lat2),
+    );
+
+  return [
+    roundCoord(((toDegrees(lng2) + 540) % 360) - 180),
+    roundCoord(toDegrees(lat2)),
+  ];
+}
+
+function buildDimensionRows(vertices = []) {
+  if (!Array.isArray(vertices) || vertices.length < 3) return [];
+  const ring = closeRing(vertices);
+  const segments = calculateSegments(ring);
+  const angles = calculateAngles(ring);
+  return segments.map((segment) => ({
+    index: segment.index,
+    lengthM: String(Number(segment.length || 0).toFixed(2)),
+    bearingDeg: String(Number(segment.bearing || 0).toFixed(1)),
+    interiorAngle: Number(angles[segment.index]?.angle || 0),
+  }));
+}
+
+export function BoundaryNumericEditor({
+  vertices = [],
+  onVerticesChange,
+  onVertexSelect,
+  selectedIndex = null,
+  disabled = false,
+}) {
+  const [activeTab, setActiveTab] = useState("coordinates");
+  const [dimensionRows, setDimensionRows] = useState(() =>
+    buildDimensionRows(vertices),
+  );
+  const [dimensionError, setDimensionError] = useState("");
+
+  useEffect(() => {
+    setDimensionRows(buildDimensionRows(vertices));
+    setDimensionError("");
+  }, [vertices]);
+
+  const handleDimensionChange = useCallback((index, field, value) => {
+    setDimensionRows((rows) =>
+      rows.map((row) =>
+        row.index === index
+          ? {
+              ...row,
+              [field]: value,
+            }
+          : row,
+      ),
+    );
+  }, []);
+
+  const handleApplySegment = useCallback(
+    (index) => {
+      if (disabled) return;
+      if (!Array.isArray(vertices) || vertices.length < 3) {
+        setDimensionError("A numeric edit needs at least 3 boundary corners.");
+        return;
+      }
+
+      const row = dimensionRows.find((entry) => entry.index === index);
+      const lengthM = Number(row?.lengthM);
+      const bearingDeg = normalizeBearing(row?.bearingDeg);
+      if (!Number.isFinite(lengthM) || lengthM <= 0 || bearingDeg === null) {
+        setDimensionError(
+          `Segment ${index + 1} needs a positive length and a valid bearing.`,
+        );
+        return;
+      }
+
+      const nextIndex = (index + 1) % vertices.length;
+      const updated = vertices.map((vertex) => [...vertex]);
+      const nextVertex = destinationFromBearing(
+        updated[index],
+        lengthM,
+        bearingDeg,
+      );
+      if (!nextVertex) {
+        setDimensionError(`Segment ${index + 1} could not be recalculated.`);
+        return;
+      }
+
+      updated[nextIndex] = nextVertex;
+      const validation = validatePolygon(closeRing(updated));
+      if (!validation.valid) {
+        setDimensionError(
+          validation.errors?.[0] ||
+            "Numeric edit creates an invalid boundary polygon.",
+        );
+        return;
+      }
+
+      setDimensionError("");
+      onVerticesChange?.(updated);
+      onVertexSelect?.(nextIndex);
+    },
+    [dimensionRows, disabled, onVertexSelect, onVerticesChange, vertices],
+  );
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg overflow-hidden">
+      <div className="border-b border-slate-200 bg-slate-900 px-4 py-3">
+        <h3 className="text-lg font-bold text-white">Manual Boundary Input</h3>
+        <p className="text-xs text-slate-300">
+          Edit coordinates, paste CSV/GeoJSON/WKT, or refine segment dimensions.
+        </p>
+        <div className="mt-3 inline-flex rounded-lg border border-slate-600 overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setActiveTab("coordinates")}
+            className={`px-3 py-1.5 text-sm font-medium ${
+              activeTab === "coordinates"
+                ? "bg-white text-slate-900"
+                : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+            }`}
+          >
+            Coordinates
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab("dimensions")}
+            className={`border-l border-slate-600 px-3 py-1.5 text-sm font-medium ${
+              activeTab === "dimensions"
+                ? "bg-white text-slate-900"
+                : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+            }`}
+          >
+            Dimensions
+          </button>
+        </div>
+      </div>
+
+      {activeTab === "coordinates" ? (
+        <VertexTableEditor
+          vertices={vertices}
+          onVerticesChange={onVerticesChange}
+          onVertexSelect={onVertexSelect}
+          selectedIndex={selectedIndex}
+          disabled={disabled}
+          embedded
+        />
+      ) : (
+        <div className="p-4 space-y-3" data-testid="boundary-dimensions-editor">
+          <div className="text-sm text-slate-600">
+            Update a segment length or bearing, then apply it to move the next
+            corner from the previous corner.
+          </div>
+
+          {dimensionError && (
+            <div
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+            >
+              {dimensionError}
+            </div>
+          )}
+
+          <div className="overflow-x-auto rounded-lg border border-slate-200">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+                    Segment
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+                    Length (m)
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+                    Bearing (deg)
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+                    Interior angle
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium uppercase tracking-wider text-slate-600">
+                    Action
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {dimensionRows.map((row) => (
+                  <tr key={row.index}>
+                    <td className="px-3 py-2 font-medium text-slate-700">
+                      {row.index + 1}
+                    </td>
+                    <td className="px-3 py-2">
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0.01"
+                        value={row.lengthM}
+                        aria-label={`Segment ${row.index + 1} length metres`}
+                        disabled={disabled}
+                        onChange={(event) =>
+                          handleDimensionChange(
+                            row.index,
+                            "lengthM",
+                            event.target.value,
+                          )
+                        }
+                        className="w-28 rounded border border-slate-300 px-2 py-1 font-mono text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:bg-slate-100"
+                      />
+                    </td>
+                    <td className="px-3 py-2">
+                      <input
+                        type="number"
+                        step="0.1"
+                        value={row.bearingDeg}
+                        aria-label={`Segment ${row.index + 1} bearing degrees`}
+                        disabled={disabled}
+                        onChange={(event) =>
+                          handleDimensionChange(
+                            row.index,
+                            "bearingDeg",
+                            event.target.value,
+                          )
+                        }
+                        className="w-28 rounded border border-slate-300 px-2 py-1 font-mono text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:bg-slate-100"
+                      />
+                    </td>
+                    <td className="px-3 py-2 font-mono text-slate-600">
+                      {row.interiorAngle.toFixed(1)}°
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        type="button"
+                        disabled={disabled}
+                        onClick={() => handleApplySegment(row.index)}
+                        aria-label={`Apply segment ${row.index + 1} dimensions`}
+                        className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+                      >
+                        Apply
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {dimensionRows.length === 0 && (
+              <div className="p-6 text-center text-sm text-slate-500">
+                Add at least 3 corners before editing dimensions.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default BoundaryNumericEditor;

--- a/src/components/map/PrecisionPolygonEditor.js
+++ b/src/components/map/PrecisionPolygonEditor.js
@@ -321,18 +321,26 @@ export class PrecisionPolygonEditor {
     const isSelected = index === this.selectedIndex;
     const isDragging = index === this.draggedIndex;
 
-    let fillColor = "#3B82F6"; // Blue
-    let scale = 8;
+    let fillColor = "#2563EB"; // Blue
+    let strokeColor = "#FFFFFF";
+    let strokeWeight = 3;
+    let scale = 10;
 
     if (isDragging) {
       fillColor = "#EF4444"; // Red
-      scale = 12;
+      strokeColor = "#7F1D1D";
+      strokeWeight = 4;
+      scale = 15;
     } else if (isSelected) {
-      fillColor = "#8B5CF6"; // Purple
-      scale = 10;
+      fillColor = "#F59E0B"; // Amber
+      strokeColor = "#1E3A8A";
+      strokeWeight = 4;
+      scale = 13;
     } else if (isHovered) {
       fillColor = "#10B981"; // Green
-      scale = 10;
+      strokeColor = "#064E3B";
+      strokeWeight = 4;
+      scale = 12;
     }
 
     return {
@@ -340,8 +348,8 @@ export class PrecisionPolygonEditor {
       scale,
       fillColor,
       fillOpacity: 1,
-      strokeColor: "#FFFFFF",
-      strokeWeight: 2,
+      strokeColor,
+      strokeWeight,
       anchor: new this.google.maps.Point(0, 0),
     };
   }
@@ -402,11 +410,11 @@ export class PrecisionPolygonEditor {
   _getMidpointIcon(isHovered = false) {
     return {
       path: this.google.maps.SymbolPath.CIRCLE,
-      scale: isHovered ? 6 : 4,
-      fillColor: isHovered ? "#10B981" : "#94A3B8",
-      fillOpacity: isHovered ? 1 : 0.6,
-      strokeColor: "#FFFFFF",
-      strokeWeight: 1,
+      scale: isHovered ? 9 : 6,
+      fillColor: isHovered ? "#10B981" : "#F59E0B",
+      fillOpacity: isHovered ? 1 : 0.9,
+      strokeColor: isHovered ? "#064E3B" : "#FFFFFF",
+      strokeWeight: isHovered ? 3 : 2,
       anchor: new this.google.maps.Point(0, 0),
     };
   }

--- a/src/components/map/SiteBoundaryEditorV2.jsx
+++ b/src/components/map/SiteBoundaryEditorV2.jsx
@@ -23,7 +23,7 @@ import { useGoogleMap } from "./useGoogleMap.js";
 import { useBoundaryState } from "./useBoundaryState.js";
 import { createPrecisionPolygonEditor } from "./PrecisionPolygonEditor.js";
 import { createPolygonDrawingManager } from "./PolygonDrawingManager.js";
-import { VertexTableEditor } from "./VertexTableEditor.jsx";
+import { BoundaryNumericEditor } from "./BoundaryNumericEditor.jsx";
 import { BoundaryDiagnostics } from "./BoundaryDiagnostics.jsx";
 import {
   fetchAutoBoundary,
@@ -130,6 +130,9 @@ export function SiteBoundaryEditorV2({
     convertToDNA,
   } = useBoundaryState(initialBoundaryPolygon);
 
+  const initialBoundaryKey = JSON.stringify(initialBoundaryPolygon || []);
+  const lastInitialBoundaryKeyRef = useRef(initialBoundaryKey);
+
   const polygonLength = polygon.length;
   const contextualBoundaryLength = Array.isArray(contextualBoundaryPolygon)
     ? contextualBoundaryPolygon.length
@@ -199,6 +202,12 @@ export function SiteBoundaryEditorV2({
 
   // Initialize polygon from props
   useEffect(() => {
+    if (lastInitialBoundaryKeyRef.current === initialBoundaryKey) {
+      return;
+    }
+
+    lastInitialBoundaryKeyRef.current = initialBoundaryKey;
+
     if (
       initialBoundaryPolygon &&
       initialBoundaryPolygon.length > 0 &&
@@ -206,7 +215,7 @@ export function SiteBoundaryEditorV2({
     ) {
       setPolygon(initialBoundaryPolygon, false);
     }
-  }, [initialBoundaryPolygon, polygon, setPolygon]);
+  }, [initialBoundaryKey, initialBoundaryPolygon, polygon, setPolygon]);
 
   // Auto-detect boundary when map loads if no polygon exists
   useEffect(() => {
@@ -880,12 +889,21 @@ export function SiteBoundaryEditorV2({
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
               exit={{ opacity: 0, height: 0 }}
-              className="mt-3 p-2 bg-green-50 border border-green-200 rounded-lg text-sm text-green-800"
+              className="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-900"
+              data-testid="edit-mode-instructions"
             >
-              <strong>Edit Mode:</strong> Drag vertices • Click midpoints to add
-              • Right-click/Delete to remove •
-              <span className="font-mono mx-1">SHIFT</span>=angle snap •
-              <span className="font-mono mx-1">ALT</span>=disable snap
+              <strong className="block mb-1">Edit Mode</strong>
+              <ul className="grid gap-1 sm:grid-cols-2">
+                <li>Drag blue corner points to adjust the boundary</li>
+                <li>Click midpoint dots to add a corner</li>
+                <li>Select a corner and press Delete/Backspace to remove it</li>
+                <li>
+                  <span className="font-mono">Shift</span> = angle snap
+                </li>
+                <li>
+                  <span className="font-mono">Alt</span> = free movement
+                </li>
+              </ul>
             </motion.div>
           )}
           {mode === MODES.DRAW && (
@@ -893,13 +911,18 @@ export function SiteBoundaryEditorV2({
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
               exit={{ opacity: 0, height: 0 }}
-              className="mt-3 p-2 bg-purple-50 border border-purple-200 rounded-lg text-sm text-purple-800"
+              className="mt-3 p-3 bg-purple-50 border border-purple-200 rounded-lg text-sm text-purple-900"
+              data-testid="draw-mode-instructions"
             >
-              <strong>Draw Mode:</strong> Click to place vertices • Double-click
-              or
-              <span className="font-mono mx-1">ENTER</span> to finish •
-              <span className="font-mono mx-1">ESC</span>/Backspace to undo last
-              point •<span className="font-mono mx-1">SHIFT</span>=45° snap
+              <strong className="block mb-1">Draw Mode</strong>
+              <ul className="grid gap-1 sm:grid-cols-2">
+                <li>Click to place corners</li>
+                <li>Double-click or Enter to finish</li>
+                <li>Esc/Backspace to undo last point</li>
+                <li>
+                  <span className="font-mono">Shift</span> = 45° snap
+                </li>
+              </ul>
             </motion.div>
           )}
         </AnimatePresence>
@@ -928,19 +951,6 @@ export function SiteBoundaryEditorV2({
           )}
         </AnimatePresence>
       </div>
-
-      {/* Always-visible summary bar — surfaces area / perimeter / vertex
-          count + reference + length-of-each-side data the moment a polygon
-          is loaded, so the user never has to discover the Diagnostics
-          toggle to see it. */}
-      {polygon.length >= 3 && (
-        <div
-          className="bg-white rounded-lg shadow p-3 mb-3"
-          data-testid="boundary-summary-bar"
-        >
-          <BoundaryDiagnostics vertices={vertices} compact={true} />
-        </div>
-      )}
 
       {/* Main Content Grid */}
       <div className={`grid gap-4 ${showTableEditor ? "lg:grid-cols-2" : ""}`}>
@@ -980,8 +990,8 @@ export function SiteBoundaryEditorV2({
           {/* Map Container */}
           <div
             ref={handleMapContainerRef}
-            className="w-full h-[450px] bg-slate-100"
-            style={{ minHeight: "450px" }}
+            className="h-[320px] w-full bg-slate-100 md:h-[390px]"
+            style={{ minHeight: "300px" }}
           />
         </div>
 
@@ -1017,7 +1027,7 @@ export function SiteBoundaryEditorV2({
               animate={{ opacity: 1, x: 0 }}
               exit={{ opacity: 0, x: 20 }}
             >
-              <VertexTableEditor
+              <BoundaryNumericEditor
                 vertices={vertices}
                 onVerticesChange={handleTableVerticesChange}
                 onVertexSelect={(index) => {
@@ -1034,28 +1044,38 @@ export function SiteBoundaryEditorV2({
         </AnimatePresence>
       </div>
 
-      {/* Diagnostics */}
-      <AnimatePresence>
-        {showDiagnostics && polygon.length >= 3 && (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 20 }}
-          >
-            <BoundaryDiagnostics
-              vertices={vertices}
-              showSegments={true}
-              showAngles={true}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      {/* Quick Metrics Bar (when diagnostics hidden) */}
-      {!showDiagnostics && polygon.length >= 3 && (
-        <div className="bg-white rounded-lg shadow p-3">
-          <BoundaryDiagnostics vertices={vertices} compact={true} />
-        </div>
+      {/* Measurements */}
+      {polygon.length >= 3 && (
+        <section
+          className="bg-white rounded-lg shadow-lg p-4 space-y-3"
+          data-testid="boundary-measurements"
+        >
+          <div>
+            <h3 className="text-lg font-bold text-slate-900">
+              Boundary Measurements
+            </h3>
+            <p className="text-sm text-slate-600">
+              Drag corners, draw a new polygon, or enter numeric values to
+              refine the site boundary.
+            </p>
+          </div>
+          <AnimatePresence initial={false}>
+            <motion.div
+              key={
+                showDiagnostics ? "diagnostics-detailed" : "diagnostics-summary"
+              }
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 8 }}
+            >
+              <BoundaryDiagnostics
+                vertices={vertices}
+                showSegments={showDiagnostics}
+                showAngles={showDiagnostics}
+              />
+            </motion.div>
+          </AnimatePresence>
+        </section>
       )}
     </div>
   );

--- a/src/components/map/VertexTableEditor.jsx
+++ b/src/components/map/VertexTableEditor.jsx
@@ -38,6 +38,7 @@ import {
  * @param {Function} props.onVertexSelect - (index) => void
  * @param {number} props.selectedIndex - Currently selected vertex
  * @param {boolean} props.disabled - Disable editing
+ * @param {boolean} props.embedded - Render inside another editor shell
  */
 export function VertexTableEditor({
   vertices = [],
@@ -45,6 +46,7 @@ export function VertexTableEditor({
   onVertexSelect,
   selectedIndex = null,
   disabled = false,
+  embedded = false,
 }) {
   const [editingCell, setEditingCell] = useState(null); // { row, col }
   const [editValue, setEditValue] = useState("");
@@ -290,7 +292,11 @@ export function VertexTableEditor({
 
   return (
     <div
-      className="bg-white rounded-lg shadow-lg overflow-hidden"
+      className={
+        embedded
+          ? "overflow-hidden"
+          : "bg-white rounded-lg shadow-lg overflow-hidden"
+      }
       onPaste={handlePaste}
     >
       {/* Header */}

--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -10,6 +10,7 @@ export { SiteBoundaryEditorV2 } from "./SiteBoundaryEditorV2.jsx";
 
 // Sub-components
 export { VertexTableEditor } from "./VertexTableEditor.jsx";
+export { BoundaryNumericEditor } from "./BoundaryNumericEditor.jsx";
 export { BoundaryDiagnostics } from "./BoundaryDiagnostics.jsx";
 export { EntranceCompassOverlay } from "./EntranceCompassOverlay.jsx";
 

--- a/src/components/site/index.js
+++ b/src/components/site/index.js
@@ -21,6 +21,7 @@ export { default as SiteBoundaryEditorLegacy } from "../map/SiteBoundaryEditor.j
 
 // V2 Sub-components
 export { VertexTableEditor } from "../map/VertexTableEditor.jsx";
+export { BoundaryNumericEditor } from "../map/BoundaryNumericEditor.jsx";
 export { BoundaryDiagnostics } from "../map/BoundaryDiagnostics.jsx";
 
 // V2 Hooks


### PR DESCRIPTION
## Summary

Restores the always-visible Site Boundary Editor measurement panel below the map and improves manual boundary editing.

## Changes

- Restores Boundary Measurements below the map:
  - Area
  - Perimeter
  - Vertices
  - Status
  - Segment Details
  - Interior Angles
- Adds clearer edit/draw instructions.
- Reduces map height so measurement information remains visible before continuing.
- Adds numeric boundary editing with Coordinates and Dimensions tabs.
- Adds segment length/bearing editing with validation.
- Improves vertex and midpoint handle visibility for mouse editing.
- Fixes manual clear behavior so the initial boundary does not reappear after clearing.
- Adds focused tests for diagnostics visibility, toggles, edit/draw instructions, numeric dimensions, numeric apply, and invalid clear payload.

## Scope

No ProjectGraph A1/image2 files were changed.

## Validation

- `npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\\.claude\\ --runTestsByPath src/__tests__/components/SiteBoundaryEditorV2.boundaryMeasurements.test.js`
- `npm run lint`
- `git diff --check`
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Known limitation

The numeric dimensions editor applies one segment at a time by moving the next vertex from the previous vertex using the entered length/bearing. It does not yet perform whole-polygon constrained solving.