### PR TITLE
Add ProjectGraph authority lock QA validators

### DIFF
--- a/src/__tests__/services/a1FinalExportContract.test.js
+++ b/src/__tests__/services/a1FinalExportContract.test.js
@@ -915,6 +915,81 @@ describe("a1FinalExportContract", () => {
       expect(gate.blockers.join(" ")).toMatch(blockerPattern);
     });
 
+    test("blocks final sheetArtifact.svgString when sheet svg hash is missing", () => {
+      const gate = evaluateFinalA1ExportGate(
+        buildHealthyGateInputs({
+          sheetArtifact: {
+            svgString:
+              '<svg xmlns="http://www.w3.org/2000/svg"><rect width="20" height="20"/></svg>',
+            svgHash: null,
+          },
+          pdfMetadata: {
+            ...HEALTHY_PDF_METADATA,
+            sourceSvgHash: null,
+          },
+        }),
+      );
+
+      expect(gate.status).toBe("blocked");
+      expect(gate.allowed).toBe(false);
+      expect(gate.blockers.join(" ")).toMatch(
+        /A1_SHEET_SVG_HASH_MISSING|sheetArtifact\.svgHash/,
+      );
+      expect(gate.evidence.sheetArtifactStatus).toEqual(
+        expect.objectContaining({
+          hasSheetSvgString: true,
+          sheetSvgHash: null,
+        }),
+      );
+    });
+
+    test("blocks blank final sheetArtifact.svgString", () => {
+      const gate = evaluateFinalA1ExportGate(
+        buildHealthyGateInputs({
+          sheetArtifact: {
+            svgString: "",
+            svgHash: "sheet-svg-hash-OK",
+          },
+          pdfMetadata: {
+            ...HEALTHY_PDF_METADATA,
+            sourceSvgHash: "sheet-svg-hash-OK",
+          },
+        }),
+      );
+
+      expect(gate.status).toBe("blocked");
+      expect(gate.blockers.join(" ")).toMatch(
+        /A1_SHEET_SOURCE_SVG_MISSING|sheetArtifact\.svgString/,
+      );
+    });
+
+    test("blocks PDF source hash mismatch against sheetArtifact.svgString hash", () => {
+      const gate = evaluateFinalA1ExportGate(
+        buildHealthyGateInputs({
+          sheetArtifact: {
+            svgString:
+              '<svg xmlns="http://www.w3.org/2000/svg"><rect width="20" height="20"/></svg>',
+            svgHash: "sheet-svg-hash-OK",
+          },
+          pdfMetadata: {
+            ...HEALTHY_PDF_METADATA,
+            sourceSvgHash: "reconstructed-empty-frame-hash",
+          },
+        }),
+      );
+
+      expect(gate.status).toBe("blocked");
+      expect(gate.blockers.join(" ")).toMatch(
+        /A1_PDF_SOURCE_SVG_HASH_MISMATCH/,
+      );
+      expect(gate.evidence.sheetArtifactStatus).toEqual(
+        expect.objectContaining({
+          sourceSvgHash: "reconstructed-empty-frame-hash",
+          sheetSvgHash: "sheet-svg-hash-OK",
+        }),
+      );
+    });
+
     test("missing material provenance warns", () => {
       const gate = evaluateFinalA1ExportGate({
         renderContract: baseRenderContract(),

--- a/src/__tests__/services/drawingConsistencyChecks.test.js
+++ b/src/__tests__/services/drawingConsistencyChecks.test.js
@@ -1,6 +1,8 @@
 import {
   runDrawingConsistencyChecks,
+  validateTechnicalPanelAuthority,
   validateCrossViewConsistency,
+  validateVisualPanelLocks,
 } from "../../services/validation/drawingConsistencyChecks.js";
 
 const SVG_HEADER = '<svg xmlns="http://www.w3.org/2000/svg">';
@@ -68,6 +70,83 @@ function sectionSvg({
   ].join("");
 }
 
+const AUTHORITY_GEOMETRY_HASH = "geometry-hash-OK";
+const AUTHORITY_VISUAL_MANIFEST_HASH = "visual-manifest-hash-OK";
+const VISUAL_AUTHORITY_PANEL_TYPES = [
+  "hero_3d",
+  "exterior_render",
+  "axonometric",
+  "interior_3d",
+];
+
+function visualAuthorityPanel(type, overrides = {}) {
+  return {
+    type,
+    geometryHash: AUTHORITY_GEOMETRY_HASH,
+    sourceGeometryHash: AUTHORITY_GEOMETRY_HASH,
+    source_model_hash: AUTHORITY_GEOMETRY_HASH,
+    visualManifestHash: AUTHORITY_VISUAL_MANIFEST_HASH,
+    visualIdentityLocked: true,
+    provider: "openai",
+    providerUsed: "openai",
+    imageProviderUsed: "openai",
+    referenceSource: "compiled_3d_control_svg",
+    imageRenderFallback: false,
+    ...overrides,
+  };
+}
+
+function visualAuthorityPanels(overridesByType = {}) {
+  return VISUAL_AUTHORITY_PANEL_TYPES.map((type) =>
+    visualAuthorityPanel(type, overridesByType[type] || {}),
+  );
+}
+
+function technicalAuthorityPanel(type, overrides = {}) {
+  return {
+    panel_type: type,
+    svgString:
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="20" height="20"/></svg>',
+    geometryHash: AUTHORITY_GEOMETRY_HASH,
+    source_model_hash: AUTHORITY_GEOMETRY_HASH,
+    renderer: "deterministic_svg",
+    providerUsed: "deterministic_svg",
+    imageProviderUsed: "none",
+    technicalDrawing: true,
+    metadata: {
+      source: "compiled_project_technical_panel",
+      renderer: "deterministic_svg",
+      providerUsed: "deterministic_svg",
+      imageProviderUsed: "none",
+      technicalDrawing: true,
+      geometryHash: AUTHORITY_GEOMETRY_HASH,
+      sourceGeometryHash: AUTHORITY_GEOMETRY_HASH,
+    },
+    ...overrides,
+  };
+}
+
+function technicalAuthorityPanels(overridesByType = {}) {
+  return {
+    floor_plan_ground: technicalAuthorityPanel(
+      "floor_plan_ground",
+      overridesByType.floor_plan_ground || {},
+    ),
+    floor_plan_first: technicalAuthorityPanel(
+      "floor_plan_first",
+      overridesByType.floor_plan_first || {},
+    ),
+    elevation_north: technicalAuthorityPanel(
+      "elevation_north",
+      overridesByType.elevation_north || {},
+    ),
+    section_AA: technicalAuthorityPanel(
+      "section_AA",
+      overridesByType.section_AA || {},
+    ),
+  };
+}
+
 function productionPlanSvg() {
   return [
     SVG_HEADER,
@@ -104,6 +183,137 @@ function productionSectionSvg() {
     SVG_FOOTER,
   ].join("");
 }
+
+describe("ProjectGraph A1 authority lock validators", () => {
+  test("visual panel with mismatched geometryHash fails", () => {
+    const result = validateVisualPanelLocks({
+      panels: visualAuthorityPanels({
+        hero_3d: { geometryHash: "wrong-geometry-hash" },
+      }),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+      expectedVisualManifestHash: AUTHORITY_VISUAL_MANIFEST_HASH,
+      imageGenEnabled: true,
+      strictPhotoreal: true,
+    });
+
+    expect(result.errors.map((error) => error.code)).toContain(
+      "PROJECT_PANEL_GEOMETRY_HASH_MISMATCH",
+    );
+    expect(result.checks.geometryMismatchPanels).toContain("hero_3d");
+  });
+
+  test("visual panel with mismatched visualManifestHash fails", () => {
+    const result = validateVisualPanelLocks({
+      panels: visualAuthorityPanels({
+        axonometric: { visualManifestHash: "wrong-manifest-hash" },
+      }),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+      expectedVisualManifestHash: AUTHORITY_VISUAL_MANIFEST_HASH,
+      imageGenEnabled: true,
+      strictPhotoreal: true,
+    });
+
+    expect(result.errors.map((error) => error.code)).toContain(
+      "VISUAL_MANIFEST_HASH_MISMATCH",
+    );
+    expect(result.checks.visualManifestMismatchPanels).toContain("axonometric");
+  });
+
+  test("visual panel imageRenderFallback=true fails in strict image mode", () => {
+    const result = validateVisualPanelLocks({
+      panels: visualAuthorityPanels({
+        exterior_render: { imageRenderFallback: true },
+      }),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+      expectedVisualManifestHash: AUTHORITY_VISUAL_MANIFEST_HASH,
+      imageGenEnabled: true,
+      strictPhotoreal: true,
+    });
+
+    expect(result.errors.map((error) => error.code)).toContain(
+      "STRICT_IMAGE_RENDER_FALLBACK",
+    );
+    expect(result.checks.strictFallbackPanels).toContain("exterior_render");
+  });
+
+  test("visual panel using openai without compiled control SVG reference fails as text-only generation", () => {
+    const result = validateVisualPanelLocks({
+      panels: visualAuthorityPanels({
+        interior_3d: { referenceSource: "prompt_text_only" },
+      }),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+      expectedVisualManifestHash: AUTHORITY_VISUAL_MANIFEST_HASH,
+      imageGenEnabled: true,
+      strictPhotoreal: true,
+    });
+
+    expect(result.errors.map((error) => error.code)).toContain(
+      "VISUAL_PANEL_TEXT_ONLY_IMAGE_GENERATION",
+    );
+    expect(result.checks.textOnlyVisualPanels).toContain("interior_3d");
+  });
+
+  test("technical panel with imageProviderUsed=openai fails", () => {
+    const result = validateTechnicalPanelAuthority({
+      technicalPanels: technicalAuthorityPanels({
+        floor_plan_ground: {
+          imageProviderUsed: "openai",
+          providerUsed: "openai",
+        },
+      }),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+    });
+
+    expect(result.errors.map((error) => error.code)).toContain(
+      "TECHNICAL_PANEL_IMAGE_MODEL_USED",
+    );
+    expect(result.checks.imageModelPanels).toContain("floor_plan_ground");
+  });
+
+  test("technical panel missing geometryHash fails", () => {
+    const result = validateTechnicalPanelAuthority({
+      technicalPanels: technicalAuthorityPanels({
+        section_AA: {
+          geometryHash: null,
+          sourceGeometryHash: null,
+          source_model_hash: null,
+          metadata: {
+            source: "compiled_project_technical_panel",
+            renderer: "deterministic_svg",
+            technicalDrawing: true,
+            geometryHash: null,
+            sourceGeometryHash: null,
+          },
+        },
+      }),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+    });
+
+    expect(result.errors.map((error) => error.code)).toContain(
+      "TECHNICAL_PANEL_GEOMETRY_HASH_MISSING",
+    );
+    expect(result.checks.missingGeometryHashPanels).toContain("section_AA");
+  });
+
+  test("valid deterministic SVG technical panels and geometry-locked visual panels pass", () => {
+    const visual = validateVisualPanelLocks({
+      panels: visualAuthorityPanels(),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+      expectedVisualManifestHash: AUTHORITY_VISUAL_MANIFEST_HASH,
+      imageGenEnabled: true,
+      strictPhotoreal: true,
+    });
+    const technical = validateTechnicalPanelAuthority({
+      technicalPanels: technicalAuthorityPanels(),
+      expectedGeometryHash: AUTHORITY_GEOMETRY_HASH,
+    });
+
+    expect(visual.errors).toEqual([]);
+    expect(visual.warnings).toEqual([]);
+    expect(technical.errors).toEqual([]);
+    expect(technical.warnings).toEqual([]);
+  });
+});
 
 describe("runDrawingConsistencyChecks — per-view reliability", () => {
   test("clean drawings produce no errors and no per-view warnings", () => {

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -743,6 +743,18 @@ describe("projectGraphVerticalSliceService", () => {
       height: 594,
     });
     expect(result.artifacts.a1Pdf.source_model_hash).toBe(result.geometryHash);
+    expect(result.artifacts.a1Sheet.svgHash).toBeTruthy();
+    expect(result.artifacts.a1Pdf.source_svg_hash).toBe(
+      result.artifacts.a1Sheet.svgHash,
+    );
+    expect(result.artifacts.a1Pdf.pdfMetadata).toEqual(
+      expect.objectContaining({
+        sourceSvgHash: result.artifacts.a1Sheet.svgHash,
+        sheetArtifactSvgStringUsed: true,
+        sourceSvgRole: "sheetArtifact.svgString",
+        emptyFrameFallbackUsed: false,
+      }),
+    );
     expect(result.artifacts.a1Pdf.renderedPngHash).toBeTruthy();
     expect(
       result.artifacts.a1Pdf.renderedProof.occupancy.nonBackgroundPixelRatio,
@@ -2125,6 +2137,44 @@ describe("projectGraphVerticalSliceService", () => {
     );
   });
 
+  test("vertical-slice QA surfaces visual panel lock drift as blocking errors", async () => {
+    const result = await buildArchitectureProjectVerticalSlice(
+      createReadingRoomBrief(),
+    );
+    const tamperedHero = {
+      ...result.artifacts.visuals3d.hero_3d,
+      geometryHash: "wrong-visual-lock-hash",
+      metadata: {
+        ...result.artifacts.visuals3d.hero_3d.metadata,
+        geometryHash: "wrong-visual-lock-hash",
+      },
+    };
+
+    const qa = validateProjectGraphVerticalSlice({
+      projectGraph: result.projectGraph,
+      artifacts: {
+        ...result.artifacts,
+        visuals3d: {
+          ...result.artifacts.visuals3d,
+          hero_3d: tamperedHero,
+        },
+      },
+    });
+
+    expect(qa.status).toBe("fail");
+    expect(qa.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "VISUAL_PANEL_LOCKS_PASS",
+          status: "fail",
+        }),
+      ]),
+    );
+    expect(qa.issues.map((issue) => issue.code)).toContain(
+      "PROJECT_PANEL_GEOMETRY_HASH_MISMATCH",
+    );
+  });
+
   test("QA fails closed when rendered PDF proof and 3D panels are missing", async () => {
     const result = await buildArchitectureProjectVerticalSlice(
       createReadingRoomBrief(),
@@ -2166,7 +2216,7 @@ describe("projectGraphVerticalSliceService", () => {
     );
   });
 
-  test("QA uses the active presentation-v3 registry for required 3D panels", async () => {
+  test("QA keeps presentation-v3 renderability scoped but visual locks still require every authority panel", async () => {
     const briefInput = createReadingRoomBrief();
     briefInput.brief.building_type = "dwelling";
     briefInput.brief.project_name = "Presentation V3 Dwelling";
@@ -2197,13 +2247,24 @@ describe("projectGraphVerticalSliceService", () => {
       (check) => check.code === "REQUIRED_3D_PANELS_PRESENT",
     );
 
-    expect(qa.status).toBe("pass");
+    expect(qa.status).toBe("fail");
+    expect(qa.issues.map((issue) => issue.code)).toContain(
+      "VISUAL_PANEL_MISSING",
+    );
     expect(qa.issues.map((issue) => issue.code)).not.toContain(
       "REQUIRED_3D_PANEL_MISSING",
     );
     expect(required3dCheck.status).toBe("pass");
     expect(required3dCheck.details.expected.sort()).toEqual(
       ["axonometric", "hero_3d", "interior_3d"].sort(),
+    );
+    expect(qa.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "VISUAL_PANEL_LOCKS_PASS",
+          status: "fail",
+        }),
+      ]),
     );
   });
 

--- a/src/services/a1/a1FinalExportContract.js
+++ b/src/services/a1/a1FinalExportContract.js
@@ -1490,6 +1490,15 @@ function evaluateSheetArtifactEvidence({ sheetArtifact, pdfMetadata } = {}) {
     );
   }
 
+  if (typeof svgString === "string" && /<svg[\s>]/i.test(svgString)) {
+    if (!sheetSvgHash) {
+      codes.push("A1_SHEET_SVG_HASH_MISSING");
+      blockers.push(
+        "A1_SHEET_SVG_HASH_MISSING: Final A1 export requires sheetArtifact.svgHash for the source SVG.",
+      );
+    }
+  }
+
   if (
     pdfMetadata?.emptyFrameFallbackUsed === true ||
     pdfMetadata?.usesEmptyFrames === true ||

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -21,6 +21,10 @@ import {
   getBlockedOpenAIReasoningCalls,
 } from "../openaiReasoningExecutor.js";
 import { computeCDSHashSync } from "../validation/cdsHash.js";
+import {
+  validateTechnicalPanelAuthority,
+  validateVisualPanelLocks,
+} from "../validation/drawingConsistencyChecks.js";
 import { validateProgrammeAdjacency } from "../validation/programmeAdjacencyValidator.js";
 import { computeQuantitativeMetrics } from "../validation/qaScorers/quantitativeScorer.js";
 import {
@@ -10697,6 +10701,63 @@ export function validateProjectGraphVerticalSlice({
     artifacts.a1Sheet?.layoutTemplate ||
       resolvePresentationLayoutTemplate(projectGraph?.brief || {}),
   );
+  const technicalPanelTypesForStoreys = buildTechnicalA1PanelTypes(
+    projectGraph?.brief?.target_storeys || 1,
+  );
+  const visualPanelLockValidation = validateVisualPanelLocks({
+    panels: Object.fromEntries(
+      REQUIRED_3D_A1_PANEL_TYPES.map((panelType) => [
+        panelType,
+        artifacts.visuals3d?.[panelType] ||
+          findPanelArtifact(panelArtifacts, panelType) ||
+          null,
+      ]),
+    ),
+    expectedGeometryHash: geometryHash,
+    expectedVisualManifestHash:
+      artifacts.visualManifest?.manifestHash ||
+      artifacts.visualManifestHash ||
+      artifacts.a1Sheet?.metadata?.visualManifestHash ||
+      null,
+    imageGenEnabled: process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED === "true",
+    strictPhotoreal: process.env.OPENAI_STRICT_IMAGE_GEN === "true",
+  });
+  addCheck(
+    checks,
+    "VISUAL_PANEL_LOCKS_PASS",
+    visualPanelLockValidation.errors.length === 0,
+    visualPanelLockValidation.checks,
+    "consistency_2d_3d",
+    0,
+  );
+  for (const error of visualPanelLockValidation.errors) {
+    issues.push(
+      buildIssue(error.code, "error", error.message, error.details || {}),
+    );
+  }
+
+  const technicalPanelAuthorityValidation = validateTechnicalPanelAuthority({
+    technicalPanels: Object.fromEntries(
+      technicalPanelTypesForStoreys.map((panelType) => [
+        panelType,
+        findPanelArtifact(artifacts.drawings || {}, panelType) || null,
+      ]),
+    ),
+    expectedGeometryHash: geometryHash,
+  });
+  addCheck(
+    checks,
+    "TECHNICAL_PANEL_AUTHORITY_PASS",
+    technicalPanelAuthorityValidation.errors.length === 0,
+    technicalPanelAuthorityValidation.checks,
+    "consistency_2d_3d",
+    0,
+  );
+  for (const error of technicalPanelAuthorityValidation.errors) {
+    issues.push(
+      buildIssue(error.code, "error", error.message, error.details || {}),
+    );
+  }
   const panelRenderabilityRecords = expectedPanels.map((panelType) => {
     const artifact = findPanelArtifact(panelArtifacts, panelType);
     const evaluation = evaluatePanelRenderability(artifact);
@@ -10887,9 +10948,6 @@ export function validateProjectGraphVerticalSlice({
     }
   }
 
-  const technicalPanelTypesForStoreys = buildTechnicalA1PanelTypes(
-    projectGraph?.brief?.target_storeys || 1,
-  );
   const technicalPanelFailures = technicalPanelTypesForStoreys.filter(
     (panelType) => {
       const artifact = findPanelArtifact(artifacts.drawings || {}, panelType);

--- a/src/services/validation/drawingConsistencyChecks.js
+++ b/src/services/validation/drawingConsistencyChecks.js
@@ -1,7 +1,36 @@
 import { isFeatureEnabled } from "../../config/featureFlags.js";
 
+const VISUAL_PANEL_LOCK_TYPES = Object.freeze([
+  "hero_3d",
+  "exterior_render",
+  "axonometric",
+  "interior_3d",
+]);
+
+const TECHNICAL_PANEL_AUTHORITY_TYPES = Object.freeze([
+  "floor_plan_ground",
+  "floor_plan_first",
+  "floor_plan_level2",
+  "floor_plan_level3",
+  "floor_plan_level4",
+  "floor_plan_level5",
+  "floor_plan_level6",
+  "floor_plan_level7",
+  "elevation_north",
+  "elevation_south",
+  "elevation_east",
+  "elevation_west",
+  "section_AA",
+  "section_BB",
+]);
+
+function unique(items = []) {
+  return [...new Set((items || []).filter(Boolean))];
+}
+
 function hasSvgPayload(entry) {
-  return Boolean(entry?.svg && String(entry.svg).includes("<svg"));
+  const svg = entry?.svg || entry?.svgString || entry?.metadata?.svgString;
+  return Boolean(svg && String(svg).includes("<svg"));
 }
 
 function classTokenRegex(token) {
@@ -47,6 +76,217 @@ function valueFromEntry(entry, keys = []) {
     }
   }
   return null;
+}
+
+function panelTypeOf(entry) {
+  return entry?.type || entry?.panelType || entry?.panel_type || null;
+}
+
+function normalizePanelEntries(panels = {}) {
+  if (Array.isArray(panels)) {
+    return panels
+      .filter((panel) => panel !== undefined)
+      .map((panel) => ({
+        panel,
+        type: panelTypeOf(panel),
+      }));
+  }
+  if (!panels || typeof panels !== "object") return [];
+  return Object.entries(panels).map(([type, panel]) => ({
+    panel,
+    type: panelTypeOf(panel) || type,
+  }));
+}
+
+function panelMetadataOf(panel) {
+  return panel?.metadata && typeof panel.metadata === "object"
+    ? panel.metadata
+    : {};
+}
+
+function readPanelField(panel, field) {
+  const metadata = panelMetadataOf(panel);
+  const candidates = [
+    panel,
+    metadata,
+    panel?.meta,
+    panel?.renderProvenance,
+    metadata?.renderProvenance,
+    panel?.imageRenderMetadata,
+    metadata?.imageRenderMetadata,
+    panel?.technicalQualityMetadata,
+    metadata?.technicalQualityMetadata,
+  ];
+  for (const candidate of candidates) {
+    if (candidate && Object.prototype.hasOwnProperty.call(candidate, field)) {
+      return candidate[field];
+    }
+  }
+  return null;
+}
+
+function readAnyPanelField(panel, fields = []) {
+  for (const field of fields) {
+    const value = readPanelField(panel, field);
+    if (value !== null && value !== undefined && value !== "") return value;
+  }
+  return null;
+}
+
+function readPanelGeometryHash(panel) {
+  return readAnyPanelField(panel, [
+    "geometryHash",
+    "sourceGeometryHash",
+    "source_model_hash",
+    "sourceModelHash",
+    "geometry_hash",
+  ]);
+}
+
+function readPanelVisualManifestHash(panel) {
+  return readAnyPanelField(panel, [
+    "visualManifestHash",
+    "visual_manifest_hash",
+  ]);
+}
+
+function normalizeAuthorityToken(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
+}
+
+function booleanPanelField(panel, field) {
+  const value = readPanelField(panel, field);
+  return value === true || value === "true";
+}
+
+function isImageModelToken(value) {
+  const token = normalizeAuthorityToken(value);
+  if (!token || token === "deterministic" || token === "none") return false;
+  return (
+    token.includes("openai") ||
+    token.includes("gpt-image") ||
+    token.includes("dall-e") ||
+    token.includes("dalle") ||
+    token.includes("flux") ||
+    token.includes("stability") ||
+    token.includes("midjourney") ||
+    token === "image_model" ||
+    token === "text_to_image"
+  );
+}
+
+function modelTokenIndicatesImageGeneration(value) {
+  const token = normalizeAuthorityToken(value);
+  if (!token) return false;
+  return (
+    token.includes("gpt-image") ||
+    token.includes("dall-e") ||
+    token.includes("dalle") ||
+    token.includes("flux") ||
+    token.includes("stability") ||
+    token.includes("midjourney") ||
+    token.includes("image")
+  );
+}
+
+function panelUsesImageModel(panel) {
+  return [
+    readPanelField(panel, "provider"),
+    readPanelField(panel, "providerUsed"),
+    readPanelField(panel, "imageProviderUsed"),
+    readPanelField(panel, "generationProvider"),
+  ].some(isImageModelToken);
+}
+
+function technicalPanelUsesImageModel(panel) {
+  if (booleanPanelField(panel, "openaiImageUsed")) return true;
+  if (booleanPanelField(panel, "imageModelGenerated")) return true;
+  if (booleanPanelField(panel, "technicalDrawingFromImageModel")) return true;
+  if (panelUsesImageModel(panel)) return true;
+  return [
+    readPanelField(panel, "model"),
+    readPanelField(panel, "imageRenderModel"),
+  ].some(modelTokenIndicatesImageGeneration);
+}
+
+function visualPanelUsesTextOnlyGeneration(panel) {
+  if (!panelUsesImageModel(panel)) return false;
+  const referenceSource = normalizeAuthorityToken(
+    readPanelField(panel, "referenceSource"),
+  );
+  const generationMode = normalizeAuthorityToken(
+    readAnyPanelField(panel, [
+      "generationMode",
+      "imageGenerationMode",
+      "renderMode",
+      "visualRenderMode",
+      "source",
+    ]),
+  );
+  if (
+    referenceSource === "compiled_3d_control_svg" ||
+    generationMode === "geometry_locked_image_render"
+  ) {
+    return false;
+  }
+  return (
+    !referenceSource ||
+    referenceSource.includes("text") ||
+    referenceSource.includes("prompt") ||
+    generationMode.includes("text_to_image") ||
+    generationMode.includes("prompt")
+  );
+}
+
+function isTechnicalPanelType(type) {
+  if (!type) return false;
+  if (TECHNICAL_PANEL_AUTHORITY_TYPES.includes(type)) return true;
+  return (
+    String(type).startsWith("floor_plan_") ||
+    String(type).startsWith("elevation_") ||
+    String(type).startsWith("section_")
+  );
+}
+
+function technicalPanelHasDeterministicSvgSource(panel) {
+  const renderer = normalizeAuthorityToken(readPanelField(panel, "renderer"));
+  const source = normalizeAuthorityToken(readPanelField(panel, "source"));
+  const sourceType = normalizeAuthorityToken(
+    readPanelField(panel, "sourceType"),
+  );
+  const providerUsed = normalizeAuthorityToken(
+    readPanelField(panel, "providerUsed"),
+  );
+  const imageProviderUsed = normalizeAuthorityToken(
+    readPanelField(panel, "imageProviderUsed"),
+  );
+  return (
+    renderer === "deterministic_svg" ||
+    providerUsed === "deterministic_svg" ||
+    sourceType === "deterministic_svg" ||
+    source === "compiled_project_technical_panel" ||
+    source === "compiled_technical_svg" ||
+    (imageProviderUsed === "none" && renderer === "deterministic_svg")
+  );
+}
+
+function authorityError(code, message, details = {}) {
+  return {
+    code,
+    message: `${code}: ${message}`,
+    details,
+  };
+}
+
+function pushAuthorityError(errors, code, panels, message) {
+  if (!panels.length) return;
+  errors.push(
+    authorityError(code, message(panels), {
+      panels,
+    }),
+  );
 }
 
 function hasAnyClassToken(svg, tokens = []) {
@@ -490,6 +730,262 @@ function validateCrossViewConsistency({ drawings = {}, projectGeometry = {} }) {
   return warnings;
 }
 
+export function validateVisualPanelLocks({
+  panels = {},
+  expectedGeometryHash = null,
+  expectedVisualManifestHash = null,
+  imageGenEnabled = false,
+  strictPhotoreal = false,
+} = {}) {
+  const warnings = [];
+  const errors = [];
+  const entries = normalizePanelEntries(panels);
+  const panelMap = new Map();
+  for (const entry of entries) {
+    if (VISUAL_PANEL_LOCK_TYPES.includes(entry.type)) {
+      panelMap.set(entry.type, entry.panel);
+    }
+  }
+
+  const missingVisualPanels = [];
+  const missingGeometryHashPanels = [];
+  const geometryMismatchPanels = [];
+  const geometryHashByPanel = {};
+  const missingVisualManifestHashPanels = [];
+  const visualManifestMismatchPanels = [];
+  const visualManifestHashByPanel = {};
+  const unlockedVisualPanels = [];
+  const textOnlyVisualPanels = [];
+  const strictFallbackPanels = [];
+
+  for (const type of VISUAL_PANEL_LOCK_TYPES) {
+    const panel = panelMap.get(type);
+    if (!panel) {
+      missingVisualPanels.push(type);
+      continue;
+    }
+
+    const geometryHash = readPanelGeometryHash(panel);
+    if (!geometryHash) {
+      missingGeometryHashPanels.push(type);
+    } else {
+      geometryHashByPanel[type] = geometryHash;
+      if (expectedGeometryHash && geometryHash !== expectedGeometryHash) {
+        geometryMismatchPanels.push(type);
+      }
+    }
+
+    const visualManifestHash = readPanelVisualManifestHash(panel);
+    if (!visualManifestHash) {
+      missingVisualManifestHashPanels.push(type);
+    } else {
+      visualManifestHashByPanel[type] = visualManifestHash;
+      if (
+        expectedVisualManifestHash &&
+        visualManifestHash !== expectedVisualManifestHash
+      ) {
+        visualManifestMismatchPanels.push(type);
+      }
+    }
+
+    if (readPanelField(panel, "visualIdentityLocked") !== true) {
+      unlockedVisualPanels.push(type);
+    }
+
+    if (visualPanelUsesTextOnlyGeneration(panel)) {
+      textOnlyVisualPanels.push(type);
+    }
+
+    if (
+      imageGenEnabled === true &&
+      strictPhotoreal === true &&
+      booleanPanelField(panel, "imageRenderFallback")
+    ) {
+      strictFallbackPanels.push(type);
+    }
+  }
+
+  pushAuthorityError(
+    errors,
+    "VISUAL_PANEL_MISSING",
+    missingVisualPanels,
+    (panelTypes) =>
+      `Required visual panel(s) missing: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "PROJECT_PANEL_GEOMETRY_HASH_MISSING",
+    missingGeometryHashPanels,
+    (panelTypes) =>
+      `Visual panel(s) missing geometryHash/sourceGeometryHash/source_model_hash: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "PROJECT_PANEL_GEOMETRY_HASH_MISMATCH",
+    geometryMismatchPanels,
+    (panelTypes) =>
+      `Visual panel geometry hash differs from expectedGeometryHash for: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "VISUAL_MANIFEST_HASH_MISSING",
+    missingVisualManifestHashPanels,
+    (panelTypes) =>
+      `Visual panel(s) missing visualManifestHash: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "VISUAL_MANIFEST_HASH_MISMATCH",
+    visualManifestMismatchPanels,
+    (panelTypes) =>
+      `Visual panel visualManifestHash differs from expectedVisualManifestHash for: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "VISUAL_IDENTITY_UNLOCKED",
+    unlockedVisualPanels,
+    (panelTypes) =>
+      `Visual panel(s) are missing visualIdentityLocked=true: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "VISUAL_PANEL_TEXT_ONLY_IMAGE_GENERATION",
+    textOnlyVisualPanels,
+    (panelTypes) =>
+      `Visual panel(s) used an image model without compiled_3d_control_svg referenceSource: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "STRICT_IMAGE_RENDER_FALLBACK",
+    strictFallbackPanels,
+    (panelTypes) =>
+      `imageRenderFallback=true while image generation and strict photoreal mode are enabled: ${panelTypes.join(", ")}.`,
+  );
+
+  return {
+    warnings,
+    errors,
+    checks: {
+      requiredVisualPanelTypes: VISUAL_PANEL_LOCK_TYPES.slice(),
+      evaluatedPanelCount: panelMap.size,
+      expectedGeometryHash,
+      expectedVisualManifestHash,
+      imageGenEnabled: imageGenEnabled === true,
+      strictPhotoreal: strictPhotoreal === true,
+      missingVisualPanels,
+      missingGeometryHashPanels,
+      geometryMismatchPanels,
+      geometryHashByPanel,
+      geometryHashes: unique(Object.values(geometryHashByPanel)),
+      missingVisualManifestHashPanels,
+      visualManifestMismatchPanels,
+      visualManifestHashByPanel,
+      visualManifestHashes: unique(Object.values(visualManifestHashByPanel)),
+      unlockedVisualPanels,
+      textOnlyVisualPanels,
+      strictFallbackPanels,
+    },
+  };
+}
+
+export function validateTechnicalPanelAuthority({
+  technicalPanels = {},
+  expectedGeometryHash = null,
+} = {}) {
+  const warnings = [];
+  const errors = [];
+  const entries = normalizePanelEntries(technicalPanels).filter((entry) =>
+    isTechnicalPanelType(entry.type),
+  );
+  const missingSvgPanels = [];
+  const missingGeometryHashPanels = [];
+  const geometryMismatchPanels = [];
+  const imageModelPanels = [];
+  const nonDeterministicPanels = [];
+  const geometryHashByPanel = {};
+
+  for (const { panel, type } of entries) {
+    if (!panel || !hasSvgPayload(panel)) {
+      missingSvgPanels.push(type);
+      if (!panel) continue;
+    }
+
+    const geometryHash = readPanelGeometryHash(panel);
+    if (!geometryHash) {
+      missingGeometryHashPanels.push(type);
+    } else {
+      geometryHashByPanel[type] = geometryHash;
+      if (expectedGeometryHash && geometryHash !== expectedGeometryHash) {
+        geometryMismatchPanels.push(type);
+      }
+    }
+
+    if (technicalPanelUsesImageModel(panel)) {
+      imageModelPanels.push(type);
+    }
+
+    if (
+      readPanelField(panel, "technicalDrawing") !== true ||
+      !technicalPanelHasDeterministicSvgSource(panel)
+    ) {
+      nonDeterministicPanels.push(type);
+    }
+  }
+
+  pushAuthorityError(
+    errors,
+    "TECHNICAL_PANEL_MISSING_SVG",
+    missingSvgPanels,
+    (panelTypes) =>
+      `Technical panel(s) missing deterministic SVG payload: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "TECHNICAL_PANEL_GEOMETRY_HASH_MISSING",
+    missingGeometryHashPanels,
+    (panelTypes) =>
+      `Technical panel(s) missing geometryHash/source_model_hash: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "TECHNICAL_PANEL_GEOMETRY_HASH_MISMATCH",
+    geometryMismatchPanels,
+    (panelTypes) =>
+      `Technical panel geometry hash differs from expectedGeometryHash for: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "TECHNICAL_PANEL_IMAGE_MODEL_USED",
+    imageModelPanels,
+    (panelTypes) =>
+      `Technical panel(s) used image generation instead of deterministic SVG: ${panelTypes.join(", ")}.`,
+  );
+  pushAuthorityError(
+    errors,
+    "TECHNICAL_PANEL_NOT_MARKED_DETERMINISTIC",
+    nonDeterministicPanels,
+    (panelTypes) =>
+      `Technical panel(s) are not marked as technicalDrawing=true with deterministic SVG renderer/source metadata: ${panelTypes.join(", ")}.`,
+  );
+
+  return {
+    warnings,
+    errors,
+    checks: {
+      expectedGeometryHash,
+      evaluatedPanelCount: entries.length,
+      technicalPanelTypes: entries.map((entry) => entry.type),
+      missingSvgPanels,
+      missingGeometryHashPanels,
+      geometryMismatchPanels,
+      geometryHashByPanel,
+      geometryHashes: unique(Object.values(geometryHashByPanel)),
+      imageModelPanels,
+      nonDeterministicPanels,
+    },
+  };
+}
+
 function validateCadGradeTechnicalQa({ drawings = {}, projectGeometry = {} }) {
   const warnings = [];
   const planEntries = drawings.plan || [];
@@ -696,4 +1192,6 @@ export { validateCrossViewConsistency };
 export default {
   runDrawingConsistencyChecks,
   validateCrossViewConsistency,
+  validateTechnicalPanelAuthority,
+  validateVisualPanelLocks,
 };


### PR DESCRIPTION
## Summary

Adds early ProjectGraph A1 authority-lock QA validators before A1 compose/export.

This complements the final `a1FinalExportContract` gate from PR #97. The final export gate remains the last line of defence, but visual/technical authority violations now fail earlier in the ProjectGraph vertical-slice QA path.

## Changes

- Adds `validateVisualPanelLocks()` in `drawingConsistencyChecks.js`.
- Adds `validateTechnicalPanelAuthority()` in `drawingConsistencyChecks.js`.
- Wires both validators into `validateProjectGraphVerticalSlice()` as blocking QA errors.
- Blocks visual hash drift, missing visual locks, text-only visual generation, and strict image fallback before compose/export.
- Blocks technical image-model usage, missing geometry hash, geometry hash drift, and missing deterministic SVG provenance before compose/export.
- Hardens final sheet artifact proof by requiring `sheetArtifact.svgHash` when `sheetArtifact.svgString` is present.

## Validation

- Focused validator/export tests passed.
- Focused vertical-slice QA tests passed.
- `npm run lint`
- `git diff --check` passed with CRLF warnings only.
- `npm run check:env` passed with existing optional warnings only.
- `npm run check:contracts`
- `npm run build:active`

Build artifact:
`build_active_2026-05-05T17-31-35-590Z`

## Notes

These checks duplicate some final export authority rules intentionally as defence-in-depth. The final A1 export contract remains authoritative.
