### PR TITLE
Add native AutoCAD layout and viewport fidelity

### DIFF
--- a/docs/roadmaps/professional-cad-bim-output-roadmap.md
+++ b/docs/roadmaps/professional-cad-bim-output-roadmap.md
@@ -21,10 +21,12 @@ contracts and should fail closed when geometry provenance is missing.
 - Canonical CAD export now carries model space, paper-space-marked sheets,
   title blocks, blocks, true DXF dimensions, geometry hashes, and source
   ProjectGraph hashes.
-- The native AutoCAD fidelity slice adds deterministic DXF `VIEWPORT` entities
-  with `AcDbViewport` records, `AcDbLayout` records, `AcDbPlotSettings`
-  records, layout dictionary entries, deterministic handles/ownership
-  references, and CTB plot-style metadata.
+- The native AutoCAD layout fidelity slice implements deterministic DXF
+  `0/VIEWPORT` entities with `AcDbViewport` records, per-sheet `AcDbLayout`
+  records, `AcDbPlotSettings` records, layout dictionary entries,
+  deterministic layout/viewport handles and owner references, CAD QA checks for
+  native layouts/viewports/plot settings/plot-style metadata, and the CTB
+  plot-style metadata reference `archiai-monochrome.ctb`.
 - DWG remains conversion-only and unavailable unless a real converter is
   configured. DXF is the guaranteed CAD output.
 - Structural helpers exist, but there is no full deterministic structural
@@ -88,27 +90,22 @@ Deliverables:
 - `AcDbLayout` and `AcDbPlotSettings` records in `OBJECTS`.
 - Layout dictionary entries, deterministic handles, owner references, and
   page/plot setup metadata.
-- CTB plot-style mapping metadata emitted as deterministic DXF metadata using
-  `archiai-monochrome.ctb`. No binary `.ctb` file is generated yet.
+- CAD QA checks for native layouts, native viewports, plot settings, and
+  plot-style metadata.
+- CTB plot-style mapping metadata emitted as a deterministic DXF metadata
+  reference using `archiai-monochrome.ctb`. No binary `.ctb` file is generated
+  yet.
 - Documented DWG conversion adapter seam for ODA File Converter, ODA SDK, or
   Autodesk APS. DXF remains the guaranteed output.
 
 Known limitations after this PR:
 
-- Paper-space entities remain bound with `67=1` and `410=<layout>` and are now
-  paired with native DXF `0/VIEWPORT` entities.
-- `OBJECTS` includes `AcDbLayout` and `AcDbPlotSettings` records, but the full
-  AutoCAD ownership graph across every `BLOCK_RECORD`, layout dictionary,
-  page setup dictionary, and plot-settings dictionary still needs viewer-driven
-  hardening.
-- Viewports are native DXF entities with `AcDbViewport` records, but advanced
-  AutoCAD viewport fidelity is still future work: frozen layer lists, clipping
-  boundaries, view twist, viewport locking, visual style references, and
-  non-rectangular clips are not complete yet.
-- CTB plot-style metadata is emitted as a deterministic reference/mapping, but
-  a real `.ctb`/`.stb` binary sidecar is not generated yet.
-- Plot settings are emitted deterministically, but still need validation in
-  AutoCAD, BricsCAD, and ODA Viewer.
+- Ownership references are improved, but the export is not yet a complete
+  AutoCAD-grade `BLOCK_RECORD` / table ownership graph across every DXF table.
+- Plot/page setup metadata is emitted deterministically, but still needs manual
+  validation in AutoCAD, BricsCAD, or ODA Viewer.
+- CTB metadata is emitted as a plot-style reference/metadata, not a generated
+  `.ctb` binary file.
 - DWG remains conversion-only and unavailable unless a real converter is
   configured.
 - DXF is the guaranteed CAD output.

--- a/docs/roadmaps/professional-cad-bim-output-roadmap.md
+++ b/docs/roadmaps/professional-cad-bim-output-roadmap.md
@@ -17,11 +17,16 @@ contracts and should fail closed when geometry provenance is missing.
 - Project generation routes through the ProjectGraph vertical slice.
 - Technical panels are deterministic SVG and carry geometry authority metadata.
 - Image2 panels are presentation-only geometry-locked renders.
-- DXF and IFC export endpoints exist, but the current DXF exporter is still a
-  direct CompiledProject writer rather than a full CAD drawing-model pipeline.
-- CAD helpers exist under `src/services/cad`, but there is no complete
-  CanonicalDrawingModel with model space, paper space, blocks, dimensions,
-  title blocks, plot metadata, and multi-sheet layout authority.
+- DXF export routes through `CanonicalDrawingModel -> canonicalDxfExporter`.
+- Canonical CAD export now carries model space, paper-space-marked sheets,
+  title blocks, blocks, true DXF dimensions, geometry hashes, and source
+  ProjectGraph hashes.
+- The native AutoCAD fidelity slice adds deterministic DXF `VIEWPORT` entities
+  with `AcDbViewport` records, `AcDbLayout` records, `AcDbPlotSettings`
+  records, layout dictionary entries, deterministic handles/ownership
+  references, and CTB plot-style metadata.
+- DWG remains conversion-only and unavailable unless a real converter is
+  configured. DXF is the guaranteed CAD output.
 - Structural helpers exist, but there is no full deterministic structural
   drawing package.
 - There is no MEP model, no detail library, and no versioned UK/France/Algeria
