### PR TITLE
Polish A1 sheet titles and drawing readability

### DIFF
--- a/src/__tests__/services/a1SheetVisualContract.test.js
+++ b/src/__tests__/services/a1SheetVisualContract.test.js
@@ -231,6 +231,7 @@ test("terraced-house A1 sheet carries the visual contract chrome and technical S
 
   try {
     const brief = {
+      project_name: "ARCHIAI PROJECT",
       programme: "Terraced House",
       property_type: "terraced-house",
       site_input: { address: "17 Kensington Road, Scunthorpe DN15 8BQ" },
@@ -349,6 +350,9 @@ test("terraced-house A1 sheet carries the visual contract chrome and technical S
 
     expect(svg).toContain('data-layout-template="presentation-v3"');
     expect(svg).toContain('data-sheet-title-bar="true"');
+    expect(svg).toContain(
+      'data-sheet-project-title="TERRACED HOUSE — 17 KENSINGTON ROAD, SCUNTHORPE"',
+    );
     expect(svg).not.toContain('data-provenance-footer="true"');
     expect(
       (svg.match(/cad-dimension-chain/g) || []).length,
@@ -374,7 +378,7 @@ test("terraced-house A1 sheet carries the visual contract chrome and technical S
   }
 });
 
-test("section wall detail caps broad interior poche opacity while preserving cut-wall hierarchy", () => {
+test("section wall detail keeps broad interior poche label-readable while preserving cut-wall hierarchy", () => {
   const { markup } = buildSectionWallDetailMarkup({
     walls: [
       {
@@ -406,15 +410,17 @@ test("section wall detail caps broad interior poche opacity while preserving cut
   });
 
   const backgroundMatch = markup.match(
-    /id="phase13-section-cut-wall-broad-upper-room-zone"[\s\S]*?data-poche-zone="interior-background" data-poche-opacity="([^"]+)"/,
+    /id="phase13-section-cut-wall-broad-upper-room-zone"[\s\S]*?data-poche-zone="interior-background" data-poche-fill-role="label-readable-background" data-poche-opacity="([^"]+)" fill="([^"]+)"/,
   );
   const cutWallMatch = markup.match(
-    /id="phase13-section-cut-wall-thin-cut-wall"[\s\S]*?data-poche-zone="cut-wall" data-poche-opacity="([^"]+)"/,
+    /id="phase13-section-cut-wall-thin-cut-wall"[\s\S]*?data-poche-zone="cut-wall" data-poche-fill-role="section-cut" data-poche-opacity="([^"]+)" fill="([^"]+)"/,
   );
 
   expect(backgroundMatch).toBeTruthy();
-  expect(Number(backgroundMatch[1])).toBeLessThanOrEqual(0.38);
+  expect(Number(backgroundMatch[1])).toBeGreaterThanOrEqual(0.85);
+  expect(backgroundMatch[2]).toBe("#f4f5f6");
   expect(cutWallMatch).toBeTruthy();
   expect(Number(cutWallMatch[1])).toBeGreaterThan(0.7);
+  expect(cutWallMatch[2]).toBe("#151515");
   expect(markup).toContain('stroke="#111"');
 });

--- a/src/services/drawing/sectionWallDetailService.js
+++ b/src/services/drawing/sectionWallDetailService.js
@@ -36,6 +36,9 @@ function isInteriorBackgroundPocheZone(wall = {}) {
   return width >= 56 && height >= 72;
 }
 
+const INTERIOR_BACKGROUND_POCHE_FILL = "#f4f5f6";
+const INTERIOR_BACKGROUND_POCHE_OPACITY = 0.92;
+
 export function buildSectionWallDetailMarkup({
   walls = [],
   lineweights = {},
@@ -69,8 +72,11 @@ export function buildSectionWallDetailMarkup({
               : 0.76 + bandCoverage * 0.1;
       const interiorBackgroundZone = isInteriorBackgroundPocheZone(wall);
       const pocheOpacity = interiorBackgroundZone
-        ? Math.min(rawPocheOpacity, 0.38)
+        ? INTERIOR_BACKGROUND_POCHE_OPACITY
         : rawPocheOpacity;
+      const pocheFill = interiorBackgroundZone
+        ? INTERIOR_BACKGROUND_POCHE_FILL
+        : "#151515";
       const outlineWeight = isCutFace
         ? Math.max(2, (lineweights.cutOutline || 1.6) * 1.22)
         : isCutProfile
@@ -87,7 +93,9 @@ export function buildSectionWallDetailMarkup({
       const interiorHatchOpacity = isCutFace
         ? 0.54
         : isCutProfile
-          ? 0.48 + profileContinuity * 0.08
+          ? interiorBackgroundZone
+            ? 0.34
+            : 0.48 + profileContinuity * 0.08
           : nearBoolean
             ? 0.42
             : contextual
@@ -112,11 +120,11 @@ export function buildSectionWallDetailMarkup({
         : "";
       return `
         <g id="phase13-section-cut-wall-${escapeXml(wall.id || index)}" data-truth-kind="${escapeXml(truthKind || truthState)}">
-          <rect x="${wall.x}" y="${wall.y}" width="${wall.width}" height="${wall.height}" data-poche-zone="${interiorBackgroundZone ? "interior-background" : "cut-wall"}" data-poche-opacity="${pocheOpacity}" fill="#151515" fill-opacity="${pocheOpacity}" stroke="#111" stroke-width="${outlineWeight}"${dashArray} />
+          <rect x="${wall.x}" y="${wall.y}" width="${wall.width}" height="${wall.height}" data-poche-zone="${interiorBackgroundZone ? "interior-background" : "cut-wall"}" data-poche-fill-role="${interiorBackgroundZone ? "label-readable-background" : "section-cut"}" data-poche-opacity="${pocheOpacity}" fill="${pocheFill}" fill-opacity="${pocheOpacity}" stroke="#111" stroke-width="${outlineWeight}"${dashArray} />
           ${cutFaceReveal}
-          <rect x="${wall.x + Math.max(1.5, wall.width * 0.08)}" y="${wall.y + 1.5}" width="${Math.max(2, wall.width - Math.max(3, wall.width * 0.16))}" height="${Math.max(6, wall.height - 3)}" fill="none" stroke="#f5f2ec" stroke-width="${isCutFace ? (lineweights.hatch || 0.7) * 1.2 : nearBoolean ? lineweights.hatch || 0.7 : lineweights.guide || 0.62}" stroke-opacity="${interiorHatchOpacity}"${interiorHatchDash} />
-          <line x1="${wall.x + wall.width * 0.2}" y1="${wall.y}" x2="${wall.x + wall.width * 0.2}" y2="${wall.y + wall.height}" stroke="#f4f1eb" stroke-width="${lineweights.guide || 0.62}" stroke-opacity="${isCutFace ? 0.46 : contextual ? 0.2 : 0.35}" />
-          <line x1="${wall.x + wall.width * 0.8}" y1="${wall.y}" x2="${wall.x + wall.width * 0.8}" y2="${wall.y + wall.height}" stroke="#f4f1eb" stroke-width="${lineweights.guide || 0.62}" stroke-opacity="${isCutFace ? 0.46 : contextual ? 0.2 : 0.35}" />
+          <rect x="${wall.x + Math.max(1.5, wall.width * 0.08)}" y="${wall.y + 1.5}" width="${Math.max(2, wall.width - Math.max(3, wall.width * 0.16))}" height="${Math.max(6, wall.height - 3)}" fill="none" stroke="${interiorBackgroundZone ? "#9ca3af" : "#f5f2ec"}" stroke-width="${isCutFace ? (lineweights.hatch || 0.7) * 1.2 : nearBoolean ? lineweights.hatch || 0.7 : lineweights.guide || 0.62}" stroke-opacity="${interiorHatchOpacity}"${interiorHatchDash} />
+          <line x1="${wall.x + wall.width * 0.2}" y1="${wall.y}" x2="${wall.x + wall.width * 0.2}" y2="${wall.y + wall.height}" stroke="${interiorBackgroundZone ? "#9ca3af" : "#f4f1eb"}" stroke-width="${lineweights.guide || 0.62}" stroke-opacity="${isCutFace ? 0.46 : contextual ? 0.2 : interiorBackgroundZone ? 0.28 : 0.35}" />
+          <line x1="${wall.x + wall.width * 0.8}" y1="${wall.y}" x2="${wall.x + wall.width * 0.8}" y2="${wall.y + wall.height}" stroke="${interiorBackgroundZone ? "#9ca3af" : "#f4f1eb"}" stroke-width="${lineweights.guide || 0.62}" stroke-opacity="${isCutFace ? 0.46 : contextual ? 0.2 : interiorBackgroundZone ? 0.28 : 0.35}" />
           ${interiorGuides}
         </g>`;
     })

--- a/src/services/drawing/svgElevationRenderer.js
+++ b/src/services/drawing/svgElevationRenderer.js
@@ -1461,7 +1461,7 @@ export function renderElevationSvg(
   const showInternalTitleBlock =
     !sheetMode || options.showInternalTitleBlock === true;
   const layout = sheetMode
-    ? { left: 28, top: 16, right: 30, bottom: 38 }
+    ? { left: 16, top: 8, right: 16, bottom: 24 }
     : { left: 80, top: 62, right: 94, bottom: 118 };
   const availableWidth = Math.max(1, width - layout.left - layout.right);
   const availableHeight = Math.max(1, height - layout.top - layout.bottom);
@@ -1483,7 +1483,7 @@ export function renderElevationSvg(
     spanM: metrics.width_m,
   });
   const roofAllowanceM = Math.max(
-    sheetMode ? 0.72 : 1.2,
+    sheetMode ? 0.56 : 1.2,
     Number(roofPitchInfoBase.riseM || 0),
   );
   const scale = Math.min(

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -7114,35 +7114,90 @@ function resolveProgrammeDisplayLabel(brief = {}) {
     .trim();
 }
 
-function resolveBriefAddress(brief = {}) {
+function normalizeTitleText(value) {
+  return String(value || "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isPlaceholderProjectTitle(value) {
+  const normalised = normalizeTitleText(value).toLowerCase();
+  return (
+    !normalised ||
+    normalised === "archiai project" ||
+    normalised === "architect ai project" ||
+    normalised === "untitled" ||
+    normalised === "untitled project"
+  );
+}
+
+function toTitleCaseLabel(value) {
+  return normalizeTitleText(value).replace(/\b([a-z])/g, (match) =>
+    match.toUpperCase(),
+  );
+}
+
+function resolveBriefAddress(brief = {}, projectContext = null) {
   return String(
     brief?.site_input?.address ||
       brief?.siteInput?.address ||
       brief?.address ||
       brief?.siteAddress ||
+      projectContext?.address ||
+      projectContext?.siteAddress ||
+      projectContext?.site_address ||
+      projectContext?.site_input?.address ||
+      projectContext?.siteInput?.address ||
       "",
   )
     .replace(/\s+/g, " ")
     .trim();
 }
 
-function resolveProjectTitle(brief = {}) {
-  const address = resolveBriefAddress(brief);
-  const title = String(
-    brief?.project_name ||
-      brief?.projectName ||
-      brief?.programme ||
-      brief?.programme_label ||
-      brief?.programmeLabel ||
-      address ||
-      "Untitled",
-  )
+function formatAddressForProjectTitle(address = "") {
+  const compact = normalizeTitleText(address);
+  const withoutPostcode = compact
+    .replace(/\b[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}\b/i, "")
+    .replace(/\s*,\s*$/g, "")
     .replace(/\s+/g, " ")
     .trim();
-  return title || "Untitled";
+  return withoutPostcode || compact;
 }
 
-function resolveSheetSubtitle(brief = {}) {
+function resolveProjectTitle(brief = {}, projectContext = null) {
+  const explicitTitle = [
+    brief?.project_name,
+    brief?.projectName,
+    brief?.name,
+    projectContext?.project_name,
+    projectContext?.projectName,
+    projectContext?.name,
+  ]
+    .map(normalizeTitleText)
+    .find((entry) => !isPlaceholderProjectTitle(entry));
+  const programme = toTitleCaseLabel(
+    brief?.programme ||
+      brief?.programme_label ||
+      brief?.programmeLabel ||
+      brief?.property_type ||
+      brief?.propertyType ||
+      brief?.building_type ||
+      brief?.buildingType ||
+      projectContext?.programme ||
+      projectContext?.buildingType ||
+      "",
+  );
+  const address = formatAddressForProjectTitle(
+    resolveBriefAddress(brief, projectContext),
+  );
+  if (!explicitTitle && programme && address) {
+    return `${programme} — ${address}`;
+  }
+  return explicitTitle || programme || address || "Untitled Project";
+}
+
+function resolveSheetSubtitle(brief = {}, projectContext = null) {
   const parts = [
     brief?.programme ||
       brief?.programme_label ||
@@ -7151,7 +7206,7 @@ function resolveSheetSubtitle(brief = {}) {
       brief?.propertyType ||
       brief?.building_type ||
       brief?.buildingType,
-    resolveBriefAddress(brief),
+    resolveBriefAddress(brief, projectContext),
   ]
     .map((entry) =>
       String(entry || "")
@@ -7174,13 +7229,13 @@ export function buildTitleBlockPanelArtifact({
   const width = 620;
   const height = 900;
   const location =
-    resolveBriefAddress(brief) ||
+    resolveBriefAddress(brief, sheetDesignContext) ||
     brief?.site_input?.postcode ||
     sheetDesignContext?.region ||
     "Project site";
   const drawingNumber = sheetPlan?.sheet_number || "A1-00";
   const sheetLabel = sheetPlan?.label || "RIBA Stage 2 Master";
-  const projectTitle = resolveProjectTitle(brief)
+  const projectTitle = resolveProjectTitle(brief, sheetDesignContext)
     .replace(/\s+/g, " ")
     .trim()
     .toUpperCase();
@@ -7219,7 +7274,7 @@ export function buildTitleBlockPanelArtifact({
   // working). The new rows surface RIBA Stage / Status / Revision / Date /
   // Drawing No. so reviewers get the full set on the sheet.
   const rows = [
-    ["Project", resolveProjectTitle(brief)],
+    ["Project", resolveProjectTitle(brief, sheetDesignContext)],
     ["Scale", sheetPlan?.scale || "As noted"],
     ["Status", status],
     ["Date", dateLabel],
@@ -7237,7 +7292,7 @@ export function buildTitleBlockPanelArtifact({
     .map((row, index) => {
       const y = rowStartY + index * rowGap;
       const rawValue = String(row[1] || "");
-      const valueMaxChars = index <= 1 ? 34 : 28;
+      const valueMaxChars = row[0] === "Location" || index <= 1 ? 34 : 28;
       const valueLines = splitNoteLines(rawValue, valueMaxChars, 2);
       const valueFontSize =
         rawValue.length > 54 ? 12 : rawValue.length > 38 ? 14 : 16;
@@ -9565,9 +9620,15 @@ function buildSheetProvenanceFooter({
 </g>`;
 }
 
-function buildSheetTitleBar({ brief, sheetNumber, sheetLabel } = {}) {
-  const title = resolveProjectTitle(brief).toUpperCase();
-  const subtitle = resolveSheetSubtitle(brief) || sheetLabel || "";
+function buildSheetTitleBar({
+  brief,
+  sheetNumber,
+  sheetLabel,
+  projectContext = null,
+} = {}) {
+  const title = resolveProjectTitle(brief, projectContext).toUpperCase();
+  const subtitle =
+    resolveSheetSubtitle(brief, projectContext) || sheetLabel || "";
   const logoDataUrl = brief?.brand?.logoDataUrl || brief?.brand?.logo_data_url;
   const logo = logoDataUrl
     ? `<image x="682" y="6.05" width="148" height="3.35" href="${escapeXml(logoDataUrl)}" preserveAspectRatio="xMaxYMid meet"/>`
@@ -9644,6 +9705,7 @@ function buildSheetSvg({
   sheetLabel = "RIBA Stage 2 Master",
   layoutTemplate = "board-v2",
   visualManifest = null,
+  projectContext = null,
 }) {
   const artifactIndex = buildPanelArtifactIndex(panelArtifacts);
   const panelGroups = panelPlacements
@@ -9665,12 +9727,18 @@ function buildSheetSvg({
         panelArtifacts,
       })
     : "";
-  const titleBar = buildSheetTitleBar({ brief, sheetNumber, sheetLabel });
+  const titleBar = buildSheetTitleBar({
+    brief,
+    sheetNumber,
+    sheetLabel,
+    projectContext,
+  });
+  const projectTitle = resolveProjectTitle(brief, projectContext);
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${A1_SHEET_SIZE_MM.width}mm" height="${A1_SHEET_SIZE_MM.height}mm" viewBox="0 0 ${A1_SHEET_SIZE_MM.width} ${A1_SHEET_SIZE_MM.height}" data-layout-version="${A1_SHEET_LAYOUT_VERSION}" data-layout-template="${escapeXml(layoutTemplate)}" data-placeholder-only="false" data-reference-match="${brief?.reference_match === true ? "true" : "false"}" data-brief-input-hash="${escapeXml(brief?.brief_input_hash || "")}" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-visual-manifest-hash="${escapeXml(visualManifest?.manifestHash || "")}" data-sheet-number="${escapeXml(sheetNumber)}" data-sheet-label="${escapeXml(sheetLabel)}" data-qa-status="${escapeXml(qaStatus || "pending")}" data-export-source="sheetArtifact.svgString">
   <rect width="${A1_SHEET_SIZE_MM.width}" height="${A1_SHEET_SIZE_MM.height}" fill="#ffffff"/>
   <rect x="5" y="5" width="831" height="584" fill="none" stroke="#111111" stroke-width="0.7"/>
-  <desc>Reference board A1 package for ${escapeXml(brief.project_name)}. Panels ${sourcePanelAssetIds.length}. Geometry hash ${escapeXml(geometryHash)}.</desc>
+  <desc>Reference board A1 package for ${escapeXml(projectTitle)}. Panels ${sourcePanelAssetIds.length}. Geometry hash ${escapeXml(geometryHash)}.</desc>
   ${titleBar}
   ${panelGroups}
   ${provenanceFooter}
@@ -9838,6 +9906,7 @@ async function buildA1Sheet({
     sheetLabel,
     layoutTemplate,
     visualManifest,
+    projectContext: sheetDesignContext,
   });
   __a1mark = __a1sheetLog(
     "build_sheet_svg",


### PR DESCRIPTION
## Summary

Merges the final A1 sheet polish commit after the merged ProjectGraph A1 authority and sheet-chrome work.

## Changes

- Replaces placeholder project title handling so `ARCHIAI PROJECT` is not used as a real title unless no better project/programme/address data exists.
- Falls back to programme + address, e.g. `Terraced House — 17 Kensington Road, Scunthorpe`.
- Threads the resolved title into the top title bar, title block, and sheet description.
- Lightens broad section background poche so labels remain readable while preserving dark section-cut hierarchy.
- Tightens sheet-mode elevation layout margins and roof allowance so elevation panels render larger.

## Validation

- `npm run check:env`
- `npm run check:contracts`
- `npm run test:compose:routing`
- `npm run lint`
- `npm run build:active`
- `git diff --check`

## Notes

This PR does not change image2 routing, technical panel authority gates, visual lock validators, or deterministic technical rendering contracts.