### PR TITLE
Improve A1 technical sheet chrome and drawing detail

### DIFF
--- a/src/__tests__/services/a1SheetVisualContract.test.js
+++ b/src/__tests__/services/a1SheetVisualContract.test.js
@@ -1,0 +1,420 @@
+import { renderElevationSvg } from "../../services/drawing/svgElevationRenderer.js";
+import { buildSectionWallDetailMarkup } from "../../services/drawing/sectionWallDetailService.js";
+import { renderPlanSvg } from "../../services/drawing/svgPlanRenderer.js";
+import { renderSectionSvg } from "../../services/drawing/svgSectionRenderer.js";
+import {
+  buildTitleBlockPanelArtifact,
+  resolvePresentationLayoutTemplate,
+  __projectGraphVerticalSliceInternals,
+} from "../../services/project/projectGraphVerticalSliceService.js";
+
+const { buildPanelPlacements, buildSheetSvg, buildSiteContextPanelArtifact } =
+  __projectGraphVerticalSliceInternals;
+
+const GEOMETRY_HASH = "visual-contract-geometry-hash";
+
+function rect(minX, minY, maxX, maxY) {
+  return [
+    { x: minX, y: minY },
+    { x: maxX, y: minY },
+    { x: maxX, y: maxY },
+    { x: minX, y: maxY },
+  ];
+}
+
+function room(id, levelId, name, minX, minY, maxX, maxY) {
+  return {
+    id,
+    level_id: levelId,
+    name,
+    actual_area: (maxX - minX) * (maxY - minY),
+    polygon: rect(minX, minY, maxX, maxY),
+    bbox: { min_x: minX, min_y: minY, max_x: maxX, max_y: maxY },
+    centroid: { x: (minX + maxX) / 2, y: (minY + maxY) / 2 },
+  };
+}
+
+function wall(id, levelId, sx, sy, ex, ey) {
+  return {
+    id,
+    level_id: levelId,
+    exterior: true,
+    thickness_m: 0.3,
+    start: { x: sx, y: sy },
+    end: { x: ex, y: ey },
+  };
+}
+
+function terracedGeometry() {
+  const footprint = rect(0, 0, 7.2, 13.4);
+  const groundWalls = [
+    wall("g-s", "ground", 0, 0, 7.2, 0),
+    wall("g-n", "ground", 0, 13.4, 7.2, 13.4),
+    wall("g-e", "ground", 7.2, 0, 7.2, 13.4),
+    wall("g-w", "ground", 0, 0, 0, 13.4),
+  ];
+  const firstWalls = groundWalls.map((entry) => ({
+    ...entry,
+    id: entry.id.replace("g-", "f-"),
+    level_id: "first",
+  }));
+  return {
+    schema_version: "canonical-project-geometry-v2",
+    project_id: "a1-visual-contract-terrace",
+    geometryHash: GEOMETRY_HASH,
+    site: {
+      boundary_bbox: {
+        min_x: -3,
+        min_y: -5,
+        max_x: 11,
+        max_y: 20,
+        width: 14,
+        height: 25,
+      },
+      buildable_bbox: {
+        min_x: 0,
+        min_y: 0,
+        max_x: 7.2,
+        max_y: 13.4,
+        width: 7.2,
+        height: 13.4,
+      },
+      boundary_polygon: rect(-3, -5, 11, 20),
+      buildable_polygon: footprint,
+      north_orientation_deg: 0,
+    },
+    metadata: { geometry_rules: { roof_pitch_degrees: 38 } },
+    footprints: [
+      {
+        id: "fp-ground",
+        level_id: "ground",
+        polygon: footprint,
+        bbox: { min_x: 0, min_y: 0, max_x: 7.2, max_y: 13.4 },
+      },
+      {
+        id: "fp-first",
+        level_id: "first",
+        polygon: footprint,
+        bbox: { min_x: 0, min_y: 0, max_x: 7.2, max_y: 13.4 },
+      },
+    ],
+    levels: [
+      {
+        id: "ground",
+        level_number: 0,
+        name: "Ground Floor",
+        height_m: 3.05,
+        footprint_id: "fp-ground",
+      },
+      {
+        id: "first",
+        level_number: 1,
+        name: "First Floor",
+        height_m: 3.0,
+        footprint_id: "fp-first",
+      },
+    ],
+    rooms: [
+      room("living", "ground", "LIVING_ROOM", 0, 0, 3.5, 4.2),
+      room("kitchen", "ground", "KITCHEN_DINING", 3.5, 0, 7.2, 4.2),
+      room("hall", "ground", "HALL", 0, 4.2, 2.2, 13.4),
+      room("bath-g", "ground", "BATH", 2.2, 4.2, 4.5, 7.2),
+      room("utility", "ground", "UTILITY", 4.5, 4.2, 7.2, 7.2),
+      room("study", "ground", "STUDY", 2.2, 7.2, 7.2, 13.4),
+      room("bed-a", "first", "BEDROOM_1", 0, 0, 3.6, 4.4),
+      room("bed-b", "first", "BEDROOM_2", 3.6, 0, 7.2, 4.4),
+      room("landing", "first", "LANDING_1", 0, 4.4, 2.2, 13.4),
+      room("bath-f", "first", "BATHROOM", 2.2, 4.4, 4.5, 7.4),
+      room("bed-c", "first", "BEDROOM_3", 4.5, 4.4, 7.2, 13.4),
+    ],
+    walls: [...groundWalls, ...firstWalls],
+    doors: [
+      {
+        id: "front-door",
+        level_id: "ground",
+        wall_id: "g-s",
+        position_m: { x: 1.1, y: 0 },
+        width_m: 0.95,
+        head_height_m: 2.1,
+      },
+    ],
+    windows: [
+      {
+        id: "living-window",
+        level_id: "ground",
+        wall_id: "g-s",
+        position_m: { x: 4.9, y: 0 },
+        width_m: 1.5,
+        sill_height_m: 0.85,
+        head_height_m: 2.1,
+      },
+      {
+        id: "bed-window-a",
+        level_id: "first",
+        wall_id: "f-s",
+        position_m: { x: 2.1, y: 0 },
+        width_m: 1.2,
+        sill_height_m: 0.85,
+        head_height_m: 2.1,
+      },
+      {
+        id: "bed-window-b",
+        level_id: "first",
+        wall_id: "f-s",
+        position_m: { x: 5.4, y: 0 },
+        width_m: 1.2,
+        sill_height_m: 0.85,
+        head_height_m: 2.1,
+      },
+    ],
+    stairs: [
+      {
+        id: "stair",
+        level_id: "ground",
+        bbox: { min_x: 0.35, min_y: 7.4, max_x: 2.0, max_y: 12.6 },
+      },
+    ],
+    sections: [
+      {
+        id: "section-aa",
+        sectionType: "longitudinal",
+        cutLine: { from: { x: 3.6, y: 0 }, to: { x: 3.6, y: 13.4 } },
+      },
+      {
+        id: "section-bb",
+        sectionType: "transverse",
+        cutLine: { from: { x: 0, y: 6.7 }, to: { x: 7.2, y: 6.7 } },
+      },
+    ],
+  };
+}
+
+function viewBox(svg) {
+  return String(svg).match(/viewBox="([^"]+)"/)?.[1] || "0 0 1000 700";
+}
+
+function artifact(panelType, svgString, metadata = {}) {
+  return {
+    asset_id: `asset-${panelType}`,
+    asset_type: "drawing_svg",
+    panel_type: panelType,
+    panelType,
+    source_model_hash: GEOMETRY_HASH,
+    geometryHash: GEOMETRY_HASH,
+    svgHash: `svg-${panelType}`,
+    width: Number(String(svgString).match(/width="(\d+)/)?.[1] || 1000),
+    height: Number(String(svgString).match(/height="(\d+)/)?.[1] || 700),
+    normalizedViewBox: viewBox(svgString),
+    svgString,
+    metadata: {
+      providerUsed: "deterministic_svg",
+      source: "compiled_project_technical_panel",
+      geometryHash: GEOMETRY_HASH,
+      ...metadata,
+    },
+    ...metadata,
+  };
+}
+
+function dummyArtifact(panelType, label) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="700" viewBox="0 0 1000 700"><rect width="1000" height="700" fill="#fff"/><text x="80" y="130" font-size="54">${label}</text></svg>`;
+  return artifact(panelType, svg, {
+    providerUsed: "deterministic",
+    imageRenderFallback: true,
+    imageRenderFallbackReason: "test_fixture",
+  });
+}
+
+test("terraced-house A1 sheet carries the visual contract chrome and technical SVG evidence", () => {
+  const oldFooter = process.env.A1_SHOW_PROVENANCE_FOOTER;
+  delete process.env.A1_SHOW_PROVENANCE_FOOTER;
+
+  try {
+    const brief = {
+      programme: "Terraced House",
+      property_type: "terraced-house",
+      site_input: { address: "17 Kensington Road, Scunthorpe DN15 8BQ" },
+      target_storeys: 2,
+      target_gia_m2: 132,
+    };
+    const geometry = terracedGeometry();
+    const styleDNA = { roof_language: "pitched gable" };
+    const sitePanel = buildSiteContextPanelArtifact({
+      projectGraphId: "project-a1-visual-contract",
+      site: {
+        local_boundary_polygon: rect(-3, -5, 11, 20),
+        buildable_polygon: rect(0, 0, 7.2, 13.4),
+        area_m2: 350,
+        boundary_authoritative: false,
+        boundary_estimated: true,
+        boundary_source: "deterministic_context",
+        boundary_confidence: 0.4,
+        address: "17 Kensington Road, Scunthorpe DN15 8BQ",
+        streetName: "Kensington Road",
+        main_entry: {
+          orientation: "south",
+          source: "fallback",
+          bearingDeg: 180,
+        },
+      },
+      geometryHash: GEOMETRY_HASH,
+    });
+    const planGround = renderPlanSvg(geometry, {
+      width: 1200,
+      height: 900,
+      levelId: "ground",
+      sheetMode: true,
+      sections: geometry.sections,
+    });
+    const planFirst = renderPlanSvg(geometry, {
+      width: 1200,
+      height: 900,
+      levelId: "first",
+      sheetMode: true,
+      sections: geometry.sections,
+    });
+    const sectionAA = renderSectionSvg(geometry, styleDNA, {
+      width: 1200,
+      height: 760,
+      sectionType: "longitudinal",
+      sheetMode: true,
+    });
+    const sectionBB = renderSectionSvg(geometry, styleDNA, {
+      width: 1200,
+      height: 760,
+      sectionType: "transverse",
+      sheetMode: true,
+    });
+    const panels = [
+      sitePanel,
+      artifact("floor_plan_ground", planGround.svg, {
+        technicalQualityMetadata: planGround.technical_quality_metadata,
+      }),
+      artifact("floor_plan_first", planFirst.svg, {
+        technicalQualityMetadata: planFirst.technical_quality_metadata,
+      }),
+      ...["north", "south", "east", "west"].map((orientation) => {
+        const result = renderElevationSvg(geometry, styleDNA, {
+          width: 1000,
+          height: 520,
+          orientation,
+          sheetMode: true,
+          allowWeakFacadeFallback: true,
+        });
+        return artifact(`elevation_${orientation}`, result.svg, {
+          technicalQualityMetadata: result.technical_quality_metadata,
+        });
+      }),
+      artifact("section_AA", sectionAA.svg, {
+        technicalQualityMetadata: sectionAA.technical_quality_metadata,
+      }),
+      artifact("section_BB", sectionBB.svg, {
+        technicalQualityMetadata: sectionBB.technical_quality_metadata,
+      }),
+      dummyArtifact("hero_3d", "EXTERIOR"),
+      dummyArtifact("axonometric", "AXONOMETRIC"),
+      dummyArtifact("interior_3d", "INTERIOR"),
+      dummyArtifact("material_palette", "MATERIALS"),
+      dummyArtifact("key_notes", "KEY NOTES"),
+      buildTitleBlockPanelArtifact({
+        projectGraphId: "project-a1-visual-contract",
+        brief,
+        geometryHash: GEOMETRY_HASH,
+        sheetPlan: { sheet_number: "A1-01", label: "RIBA Stage 2" },
+      }),
+    ];
+    const panelArtifacts = Object.fromEntries(
+      panels.map((panel) => [panel.asset_id, panel]),
+    );
+    const layoutTemplate = resolvePresentationLayoutTemplate(brief);
+    const panelPlacements = buildPanelPlacements({
+      drawingSet: { drawings: [] },
+      panelArtifacts,
+      targetStoreys: 2,
+      layoutTemplate,
+      geometryHash: GEOMETRY_HASH,
+      briefInputHash: "brief-visual-contract",
+    });
+    const svg = buildSheetSvg({
+      projectGraphId: "project-a1-visual-contract",
+      brief,
+      geometryHash: GEOMETRY_HASH,
+      panelPlacements,
+      panelArtifacts,
+      qaStatus: "pending",
+      sheetNumber: "A1-01",
+      sheetLabel: "RIBA Stage 2",
+      layoutTemplate,
+    });
+
+    expect(svg).toContain('data-layout-template="presentation-v3"');
+    expect(svg).toContain('data-sheet-title-bar="true"');
+    expect(svg).not.toContain('data-provenance-footer="true"');
+    expect(
+      (svg.match(/cad-dimension-chain/g) || []).length,
+    ).toBeGreaterThanOrEqual(4);
+    expect(
+      (svg.match(/cad-text-room-area/g) || []).length,
+    ).toBeGreaterThanOrEqual(3);
+    expect(svg).toContain('data-datum-role="ffl"');
+    expect(svg).toContain('data-datum-role="eaves"');
+    expect(svg).toContain('data-datum-role="ridge"');
+    expect(svg).toContain('data-datum-role="foundation"');
+    expect(svg).toContain('id="phase3-section-ground-hatch"');
+    expect(svg).toContain('data-site-zone-fill="lawn"');
+    expect(svg).not.toContain(">BEDROOM 1<");
+    expect(svg).not.toContain(">LANDING 1<");
+    expect(svg).not.toContain("ARCHIAI PROJECT");
+  } finally {
+    if (oldFooter === undefined) {
+      delete process.env.A1_SHOW_PROVENANCE_FOOTER;
+    } else {
+      process.env.A1_SHOW_PROVENANCE_FOOTER = oldFooter;
+    }
+  }
+});
+
+test("section wall detail caps broad interior poche opacity while preserving cut-wall hierarchy", () => {
+  const { markup } = buildSectionWallDetailMarkup({
+    walls: [
+      {
+        id: "broad-upper-room-zone",
+        x: 20,
+        y: 40,
+        width: 128,
+        height: 132,
+        truthState: "direct",
+        clipGeometry: {
+          truthKind: "cut_profile",
+          bandCoverageRatio: 1,
+        },
+      },
+      {
+        id: "thin-cut-wall",
+        x: 180,
+        y: 40,
+        width: 18,
+        height: 132,
+        truthState: "direct",
+        clipGeometry: {
+          truthKind: "cut_profile",
+          bandCoverageRatio: 1,
+        },
+      },
+    ],
+    lineweights: { cutOutline: 2, guide: 0.7, hatch: 0.7 },
+  });
+
+  const backgroundMatch = markup.match(
+    /id="phase13-section-cut-wall-broad-upper-room-zone"[\s\S]*?data-poche-zone="interior-background" data-poche-opacity="([^"]+)"/,
+  );
+  const cutWallMatch = markup.match(
+    /id="phase13-section-cut-wall-thin-cut-wall"[\s\S]*?data-poche-zone="cut-wall" data-poche-opacity="([^"]+)"/,
+  );
+
+  expect(backgroundMatch).toBeTruthy();
+  expect(Number(backgroundMatch[1])).toBeLessThanOrEqual(0.38);
+  expect(cutWallMatch).toBeTruthy();
+  expect(Number(cutWallMatch[1])).toBeGreaterThan(0.7);
+  expect(markup).toContain('stroke="#111"');
+});

--- a/src/__tests__/services/projectGraphA1ComposerPhase4.test.js
+++ b/src/__tests__/services/projectGraphA1ComposerPhase4.test.js
@@ -144,9 +144,23 @@ function buildFixtureSheet({ fallbackHero = false } = {}) {
   });
 }
 
+function withProvenanceFooter(fn) {
+  const previous = process.env.A1_SHOW_PROVENANCE_FOOTER;
+  process.env.A1_SHOW_PROVENANCE_FOOTER = "true";
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.A1_SHOW_PROVENANCE_FOOTER;
+    } else {
+      process.env.A1_SHOW_PROVENANCE_FOOTER = previous;
+    }
+  }
+}
+
 describe("ProjectGraph A1 composer Phase 4", () => {
   test("final sheet SVG embeds actual technical SVG content, not empty frames", () => {
-    const svg = buildFixtureSheet();
+    const svg = withProvenanceFooter(() => buildFixtureSheet());
 
     expect(svg).toContain("phase4-dimension-chain");
     expect(svg).toContain("Living Room");
@@ -156,7 +170,7 @@ describe("ProjectGraph A1 composer Phase 4", () => {
   });
 
   test("visual image panels are embedded when image2 artifacts are present", () => {
-    const svg = buildFixtureSheet();
+    const svg = withProvenanceFooter(() => buildFixtureSheet());
 
     expect(svg).toContain('data-panel-id="hero_3d"');
     expect(svg).toContain('data-panel-id="axonometric"');
@@ -169,7 +183,7 @@ describe("ProjectGraph A1 composer Phase 4", () => {
   });
 
   test("embedded panels use object-contain preserveAspectRatio behavior", () => {
-    const svg = buildFixtureSheet();
+    const svg = withProvenanceFooter(() => buildFixtureSheet());
     const wrappedPng = wrapPngAsSvgPanel(
       Buffer.from("phase4-png"),
       "0 0 1000 700",
@@ -201,7 +215,7 @@ describe("ProjectGraph A1 composer Phase 4", () => {
         date: "2026-05-05",
       },
     });
-    const svg = buildFixtureSheet();
+    const svg = withProvenanceFooter(() => buildFixtureSheet());
 
     expect(titleBlock.svgString).toContain(
       `geometryHash ${GEOMETRY_HASH.slice(0, 18)}`,
@@ -234,7 +248,9 @@ describe("ProjectGraph A1 composer Phase 4", () => {
   });
 
   test("fallback visual panels are labeled deterministic and do not claim OpenAI success", () => {
-    const svg = buildFixtureSheet({ fallbackHero: true });
+    const svg = withProvenanceFooter(() =>
+      buildFixtureSheet({ fallbackHero: true }),
+    );
 
     expect(svg).toContain('data-panel-id="hero_3d"');
     expect(svg).toContain('data-image-render-fallback="true"');
@@ -253,22 +269,24 @@ describe("ProjectGraph A1 composer Phase 4", () => {
       geometryHash: GEOMETRY_HASH,
       briefInputHash: "brief-hash-phase4",
     });
-    const svg = buildSheetSvg({
-      projectGraphId: "project-phase4",
-      brief: {
-        project_name: "Phase 4 Composer Test",
-        reference_match: false,
-        brief_input_hash: "brief-hash-phase4",
-      },
-      geometryHash: GEOMETRY_HASH,
-      panelPlacements,
-      panelArtifacts,
-      qaStatus: "pending",
-      sheetNumber: "A1-01",
-      sheetLabel: "Phase 4",
-      layoutTemplate: "presentation-v3",
-      visualManifest: VISUAL_MANIFEST,
-    });
+    const svg = withProvenanceFooter(() =>
+      buildSheetSvg({
+        projectGraphId: "project-phase4",
+        brief: {
+          project_name: "Phase 4 Composer Test",
+          reference_match: false,
+          brief_input_hash: "brief-hash-phase4",
+        },
+        geometryHash: GEOMETRY_HASH,
+        panelPlacements,
+        panelArtifacts,
+        qaStatus: "pending",
+        sheetNumber: "A1-01",
+        sheetLabel: "Phase 4",
+        layoutTemplate: "presentation-v3",
+        visualManifest: VISUAL_MANIFEST,
+      }),
+    );
     const lastPanelBottom = Math.max(
       ...panelPlacements.map((placement) => placement.y + placement.height),
     );
@@ -325,10 +343,10 @@ describe("ProjectGraph A1 composer Phase 4", () => {
       layoutTemplate: "presentation-v3",
     });
 
-    expect(values[0]).toBeCloseTo(87.7, 1);
-    expect(values[1]).toBeCloseTo(216.1, 1);
-    expect(values[2]).toBeCloseTo(844.6, 1);
-    expect(values[3]).toBeCloseTo(267.8, 1);
+    expect(values[0]).toBeCloseTo(79.5, 1);
+    expect(values[1]).toBeCloseTo(213.5, 1);
+    expect(values[2]).toBeCloseTo(861, 1);
+    expect(values[3]).toBeCloseTo(273, 1);
     expect(fit.viewBox).toBe(viewBox);
     expect(fit.occupancyRatio).toBeGreaterThanOrEqual(0.75);
     expect(fit.occupancyRatio).toBeLessThanOrEqual(0.9);

--- a/src/services/drawing/sectionWallDetailService.js
+++ b/src/services/drawing/sectionWallDetailService.js
@@ -30,6 +30,12 @@ function resolveWallTruthKind(wall = {}) {
   return kind;
 }
 
+function isInteriorBackgroundPocheZone(wall = {}) {
+  const width = Number(wall.width || 0);
+  const height = Number(wall.height || 0);
+  return width >= 56 && height >= 72;
+}
+
 export function buildSectionWallDetailMarkup({
   walls = [],
   lineweights = {},
@@ -52,7 +58,7 @@ export function buildSectionWallDetailMarkup({
       const truthKind = phase21 ? resolveWallTruthKind(wall) : null;
       const isCutFace = phase21 && truthKind === "cut_face";
       const isCutProfile = phase21 && truthKind === "cut_profile";
-      const pocheOpacity = isCutFace
+      const rawPocheOpacity = isCutFace
         ? 0.96
         : isCutProfile
           ? 0.86 + bandCoverage * 0.06
@@ -61,6 +67,10 @@ export function buildSectionWallDetailMarkup({
             : contextual
               ? 0.62
               : 0.76 + bandCoverage * 0.1;
+      const interiorBackgroundZone = isInteriorBackgroundPocheZone(wall);
+      const pocheOpacity = interiorBackgroundZone
+        ? Math.min(rawPocheOpacity, 0.38)
+        : rawPocheOpacity;
       const outlineWeight = isCutFace
         ? Math.max(2, (lineweights.cutOutline || 1.6) * 1.22)
         : isCutProfile
@@ -102,7 +112,7 @@ export function buildSectionWallDetailMarkup({
         : "";
       return `
         <g id="phase13-section-cut-wall-${escapeXml(wall.id || index)}" data-truth-kind="${escapeXml(truthKind || truthState)}">
-          <rect x="${wall.x}" y="${wall.y}" width="${wall.width}" height="${wall.height}" fill="#151515" fill-opacity="${pocheOpacity}" stroke="#111" stroke-width="${outlineWeight}"${dashArray} />
+          <rect x="${wall.x}" y="${wall.y}" width="${wall.width}" height="${wall.height}" data-poche-zone="${interiorBackgroundZone ? "interior-background" : "cut-wall"}" data-poche-opacity="${pocheOpacity}" fill="#151515" fill-opacity="${pocheOpacity}" stroke="#111" stroke-width="${outlineWeight}"${dashArray} />
           ${cutFaceReveal}
           <rect x="${wall.x + Math.max(1.5, wall.width * 0.08)}" y="${wall.y + 1.5}" width="${Math.max(2, wall.width - Math.max(3, wall.width * 0.16))}" height="${Math.max(6, wall.height - 3)}" fill="none" stroke="#f5f2ec" stroke-width="${isCutFace ? (lineweights.hatch || 0.7) * 1.2 : nearBoolean ? lineweights.hatch || 0.7 : lineweights.guide || 0.62}" stroke-opacity="${interiorHatchOpacity}"${interiorHatchDash} />
           <line x1="${wall.x + wall.width * 0.2}" y1="${wall.y}" x2="${wall.x + wall.width * 0.2}" y2="${wall.y + wall.height}" stroke="#f4f1eb" stroke-width="${lineweights.guide || 0.62}" stroke-opacity="${isCutFace ? 0.46 : contextual ? 0.2 : 0.35}" />

--- a/src/services/drawing/svgElevationRenderer.js
+++ b/src/services/drawing/svgElevationRenderer.js
@@ -472,6 +472,11 @@ function renderLevelDatums(
         ? resolveFloorStageLabel(levelProfiles[index + 1])
         : "ROOF";
     labels.push(`
+      <line class="cad-elevation-ffl-datum-line cad-lineweight-detail" x1="${formatNumber(
+        baseX,
+      )}" y1="${formatNumber(topY)}" x2="${formatNumber(
+        baseX + widthPx,
+      )}" y2="${formatNumber(topY)}" stroke="${theme.lineMuted}" stroke-width="${datumStroke}" stroke-dasharray="9 5" data-datum-role="ffl" />
       <line x1="${formatNumber(baseX - 46)}" y1="${formatNumber(
         topY,
       )}" x2="${formatNumber(baseX - 6)}" y2="${formatNumber(
@@ -493,6 +498,11 @@ function renderLevelDatums(
   // Ground line: explicitly labelled "FFL GROUND +0.00m" so reviewers can
   // read the datum without inferring the stage from the absence of a name.
   labels.push(`
+    <line class="cad-elevation-ffl-ground-datum-line cad-lineweight-detail" x1="${formatNumber(
+      baseX,
+    )}" y1="${formatNumber(baseY)}" x2="${formatNumber(
+      baseX + widthPx,
+    )}" y2="${formatNumber(baseY)}" stroke="${theme.line}" stroke-width="${datumStroke}" data-datum-role="ffl" />
     <line x1="${formatNumber(baseX - 46)}" y1="${formatNumber(
       baseY,
     )}" x2="${formatNumber(baseX - 6)}" y2="${formatNumber(
@@ -512,6 +522,11 @@ function renderLevelDatums(
     const eavesY = baseY - Number(lastLevel.top_m) * scale;
     const eavesFont = polishSize(9, fontScale);
     labels.push(`
+      <line class="cad-eaves-datum cad-lineweight-detail" x1="${formatNumber(baseX)}" y1="${formatNumber(
+        eavesY,
+      )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
+        eavesY,
+      )}" stroke="${theme.lineMuted}" stroke-width="${guideStroke}" stroke-dasharray="9 5" data-datum-role="eaves" />
       <line class="cad-eaves-datum cad-lineweight-detail" x1="${formatNumber(baseX + widthPx + 6)}" y1="${formatNumber(
         eavesY,
       )}" x2="${formatNumber(baseX + widthPx + 44)}" y2="${formatNumber(
@@ -535,6 +550,11 @@ function renderLevelDatums(
     const ridgeY = ridgeInfo.y;
     const ridgeFont = polishSize(9, fontScale);
     labels.push(`
+      <line class="cad-ridge-datum cad-lineweight-detail" x1="${formatNumber(baseX)}" y1="${formatNumber(
+        ridgeY,
+      )}" x2="${formatNumber(baseX + widthPx)}" y2="${formatNumber(
+        ridgeY,
+      )}" stroke="${theme.line}" stroke-width="${datumStroke}" stroke-dasharray="9 5" data-datum-role="ridge" />
       <line x1="${formatNumber(baseX - 46)}" y1="${formatNumber(
         ridgeY,
       )}" x2="${formatNumber(baseX - 6)}" y2="${formatNumber(
@@ -1163,15 +1183,24 @@ function renderFacadeFeatures(
   };
 }
 
-function renderGroundLine(baseX, baseY, widthPx, theme) {
+function renderGroundLine(baseX, baseY, widthPx, theme, options = {}) {
+  const fullWidth = Number(options.fullWidth);
+  const groundX = Number.isFinite(fullWidth) && fullWidth > 0 ? 8 : baseX - 18;
+  const groundWidth =
+    Number.isFinite(fullWidth) && fullWidth > 0 ? fullWidth - 16 : widthPx + 36;
+  const lineX1 = Number.isFinite(fullWidth) && fullWidth > 0 ? 8 : baseX - 22;
+  const lineX2 =
+    Number.isFinite(fullWidth) && fullWidth > 0
+      ? fullWidth - 8
+      : baseX + widthPx + 22;
   return `
     <g id="phase8-ground-line" class="cad-layer-site-ground cad-lineweight-outline">
-      <rect x="${formatNumber(baseX - 18)}" y="${formatNumber(
+      <rect x="${formatNumber(groundX)}" y="${formatNumber(
         baseY,
-      )}" width="${formatNumber(widthPx + 36)}" height="24" fill="url(#phase8-elev-ground)" />
-      <line x1="${formatNumber(baseX - 22)}" y1="${formatNumber(
+      )}" width="${formatNumber(groundWidth)}" height="24" fill="url(#phase8-elev-ground)" />
+      <line x1="${formatNumber(lineX1)}" y1="${formatNumber(
         baseY,
-      )}" x2="${formatNumber(baseX + widthPx + 22)}" y2="${formatNumber(
+      )}" x2="${formatNumber(lineX2)}" y2="${formatNumber(
         baseY,
       )}" stroke="${theme.line}" stroke-width="1.8" />
     </g>
@@ -1432,7 +1461,7 @@ export function renderElevationSvg(
   const showInternalTitleBlock =
     !sheetMode || options.showInternalTitleBlock === true;
   const layout = sheetMode
-    ? { left: 34, top: 18, right: 38, bottom: 64 }
+    ? { left: 28, top: 16, right: 30, bottom: 38 }
     : { left: 80, top: 62, right: 94, bottom: 118 };
   const availableWidth = Math.max(1, width - layout.left - layout.right);
   const availableHeight = Math.max(1, height - layout.top - layout.bottom);
@@ -1765,7 +1794,9 @@ export function renderElevationSvg(
         )}</text>`
   }
   ${packLabelMarkup}
-  ${renderGroundLine(baseX, baseY, widthPx, theme)}
+  ${renderGroundLine(baseX, baseY, widthPx, theme, {
+    fullWidth: sheetMode ? width : 0,
+  })}
   ${semiBasementMarkup}
   ${materialZones.markup}
   ${articulation.markup}

--- a/src/services/drawing/svgPlanRenderer.js
+++ b/src/services/drawing/svgPlanRenderer.js
@@ -201,7 +201,10 @@ function summarizePlanGeometry(rooms = [], walls = [], hasFootprint = false) {
 
 function uppercaseLabel(value, fallback = "ROOM") {
   const text = String(value || fallback).trim();
-  return (text || fallback).replace(/[_-]+/g, " ").toUpperCase();
+  return (text || fallback)
+    .replace(/[_-]\d+$/g, "")
+    .replace(/[_-]+/g, " ")
+    .toUpperCase();
 }
 
 function polygonPath(points = [], project) {
@@ -322,7 +325,7 @@ function buildTransform(bounds, width, height, layout = {}) {
   };
 }
 
-function renderRoomLabel(room = {}, project, theme) {
+function renderRoomLabel(room = {}, project, theme, options = {}) {
   const bbox = resolveRoomBBox(room);
   const centroid = pointFrom(room.centroid, {
     x: (Number(bbox.min_x) + Number(bbox.max_x)) / 2,
@@ -334,8 +337,12 @@ function renderRoomLabel(room = {}, project, theme) {
   const areaText = `${Number.isFinite(areaValue) ? areaValue.toFixed(1) : "0.0"} M2`;
   const dimensionText = getRoomDimensionText(room);
   const secondaryLine = dimensionText
-    ? `${areaText} · ${dimensionText}`
+    ? `${dimensionText} / ${areaText}`
     : areaText;
+  const fontScale = options.sheetMode ? 1.18 : 1;
+  const nameFontSize = round(13 * fontScale, 1);
+  const secondaryFontSize = round(10 * fontScale, 1);
+  const labelHeight = 38 * fontScale;
   const labelWidth = Math.max(
     110,
     name.length * 8.4,
@@ -345,24 +352,26 @@ function renderRoomLabel(room = {}, project, theme) {
   return `
     <g class="plan-room-label" data-room-id="${escapeXml(room.id || room.name || "")}" data-room-area-m2="${formatNumber(areaValue, 1)}">
       <rect x="${formatNumber(labelPoint.x - labelWidth / 2)}" y="${formatNumber(
-        labelPoint.y - 22,
-      )}" width="${formatNumber(labelWidth)}" height="38" fill="${theme.paper}" fill-opacity="0.95" stroke="${theme.guide}" stroke-width="0.95" rx="4" ry="4" class="cad-room-label-backplate cad-lineweight-detail"/>
+        labelPoint.y - labelHeight * 0.58,
+      )}" width="${formatNumber(labelWidth)}" height="${formatNumber(labelHeight)}" fill="${theme.paper}" fill-opacity="0.95" stroke="${theme.guide}" stroke-width="0.95" rx="4" ry="4" class="cad-room-label-backplate cad-lineweight-detail"/>
       <text x="${formatNumber(labelPoint.x)}" y="${formatNumber(
         labelPoint.y - 6,
-      )}" font-size="13" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" class="sheet-critical-label cad-room-name-label" data-text-role="critical">${name}</text>
+      )}" font-size="${nameFontSize}" font-family="Arial, sans-serif" font-weight="700" text-anchor="middle" class="sheet-critical-label cad-room-name-label" data-text-role="critical">${name}</text>
       <text x="${formatNumber(labelPoint.x)}" y="${formatNumber(
-        labelPoint.y + 10,
-      )}" font-size="10" font-family="Arial, sans-serif" text-anchor="middle" class="sheet-critical-label room-area-label cad-text-room-area" data-text-role="critical">${escapeXml(
+        labelPoint.y + 11 * fontScale,
+      )}" font-size="${secondaryFontSize}" font-family="Arial, sans-serif" text-anchor="middle" class="sheet-critical-label room-area-label cad-text-room-area" data-text-role="critical">${escapeXml(
         secondaryLine,
       )}</text>
     </g>
   `;
 }
 
-function renderFurnitureHints(rooms = [], project, theme) {
+function renderFurnitureHints(rooms = [], project, theme, options = {}) {
+  const minWidth = options.sheetMode ? 42 : 70;
+  const minHeight = options.sheetMode ? 34 : 56;
   const entries = sortByStableKey(rooms).flatMap((room) => {
     const rect = projectRoomRect(room, project);
-    if (!rect || rect.width < 70 || rect.height < 56) {
+    if (!rect || rect.width < minWidth || rect.height < minHeight) {
       return [];
     }
 
@@ -379,13 +388,15 @@ function renderFurnitureHints(rooms = [], project, theme) {
         `<rect x="${formatNumber(rect.x + 8)}" y="${formatNumber(rect.y + 8)}" width="${formatNumber(sofaW)}" height="${formatNumber(Math.max(6, sofaH * 0.38))}" fill="none" stroke="${guide}" stroke-width="0.8" rx="4" ry="4"/>`,
         `<rect x="${formatNumber(rect.x + rect.width * 0.52)}" y="${formatNumber(rect.y + rect.height * 0.56)}" width="${formatNumber(Math.min(30, rect.width * 0.22))}" height="${formatNumber(Math.min(18, rect.height * 0.16))}" fill="none" stroke="${guide}" stroke-width="0.8" rx="3" ry="3"/>`,
       );
-    } else if (name.includes("kitchen")) {
+    }
+    if (name.includes("kitchen")) {
       const counterDepth = Math.min(rect.height * 0.16, 16);
       furniture.push(
         `<rect x="${formatNumber(rect.x + 6)}" y="${formatNumber(rect.y + 6)}" width="${formatNumber(rect.width - 12)}" height="${formatNumber(counterDepth)}" fill="none" stroke="${stroke}" stroke-width="0.95"/>`,
         `<rect x="${formatNumber(rect.x + rect.width * 0.22)}" y="${formatNumber(rect.y + rect.height * 0.48)}" width="${formatNumber(Math.min(rect.width * 0.42, 68))}" height="${formatNumber(Math.min(rect.height * 0.2, 20))}" fill="none" stroke="${guide}" stroke-width="0.85" rx="3" ry="3"/>`,
       );
-    } else if (name.includes("bed")) {
+    }
+    if (name.includes("bed")) {
       const bedW = Math.min(rect.width * 0.46, 74);
       const bedH = Math.min(rect.height * 0.3, 44);
       furniture.push(
@@ -393,18 +404,21 @@ function renderFurnitureHints(rooms = [], project, theme) {
         `<line x1="${formatNumber(rect.x + 8 + bedW * 0.5)}" y1="${formatNumber(rect.y + 8)}" x2="${formatNumber(rect.x + 8 + bedW * 0.5)}" y2="${formatNumber(rect.y + 8 + bedH)}" stroke="${guide}" stroke-width="0.8"/>`,
         `<rect x="${formatNumber(rect.x + bedW + 14)}" y="${formatNumber(rect.y + 10)}" width="${formatNumber(Math.min(16, rect.width * 0.12))}" height="${formatNumber(Math.min(24, rect.height * 0.22))}" fill="none" stroke="${guide}" stroke-width="0.8"/>`,
       );
-    } else if (name.includes("study") || name.includes("office")) {
+    }
+    if (name.includes("study") || name.includes("office")) {
       furniture.push(
         `<rect x="${formatNumber(rect.x + 8)}" y="${formatNumber(rect.y + 8)}" width="${formatNumber(Math.min(rect.width * 0.42, 64))}" height="${formatNumber(Math.min(rect.height * 0.18, 18))}" fill="none" stroke="${stroke}" stroke-width="0.95"/>`,
         `<circle cx="${formatNumber(rect.x + rect.width * 0.34)}" cy="${formatNumber(rect.y + rect.height * 0.46)}" r="${formatNumber(Math.min(9, rect.width * 0.07), 1)}" fill="none" stroke="${guide}" stroke-width="0.8"/>`,
       );
-    } else if (name.includes("dining")) {
+    }
+    if (name.includes("dining")) {
       furniture.push(
         `<rect x="${formatNumber(rect.x + rect.width * 0.28)}" y="${formatNumber(rect.y + rect.height * 0.28)}" width="${formatNumber(Math.min(rect.width * 0.34, 54))}" height="${formatNumber(Math.min(rect.height * 0.2, 20))}" fill="none" stroke="${stroke}" stroke-width="0.95" rx="3" ry="3"/>`,
         `<circle cx="${formatNumber(rect.x + rect.width * 0.26)}" cy="${formatNumber(rect.y + rect.height * 0.38)}" r="3.2" fill="none" stroke="${guide}" stroke-width="0.8"/>`,
         `<circle cx="${formatNumber(rect.x + rect.width * 0.66)}" cy="${formatNumber(rect.y + rect.height * 0.38)}" r="3.2" fill="none" stroke="${guide}" stroke-width="0.8"/>`,
       );
-    } else if (name.includes("bath")) {
+    }
+    if (name.includes("bath")) {
       furniture.push(
         `<rect x="${formatNumber(rect.x + 8)}" y="${formatNumber(rect.y + 8)}" width="${formatNumber(Math.min(rect.width * 0.46, 60))}" height="${formatNumber(Math.min(rect.height * 0.22, 22))}" fill="none" stroke="${stroke}" stroke-width="0.95" rx="8" ry="8"/>`,
         `<rect x="${formatNumber(rect.x + rect.width * 0.64)}" y="${formatNumber(rect.y + 10)}" width="${formatNumber(Math.min(rect.width * 0.18, 18))}" height="${formatNumber(Math.min(rect.height * 0.18, 18))}" fill="none" stroke="${guide}" stroke-width="0.8"/>`,
@@ -995,7 +1009,7 @@ function renderExternalDimensions(
   });
 
   const markup = `
-    <g id="external-dimensions" class="cad-layer-dimensions cad-dimension-chain-overall cad-lineweight-detail" data-dimension-chain-types="overall bay opening internal">
+    <g id="external-dimensions" class="cad-layer-dimensions cad-dimension-chain cad-dimension-chain-overall cad-lineweight-detail" data-dimension-chain-types="overall bay opening internal">
       <line x1="${formatNumber(topLeft.x)}" y1="${formatNumber(
         topLeft.y,
       )}" x2="${formatNumber(topLeft.x)}" y2="${formatNumber(
@@ -1059,8 +1073,8 @@ function renderExternalDimensions(
       )} ${formatNumber(
         (topRight.y + bottomRight.y) / 2,
       )})" text-anchor="middle">${escapeXml(formatMeters(bounds.height))}</text>
-      ${horizontalChain.markup ? `<g class="dimension-chain horizontal"><g class="cad-dimension-chain cad-dimension-chain-bay cad-dimension-chain-internal">${horizontalChain.markup}</g></g>` : ""}
-      ${verticalChain.markup ? `<g class="dimension-chain vertical"><g class="cad-dimension-chain cad-dimension-chain-opening cad-dimension-chain-internal">${verticalChain.markup}</g></g>` : ""}
+      <g class="dimension-chain horizontal"><g class="cad-dimension-chain cad-dimension-chain-overall cad-dimension-chain-bay cad-dimension-chain-internal">${horizontalChain.markup}</g></g>
+      <g class="dimension-chain vertical"><g class="cad-dimension-chain cad-dimension-chain-overall cad-dimension-chain-opening cad-dimension-chain-internal">${verticalChain.markup}</g></g>
     </g>
   `;
 
@@ -1330,7 +1344,9 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
     .join("");
   const roomLabelMarkup = options.hideRoomLabels
     ? ""
-    : levelRooms.map((room) => renderRoomLabel(room, project, theme)).join("");
+    : levelRooms
+        .map((room) => renderRoomLabel(room, project, theme, { sheetMode }))
+        .join("");
   const wallMarkup = renderWallMarkup(levelWalls, project, theme);
   const doorEntries = (geometry.doors || []).filter(
     (door) => door.level_id === level.id,
@@ -1396,7 +1412,9 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
         boundsSource,
       })
     : "";
-  const furnitureHints = renderFurnitureHints(levelRooms, project, theme);
+  const furnitureHints = renderFurnitureHints(levelRooms, project, theme, {
+    sheetMode,
+  });
   // Section markers (A-A, B-B) — render the global section cuts on every
   // level's plan, which matches standard architectural practice (the cut
   // runs through the full building, not per-storey). When a section is
@@ -1409,7 +1427,39 @@ export function renderPlanSvg(geometryInput = {}, options = {}) {
   const callerSections = Array.isArray(options.sections)
     ? options.sections
     : null;
-  const candidateSections = callerSections || geometry.sections || [];
+  const fallbackSections = [
+    {
+      id: "section-aa-fallback",
+      sectionType: "longitudinal",
+      cutLine: {
+        from: {
+          x: (Number(bounds.min_x) + Number(bounds.max_x)) / 2,
+          y: Number(bounds.min_y),
+        },
+        to: {
+          x: (Number(bounds.min_x) + Number(bounds.max_x)) / 2,
+          y: Number(bounds.max_y),
+        },
+      },
+    },
+    {
+      id: "section-bb-fallback",
+      sectionType: "transverse",
+      cutLine: {
+        from: {
+          x: Number(bounds.min_x),
+          y: (Number(bounds.min_y) + Number(bounds.max_y)) / 2,
+        },
+        to: {
+          x: Number(bounds.max_x),
+          y: (Number(bounds.min_y) + Number(bounds.max_y)) / 2,
+        },
+      },
+    },
+  ];
+  const candidateSections = (callerSections || geometry.sections || []).length
+    ? callerSections || geometry.sections || []
+    : fallbackSections;
   const levelSections = candidateSections.filter((section) => {
     if (!section?.cutLine) return false;
     if (section.level_id && section.level_id !== level.id) return false;

--- a/src/services/drawing/svgSectionRenderer.js
+++ b/src/services/drawing/svgSectionRenderer.js
@@ -636,6 +636,16 @@ function renderLevelDatums(
     <text x="${baseX - 134}" y="${baseY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical" data-datum-role="ffl">FFL +0.00m</text>
   `);
 
+  const foundationDepthM = Number.isFinite(Number(options.foundationDepthM))
+    ? Number(options.foundationDepthM)
+    : 1;
+  const foundationY = baseY + Math.max(0.35, foundationDepthM) * scale;
+  labels.push(`
+    <line class="cad-section-foundation-datum cad-lineweight-detail" x1="${baseX - 52}" y1="${foundationY}" x2="${baseX + widthPx}" y2="${foundationY}" stroke="${SECTION_THEME.lineMuted}" stroke-width="${secondaryStroke}" stroke-dasharray="8 5" data-datum-role="foundation" />
+    <rect x="${baseX - 158}" y="${foundationY - 11}" width="100" height="16" rx="3" ry="3" fill="${SECTION_THEME.paper}" fill-opacity="0.94" stroke="${SECTION_THEME.guide}" stroke-width="${labelStroke}" />
+    <text x="${baseX - 148}" y="${foundationY + 1}" font-size="${primaryLabelFont}" font-family="Arial, sans-serif" font-weight="700" text-anchor="start" class="sheet-critical-label" data-text-role="critical" data-datum-role="foundation">FOUND -1.000m</text>
+  `);
+
   let eavesDatumCount = 0;
   const eavesHeightM = Number(options.eavesHeightM);
   if (Number.isFinite(eavesHeightM) && eavesHeightM > 0) {
@@ -940,8 +950,17 @@ function renderRoof(
     <path d="M ${roofX - 4} ${topY} L ${roofX + roofWidth / 2} ${ridgeY} L ${roofX + roofWidth + 4} ${topY} L ${roofX + roofWidth - 12} ${topY} L ${roofX + roofWidth / 2} ${undersideY} L ${roofX + 12} ${topY} Z" fill="${SECTION_THEME.fillSoft}" fill-opacity="${quality === "blocked" ? 0.42 : quality === "weak" ? 0.66 : 0.92}" stroke="${SECTION_THEME.lineMuted}" stroke-opacity="${strokeOpacity}" stroke-width="${lineweights.primary || 1.4}"${dasharray} />
     <path d="M ${roofX} ${topY} L ${roofX + roofWidth / 2} ${ridgeY} L ${roofX + roofWidth} ${topY}" fill="none" stroke="${SECTION_THEME.line}" stroke-opacity="${strokeOpacity}" stroke-width="${lineweights.cutOutline || 2}"${dasharray} />
     <path d="M ${roofX + 12} ${topY} L ${roofX + roofWidth / 2} ${undersideY} L ${roofX + roofWidth - 12} ${topY}" fill="none" stroke="${SECTION_THEME.lineMuted}" stroke-opacity="${strokeOpacity}" stroke-width="${lineweights.primary || 1.2}"${dasharray} />
-    <line x1="${roofX + roofWidth / 2}" y1="${ridgeY}" x2="${roofX + roofWidth / 2}" y2="${ridgeY + 10}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.secondary || 1}" />
+    <line class="cad-roof-ridge-beam" x1="${roofX + roofWidth / 2}" y1="${ridgeY}" x2="${roofX + roofWidth / 2}" y2="${ridgeY + 14}" stroke="${SECTION_THEME.line}" stroke-width="${lineweights.secondary || 1}" data-roof-framing="ridge-beam" />
     <line x1="${roofX + 10}" y1="${topY - 8}" x2="${roofX + roofWidth - 10}" y2="${topY - 8}" stroke="${SECTION_THEME.lineLight}" stroke-width="${lineweights.tertiary || 0.8}" stroke-dasharray="4 4" />
+    <g class="cad-roof-rafter-lines" data-roof-framing="rafters">
+      ${[0.18, 0.34, 0.66, 0.82]
+        .map((ratio) => {
+          const eavesX = roofX + roofWidth * ratio;
+          const ridgeX = roofX + roofWidth / 2;
+          return `<line x1="${formatNumber(ridgeX)}" y1="${formatNumber(ridgeY + 10)}" x2="${formatNumber(eavesX)}" y2="${formatNumber(topY - 3)}" stroke="${SECTION_THEME.lineLight}" stroke-width="${lineweights.tertiary || 0.8}" />`;
+        })
+        .join("")}
+    </g>
     ${cutPlaneMarkup}
     ${roofBreakMarkup}
     ${hipMarkup}
@@ -1378,7 +1397,7 @@ export function renderSectionSvg(
     sheetMode ? 0.82 : 1.4,
     Number(roofPitchInfoBase.riseM || 0),
   );
-  const groundAllowanceM = sheetMode ? 0.42 : 0;
+  const groundAllowanceM = sheetMode ? 1.12 : 0;
   const scale = Math.min(
     (width - padding * 2) / Math.max(horizontalExtent, 1),
     (height - padding * 2) /
@@ -1552,6 +1571,7 @@ export function renderSectionSvg(
     {
       eavesHeightM: sectionEavesHeightM,
       ridgeHeightM: sectionRidgeHeightM,
+      foundationDepthM: 1,
     },
   );
   const foundation = renderFoundation(
@@ -1843,6 +1863,7 @@ export function renderSectionSvg(
       cut_opening_count: cutOpenings.length,
       section_opening_cut_count: openingMarkup.count,
       foundation_marker_count: 1,
+      foundation_datum_count: 1,
       ground_hatch_band_lines: groundHatch.count,
       ground_hatch_visible: groundHatch.count > 0,
       vertical_dimension_chain_count: 1,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -22,6 +22,7 @@ import {
 } from "../openaiReasoningExecutor.js";
 import { computeCDSHashSync } from "../validation/cdsHash.js";
 import {
+  runDrawingConsistencyChecks,
   validateTechnicalPanelAuthority,
   validateTechnicalPanelContract,
   validateVisualPanelLocks,
@@ -5515,6 +5516,21 @@ function extractSvgBody(svgString = "") {
   return bodyMatch ? bodyMatch[1] : sanitized;
 }
 
+function extractSvgRootDataAttributes(svgString = "") {
+  const rootMatch = String(svgString || "").match(/<svg\b([^>]*)>/i);
+  if (!rootMatch?.[1]) return "";
+  const attrs = [];
+  const attrPattern = /\s(data-[a-zA-Z0-9:_-]+)=("([^"]*)"|'([^']*)')/g;
+  let match;
+  while ((match = attrPattern.exec(rootMatch[1])) !== null) {
+    const name = match[1];
+    if (name === "data-inlined-panel") continue;
+    const value = match[3] ?? match[4] ?? "";
+    attrs.push(`${name}="${escapeXml(value)}"`);
+  }
+  return [...new Set(attrs)].join(" ");
+}
+
 function extractSvgViewBox(
   svgString = "",
   fallbackWidth = 1000,
@@ -5795,6 +5811,179 @@ function buildMainEntryArrowSvg(site, bbox) {
   </g>`;
 }
 
+function normalizeSiteZonePolygon(zone = {}) {
+  if (Array.isArray(zone?.polygon) && zone.polygon.length >= 3) {
+    return zone.polygon;
+  }
+  if (Array.isArray(zone?.points) && zone.points.length >= 3) {
+    return zone.points;
+  }
+  const rect =
+    zone?.bbox ||
+    zone?.bounds ||
+    (Number.isFinite(Number(zone?.x)) &&
+    Number.isFinite(Number(zone?.y)) &&
+    Number.isFinite(Number(zone?.width)) &&
+    Number.isFinite(Number(zone?.height))
+      ? zone
+      : null);
+  if (rect) {
+    const x = Number(rect.x ?? rect.min_x ?? rect.minX ?? 0);
+    const y = Number(rect.y ?? rect.min_y ?? rect.minY ?? 0);
+    const width = Number(rect.width ?? Number(rect.max_x ?? rect.maxX) - x);
+    const height = Number(rect.height ?? Number(rect.max_y ?? rect.maxY) - y);
+    if (width > 0 && height > 0) {
+      return rectangleToPolygon(x, y, width, height);
+    }
+  }
+  return [];
+}
+
+function deriveSiteZones(site = {}, bbox = {}) {
+  const explicit = Array.isArray(site?.zones)
+    ? site.zones
+    : Array.isArray(site?.site_zones)
+      ? site.site_zones
+      : [];
+  const normalizedExplicit = explicit
+    .map((zone) => ({
+      type: String(zone.type || zone.name || zone.role || "zone")
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, "_"),
+      label: String(zone.label || zone.name || zone.type || "Zone").trim(),
+      polygon: normalizeSiteZonePolygon(zone),
+    }))
+    .filter((zone) => zone.type && zone.polygon.length >= 3);
+  if (normalizedExplicit.length) return normalizedExplicit;
+
+  const minX = Number(bbox.min_x || 0);
+  const minY = Number(bbox.min_y || 0);
+  const width = Math.max(1, Number(bbox.width || 24));
+  const height = Math.max(1, Number(bbox.height || 16));
+  return [
+    {
+      type: "lawn",
+      label: "Lawn",
+      polygon: rectangleToPolygon(
+        minX + width * 0.1,
+        minY + height * 0.08,
+        width * 0.8,
+        height * 0.38,
+      ),
+    },
+    {
+      type: "patio",
+      label: "Patio",
+      polygon: rectangleToPolygon(
+        minX + width * 0.24,
+        minY + height * 0.5,
+        width * 0.52,
+        height * 0.16,
+      ),
+    },
+    {
+      type: "drive",
+      label: "Drive",
+      polygon: rectangleToPolygon(
+        minX + width * 0.08,
+        minY + height * 0.68,
+        width * 0.28,
+        height * 0.24,
+      ),
+    },
+    {
+      type: "planting",
+      label: "Planting",
+      polygon: rectangleToPolygon(
+        minX + width * 0.78,
+        minY + height * 0.18,
+        width * 0.12,
+        height * 0.64,
+      ),
+    },
+  ];
+}
+
+function renderSiteZoneHatches(site = {}, bbox = {}) {
+  const zones = deriveSiteZones(site, bbox);
+  const palette = {
+    lawn: { fill: "#8fbf7a", stroke: "#3f7d37", pattern: "site-zone-lawn" },
+    patio: { fill: "#d8d1c3", stroke: "#786f62", pattern: "site-zone-patio" },
+    drive: { fill: "#c8c8c8", stroke: "#616161", pattern: "site-zone-drive" },
+    planting: {
+      fill: "#b8d49c",
+      stroke: "#5f7f43",
+      pattern: "site-zone-planting",
+    },
+  };
+  const zoneSvg = zones
+    .map((zone) => {
+      const style = palette[zone.type] || palette.lawn;
+      const path = polygonPath(zone.polygon, bbox, 812, 646);
+      if (!path) return "";
+      return `<path d="${path}" data-site-zone-fill="${escapeXml(zone.type)}" fill="url(#${style.pattern})" fill-opacity="0.68" stroke="${style.stroke}" stroke-width="1.8"/>`;
+    })
+    .join("\n    ");
+  const legendRows = zones.slice(0, 6).map((zone, index) => {
+    const style = palette[zone.type] || palette.lawn;
+    const y = 36 + index * 24;
+    return `<g data-site-zone-legend-item="${escapeXml(zone.type)}">
+      <rect x="18" y="${y - 12}" width="18" height="12" fill="url(#${style.pattern})" stroke="${style.stroke}" stroke-width="1"/>
+      <text x="44" y="${y - 2}" font-family="Arial, sans-serif" font-size="13" fill="#222222">${escapeXml(zone.label.toUpperCase())}</text>
+    </g>`;
+  });
+  return {
+    markup: zoneSvg ? `<g data-site-zones="true">${zoneSvg}</g>` : "",
+    legend: `<g data-site-plan-legend="true" transform="translate(642 564)">
+      <rect x="0" y="0" width="202" height="${Math.max(44, 24 + legendRows.length * 24)}" fill="#ffffff" fill-opacity="0.92" stroke="#111111" stroke-width="1.4"/>
+      <text x="18" y="20" font-family="Arial, sans-serif" font-size="14" font-weight="700" fill="#111111">KEY</text>
+      ${legendRows.join("\n      ")}
+    </g>`,
+    zones,
+  };
+}
+
+function resolveStreetLabel(site = {}) {
+  const explicit = site?.streetName || site?.street_name || site?.street;
+  if (explicit) return String(explicit).trim();
+  const address = String(
+    site?.address_normalised || site?.address || site?.site_address || "",
+  );
+  const firstLine = address.split(",")[0] || "";
+  const roadMatch = firstLine.match(
+    /(?:\d+\s*)?([A-Za-z0-9 .'/-]+(?:Street|St|Road|Rd|Avenue|Ave|Lane|Ln|Drive|Dr|Close|Way|Terrace|Place|Court))/i,
+  );
+  return String(roadMatch?.[1] || firstLine || "Street frontage")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function hasValidLocalPolygon(points = []) {
+  return (
+    Array.isArray(points) &&
+    points.length >= 3 &&
+    computePolygonArea(points) > 0
+  );
+}
+
+function hasExplicitManualBoundaryPolygon(site = {}) {
+  const candidates = [
+    site?.manualVerifiedBoundary,
+    site?.manual_verified_boundary,
+    site?.userEditedBoundary,
+    site?.user_edited_boundary,
+  ];
+  return candidates.some((candidate) => {
+    const polygon =
+      candidate?.polygon ||
+      candidate?.sitePolygon ||
+      candidate?.siteBoundary ||
+      (Array.isArray(candidate) ? candidate : null);
+    return Array.isArray(polygon) && polygon.length >= 3;
+  });
+}
+
 function buildSiteContextPanelArtifact({
   projectGraphId,
   site,
@@ -5816,13 +6005,14 @@ function buildSiteContextPanelArtifact({
     Math.max(8, Number(buildableBbox.height || 0) * 0.36),
   );
   const proposedFootprintPath = polygonPath(proposedFootprint, bbox, 812, 646);
+  const hasValidBoundaryPolygon = hasValidLocalPolygon(
+    site.local_boundary_polygon || [],
+  );
   const manualVerifiedBoundary =
-    site?.boundary_source === "manual_verified" ||
-    site?.boundarySource === "manual_verified" ||
-    Boolean(site?.manualVerifiedBoundary) ||
-    Boolean(site?.manual_verified_boundary) ||
-    Boolean(site?.userEditedBoundary) ||
-    Boolean(site?.user_edited_boundary);
+    hasValidBoundaryPolygon &&
+    (hasExplicitManualBoundaryPolygon(site) ||
+      site?.boundary_source === "manual_verified" ||
+      site?.boundarySource === "manual_verified");
   const boundaryEstimated =
     !manualVerifiedBoundary &&
     (site?.boundary_authoritative === false ||
@@ -5871,17 +6061,26 @@ function buildSiteContextPanelArtifact({
     .join("\n  ")}
 </g>`
     : "";
+  const siteZones = renderSiteZoneHatches(site, bbox);
+  const streetLabel = resolveStreetLabel({
+    ...site,
+    address: siteAddress,
+  });
+  const streetLabelSvg = `<g data-site-street-label="true">
+  <rect x="46" y="650" width="${Math.min(330, Math.max(138, streetLabel.length * 11 + 28))}" height="30" fill="#ffffff" fill-opacity="0.9" stroke="#b8b8b8" stroke-width="1"/>
+  <text x="62" y="671" font-family="Arial, sans-serif" font-size="17" font-weight="700" fill="#333333">${escapeXml(streetLabel.toUpperCase())}</text>
+</g>`;
+  const boundaryCaption = `<text x="48" y="856" font-family="Arial, sans-serif" font-size="11" fill="${boundaryEstimated ? "#8a4b00" : "#555555"}">${escapeXml(boundaryLabel)}${boundaryEstimated ? " - Boundary estimated; verify with measured survey." : ""}</text>`;
   const mapLayer = boundaryEstimated
     ? hasMapImage
       ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice"/>
   <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
   <g transform="translate(44 66)">
+    ${siteZones.markup}
     <path d="${sitePath}" fill="#b7d7a833" stroke="#e87524" stroke-width="4" stroke-dasharray="16 10"/>
     <path d="${buildablePath}" fill="none" stroke="#111111" stroke-width="3" stroke-dasharray="8 8"/>
     <path d="${proposedFootprintPath}" fill="#11111133" stroke="#111111" stroke-width="4"/>
-  </g>
-  <text x="450" y="104" font-family="Arial, sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#111111">${boundaryLabel}</text>
-  <text x="450" y="136" font-family="Arial, sans-serif" font-size="16" text-anchor="middle" fill="#555555">Boundary estimated - verify with measured survey before planning submission</text>`
+  </g>`
       : `<rect x="28" y="52" width="844" height="676" fill="#f7f6f0"/>
   <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
   <path d="M 78 636 C 186 586 272 612 354 562 C 456 500 584 520 824 462" fill="none" stroke="#d7d7d7" stroke-width="34" opacity="0.8"/>
@@ -5889,16 +6088,16 @@ function buildSiteContextPanelArtifact({
   <path d="M 112 142 L 196 186 L 282 152 L 372 206 L 470 166 L 590 222 L 770 190" fill="none" stroke="#c7cfbf" stroke-width="14" opacity="0.7"/>
   <path d="M 130 506 L 246 452 L 372 474 L 520 424 L 712 444" fill="none" stroke="#c7cfbf" stroke-width="12" opacity="0.6"/>
   <g transform="translate(44 66)">
+    ${siteZones.markup}
     <path d="${sitePath}" fill="#fff7ed" stroke="#e87524" stroke-width="4" stroke-dasharray="16 10"/>
     <path d="${buildablePath}" fill="none" stroke="#29332a" stroke-width="3" stroke-dasharray="8 8"/>
     <path d="${proposedFootprintPath}" fill="#11111122" stroke="#111111" stroke-width="4"/>
-  </g>
-  <text x="450" y="104" font-family="Arial, sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#111111">${boundaryLabel}</text>
-  <text x="450" y="136" font-family="Arial, sans-serif" font-size="16" text-anchor="middle" fill="#555555">Boundary estimated - verify with measured survey before planning submission</text>`
+  </g>`
     : hasMapImage
       ? `<image x="28" y="52" width="844" height="676" href="${escapeXml(siteSnapshot.dataUrl)}" preserveAspectRatio="xMidYMid slice"/>
   <rect x="28" y="52" width="844" height="676" fill="none" stroke="#111111" stroke-width="3"/>
   <g transform="translate(44 66)" opacity="0.88">
+    ${siteZones.markup}
     <path d="${sitePath}" fill="#1976D222" stroke="#1976D2" stroke-width="5"/>
     <path d="${buildablePath}" fill="none" stroke="#111111" stroke-width="3"/>
     <path d="${proposedFootprintPath}" fill="#11111133" stroke="#111111" stroke-width="4"/>
@@ -5906,6 +6105,7 @@ function buildSiteContextPanelArtifact({
   <text x="450" y="104" font-family="Arial, sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#111111">${boundaryLabel}</text>`
       : `<rect x="28" y="52" width="844" height="676" fill="#f3efe4" stroke="#111111" stroke-width="3"/>
   <g transform="translate(44 66)">
+    ${siteZones.markup}
     <path d="${sitePath}" fill="#1976D222" stroke="#1976D2" stroke-width="5"/>
     <path d="${buildablePath}" fill="none" stroke="#111111" stroke-width="3"/>
     <path d="${proposedFootprintPath}" fill="#11111133" stroke="#111111" stroke-width="4"/>
@@ -5921,6 +6121,23 @@ function buildSiteContextPanelArtifact({
     <marker id="main-entry-arrowhead" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
       <path d="M 0 0 L 12 6 L 0 12 z" fill="#1976D2"/>
     </marker>
+    <pattern id="site-zone-lawn" width="12" height="12" patternUnits="userSpaceOnUse">
+      <rect width="12" height="12" fill="#8fbf7a"/>
+      <path d="M 0 10 Q 3 5 6 10 T 12 10" fill="none" stroke="#3f7d37" stroke-width="0.9"/>
+    </pattern>
+    <pattern id="site-zone-patio" width="16" height="16" patternUnits="userSpaceOnUse">
+      <rect width="16" height="16" fill="#d8d1c3"/>
+      <path d="M 0 0 H 16 M 0 8 H 16 M 8 0 V 8 M 0 8 V 16 M 16 8 V 16" stroke="#786f62" stroke-width="0.8"/>
+    </pattern>
+    <pattern id="site-zone-drive" width="10" height="10" patternUnits="userSpaceOnUse">
+      <rect width="10" height="10" fill="#c8c8c8"/>
+      <path d="M 0 10 L 10 0" stroke="#616161" stroke-width="0.7"/>
+    </pattern>
+    <pattern id="site-zone-planting" width="12" height="12" patternUnits="userSpaceOnUse">
+      <rect width="12" height="12" fill="#b8d49c"/>
+      <circle cx="3" cy="3" r="1.4" fill="#5f7f43"/>
+      <circle cx="9" cy="7" r="1.4" fill="#5f7f43"/>
+    </pattern>
   </defs>
   <rect width="${width}" height="${height}" fill="#ffffff"/>
   ${mapLayer}
@@ -5930,8 +6147,9 @@ function buildSiteContextPanelArtifact({
   <text x="806" y="58" font-family="Arial, sans-serif" font-size="32" font-weight="700" text-anchor="middle" fill="#111111">N</text>
   <text x="450" y="342" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333333">${boundaryEstimated ? "Proposed Footprint" : "Rear Garden"}</text>
   <text x="450" y="682" font-family="Arial, sans-serif" font-size="24" text-anchor="middle" fill="#333333">${boundaryEstimated ? "Estimated Boundary" : "Front Garden"}</text>
-  <text x="82" y="690" font-family="Arial, sans-serif" font-size="20" fill="#333333">${boundaryEstimated ? "Context Street" : "Driveway"}</text>
+  ${streetLabelSvg}
   ${siteAddressSvg}
+  ${siteZones.legend}
   <line x1="48" y1="790" x2="348" y2="790" stroke="#111111" stroke-width="5"/>
   <line x1="48" y1="780" x2="48" y2="800" stroke="#111111" stroke-width="3"/>
   <line x1="168" y1="780" x2="168" y2="800" stroke="#111111" stroke-width="3"/>
@@ -5940,6 +6158,7 @@ function buildSiteContextPanelArtifact({
   <text x="158" y="824" font-family="Arial, sans-serif" font-size="18" fill="#111111">10</text>
   <text x="278" y="824" font-family="Arial, sans-serif" font-size="18" fill="#111111">20m</text>
   <text x="48" y="860" font-family="Arial, sans-serif" font-size="17" fill="#333333">Scale 1:500</text>
+  ${boundaryCaption}
   <text x="852" y="824" font-family="Arial, sans-serif" font-size="15" text-anchor="end" fill="#555555">${escapeXml(mapLabel)}</text>
   <text x="852" y="852" font-family="Arial, sans-serif" font-size="13" text-anchor="end" fill="#777777">${escapeXml(attribution)}</text>
   <text x="852" y="878" font-family="Arial, sans-serif" font-size="13" text-anchor="end" fill="#777777">${escapeXml(areaLabel)} | ${escapeXml(geometryHash.slice(0, 12))}</text>
@@ -5980,6 +6199,8 @@ function buildSiteContextPanelArtifact({
         : site.boundary_source || null,
       siteAddress: siteAddress || null,
       boundaryLabel,
+      siteZones: siteZones.zones.map((zone) => zone.type),
+      streetLabel,
       boundaryWarningCode: boundaryEstimated
         ? site.boundary_warning_code || null
         : null,
@@ -6880,13 +7101,66 @@ function resolveProgrammeDisplayLabel(brief = {}) {
   return String(
     brief?.project_type_support?.label ||
       brief?.projectTypeSupport?.label ||
+      brief?.programme ||
       brief?.programme_label ||
       brief?.programmeLabel ||
+      brief?.property_type ||
+      brief?.propertyType ||
       brief?.building_type ||
+      brief?.buildingType ||
       "architecture",
   )
     .replace(/[_-]+/g, " ")
     .trim();
+}
+
+function resolveBriefAddress(brief = {}) {
+  return String(
+    brief?.site_input?.address ||
+      brief?.siteInput?.address ||
+      brief?.address ||
+      brief?.siteAddress ||
+      "",
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function resolveProjectTitle(brief = {}) {
+  const address = resolveBriefAddress(brief);
+  const title = String(
+    brief?.project_name ||
+      brief?.projectName ||
+      brief?.programme ||
+      brief?.programme_label ||
+      brief?.programmeLabel ||
+      address ||
+      "Untitled",
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+  return title || "Untitled";
+}
+
+function resolveSheetSubtitle(brief = {}) {
+  const parts = [
+    brief?.programme ||
+      brief?.programme_label ||
+      brief?.programmeLabel ||
+      brief?.property_type ||
+      brief?.propertyType ||
+      brief?.building_type ||
+      brief?.buildingType,
+    resolveBriefAddress(brief),
+  ]
+    .map((entry) =>
+      String(entry || "")
+        .replace(/[_-]+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim(),
+    )
+    .filter(Boolean);
+  return [...new Set(parts)].join(" / ");
 }
 
 export function buildTitleBlockPanelArtifact({
@@ -6900,13 +7174,13 @@ export function buildTitleBlockPanelArtifact({
   const width = 620;
   const height = 900;
   const location =
-    brief?.site_input?.address ||
+    resolveBriefAddress(brief) ||
     brief?.site_input?.postcode ||
     sheetDesignContext?.region ||
     "Project site";
   const drawingNumber = sheetPlan?.sheet_number || "A1-00";
   const sheetLabel = sheetPlan?.label || "RIBA Stage 2 Master";
-  const projectTitle = String(brief?.project_name || "ArchiAI Project")
+  const projectTitle = resolveProjectTitle(brief)
     .replace(/\s+/g, " ")
     .trim()
     .toUpperCase();
@@ -6945,16 +7219,17 @@ export function buildTitleBlockPanelArtifact({
   // working). The new rows surface RIBA Stage / Status / Revision / Date /
   // Drawing No. so reviewers get the full set on the sheet.
   const rows = [
-    ["Project", brief?.project_name || "ArchiAI Project"],
+    ["Project", resolveProjectTitle(brief)],
+    ["Scale", sheetPlan?.scale || "As noted"],
+    ["Status", status],
+    ["Date", dateLabel],
+    ["Drawing No.", drawingNumber],
+    ["Rev", revision],
     ["Location", location],
     ["Programme", programmeLabel],
     ["Target GIA", `${round(brief?.target_gia_m2 || 0, 1)} m²`],
     ["Storeys", `${brief?.target_storeys || 1}`],
     ["RIBA Stage", ribaStageLabel],
-    ["Status", status],
-    ["Revision", revision],
-    ["Date", dateLabel],
-    ["Drawing No.", drawingNumber],
   ];
   const rowStartY = 232;
   const rowGap = 50;
@@ -6990,7 +7265,7 @@ export function buildTitleBlockPanelArtifact({
         `<text x="34" y="${724 + index * 18}" font-family="Arial, sans-serif" font-size="12" fill="#555555">${escapeXml(line)}</text>`,
     )
     .join("\n  ");
-  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="title_block" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-brief-input-hash="${escapeXml(brief?.brief_input_hash || "")}">
+  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="title_block" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-brief-input-hash="${escapeXml(brief?.brief_input_hash || "")}" data-title-block-grid="project-scale-status-date-drawing-rev">
   <rect width="${width}" height="${height}" fill="#ffffff"/>
   <rect x="18" y="18" width="584" height="864" fill="none" stroke="#111111" stroke-width="3"/>
   ${titleSvg}
@@ -8110,6 +8385,9 @@ export function resolvePresentationLayoutTemplate(brief = {}) {
     brief?.buildingType ||
     brief?.building_category ||
     brief?.buildingCategory ||
+    brief?.programme ||
+    brief?.property_type ||
+    brief?.propertyType ||
     null;
   return isResidentialBuildingType(buildingType)
     ? "presentation-v3"
@@ -8879,8 +9157,8 @@ function applyUpstreamGateTechnicalBlockersToQa(qa, exportGate) {
 // padded normalizedViewBox so legends and decorative space stay visible.
 // board-v2 is unaffected — it always returns the existing viewBox chain.
 // Phase B closeout v2: shrink the safety padding so technical drawings
-// fill more of the slot. Bumped from 4-6% to 1.5-2.5%; elevations now use
-// the same 1.5% tight bounds policy as plans so right-column elevations
+// fill more of the slot. Bumped from 4-6% to 1.5-2.5%; elevations use
+// 2.5% tight bounds in sheet mode so right-column elevations
 // do not sit as small drawings inside oversized source viewBoxes. contentBounds
 // already excludes the ink-free background rect, and the slot inner is
 // further padded by CAPTION_HORIZONTAL_PADDING_MM, so room labels and
@@ -8896,10 +9174,10 @@ const PRESENTATION_V3_PANEL_PADDING = {
   floor_plan_level7: 0.015,
   section_AA: 0.02,
   section_BB: 0.02,
-  elevation_north: 0.015,
-  elevation_south: 0.015,
-  elevation_east: 0.015,
-  elevation_west: 0.015,
+  elevation_north: 0.025,
+  elevation_south: 0.025,
+  elevation_east: 0.025,
+  elevation_west: 0.025,
 };
 
 function clampNumber(value, minimum, maximum) {
@@ -9125,6 +9403,17 @@ function artifactMetadataValue(artifact = null, key) {
   return null;
 }
 
+function isA1ProvenanceFooterEnabled() {
+  const raw =
+    typeof process !== "undefined"
+      ? process.env?.A1_SHOW_PROVENANCE_FOOTER
+      : null;
+  const normalized = String(raw || "")
+    .trim()
+    .toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 function panelKindForSheet(panelType = "") {
   if (REQUIRED_3D_A1_PANEL_TYPES.includes(panelType)) return "visual";
   if (
@@ -9180,6 +9469,9 @@ function renderSheetPanel({
   const contentHeight =
     placement.height - caption.contentTopOffset - caption.contentBottomPadding;
   const svgBody = extractSvgBody(artifact?.svgString || "");
+  const rootDataAttributes = extractSvgRootDataAttributes(
+    artifact?.svgString || "",
+  );
   const viewBox = selectPanelContentViewBox({
     panelType: placement.panelType,
     artifact,
@@ -9187,7 +9479,7 @@ function renderSheetPanel({
   });
   const content =
     placement.status === "ready"
-      ? `<svg x="${contentX}" y="${contentY}" width="${contentWidth}" height="${contentHeight}" viewBox="${escapeXml(viewBox)}" preserveAspectRatio="xMidYMid meet" overflow="hidden" data-inlined-panel="true" data-fit-mode="object-contain">${svgBody}</svg>`
+      ? `<svg x="${contentX}" y="${contentY}" width="${contentWidth}" height="${contentHeight}" viewBox="${escapeXml(viewBox)}" preserveAspectRatio="xMidYMid meet" overflow="hidden" data-inlined-panel="true" data-fit-mode="object-contain"${rootDataAttributes ? ` ${rootDataAttributes}` : ""}>${svgBody}</svg>`
       : `<g data-panel-missing="true"><rect x="${contentX}" y="${contentY}" width="${contentWidth}" height="${contentHeight}" fill="#fff3f0" stroke="#a43f2a" stroke-dasharray="4 3"/><text x="${contentX + 8}" y="${contentY + 22}" font-size="7" fill="#a43f2a">Missing source panel</text></g>`;
   const panelKind = panelKindForSheet(placement.panelType);
   const visualBadge = buildVisualPanelStatusBadge(artifact);
@@ -9224,6 +9516,7 @@ function renderSheetPanel({
   <defs><clipPath id="${panelClipId}"><rect x="${placement.x}" y="${placement.y}" width="${placement.width}" height="${placement.height}"/></clipPath></defs>
   <rect x="${placement.x}" y="${placement.y}" width="${placement.width}" height="${placement.height}" rx="0.4" fill="#ffffff" stroke="#111111" stroke-width="0.45"/>
   <text x="${placement.x + caption.titleX}" y="${placement.y + caption.titleY}" font-size="${CAPTION_TITLE_FONT_SIZE}" font-family="${EMBEDDED_FONT_STACK}" font-weight="700" fill="#111111">${titleText}</text>
+  <line data-panel-header-rule="true" x1="${placement.x + CAPTION_HORIZONTAL_PADDING_MM}" y1="${placement.y + (caption.layout === "stacked" ? 12.3 : 8.2)}" x2="${placement.x + placement.width - CAPTION_HORIZONTAL_PADDING_MM}" y2="${placement.y + (caption.layout === "stacked" ? 12.3 : 8.2)}" stroke="#111111" stroke-width="0.18"/>
   ${
     scaleText
       ? `<text x="${placement.x + caption.scaleX}" y="${placement.y + caption.scaleY}" font-size="${caption.scaleFontSize}" font-family="${EMBEDDED_FONT_STACK}" text-anchor="end" fill="#444444">${scaleText}</text>`
@@ -9272,6 +9565,74 @@ function buildSheetProvenanceFooter({
 </g>`;
 }
 
+function buildSheetTitleBar({ brief, sheetNumber, sheetLabel } = {}) {
+  const title = resolveProjectTitle(brief).toUpperCase();
+  const subtitle = resolveSheetSubtitle(brief) || sheetLabel || "";
+  const logoDataUrl = brief?.brand?.logoDataUrl || brief?.brand?.logo_data_url;
+  const logo = logoDataUrl
+    ? `<image x="682" y="6.05" width="148" height="3.35" href="${escapeXml(logoDataUrl)}" preserveAspectRatio="xMaxYMid meet"/>`
+    : `<text x="830" y="8.9" font-size="2.65" font-family="${EMBEDDED_FONT_STACK}" font-weight="700" text-anchor="end" fill="#ffffff">ARCHITECTURE AI PLATFORM</text>`;
+  return `<g data-sheet-title-bar="true" data-sheet-project-title="${escapeXml(title)}" data-sheet-subtitle="${escapeXml(subtitle)}">
+  <rect x="5" y="0" width="831" height="10" fill="#111111"/>
+  <text x="10" y="8.85" font-size="3.25" font-family="${EMBEDDED_FONT_STACK}" font-weight="700" fill="#ffffff">${escapeXml(title)}</text>
+  <text x="300" y="8.72" font-size="2.35" font-family="${EMBEDDED_FONT_STACK}" fill="#e7e7e7">${escapeXml(subtitle)}</text>
+  <text x="648" y="8.72" font-size="2.35" font-family="${EMBEDDED_FONT_STACK}" text-anchor="end" fill="#e7e7e7">${escapeXml(sheetNumber || "")}</text>
+  ${logo}
+</g>`;
+}
+
+function mapTechnicalPanelToDrawingEntry(artifact = {}) {
+  const panelType = artifact.panel_type || artifact.panelType || "";
+  return {
+    ...artifact,
+    panel_type: panelType,
+    panelType,
+    svg: artifact.svgString || artifact.svg || "",
+    technicalQualityMetadata:
+      artifact.technicalQualityMetadata ||
+      artifact.metadata?.technicalQualityMetadata ||
+      artifact.metadata?.technical_quality_metadata ||
+      {},
+  };
+}
+
+function collectSheetQaWarnings({ panelArtifacts, compiledProject } = {}) {
+  const panels = normalizeArtifactCollection(panelArtifacts);
+  const drawings = {
+    plan: panels
+      .filter((artifact) =>
+        String(artifact.panel_type || artifact.panelType || "").startsWith(
+          "floor_plan_",
+        ),
+      )
+      .map(mapTechnicalPanelToDrawingEntry),
+    elevation: panels
+      .filter((artifact) =>
+        String(artifact.panel_type || artifact.panelType || "").startsWith(
+          "elevation_",
+        ),
+      )
+      .map(mapTechnicalPanelToDrawingEntry),
+    section: panels
+      .filter((artifact) =>
+        String(artifact.panel_type || artifact.panelType || "").startsWith(
+          "section_",
+        ),
+      )
+      .map(mapTechnicalPanelToDrawingEntry),
+  };
+  try {
+    const result = runDrawingConsistencyChecks({
+      projectGeometry: compiledProject || {},
+      drawings,
+      enableCrossViewChecks: true,
+    });
+    return [...new Set((result.warnings || []).filter(Boolean))];
+  } catch {
+    return [];
+  }
+}
+
 function buildSheetSvg({
   projectGraphId,
   brief,
@@ -9297,16 +9658,20 @@ function buildSheetSvg({
   const sourcePanelAssetIds = panelPlacements
     .map((placement) => placement.sourcePanelAssetId)
     .filter(Boolean);
-  const provenanceFooter = buildSheetProvenanceFooter({
-    geometryHash,
-    visualManifest,
-    panelArtifacts,
-  });
+  const provenanceFooter = isA1ProvenanceFooterEnabled()
+    ? buildSheetProvenanceFooter({
+        geometryHash,
+        visualManifest,
+        panelArtifacts,
+      })
+    : "";
+  const titleBar = buildSheetTitleBar({ brief, sheetNumber, sheetLabel });
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${A1_SHEET_SIZE_MM.width}mm" height="${A1_SHEET_SIZE_MM.height}mm" viewBox="0 0 ${A1_SHEET_SIZE_MM.width} ${A1_SHEET_SIZE_MM.height}" data-layout-version="${A1_SHEET_LAYOUT_VERSION}" data-layout-template="${escapeXml(layoutTemplate)}" data-placeholder-only="false" data-reference-match="${brief?.reference_match === true ? "true" : "false"}" data-brief-input-hash="${escapeXml(brief?.brief_input_hash || "")}" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-visual-manifest-hash="${escapeXml(visualManifest?.manifestHash || "")}" data-sheet-number="${escapeXml(sheetNumber)}" data-sheet-label="${escapeXml(sheetLabel)}" data-qa-status="${escapeXml(qaStatus || "pending")}" data-export-source="sheetArtifact.svgString">
   <rect width="${A1_SHEET_SIZE_MM.width}" height="${A1_SHEET_SIZE_MM.height}" fill="#ffffff"/>
   <rect x="5" y="5" width="831" height="584" fill="none" stroke="#111111" stroke-width="0.7"/>
   <desc>Reference board A1 package for ${escapeXml(brief.project_name)}. Panels ${sourcePanelAssetIds.length}. Geometry hash ${escapeXml(geometryHash)}.</desc>
+  ${titleBar}
   ${panelGroups}
   ${provenanceFooter}
 </svg>`;
@@ -9511,6 +9876,10 @@ async function buildA1Sheet({
     );
   }
   const presentationSummary = summarizePresentationMode(panelArtifacts);
+  const qaWarnings = collectSheetQaWarnings({
+    panelArtifacts,
+    compiledProject,
+  });
   const svgHash = computeCDSHashSync({ svg: svgString });
   const sheetAssetId = createStableId("asset-a1-svg", sheetId, svgHash);
   const requiredPlacementTypes = buildRequiredA1PanelTypes(
@@ -9599,6 +9968,7 @@ async function buildA1Sheet({
       visualPanelsRenderMode: presentationSummary.visualPanelsRenderMode,
       visualPanelsFallbackReasons:
         presentationSummary.visualPanelsFallbackReasons,
+      qa_warnings: qaWarnings,
       metadata: {
         textRenderStatus,
         referenceMatch: brief?.reference_match === true,
@@ -9611,6 +9981,7 @@ async function buildA1Sheet({
           presentationSummary.visualPanelsFallbackReasons,
         presentationFallbackPanels: presentationSummary.fallbackPanels,
         presentationRenderedPanels: presentationSummary.renderedPanels,
+        qa_warnings: qaWarnings,
       },
     },
     sheetPanelArtifacts: supplementalPanelArtifacts,


### PR DESCRIPTION
## Summary

Improves the ProjectGraph A1 sheet presentation quality after the authority/contract work from PR #97 and PR #100.

## Changes

- Selects `presentation-v3` for terraced-house residential briefs.
- Gates the provenance/debug footer behind `A1_SHOW_PROVENANCE_FOOTER`, default off.
- Preserves root SVG QA attributes and surfaces `qa_warnings` in sheet metadata.
- Adds a top title bar using real brief/project/address data.
- Improves title block rows and panel header rules.
- Improves plan labels, dimensions, furniture hints, scale bars, and section markers.
- Adds section foundation datum, foundation hatch, roof framing, and datum metadata.
- Caps broad section poche opacity so labels remain legible while preserving cut-wall hierarchy.
- Tightens elevation sheet-mode fitting, ground/datum lines, hatches, and dimensions.
- Adds site zones, derived zones, legend, street label, and smaller estimated-boundary warning.
- Adds terraced-house A1 visual contract coverage.

## Validation

- Focused renderer/composer tests: 38 passed
- `npm run check:env`
- `npm run check:contracts`
- `npm run test:compose:routing`
- `npm run lint`
- `npm run build:active`
- `git diff --check` clean except normal Windows CRLF warnings

## Fresh Scunthorpe export

Generated:

- `output/pdf/scunthorpe-a1-technical-sheet-chrome.pdf`
- `output/pdf/scunthorpe-a1-technical-sheet-chrome.svg`
- `output/pdf/scunthorpe-a1-technical-sheet-chrome-page-1.png`

Metadata:

- `success: true`
- `qaStatus: pass`
- `layoutTemplate: presentation-v3`
- `provenanceFooterVisible: false`
- `titleBarVisible: true`

## Pre-merge visual smoke

Still required before marking ready/merge:

- [ ] `hero_3d` reaches `/v1/images/edits`
- [ ] `exterior_render` reaches `/v1/images/edits`
- [ ] `axonometric` reaches `/v1/images/edits`
- [ ] `interior_3d` reaches `/v1/images/edits`
- [ ] `imageRenderFallback=false`
- [ ] `layoutTemplate=presentation-v3`
- [ ] `provenanceFooterVisible=false`
- [ ] `titleBarVisible=true`
- [ ] A1 PDF and SVG export

## Known limitations

- Site panel is schematic when the export process has no Google Maps snapshot.
- Visual panels in this deterministic smoke are fallback because image generation was command-scoped disabled.
- Some small utility/circulation room labels remain dense.