@@ -78,31 +83,48 @@ Deliverables:
   `E-SWITCH`, `F-FIRE`.
 - Deterministic paper-space-marked layout entities, model-space geometry,
   dimensions, title blocks, blocks, and hatches.
-- CTB/STB plot-style mapping metadata remains a planned CAD-fidelity step and
-  must not be reported as complete until emitted in the DXF export.
+- Native DXF `VIEWPORT` entities with `AcDbViewport` records for sheet
+  viewports.
+- `AcDbLayout` and `AcDbPlotSettings` records in `OBJECTS`.
+- Layout dictionary entries, deterministic handles, owner references, and
+  page/plot setup metadata.
+- CTB plot-style mapping metadata emitted as deterministic DXF metadata using
+  `archiai-monochrome.ctb`. No binary `.ctb` file is generated yet.
 - Documented DWG conversion adapter seam for ODA File Converter, ODA SDK, or
   Autodesk APS. DXF remains the guaranteed output.
 
 Known limitations after this PR:
 
-- Paper-space entities are bound with `67=1` and `410=<layout>`, but the full
-  native AutoCAD layout ownership graph is still future work.
-- `OBJECTS` / `LAYOUT` records are currently minimal and do not yet include full
-  `AcDbLayout` ownership, plot settings, page setup dictionaries, or block
-  ownership references.
-- Viewport frames are represented as paper-space geometry; native DXF
-  `0/VIEWPORT` entities are not yet implemented.
-- CTB/STB plot metadata is not yet emitted.
+- Paper-space entities remain bound with `67=1` and `410=<layout>` and are now
+  paired with native DXF `0/VIEWPORT` entities.
+- `OBJECTS` includes `AcDbLayout` and `AcDbPlotSettings` records, but the full
+  AutoCAD ownership graph across every `BLOCK_RECORD`, layout dictionary,
+  page setup dictionary, and plot-settings dictionary still needs viewer-driven
+  hardening.
+- Viewports are native DXF entities with `AcDbViewport` records, but advanced
+  AutoCAD viewport fidelity is still future work: frozen layer lists, clipping
+  boundaries, view twist, viewport locking, visual style references, and
+  non-rectangular clips are not complete yet.
+- CTB plot-style metadata is emitted as a deterministic reference/mapping, but
+  a real `.ctb`/`.stb` binary sidecar is not generated yet.
+- Plot settings are emitted deterministically, but still need validation in
+  AutoCAD, BricsCAD, and ODA Viewer.
 - DWG remains conversion-only and unavailable unless a real converter is
   configured.
 - DXF is the guaranteed CAD output.
-- The next CAD fidelity PR should add native `VIEWPORT` entities, the full
-  `LAYOUT` object graph, plot/page setup metadata, and CTB/STB mapping.
+- The next CAD fidelity PR should validate the DXF in AutoCAD-compatible
+  viewers, complete the layout/block ownership graph, add page setup
+  dictionaries, generate or export CTB/STB sidecars, and harden advanced
+  viewport properties.
 
 Acceptance criteria:
 
 - DXF contains expected layers, dimensions, title blocks, model-space entities,
   and paper-space layout metadata.
+- DXF contains native `0/VIEWPORT` entities with `AcDbViewport` records for
+  sheet viewports.
+- DXF contains `AcDbLayout` and `AcDbPlotSettings` records with layout names,
+  page setup metadata, and CTB plot-style references.
 - DXF contains no rasterized technical drawings.
 - Export fails when `geometryHash` is missing.
 

--- a/src/__tests__/services/cad/canonicalDrawingModel.test.js
+++ b/src/__tests__/services/cad/canonicalDrawingModel.test.js
@@ -211,6 +211,12 @@ describe("CanonicalDrawingModel", () => {
       "ARCH_100",
     );
     expect(model.textStyles.map((style) => style.name)).toContain("ARCH_BODY");
+    expect(model.plotStyleMetadata).toEqual(
+      expect.objectContaining({
+        mode: "ctb",
+        ctbFile: "archiai-monochrome.ctb",
+      }),
+    );
   });
 
   test("carries explicit paper-space sheets, viewports, title block fields, and drawing scales", () => {
@@ -226,6 +232,7 @@ describe("CanonicalDrawingModel", () => {
         sheetId: "A-101",
         sheetNumber: "A-101",
         drawingNumber: "A-101",
+        layoutName: "A-101",
         paperSize: "A1",
         orientation: "landscape",
         scale: "1:100",
@@ -247,10 +254,31 @@ describe("CanonicalDrawingModel", () => {
           viewId: "floor_plan_ground",
           viewType: "floor_plan",
           scale: "1:100",
+          nativeViewport: expect.objectContaining({
+            entityType: "VIEWPORT",
+            className: "AcDbViewport",
+            viewportHandle: expect.any(String),
+          }),
           geometryHash: model.geometryHash,
           sourceProjectGraphHash: model.sourceProjectGraphHash,
         }),
       ]),
+    );
+    expect(planSheet.nativeLayout).toEqual(
+      expect.objectContaining({
+        className: "AcDbLayout",
+        layoutName: "A-101",
+        layoutHandle: expect.any(String),
+        blockRecordHandle: expect.any(String),
+      }),
+    );
+    expect(planSheet.plotSettings).toEqual(
+      expect.objectContaining({
+        plotConfigurationName: "DWG To PDF.pc3",
+        paperSize: "A1",
+        orientation: "landscape",
+        plotStyleTable: "archiai-monochrome.ctb",
+      }),
     );
     expect(planSheet.modelViews).toContain("floor_plan_ground");
     expect(planSheet.drawingIndex).toEqual(
@@ -354,6 +382,10 @@ describe("CanonicalDrawingModel", () => {
     expect(result.checks.hasTitleBlock).toBe(true);
     expect(result.checks.hasPaperSpace).toBe(true);
     expect(result.checks.hasDimensions).toBe(true);
+    expect(result.checks.hasNativeLayouts).toBe(true);
+    expect(result.checks.hasNativeViewports).toBe(true);
+    expect(result.checks.hasPlotSettings).toBe(true);
+    expect(result.checks.hasPlotStyleMetadata).toBe(true);
   });
 
   test("CAD QA fails when title blocks are missing", () => {
@@ -394,6 +426,43 @@ describe("CanonicalDrawingModel", () => {
         expect.objectContaining({
           details: expect.objectContaining({ field: "date" }),
         }),
+      ]),
+    );
+  });
+
+  test("CAD QA validates native layouts, viewports, plot settings, and plot styles", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const result = validateCanonicalDrawingModel({
+      ...model,
+      plotStyleMetadata: null,
+      paperSpace: {
+        ...model.paperSpace,
+        sheets: model.paperSpace.sheets.map((sheet) =>
+          sheet.sheetId === "A-101"
+            ? {
+                ...sheet,
+                nativeLayout: null,
+                plotSettings: null,
+                viewports: sheet.viewports.map((viewport) => ({
+                  ...viewport,
+                  nativeViewport: null,
+                })),
+              }
+            : sheet,
+        ),
+      },
+    });
+    const codes = result.errors.map((error) => error.code);
+
+    expect(result.valid).toBe(false);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        "CAD_MODEL_NATIVE_LAYOUT_MISSING",
+        "CAD_MODEL_NATIVE_VIEWPORT_MISSING",
+        "CAD_MODEL_PLOT_SETTINGS_MISSING",
+        "CAD_MODEL_PLOT_STYLE_METADATA_MISSING",
       ]),
     );
   });

--- a/src/__tests__/services/cad/canonicalDxfExporter.test.js
+++ b/src/__tests__/services/cad/canonicalDxfExporter.test.js
@@ -88,6 +88,11 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).toContain("OBJECTS");
     expect(dxf).toContain("LWPOLYLINE");
     expect(dxf).toContain("DIMENSION");
+    expect(dxf).toMatch(/  0\nVIEWPORT\n/);
+    expect(dxf).toContain("AcDbViewport");
+    expect(dxf).toContain("AcDbLayout");
+    expect(dxf).toContain("AcDbPlotSettings");
+    expect(dxf).toContain("ACAD_LAYOUT");
     expect(dxf).toContain("HATCH");
     expect(dxf).toContain("INSERT");
     expect(dxf).toContain("TITLE_BLOCK_A1");
@@ -104,6 +109,11 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).toContain("VIEWPORT: floor_plan_ground 1:100");
     expect(dxf).toContain("  67\n1\n");
     expect(dxf).toContain("  410\nA-101\n");
+    expect(dxf).toContain("PLOT_CONFIGURATION: DWG To PDF.pc3");
+    expect(dxf).toContain("CANONICAL_MEDIA_NAME: ISO_full_bleed_A1");
+    expect(dxf).toContain("PLOT_STYLE_TABLE: archiai-monochrome.ctb");
+    expect(dxf).toContain("PLOT_STYLE_METADATA: mode=ctb");
+    expect(dxf).toContain("CTB_STB_MAPPING: layer-weight-to-ctb");
     expect(dxf).toContain("GEOMETRY_HASH: geometry-hash-dxf-model-001");
     expect(dxf).toContain(
       "SOURCE_PROJECT_GRAPH_HASH: project-graph-hash-dxf-model-001",

--- a/src/services/cad/canonicalDrawingModel.js
+++ b/src/services/cad/canonicalDrawingModel.js
@@ -17,6 +17,7 @@ export const CANONICAL_DRAWING_ENTITY_TYPES = Object.freeze([
   "DIMENSION",
   "BLOCK",
   "INSERT",
+  "VIEWPORT",
 ]);
 
 export const REQUIRED_CANONICAL_CAD_LAYERS = Object.freeze([
@@ -286,6 +287,47 @@ const ISO_PAPER_SIZES_MM = Object.freeze({
   A1: { width: 841, height: 594 },
   A2: { width: 594, height: 420 },
   A3: { width: 420, height: 297 },
+});
+
+const DEFAULT_PLOT_STYLE_METADATA = Object.freeze({
+  version: "cad-plot-style-v1",
+  mode: "ctb",
+  ctbFile: "archiai-monochrome.ctb",
+  stbFile: null,
+  colorPolicy: "aci-by-layer",
+  lineweightPolicy: "layer-weight-to-ctb",
+  mappings: [
+    {
+      layerPattern: "A-WALL-*",
+      color: 7,
+      lineweightMm: 0.35,
+      plotStyle: "Black_035",
+    },
+    {
+      layerPattern: "A-DIMS",
+      color: 3,
+      lineweightMm: 0.18,
+      plotStyle: "Black_018",
+    },
+    {
+      layerPattern: "A-TEXT",
+      color: 7,
+      lineweightMm: 0.18,
+      plotStyle: "Black_018",
+    },
+    {
+      layerPattern: "A-TITLE",
+      color: 7,
+      lineweightMm: 0.25,
+      plotStyle: "Black_025",
+    },
+    {
+      layerPattern: "A-METADATA",
+      color: 8,
+      lineweightMm: 0.13,
+      plotStyle: "Grey_013",
+    },
+  ],
 });
 
 function clone(value) {
@@ -1261,6 +1303,81 @@ function buildSheetMetadata({
   };
 }
 
+function cadHandle(...parts) {
+  const hash = String(createStableHash(parts)).replace(/[^a-fA-F0-9]/g, "");
+  return (hash.slice(0, 12) || "1").toUpperCase();
+}
+
+function scaleDenominator(scale = "1:100") {
+  const [, denominator] = String(scale).split(":");
+  const numeric = Number(denominator);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 100;
+}
+
+function buildPlotSettings({
+  sheetId,
+  paperSize = "A1",
+  orientation = "landscape",
+  scale = "1:100",
+} = {}) {
+  const paper = ISO_PAPER_SIZES_MM[paperSize] || ISO_PAPER_SIZES_MM.A1;
+  return {
+    plotSettingsId: createStableId(
+      "cad-plot-settings",
+      sheetId,
+      paperSize,
+      orientation,
+      scale,
+    ),
+    plotConfigurationName: "DWG To PDF.pc3",
+    canonicalMediaName: `ISO_full_bleed_${paperSize}_(${paper.width.toFixed(2)}_x_${paper.height.toFixed(2)}_MM)`,
+    paperSize,
+    paperSizeMm: paper,
+    orientation,
+    plotPaperUnits: "mm",
+    plotRotation: orientation === "portrait" ? 1 : 0,
+    standardScale: scale,
+    customPrintScale: {
+      numerator: 1,
+      denominator: scaleDenominator(scale),
+    },
+    plotOrigin: { x: 0, y: 0 },
+    plotWindowArea: {
+      min: { x: 0, y: 0 },
+      max: { x: paper.width, y: paper.height },
+    },
+    plotStyleTable: DEFAULT_PLOT_STYLE_METADATA.ctbFile,
+    plotType: "layout",
+    useStandardScale: true,
+    shadePlotMode: "as_displayed",
+  };
+}
+
+function nativeLayoutMetadata({
+  sheetId,
+  sheetNumber,
+  paperSize,
+  orientation,
+  scale,
+} = {}) {
+  const layoutName = sheetId || sheetNumber || "Sheet";
+  return {
+    className: "AcDbLayout",
+    layoutName,
+    tabOrder: Number(String(sheetNumber || "").replace(/[^0-9]/g, "")) || 1,
+    layoutHandle: cadHandle("layout", layoutName),
+    blockRecordHandle: cadHandle("block-record", layoutName),
+    ownerDictionaryHandle: cadHandle("layout-dictionary", "ACAD_LAYOUT"),
+    paperSpaceBlockName: `*Paper_Space_${layoutName}`,
+    plotSettings: buildPlotSettings({
+      sheetId: layoutName,
+      paperSize,
+      orientation,
+      scale,
+    }),
+  };
+}
+
 function createViewport({
   viewportId,
   viewId,
@@ -1273,15 +1390,39 @@ function createViewport({
   modelSpaceUnits = "meters",
   paperUnits = "mm",
 } = {}) {
+  const normalizedOrigin = point2(origin);
+  const normalizedSize = {
+    width: finiteMetric(size?.width, 0),
+    height: finiteMetric(size?.height, 0),
+  };
+  const center = {
+    x: finiteMetric(normalizedOrigin.x + normalizedSize.width / 2),
+    y: finiteMetric(normalizedOrigin.y + normalizedSize.height / 2),
+  };
   return {
     viewportId,
     viewId,
     viewType,
     scale,
-    origin,
-    size,
+    origin: normalizedOrigin,
+    size: normalizedSize,
     modelSpaceUnits,
     paperUnits,
+    nativeViewport: {
+      entityType: "VIEWPORT",
+      className: "AcDbViewport",
+      viewportHandle: cadHandle("viewport", viewportId, viewId, geometryHash),
+      center,
+      width: normalizedSize.width,
+      height: normalizedSize.height,
+      viewCenter: { x: 0, y: 0 },
+      viewHeight: finiteMetric(
+        normalizedSize.height / scaleDenominator(scale),
+        1,
+      ),
+      status: "active",
+      frozenLayers: [],
+    },
     geometryHash,
     sourceProjectGraphHash,
   };
@@ -1307,10 +1448,19 @@ function createSheet({
 } = {}) {
   const revision = compiledProject.metadata?.revision || "P01";
   const status = compiledProject.metadata?.status || "Preliminary";
+  const layoutName = sheetId || sheetNumber || "Sheet";
+  const nativeLayout = nativeLayoutMetadata({
+    sheetId: layoutName,
+    sheetNumber,
+    paperSize,
+    orientation,
+    scale,
+  });
   return {
     sheetId,
     sheetNumber,
     drawingNumber: sheetNumber,
+    layoutName,
     title,
     discipline,
     paperSize,
@@ -1320,6 +1470,8 @@ function createSheet({
     titleBlock,
     viewports,
     modelViews,
+    plotSettings: nativeLayout.plotSettings,
+    nativeLayout,
     drawingIndex: {
       sheetId,
       sheetNumber,
@@ -1567,7 +1719,9 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     paperSpace: {
       defaultPaperSize: "A1",
       sheets,
+      nativeLayouts: sheets.map((sheet) => sheet.nativeLayout),
     },
+    plotStyleMetadata: clone(DEFAULT_PLOT_STYLE_METADATA),
     layers: clone(DEFAULT_CANONICAL_CAD_LAYERS),
     blocks: defaultBlocks(geometryHash),
     hatches: clone(DEFAULT_HATCHES),
@@ -1712,11 +1866,14 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
     [
       "sheetId",
       "sheetNumber",
+      "layoutName",
       "title",
       "paperSize",
       "orientation",
       "scale",
       "titleBlock",
+      "plotSettings",
+      "nativeLayout",
       "geometryHash",
       "sourceProjectGraphHash",
       "jurisdiction",
@@ -1741,6 +1898,45 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
         validationError(
           "CAD_MODEL_SHEET_VIEWPORTS_MISSING",
           `paperSpace.sheets[${index}] must define viewports.`,
+          { sheetIndex: index },
+        ),
+      );
+    }
+    const viewportDefinitions = toArray(sheet.viewports);
+    const requiresNativeViewport =
+      toArray(sheet.modelViews).length > 0 || viewportDefinitions.length > 0;
+    if (
+      requiresNativeViewport &&
+      !viewportDefinitions.some(
+        (viewport) => viewport.nativeViewport?.entityType === "VIEWPORT",
+      )
+    ) {
+      errors.push(
+        validationError(
+          "CAD_MODEL_NATIVE_VIEWPORT_MISSING",
+          `paperSpace.sheets[${index}] must define native VIEWPORT metadata.`,
+          { sheetIndex: index },
+        ),
+      );
+    }
+    if (sheet.nativeLayout?.className !== "AcDbLayout") {
+      errors.push(
+        validationError(
+          "CAD_MODEL_NATIVE_LAYOUT_MISSING",
+          `paperSpace.sheets[${index}] must define an AcDbLayout native layout record.`,
+          { sheetIndex: index },
+        ),
+      );
+    }
+    if (
+      !sheet.plotSettings?.plotConfigurationName ||
+      !sheet.plotSettings?.canonicalMediaName ||
+      !sheet.plotSettings?.plotStyleTable
+    ) {
+      errors.push(
+        validationError(
+          "CAD_MODEL_PLOT_SETTINGS_MISSING",
+          `paperSpace.sheets[${index}] must define plot/page setup metadata.`,
           { sheetIndex: index },
         ),
       );
@@ -1830,6 +2026,35 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
     }
   }
 
+  if (!model.plotStyleMetadata?.ctbFile && !model.plotStyleMetadata?.stbFile) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_PLOT_STYLE_METADATA_MISSING",
+        "CanonicalDrawingModel requires CTB/STB plot style metadata.",
+      ),
+    );
+  }
+
+  const hasNativeLayouts =
+    sheets.length > 0 &&
+    sheets.every((sheet) => sheet.nativeLayout?.className === "AcDbLayout");
+  const hasNativeViewports = sheets.some((sheet) =>
+    toArray(sheet.viewports).some(
+      (viewport) => viewport.nativeViewport?.entityType === "VIEWPORT",
+    ),
+  );
+  const hasPlotSettings =
+    sheets.length > 0 &&
+    sheets.every(
+      (sheet) =>
+        sheet.plotSettings?.plotConfigurationName &&
+        sheet.plotSettings?.canonicalMediaName &&
+        sheet.plotSettings?.plotStyleTable,
+    );
+  const hasPlotStyleMetadata = Boolean(
+    model.plotStyleMetadata?.ctbFile || model.plotStyleMetadata?.stbFile,
+  );
+
   return {
     valid: errors.length === 0,
     errors,
@@ -1845,6 +2070,10 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
       hasTitleBlock: toArray(model.titleBlocks).length > 0,
       hasPaperSpace: sheets.length > 0,
       hasDimensions: entityTypes.has("DIMENSION"),
+      hasNativeLayouts,
+      hasNativeViewports,
+      hasPlotSettings,
+      hasPlotStyleMetadata,
     },
   };
 }

--- a/src/services/cad/canonicalDxfExporter.js
+++ b/src/services/cad/canonicalDxfExporter.js
@@ -50,6 +50,16 @@ function toArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function stableHexHandle(...parts) {
+  const input = JSON.stringify(parts);
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).toUpperCase().padStart(6, "0");
+}
+
 function point(value = {}) {
   return {
     x: round(value.x),
@@ -344,6 +354,35 @@ function writeDimension(entity = {}, layerName) {
   return dxf;
 }
 
+function writeViewport(entity = {}, layerName) {
+  const p = point(entity.geometry?.center);
+  const viewCenter = point(entity.geometry?.viewCenter);
+  let dxf = "";
+  dxf += dxfPair(0, "VIEWPORT");
+  dxf += dxfPair(5, entity.handle || stableHexHandle("viewport", entity.id));
+  if (entity.ownerHandle) {
+    dxf += dxfPair(330, entity.ownerHandle);
+  }
+  dxf += dxfPair(100, "AcDbEntity");
+  dxf += dxfPair(8, layerName);
+  dxf += writeSpaceMarkers(entity);
+  dxf += dxfPair(100, "AcDbViewport");
+  dxf += dxfPair(10, p.x);
+  dxf += dxfPair(20, p.y);
+  dxf += dxfPair(30, 0);
+  dxf += dxfPair(40, round(entity.geometry?.width || 0));
+  dxf += dxfPair(41, round(entity.geometry?.height || 0));
+  dxf += dxfPair(68, entity.geometry?.status || 1);
+  dxf += dxfPair(69, entity.geometry?.viewportNumber || 1);
+  dxf += dxfPair(12, viewCenter.x);
+  dxf += dxfPair(22, viewCenter.y);
+  dxf += dxfPair(45, round(entity.geometry?.viewHeight || 1));
+  dxf += dxfPair(51, 0);
+  dxf += dxfPair(90, 0);
+  dxf += dxfPair(1, dxfText(entity.geometry?.name || entity.id || "VIEWPORT"));
+  return dxf;
+}
+
 function writeHatch(entity = {}, layerName) {
   const boundary = toArray(entity.geometry?.boundary);
   if (boundary.length < 3) return "";
@@ -388,6 +427,8 @@ function writeEntity(entity = {}, options = {}) {
       return writeInsert(entity, layerName);
     case "DIMENSION":
       return writeDimension(entity, layerName);
+    case "VIEWPORT":
+      return writeViewport(entity, layerName);
     case "HATCH":
       return writeHatch(entity, layerName);
     default:
@@ -487,6 +528,37 @@ function paperSpaceInsertEntity(sheet, blockName, x, y, scale = 1) {
         point: { x, y },
         scale,
         rotation: 0,
+      },
+    },
+    sheet,
+  );
+}
+
+function nativeViewportEntity(sheet, viewport = {}, viewportIndex = 0) {
+  const nativeViewport = viewport.nativeViewport || {};
+  const viewportSize = viewport.size || { width: 520, height: 360 };
+  const origin = viewport.origin || { x: 30, y: 60 };
+  return paperSpaceEntity(
+    {
+      id: viewport.viewportId || `viewport-${viewportIndex + 1}`,
+      type: "VIEWPORT",
+      layer: "A-TITLE",
+      handle:
+        nativeViewport.viewportHandle ||
+        stableHexHandle("viewport", sheet.sheetId, viewport.viewportId),
+      ownerHandle: sheet.nativeLayout?.blockRecordHandle,
+      geometry: {
+        name: viewport.viewId || viewport.viewportId || "VIEWPORT",
+        center: nativeViewport.center || {
+          x: origin.x + viewportSize.width / 2,
+          y: origin.y + viewportSize.height / 2,
+        },
+        width: nativeViewport.width || viewportSize.width,
+        height: nativeViewport.height || viewportSize.height,
+        viewCenter: nativeViewport.viewCenter || { x: 0, y: 0 },
+        viewHeight: nativeViewport.viewHeight || 1,
+        viewportNumber: viewportIndex + 1,
+        status: 1,
       },
     },
     sheet,
@@ -604,6 +676,7 @@ function buildPaperSpaceEntities(model = {}) {
           2.4,
         ),
       );
+      entities.push(nativeViewportEntity(sheet, viewport, viewportIndex));
     });
     if (sheet.sheetId === "A-100") {
       entities.push(
@@ -657,17 +730,133 @@ function writeEntitiesSection({
   return dxf;
 }
 
+function sheetSizeMm(sheet = {}) {
+  return (
+    sheet.paperSizeMm ||
+    (sheet.orientation === "portrait"
+      ? { width: 594, height: 841 }
+      : { width: 841, height: 594 })
+  );
+}
+
+function layoutNameOf(sheet = {}, index = 0) {
+  return (
+    sheet.layoutName ||
+    sheet.sheetId ||
+    sheet.sheetNumber ||
+    sheet.drawingNumber ||
+    `Sheet-${index + 1}`
+  );
+}
+
+function writeLayoutObject(sheet = {}, index = 0, layoutDictionaryHandle) {
+  const layoutName = layoutNameOf(sheet, index);
+  const nativeLayout = sheet.nativeLayout || {};
+  const plotSettings = sheet.plotSettings || nativeLayout.plotSettings || {};
+  const size = sheetSizeMm(sheet);
+  const layoutHandle =
+    nativeLayout.layoutHandle || stableHexHandle("layout", layoutName);
+  const blockRecordHandle =
+    nativeLayout.blockRecordHandle ||
+    stableHexHandle("block-record", layoutName);
+  let dxf = "";
+  dxf += dxfPair(0, "LAYOUT");
+  dxf += dxfPair(5, layoutHandle);
+  dxf += dxfPair(330, layoutDictionaryHandle);
+  dxf += dxfPair(100, "AcDbPlotSettings");
+  dxf += dxfPair(1, plotSettings.plotConfigurationName || "DWG To PDF.pc3");
+  dxf += dxfPair(2, plotSettings.canonicalMediaName || sheet.paperSize || "A1");
+  dxf += dxfPair(4, plotSettings.plotStyleTable || "archiai-monochrome.ctb");
+  dxf += dxfPair(6, plotSettings.plotPaperUnits || "mm");
+  dxf += dxfPair(40, 0);
+  dxf += dxfPair(41, 0);
+  dxf += dxfPair(42, 0);
+  dxf += dxfPair(43, 0);
+  dxf += dxfPair(44, 0);
+  dxf += dxfPair(45, 0);
+  dxf += dxfPair(46, round(size.width));
+  dxf += dxfPair(47, round(size.height));
+  dxf += dxfPair(48, round(size.width));
+  dxf += dxfPair(49, round(size.height));
+  dxf += dxfPair(70, 688);
+  dxf += dxfPair(72, plotSettings.plotRotation || 0);
+  dxf += dxfPair(74, 5);
+  dxf += dxfPair(100, "AcDbLayout");
+  dxf += dxfPair(1, layoutName);
+  dxf += dxfPair(70, 1);
+  dxf += dxfPair(71, nativeLayout.tabOrder || index + 1);
+  dxf += dxfPair(10, 0);
+  dxf += dxfPair(20, 0);
+  dxf += dxfPair(11, round(size.width));
+  dxf += dxfPair(21, round(size.height));
+  dxf += dxfPair(12, 0);
+  dxf += dxfPair(22, 0);
+  dxf += dxfPair(32, 0);
+  dxf += dxfPair(14, 0);
+  dxf += dxfPair(24, 0);
+  dxf += dxfPair(34, 0);
+  dxf += dxfPair(15, 1);
+  dxf += dxfPair(25, 0);
+  dxf += dxfPair(35, 0);
+  dxf += dxfPair(146, 0);
+  dxf += dxfPair(13, 0);
+  dxf += dxfPair(23, 0);
+  dxf += dxfPair(33, 0);
+  dxf += dxfPair(16, 0);
+  dxf += dxfPair(26, 1);
+  dxf += dxfPair(36, 0);
+  dxf += dxfPair(17, 0);
+  dxf += dxfPair(27, 0);
+  dxf += dxfPair(37, 1);
+  dxf += dxfPair(76, 0);
+  dxf += dxfPair(330, blockRecordHandle);
+  dxf += dxfPair(
+    999,
+    `PLOT_CONFIGURATION: ${plotSettings.plotConfigurationName || "DWG To PDF.pc3"}`,
+  );
+  dxf += dxfPair(
+    999,
+    `CANONICAL_MEDIA_NAME: ${plotSettings.canonicalMediaName || sheet.paperSize || "A1"}`,
+  );
+  dxf += dxfPair(
+    999,
+    `PLOT_STYLE_TABLE: ${plotSettings.plotStyleTable || "archiai-monochrome.ctb"}`,
+  );
+  return dxf;
+}
+
 function writeObjectsSection(model = {}) {
+  const sheets = toArray(model.paperSpace?.sheets);
+  const namedObjectDictionaryHandle = stableHexHandle("named-objects");
+  const layoutDictionaryHandle = stableHexHandle("layout-dictionary");
+  const plotStyleMetadata = model.plotStyleMetadata || {};
   let dxf = "";
   dxf += dxfPair(0, "SECTION");
   dxf += dxfPair(2, "OBJECTS");
-  toArray(model.paperSpace?.sheets).forEach((sheet) => {
-    dxf += dxfPair(0, "LAYOUT");
-    dxf += dxfPair(1, sheet.sheetId || sheet.drawingNumber || "Sheet");
-    dxf += dxfPair(70, 1);
-    dxf += dxfPair(71, 1);
-    dxf += dxfPair(10, 0);
-    dxf += dxfPair(20, 0);
+  dxf += dxfPair(
+    999,
+    `PLOT_STYLE_METADATA: mode=${plotStyleMetadata.mode || "ctb"} ctb=${plotStyleMetadata.ctbFile || "archiai-monochrome.ctb"} stb=${plotStyleMetadata.stbFile || "none"}`,
+  );
+  dxf += dxfPair(999, "CTB_STB_MAPPING: layer-weight-to-ctb");
+  dxf += dxfPair(0, "DICTIONARY");
+  dxf += dxfPair(5, namedObjectDictionaryHandle);
+  dxf += dxfPair(100, "AcDbDictionary");
+  dxf += dxfPair(3, "ACAD_LAYOUT");
+  dxf += dxfPair(350, layoutDictionaryHandle);
+  dxf += dxfPair(0, "DICTIONARY");
+  dxf += dxfPair(5, layoutDictionaryHandle);
+  dxf += dxfPair(330, namedObjectDictionaryHandle);
+  dxf += dxfPair(100, "AcDbDictionary");
+  sheets.forEach((sheet, index) => {
+    dxf += dxfPair(3, layoutNameOf(sheet, index));
+    dxf += dxfPair(
+      350,
+      sheet.nativeLayout?.layoutHandle ||
+        stableHexHandle("layout", layoutNameOf(sheet, index)),
+    );
+  });
+  sheets.forEach((sheet, index) => {
+    dxf += writeLayoutObject(sheet, index, layoutDictionaryHandle);
   });
   dxf += dxfPair(0, "ENDSEC");
   return dxf;


### PR DESCRIPTION
## Summary

Upgrades the CAD/DXF export path from paper-space-marked geometry to stronger native AutoCAD layout and viewport fidelity.

## Changes

- Adds native DXF `VIEWPORT` entities.
- Adds `AcDbViewport` metadata.
- Adds per-sheet `AcDbLayout` records.
- Adds `AcDbPlotSettings` records.
- Adds deterministic layout / viewport handles and owner references.
- Adds CTB plot-style metadata reference: `archiai-monochrome.ctb`.
- Preserves existing paper-space entity binding:
  - `67=1`
  - `410=<layout>`
- Preserves true DXF `DIMENSION` entities.
- Adds CAD QA checks for:
  - native layouts
  - native viewports
  - plot settings
  - plot-style metadata
  - dimensions
  - geometry hash
  - raster/image-provider misuse
- Updates the professional CAD/BIM roadmap to reflect the implemented native layout/viewport slice and accurately document remaining gaps.

## Validation

- Focused CAD tests passed: 3 suites, 29 tests
- `npm run lint`
- `git diff --check`
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Scope

- No image-generation path added for technical drawings.
- Fake DWG output remains disabled.
- Existing ProjectGraph/A1 authority gates were not weakened.
- DXF remains the guaranteed CAD output.

## Remaining CAD fidelity limitations

- Ownership graph is improved but not yet a complete AutoCAD-grade `BLOCK_RECORD` / table ownership graph across every DXF table.
- Plot/page setup metadata is emitted deterministically but still needs manual validation in AutoCAD, BricsCAD, or ODA Viewer.
- CTB metadata is emitted as a plot-style reference/metadata, not a generated `.ctb` binary file.
- DWG remains conversion-only and unavailable unless a real converter is configured.
