### PR TITLE
Add opt-in preliminary structural model and CAD drawings

### DIFF
--- a/docs/roadmaps/professional-cad-bim-output-roadmap.md
+++ b/docs/roadmaps/professional-cad-bim-output-roadmap.md
@@ -29,8 +29,9 @@ contracts and should fail closed when geometry provenance is missing.
   plot-style metadata reference `archiai-monochrome.ctb`.
 - DWG remains conversion-only and unavailable unless a real converter is
   configured. DXF is the guaranteed CAD output.
-- Structural helpers exist, but there is no full deterministic structural
-  drawing package.
+- Structural CAD/BIM output is being introduced as an opt-in package behind
+  `STRUCTURAL_DRAWINGS_ENABLED` or an explicit `includeStructuralDrawings`
+  option. Default architectural DXF exports remain non-structural.
 - There is no MEP model, no detail library, and no versioned UK/France/Algeria
   jurisdiction-pack system.
 
@@ -128,6 +129,10 @@ Acceptance criteria:
 ## PR 3: Structural model and drawings
 
 Add deterministic `structuralModel` derived from ProjectGraph / CompiledProject.
+This package is opt-in: structural drawings and structural CAD/DXF entities are
+included only when `STRUCTURAL_DRAWINGS_ENABLED=true` or an explicit
+`includeStructuralDrawings` option is passed. Existing architectural CAD/DXF
+exports remain architectural-only by default.
 
 Deliverables:
 
@@ -136,13 +141,23 @@ Deliverables:
 - Deterministic preliminary engineering assumptions.
 - Structural grid, member IDs, jurisdiction/design-standard metadata, and
   engineer-review-required status.
+- DXF structural layers/entities (`S-FOUNDATION`, `S-COLUMN`, `S-BEAM`,
+  `S-SLAB`, `S-ROOF`, `S-GRID`, `S-NOTES`, `S-DIMS`) when structural drawings
+  are enabled.
+- Structural outputs labelled preliminary with licensed structural engineer
+  review required.
 
 Acceptance criteria:
 
 - Structural model includes foundations, slabs, beams, columns, and roof framing
   where applicable.
-- Structural drawings export to SVG and DXF.
+- Structural drawings export to SVG and DXF only when structural drawings are
+  enabled.
+- Default CanonicalDrawingModel/DXF export remains architectural-only and does
+  not emit structural model data or `S-*` structural entities.
 - Missing structural model blocks structural drawing export.
+- Structural model and drawings carry deterministic hashes, no image-provider
+  technical drawing path, and licensed structural engineer review disclaimers.
 
 ## PR 4: MEP model and drawings
 

--- a/src/__tests__/services/cad/canonicalDrawingModel.test.js
+++ b/src/__tests__/services/cad/canonicalDrawingModel.test.js
@@ -217,6 +217,12 @@ describe("CanonicalDrawingModel", () => {
         ctbFile: "archiai-monochrome.ctb",
       }),
     );
+    expect(model.structuralModel).toBeUndefined();
+    expect(
+      model.modelSpace.entities.filter((entity) =>
+        String(entity.layer || "").startsWith("S-"),
+      ),
+    ).toEqual([]);
   });
 
   test("carries explicit paper-space sheets, viewports, title block fields, and drawing scales", () => {
@@ -311,8 +317,20 @@ describe("CanonicalDrawingModel", () => {
       compiledProject: fixtureCompiledProject(),
     });
     const layerNames = model.layers.map((layer) => layer.name);
+    const architecturalLayerNames = REQUIRED_CANONICAL_CAD_LAYERS.filter(
+      (layerName) => !layerName.startsWith("S-"),
+    );
 
-    expect(layerNames).toEqual(
+    expect(layerNames).toEqual(expect.arrayContaining(architecturalLayerNames));
+    expect(layerNames).not.toEqual(
+      expect.arrayContaining(["S-FOUNDATION", "S-BEAM", "S-GRID"]),
+    );
+
+    const structuralModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeStructuralDrawings: true,
+    });
+    expect(structuralModel.layers.map((layer) => layer.name)).toEqual(
       expect.arrayContaining(REQUIRED_CANONICAL_CAD_LAYERS),
     );
   });
@@ -386,6 +404,61 @@ describe("CanonicalDrawingModel", () => {
     expect(result.checks.hasNativeViewports).toBe(true);
     expect(result.checks.hasPlotSettings).toBe(true);
     expect(result.checks.hasPlotStyleMetadata).toBe(true);
+    expect(result.checks.hasStructuralModelHash).toBe(false);
+    expect(result.checks.hasStructuralDisclaimer).toBe(false);
+    expect(result.checks.structuralReviewRequired).toBe(false);
+    expect(result.checks.structuralImageProviderUsed).toBe(null);
+  });
+
+  test("adds structural CAD entities, dimensions, grid, and review notes", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeStructuralDrawings: true,
+    });
+    expect(model.structuralModel).toEqual(
+      expect.objectContaining({
+        geometryHash: model.geometryHash,
+        sourceProjectGraphHash: model.sourceProjectGraphHash,
+        reviewRequired: true,
+        imageProviderUsed: "none",
+      }),
+    );
+    expect(model.structuralModel.disclaimers.join(" ")).toMatch(
+      /licensed structural engineer/i,
+    );
+    const structuralEntities = model.modelSpace.entities.filter((entity) =>
+      String(entity.layer || "").startsWith("S-"),
+    );
+    const layers = new Set(structuralEntities.map((entity) => entity.layer));
+    const roles = new Set(
+      structuralEntities.map((entity) => entity.metadata?.role).filter(Boolean),
+    );
+
+    expect([...layers]).toEqual(
+      expect.arrayContaining([
+        "S-FOUNDATION",
+        "S-COLUMN",
+        "S-BEAM",
+        "S-SLAB",
+        "S-ROOF",
+        "S-GRID",
+        "S-NOTES",
+        "S-DIMS",
+      ]),
+    );
+    expect([...roles]).toEqual(
+      expect.arrayContaining([
+        "foundation_outline",
+        "structural_grid",
+        "roof_rafter",
+        "review_disclaimer",
+      ]),
+    );
+    structuralEntities.forEach((entity) => {
+      expect(entity.imageProviderUsed).toBe("none");
+      expect(entity.technicalDrawing).toBe(true);
+      expect(entity.geometryHash).toBe(model.geometryHash);
+    });
   });
 
   test("CAD QA fails when title blocks are missing", () => {

--- a/src/__tests__/services/cad/canonicalDxfExporter.test.js
+++ b/src/__tests__/services/cad/canonicalDxfExporter.test.js
@@ -154,6 +154,44 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).toContain("SCALE: 1:500");
   });
 
+  test("keeps default DXF export architectural-only without structural opt-in", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const dxf = exportCanonicalDrawingModelToDXF({
+      canonicalDrawingModel: model,
+    });
+
+    expect(dxf).not.toContain("S-FOUNDATION");
+    expect(dxf).not.toContain("S-BEAM");
+    expect(dxf).not.toContain("S-GRID");
+    expect(dxf).not.toContain("PRELIMINARY STRUCTURAL INFORMATION ONLY");
+  });
+
+  test("emits structural CAD layers, grid, foundations, roof framing, notes, and no raster entities", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeStructuralDrawings: true,
+    });
+    const dxf = exportCanonicalDrawingModelToDXF({
+      canonicalDrawingModel: model,
+    });
+
+    expect(dxf).toContain("S-FOUNDATION");
+    expect(dxf).toContain("S-COLUMN");
+    expect(dxf).toContain("S-BEAM");
+    expect(dxf).toContain("S-SLAB");
+    expect(dxf).toContain("S-ROOF");
+    expect(dxf).toContain("S-GRID");
+    expect(dxf).toContain("S-NOTES");
+    expect(dxf).toContain("S-DIMS");
+    expect(dxf).toContain("PRELIMINARY STRUCTURAL INFORMATION ONLY");
+    expect(dxf).toContain("FND-001");
+    expect(dxf).toContain("RFT-001");
+    expect(dxf).not.toMatch(/  0\nIMAGE\n/);
+    expect(dxf).not.toMatch(/  0\nRASTER\n/);
+  });
+
   test("fails closed when the drawing model is invalid", () => {
     const model = buildCanonicalDrawingModelFromCompiledProject({
       compiledProject: fixtureCompiledProject(),

--- a/src/__tests__/services/structure/structuralDrawingSetIntegration.test.js
+++ b/src/__tests__/services/structure/structuralDrawingSetIntegration.test.js
@@ -1,0 +1,149 @@
+import { __projectGraphVerticalSliceInternals } from "../../../services/project/projectGraphVerticalSliceService.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geometry-hash-structural-drawing-set-001",
+    projectGraphHash: "project-graph-hash-structural-drawing-set-001",
+    site: {
+      boundary_polygon: [
+        { x: 0, y: 0 },
+        { x: 18, y: 0 },
+        { x: 18, y: 12 },
+        { x: 0, y: 12 },
+      ],
+    },
+    levels: [{ id: "level-0", level_number: 0, name: "Ground", height_m: 3.2 }],
+    slabs: [
+      {
+        id: "slab-0",
+        levelId: "level-0",
+        polygon: [
+          { x: 3, y: 3 },
+          { x: 14, y: 3 },
+          { x: 14, y: 9 },
+          { x: 3, y: 9 },
+        ],
+      },
+    ],
+    rooms: [
+      {
+        id: "room-0",
+        levelId: "level-0",
+        name: "Living",
+        polygon: [
+          { x: 3, y: 3 },
+          { x: 14, y: 3 },
+          { x: 14, y: 9 },
+          { x: 3, y: 9 },
+        ],
+      },
+    ],
+    walls: [
+      {
+        id: "wall-0",
+        levelId: "level-0",
+        exterior: true,
+        start: { x: 3, y: 3 },
+        end: { x: 14, y: 3 },
+      },
+    ],
+  };
+}
+
+describe("structural drawing-set integration", () => {
+  test("keeps structural sheets disabled by default", () => {
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+      {
+        layoutTemplate: "presentation-v3",
+      },
+    );
+    const panelTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(panelTypes).not.toContain("foundation_plan");
+    expect(panelTypes).not.toContain("structural_ground_floor");
+    expect(result.technicalBuild.structuralModel).toBeNull();
+  });
+
+  test("adds structural drawing sheets and manifest entries when enabled", () => {
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+      {
+        layoutTemplate: "presentation-v3",
+        structuralDrawingsEnabled: true,
+      },
+    );
+    const panelTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+    const structuralArtifacts = Object.values(result.drawingArtifacts).filter(
+      (artifact) => artifact.drawingType === "structural",
+    );
+
+    expect(panelTypes).toEqual(
+      expect.arrayContaining([
+        "foundation_plan",
+        "structural_ground_floor",
+        "roof_framing_plan",
+        "structural_section",
+        "structural_notes",
+      ]),
+    );
+    expect(structuralArtifacts.length).toBeGreaterThan(0);
+    structuralArtifacts.forEach((artifact) => {
+      expect(artifact.technicalDrawing).toBe(true);
+      expect(artifact.imageProviderUsed).toBe("none");
+      expect(artifact.metadata.structuralModelHash).toBeTruthy();
+      expect(artifact.metadata.reviewRequired).toBe(true);
+      expect(artifact.svgString).toContain("ENGINEER REVIEW REQUIRED");
+    });
+  });
+});
+
+describe("structural drawing set environment gating", () => {
+  const originalStructuralEnv = process.env.STRUCTURAL_DRAWINGS_ENABLED;
+
+  afterEach(() => {
+    if (originalStructuralEnv === undefined) {
+      delete process.env.STRUCTURAL_DRAWINGS_ENABLED;
+    } else {
+      process.env.STRUCTURAL_DRAWINGS_ENABLED = originalStructuralEnv;
+    }
+  });
+
+  test("includes structural panels when STRUCTURAL_DRAWINGS_ENABLED=true", () => {
+    process.env.STRUCTURAL_DRAWINGS_ENABLED = "true";
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+    );
+    const drawingTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(drawingTypes).toEqual(
+      expect.arrayContaining([
+        "foundation_plan",
+        "structural_ground_floor",
+        "roof_framing_plan",
+        "structural_section",
+        "structural_notes",
+      ]),
+    );
+  });
+
+  test("keeps structural panels absent when STRUCTURAL_DRAWINGS_ENABLED=false", () => {
+    process.env.STRUCTURAL_DRAWINGS_ENABLED = "false";
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+    );
+    const drawingTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(drawingTypes).not.toEqual(
+      expect.arrayContaining(["foundation_plan", "structural_ground_floor"]),
+    );
+  });
+});

--- a/src/__tests__/services/structure/structuralModelService.test.js
+++ b/src/__tests__/services/structure/structuralModelService.test.js
@@ -1,0 +1,156 @@
+import {
+  STRUCTURAL_REVIEW_DISCLAIMER,
+  buildStructuralDrawingPanelsFromCompiledProject,
+  buildStructuralModelFromCompiledProject,
+  validateStructuralModel,
+} from "../../../services/structure/structuralModelService.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geometry-hash-structural-001",
+    projectGraphHash: "project-graph-hash-structural-001",
+    projectName: "Structural Fixture",
+    jurisdiction: "uk",
+    buildingType: "residential",
+    site: {
+      boundary_polygon: [
+        { x: 0, y: 0 },
+        { x: 20, y: 0 },
+        { x: 20, y: 14 },
+        { x: 0, y: 14 },
+      ],
+    },
+    levels: [
+      {
+        id: "level-0",
+        level_number: 0,
+        name: "Ground",
+        elevation_m: 0,
+        height_m: 3.2,
+      },
+      {
+        id: "level-1",
+        level_number: 1,
+        name: "First",
+        elevation_m: 3.2,
+        height_m: 3.2,
+      },
+    ],
+    slabs: [
+      {
+        id: "slab-ground",
+        levelId: "level-0",
+        polygon: [
+          { x: 3, y: 3 },
+          { x: 15, y: 3 },
+          { x: 15, y: 10 },
+          { x: 3, y: 10 },
+        ],
+      },
+      {
+        id: "slab-first",
+        levelId: "level-1",
+        polygon: [
+          { x: 3, y: 3 },
+          { x: 15, y: 3 },
+          { x: 15, y: 10 },
+          { x: 3, y: 10 },
+        ],
+      },
+    ],
+    walls: [
+      {
+        id: "wall-south",
+        levelId: "level-0",
+        exterior: true,
+        start: { x: 3, y: 3 },
+        end: { x: 15, y: 3 },
+      },
+    ],
+    roof_primitives: [
+      {
+        id: "roof-main",
+        levelId: "level-1",
+        polygon: [
+          { x: 3, y: 3 },
+          { x: 15, y: 3 },
+          { x: 15, y: 10 },
+          { x: 3, y: 10 },
+        ],
+      },
+    ],
+  };
+}
+
+describe("structuralModelService", () => {
+  test("builds a deterministic preliminary StructuralModel with authority hashes", () => {
+    const first = buildStructuralModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const second = buildStructuralModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+
+    expect(first.geometryHash).toBe("geometry-hash-structural-001");
+    expect(first.sourceProjectGraphHash).toBe(
+      "project-graph-hash-structural-001",
+    );
+    expect(first.structuralModelHash).toBe(second.structuralModelHash);
+    expect(first.structuralModelId).toBe(second.structuralModelId);
+  });
+
+  test("derives foundations, slabs, roof framing, grid, and member IDs", () => {
+    const model = buildStructuralModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+
+    expect(model.foundationSystem.foundations.length).toBeGreaterThan(0);
+    expect(model.slabs.length).toBeGreaterThan(0);
+    expect(model.roofFraming.rafters.length).toBeGreaterThan(0);
+    expect(model.structuralGrid.x_axes.length).toBeGreaterThan(1);
+    expect(model.memberIds.length).toBeGreaterThan(0);
+    expect(model.schedules.beams).toBeDefined();
+  });
+
+  test("requires licensed structural engineer review and disclaimer", () => {
+    const model = buildStructuralModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const result = validateStructuralModel(model, {
+      compiledProject: fixtureCompiledProject(),
+    });
+
+    expect(model.reviewRequired).toBe(true);
+    expect(model.disclaimers).toContain(STRUCTURAL_REVIEW_DISCLAIMER);
+    expect(result.valid).toBe(true);
+    expect(result.checks.imageProviderUsed).toBe("none");
+  });
+
+  test("generates deterministic SVG structural panels without image providers", () => {
+    const { structuralModel, structuralPanels } =
+      buildStructuralDrawingPanelsFromCompiledProject({
+        compiledProject: fixtureCompiledProject(),
+      });
+
+    expect(Object.keys(structuralPanels)).toEqual(
+      expect.arrayContaining([
+        "foundation_plan",
+        "structural_ground_floor",
+        "structural_upper_floor",
+        "roof_framing_plan",
+        "structural_section",
+        "structural_notes",
+      ]),
+    );
+    Object.values(structuralPanels).forEach((panel) => {
+      expect(panel.svgString).toContain("<svg");
+      expect(panel.svgString).toContain("s-grid");
+      expect(panel.svgString).toContain("member-tag");
+      expect(panel.svgString).toContain("ENGINEER REVIEW REQUIRED");
+      expect(panel.technicalDrawing).toBe(true);
+      expect(panel.imageProviderUsed).toBe("none");
+      expect(panel.geometryHash).toBe(structuralModel.geometryHash);
+      expect(panel.sourceGeometryHash).toBe(structuralModel.geometryHash);
+    });
+  });
+});

--- a/src/services/cad/canonicalDrawingModel.js
+++ b/src/services/cad/canonicalDrawingModel.js
@@ -5,6 +5,7 @@ import {
   createStableId,
   roundMetric,
 } from "./projectGeometrySchema.js";
+import { buildStructuralModelFromCompiledProject } from "../structure/structuralModelService.js";
 
 export const CANONICAL_DRAWING_MODEL_VERSION = "canonical-drawing-model-v1";
 
@@ -32,6 +33,8 @@ export const REQUIRED_CANONICAL_CAD_LAYERS = Object.freeze([
   "A-HATCH",
   "A-SITE",
   "A-TITLE",
+  "A-COLU",
+  "A-SLAB",
   "S-FOUNDATION",
   "S-COLUMN",
   "S-BEAM",
@@ -39,6 +42,7 @@ export const REQUIRED_CANONICAL_CAD_LAYERS = Object.freeze([
   "S-ROOF",
   "S-GRID",
   "S-NOTES",
+  "S-DIMS",
   "M-DUCT",
   "M-PIPE",
   "P-DRAIN",
@@ -46,6 +50,17 @@ export const REQUIRED_CANONICAL_CAD_LAYERS = Object.freeze([
   "E-POWER",
   "E-SWITCH",
   "F-FIRE",
+]);
+
+const STRUCTURAL_CANONICAL_CAD_LAYER_NAMES = new Set([
+  "S-FOUNDATION",
+  "S-COLUMN",
+  "S-BEAM",
+  "S-SLAB",
+  "S-ROOF",
+  "S-GRID",
+  "S-NOTES",
+  "S-DIMS",
 ]);
 
 export const DEFAULT_CANONICAL_CAD_LAYERS = Object.freeze([
@@ -127,6 +142,20 @@ export const DEFAULT_CANONICAL_CAD_LAYERS = Object.freeze([
     linetype: "CONTINUOUS",
   },
   {
+    name: "A-COLU",
+    discipline: "architectural",
+    color: 1,
+    lineweight: 50,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "A-SLAB",
+    discipline: "architectural",
+    color: 3,
+    lineweight: 25,
+    linetype: "CONTINUOUS",
+  },
+  {
     name: "S-FOUNDATION",
     discipline: "structural",
     color: 1,
@@ -172,6 +201,13 @@ export const DEFAULT_CANONICAL_CAD_LAYERS = Object.freeze([
     name: "S-NOTES",
     discipline: "structural",
     color: 7,
+    lineweight: 18,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "S-DIMS",
+    discipline: "structural",
+    color: 2,
     lineweight: 18,
     linetype: "CONTINUOUS",
   },
@@ -551,6 +587,7 @@ function dimensionEntity({
   end,
   offset,
   text,
+  layer = "A-DIMS",
   viewType,
   viewId,
   geometryHash,
@@ -560,7 +597,7 @@ function dimensionEntity({
 }) {
   return createEntity({
     type: "DIMENSION",
-    layer: "A-DIMS",
+    layer,
     viewType,
     viewId,
     geometryHash,
@@ -574,7 +611,7 @@ function dimensionEntity({
       text: String(text || ""),
       styleName: "ARCH_100",
       arrowStyle: "architectural_tick",
-      layer: "A-DIMS",
+      layer,
     },
     metadata,
   });
@@ -727,7 +764,7 @@ function buildFloorPlanEntities(compiledProject = {}, geometryHash) {
         entities.push(
           polylineEntity({
             points: slab.polygon,
-            layer: "S-SLAB",
+            layer: "A-SLAB",
             viewType: "floor_plan",
             viewId,
             geometryHash,
@@ -873,7 +910,7 @@ function buildFloorPlanEntities(compiledProject = {}, geometryHash) {
             { x: position.x + half, y: position.y + half },
             { x: position.x - half, y: position.y + half },
           ],
-          layer: "S-COLUMN",
+          layer: "A-COLU",
           viewType: "floor_plan",
           viewId,
           geometryHash,
@@ -890,7 +927,7 @@ function buildFloorPlanEntities(compiledProject = {}, geometryHash) {
           lineEntity({
             start: beam.start,
             end: beam.end,
-            layer: "S-BEAM",
+            layer: "A-SLAB",
             viewType: "floor_plan",
             viewId,
             geometryHash,
@@ -1038,7 +1075,7 @@ function buildSectionEntities(compiledProject = {}, geometryHash) {
         lineEntity({
           start: { x: 0, y },
           end: { x: width, y },
-          layer: "S-SLAB",
+          layer: "A-SLAB",
           viewType: "section",
           viewId,
           geometryHash,
@@ -1128,40 +1165,381 @@ function buildSiteEntities(compiledProject = {}, geometryHash) {
   return entities;
 }
 
-function buildStructuralPrimitiveEntities(compiledProject = {}, geometryHash) {
+function buildStructuralModelEntities(structuralModel = {}, geometryHash) {
   const entities = [];
-  toArray(compiledProject.foundations).forEach((foundation, index) => {
-    if (hasUsablePolygon(foundation.polygon)) {
+  toArray(structuralModel.foundationSystem?.foundations).forEach(
+    (foundation, index) => {
+      if (hasUsablePolygon(foundation.polygon)) {
+        entities.push(
+          polylineEntity({
+            points: foundation.polygon,
+            layer: "S-FOUNDATION",
+            viewType: "structural_plan",
+            viewId: "foundation_plan",
+            geometryHash,
+            sourceId: foundation.id || `foundation-${index}`,
+            levelId: foundation.levelId || levelIdOf(foundation),
+            metadata: {
+              role: "foundation_outline",
+              memberId: foundation.memberId,
+              structuralModelHash: structuralModel.structuralModelHash,
+            },
+          }),
+          hatchEntity({
+            boundary: foundation.polygon,
+            layer: "S-FOUNDATION",
+            pattern: "CONCRETE",
+            viewType: "structural_plan",
+            viewId: "foundation_plan",
+            geometryHash,
+            sourceId: `${foundation.id || `foundation-${index}`}-hatch`,
+            levelId: foundation.levelId || levelIdOf(foundation),
+            metadata: {
+              role: "foundation_hatch",
+              memberId: foundation.memberId,
+              structuralModelHash: structuralModel.structuralModelHash,
+            },
+          }),
+        );
+        const center = computeCentroid(foundation.polygon);
+        entities.push(
+          textEntity({
+            point: center,
+            text: foundation.memberId || foundation.id || `FND-${index + 1}`,
+            layer: "S-NOTES",
+            viewType: "structural_plan",
+            viewId: "foundation_plan",
+            geometryHash,
+            sourceId: `${foundation.id || index}-tag`,
+            levelId: foundation.levelId || levelIdOf(foundation),
+            height: 0.28,
+            metadata: {
+              role: "member_tag",
+              structuralModelHash: structuralModel.structuralModelHash,
+            },
+          }),
+        );
+      }
+    },
+  );
+
+  toArray(structuralModel.slabs).forEach((slab, index) => {
+    const viewId =
+      Number(String(slab.levelId || "").replace(/[^0-9]/g, "")) > 0
+        ? "structural_upper_floor"
+        : "structural_ground_floor";
+    if (hasUsablePolygon(slab.polygon)) {
       entities.push(
         polylineEntity({
-          points: foundation.polygon,
-          layer: "S-FOUNDATION",
+          points: slab.polygon,
+          layer: "S-SLAB",
           viewType: "structural_plan",
-          viewId: "foundation_plan",
+          viewId,
           geometryHash,
-          sourceId: foundation.id || `foundation-${index}`,
-          levelId: levelIdOf(foundation),
-          metadata: { role: "foundation_outline" },
+          sourceId: slab.id || `structural-slab-${index}`,
+          levelId: slab.levelId,
+          metadata: {
+            role: "structural_slab",
+            memberId: slab.memberId,
+            structuralModelHash: structuralModel.structuralModelHash,
+          },
         }),
       );
     }
   });
-  toArray(compiledProject.roof_primitives).forEach((roof, index) => {
-    if (hasUsablePolygon(roof.polygon)) {
+
+  toArray(structuralModel.structuralGrid?.x_axes).forEach((axis) => {
+    const bbox = structuralModel.roofFraming?.outline
+      ? buildBoundingBoxFromPolygon(structuralModel.roofFraming.outline)
+      : null;
+    if (!bbox) return;
+    entities.push(
+      lineEntity({
+        start: { x: axis.position_m, y: bbox.min_y },
+        end: { x: axis.position_m, y: bbox.max_y },
+        layer: "S-GRID",
+        viewType: "structural_plan",
+        viewId: "structural_ground_floor",
+        geometryHash,
+        sourceId: `grid-x-${axis.label}`,
+        metadata: {
+          role: "structural_grid",
+          gridLabel: axis.label,
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+    );
+    entities.push(
+      textEntity({
+        point: { x: axis.position_m, y: bbox.max_y + 0.4 },
+        text: axis.label,
+        layer: "S-NOTES",
+        viewType: "structural_plan",
+        viewId: "structural_ground_floor",
+        geometryHash,
+        sourceId: `grid-x-${axis.label}-label`,
+        height: 0.25,
+        metadata: { role: "grid_bubble" },
+      }),
+    );
+  });
+
+  toArray(structuralModel.structuralGrid?.y_axes).forEach((axis) => {
+    const bbox = structuralModel.roofFraming?.outline
+      ? buildBoundingBoxFromPolygon(structuralModel.roofFraming.outline)
+      : null;
+    if (!bbox) return;
+    entities.push(
+      lineEntity({
+        start: { x: bbox.min_x, y: axis.position_m },
+        end: { x: bbox.max_x, y: axis.position_m },
+        layer: "S-GRID",
+        viewType: "structural_plan",
+        viewId: "structural_ground_floor",
+        geometryHash,
+        sourceId: `grid-y-${axis.label}`,
+        metadata: {
+          role: "structural_grid",
+          gridLabel: axis.label,
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+    );
+    entities.push(
+      textEntity({
+        point: { x: bbox.min_x - 0.4, y: axis.position_m },
+        text: axis.label,
+        layer: "S-NOTES",
+        viewType: "structural_plan",
+        viewId: "structural_ground_floor",
+        geometryHash,
+        sourceId: `grid-y-${axis.label}-label`,
+        height: 0.25,
+        metadata: { role: "grid_bubble" },
+      }),
+    );
+  });
+
+  toArray(structuralModel.beams).forEach((beam, index) => {
+    if (beam.start && beam.end) {
       entities.push(
-        polylineEntity({
-          points: roof.polygon,
-          layer: "S-ROOF",
+        lineEntity({
+          start: beam.start,
+          end: beam.end,
+          layer: "S-BEAM",
           viewType: "structural_plan",
-          viewId: "roof_framing_plan",
+          viewId: "structural_ground_floor",
           geometryHash,
-          sourceId: roof.id || `roof-${index}`,
-          levelId: levelIdOf(roof),
-          metadata: { role: "roof_primitive" },
+          sourceId: beam.id || `structural-beam-${index}`,
+          levelId: beam.levelId,
+          metadata: {
+            role: "structural_beam",
+            memberId: beam.memberId,
+            structuralModelHash: structuralModel.structuralModelHash,
+          },
+        }),
+        textEntity({
+          point: {
+            x: (Number(beam.start.x || 0) + Number(beam.end.x || 0)) / 2,
+            y: (Number(beam.start.y || 0) + Number(beam.end.y || 0)) / 2,
+          },
+          text: beam.memberId || `BM-${index + 1}`,
+          layer: "S-NOTES",
+          viewType: "structural_plan",
+          viewId: "structural_ground_floor",
+          geometryHash,
+          sourceId: `${beam.id || index}-tag`,
+          levelId: beam.levelId,
+          height: 0.24,
+          metadata: { role: "member_tag" },
         }),
       );
     }
   });
+
+  toArray(structuralModel.columns).forEach((column, index) => {
+    const position = column.position;
+    if (!position) return;
+    const half = finiteMetric(column.width_m || column.depth_m, 0.3) / 2;
+    entities.push(
+      polylineEntity({
+        points: [
+          { x: position.x - half, y: position.y - half },
+          { x: position.x + half, y: position.y - half },
+          { x: position.x + half, y: position.y + half },
+          { x: position.x - half, y: position.y + half },
+        ],
+        layer: "S-COLUMN",
+        viewType: "structural_plan",
+        viewId: "structural_ground_floor",
+        geometryHash,
+        sourceId: column.id || `structural-column-${index}`,
+        levelId: column.levelId,
+        metadata: {
+          role: "structural_column",
+          memberId: column.memberId,
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+      textEntity({
+        point: { x: position.x + half + 0.12, y: position.y + half + 0.12 },
+        text: column.memberId || `COL-${index + 1}`,
+        layer: "S-NOTES",
+        viewType: "structural_plan",
+        viewId: "structural_ground_floor",
+        geometryHash,
+        sourceId: `${column.id || index}-tag`,
+        levelId: column.levelId,
+        height: 0.22,
+        metadata: { role: "member_tag" },
+      }),
+    );
+  });
+
+  toArray(structuralModel.loadBearingWalls).forEach((wall, index) => {
+    entities.push(
+      lineEntity({
+        start: wall.start,
+        end: wall.end,
+        layer: "S-BEAM",
+        viewType: "structural_plan",
+        viewId: "structural_ground_floor",
+        geometryHash,
+        sourceId: wall.id || `load-bearing-wall-${index}`,
+        levelId: wall.levelId,
+        metadata: {
+          role: "load_bearing_wall",
+          memberId: wall.memberId,
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+    );
+  });
+
+  const roof = structuralModel.roofFraming || {};
+  if (hasUsablePolygon(roof.outline)) {
+    entities.push(
+      polylineEntity({
+        points: roof.outline,
+        layer: "S-ROOF",
+        viewType: "structural_plan",
+        viewId: "roof_framing_plan",
+        geometryHash,
+        sourceId: roof.id || "roof-framing",
+        levelId: roof.levelId,
+        metadata: {
+          role: "roof_framing_outline",
+          memberId: roof.memberId,
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+    );
+  }
+  toArray(roof.rafters).forEach((rafter, index) => {
+    const rafterMemberId =
+      rafter.memberId ||
+      rafter.id ||
+      `RFT-${String(index + 1).padStart(3, "0")}`;
+    entities.push(
+      lineEntity({
+        start: rafter.start,
+        end: rafter.end,
+        layer: "S-ROOF",
+        viewType: "structural_plan",
+        viewId: "roof_framing_plan",
+        geometryHash,
+        sourceId: rafter.id || `rafter-${index}`,
+        levelId: roof.levelId,
+        metadata: {
+          role: "roof_rafter",
+          memberId: rafter.memberId,
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+      textEntity({
+        point: {
+          x: ((rafter.start?.x ?? 0) + (rafter.end?.x ?? 0)) / 2,
+          y: ((rafter.start?.y ?? 0) + (rafter.end?.y ?? 0)) / 2,
+        },
+        text: rafterMemberId,
+        layer: "S-NOTES",
+        viewType: "structural_plan",
+        viewId: "roof_framing_plan",
+        geometryHash,
+        sourceId: `${rafter.id || `rafter-${index}`}-tag`,
+        levelId: roof.levelId,
+        height: 0.22,
+        metadata: {
+          role: "roof_rafter_tag",
+          memberId: rafterMemberId,
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+    );
+  });
+
+  const notes = [
+    ...toArray(structuralModel.preliminaryLoadPathNotes),
+    ...toArray(structuralModel.disclaimers),
+  ];
+  notes.slice(0, 6).forEach((note, index) => {
+    entities.push(
+      textEntity({
+        point: { x: 0, y: -2 - index * 0.45 },
+        text: note,
+        layer: "S-NOTES",
+        viewType: "structural_notes",
+        viewId: "structural_notes",
+        geometryHash,
+        sourceId: `structural-note-${index}`,
+        height: 0.2,
+        metadata: {
+          role:
+            index === notes.length - 1
+              ? "review_disclaimer"
+              : "structural_note",
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+    );
+  });
+
+  const foundation = toArray(structuralModel.foundationSystem?.foundations)[0];
+  if (foundation?.polygon) {
+    const bbox = buildBoundingBoxFromPolygon(foundation.polygon);
+    entities.push(
+      dimensionEntity({
+        start: { x: bbox.min_x, y: bbox.min_y },
+        end: { x: bbox.max_x, y: bbox.min_y },
+        offset: { x: bbox.min_x, y: bbox.min_y - 0.8 },
+        text: dimensionText(bbox.width),
+        layer: "S-DIMS",
+        viewType: "structural_plan",
+        viewId: "foundation_plan",
+        geometryHash,
+        sourceId: "foundation-width-dim",
+        metadata: {
+          role: "foundation_dimension",
+          structuralModelHash: structuralModel.structuralModelHash,
+        },
+      }),
+    );
+  }
+  return entities;
+}
+
+function buildStructuralPrimitiveEntities(
+  compiledProject = {},
+  geometryHash,
+  includeStructuralDrawings = false,
+) {
+  if (!includeStructuralDrawings) {
+    return [];
+  }
+  const structuralModel = buildStructuralModelFromCompiledProject({
+    compiledProject,
+  });
+  const entities = buildStructuralModelEntities(structuralModel, geometryHash);
   return entities;
 }
 
@@ -1676,6 +2054,8 @@ export function buildCanonicalDrawingModelFromCompiledProject({
   projectName = null,
   jurisdiction = null,
   units = "meters",
+  includeStructuralDrawings = false,
+  structuralDrawingsEnabled = false,
 } = {}) {
   if (!compiledProject?.geometryHash) {
     throw new Error(
@@ -1687,12 +2067,24 @@ export function buildCanonicalDrawingModelFromCompiledProject({
   const resolvedProjectName = projectName || projectNameOf(compiledProject);
   const resolvedJurisdiction = jurisdiction || jurisdictionOf(compiledProject);
   const sourceProjectGraphHash = sourceProjectGraphHashOf(compiledProject);
+  const shouldIncludeStructuralDrawings =
+    includeStructuralDrawings === true || structuralDrawingsEnabled === true;
+  const structuralModel = shouldIncludeStructuralDrawings
+    ? buildStructuralModelFromCompiledProject({
+        compiledProject,
+        jurisdiction: resolvedJurisdiction,
+      })
+    : null;
   const modelSpaceEntities = [
     ...buildSiteEntities(compiledProject, geometryHash),
     ...buildFloorPlanEntities(compiledProject, geometryHash),
     ...buildElevationEntities(compiledProject, geometryHash),
     ...buildSectionEntities(compiledProject, geometryHash),
-    ...buildStructuralPrimitiveEntities(compiledProject, geometryHash),
+    ...buildStructuralPrimitiveEntities(
+      compiledProject,
+      geometryHash,
+      shouldIncludeStructuralDrawings,
+    ),
   ];
   const sheets = buildPaperSpaceSheets({
     compiledProject,
@@ -1722,7 +2114,12 @@ export function buildCanonicalDrawingModelFromCompiledProject({
       nativeLayouts: sheets.map((sheet) => sheet.nativeLayout),
     },
     plotStyleMetadata: clone(DEFAULT_PLOT_STYLE_METADATA),
-    layers: clone(DEFAULT_CANONICAL_CAD_LAYERS),
+    ...(structuralModel ? { structuralModel } : {}),
+    layers: clone(DEFAULT_CANONICAL_CAD_LAYERS).filter(
+      (layer) =>
+        shouldIncludeStructuralDrawings ||
+        !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layer.name),
+    ),
     blocks: defaultBlocks(geometryHash),
     hatches: clone(DEFAULT_HATCHES),
     lineweights: clone(DEFAULT_LINEWEIGHTS),
@@ -1800,6 +2197,8 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
   const errors = [];
   const warnings = [];
   const dimensionPolicy = options.dimensionPolicy || "warn";
+  const shouldValidateStructuralModel =
+    Boolean(model.structuralModel) || options.requireStructuralModel === true;
 
   if (model.schema_version !== CANONICAL_DRAWING_MODEL_VERSION) {
     errors.push(
@@ -1953,7 +2352,12 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
   });
 
   const layerNames = new Set(toArray(model.layers).map((layer) => layer.name));
-  REQUIRED_CANONICAL_CAD_LAYERS.forEach((layerName) => {
+  const requiredLayerNames = REQUIRED_CANONICAL_CAD_LAYERS.filter(
+    (layerName) =>
+      shouldValidateStructuralModel ||
+      !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layerName),
+  );
+  requiredLayerNames.forEach((layerName) => {
     if (!layerNames.has(layerName)) {
       errors.push(
         validationError(
@@ -2035,6 +2439,81 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
     );
   }
 
+  if (
+    shouldValidateStructuralModel &&
+    !model.structuralModel?.structuralModelHash
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_STRUCTURAL_MODEL_HASH_MISSING",
+        "CanonicalDrawingModel requires structuralModel.structuralModelHash.",
+      ),
+    );
+  }
+  if (
+    shouldValidateStructuralModel &&
+    model.structuralModel?.geometryHash &&
+    model.geometryHash &&
+    model.structuralModel.geometryHash !== model.geometryHash
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_STRUCTURAL_GEOMETRY_HASH_MISMATCH",
+        "StructuralModel geometryHash must match CanonicalDrawingModel geometryHash.",
+        {
+          structuralGeometryHash: model.structuralModel.geometryHash,
+          geometryHash: model.geometryHash,
+        },
+      ),
+    );
+  }
+  if (
+    shouldValidateStructuralModel &&
+    model.structuralModel?.reviewRequired !== true
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_STRUCTURAL_REVIEW_REQUIRED_MISSING",
+        "StructuralModel must be marked reviewRequired=true.",
+      ),
+    );
+  }
+  if (
+    shouldValidateStructuralModel &&
+    !toArray(model.structuralModel?.disclaimers)
+      .join(" ")
+      .match(/licensed structural engineer/i)
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_STRUCTURAL_DISCLAIMER_MISSING",
+        "StructuralModel requires licensed structural engineer review disclaimer.",
+      ),
+    );
+  }
+  if (
+    shouldValidateStructuralModel &&
+    !toArray(model.structuralModel?.foundationSystem?.foundations).length
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_STRUCTURAL_FOUNDATIONS_MISSING",
+        "StructuralModel requires preliminary foundations for applicable buildings.",
+      ),
+    );
+  }
+  if (
+    shouldValidateStructuralModel &&
+    model.structuralModel?.imageProviderUsed !== "none"
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_STRUCTURAL_IMAGE_PROVIDER_FORBIDDEN",
+        "StructuralModel must not use image generation.",
+      ),
+    );
+  }
+
   const hasNativeLayouts =
     sheets.length > 0 &&
     sheets.every((sheet) => sheet.nativeLayout?.className === "AcDbLayout");
@@ -2054,6 +2533,12 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
   const hasPlotStyleMetadata = Boolean(
     model.plotStyleMetadata?.ctbFile || model.plotStyleMetadata?.stbFile,
   );
+  const hasStructuralModelHash = Boolean(
+    model.structuralModel?.structuralModelHash,
+  );
+  const hasStructuralDisclaimer = toArray(model.structuralModel?.disclaimers)
+    .join(" ")
+    .match(/licensed structural engineer/i);
 
   return {
     valid: errors.length === 0,
@@ -2074,6 +2559,11 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
       hasNativeViewports,
       hasPlotSettings,
       hasPlotStyleMetadata,
+      hasStructuralModelHash,
+      hasStructuralDisclaimer: Boolean(hasStructuralDisclaimer),
+      structuralReviewRequired: model.structuralModel?.reviewRequired === true,
+      structuralImageProviderUsed:
+        model.structuralModel?.imageProviderUsed || null,
     },
   };
 }

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -12,6 +12,7 @@ import {
   roundMetric,
 } from "../cad/projectGeometrySchema.js";
 import { buildCompiledProjectTechnicalPanels } from "../canonical/compiledProjectTechnicalPackBuilder.js";
+import { buildStructuralDrawingPanelsFromCompiledProject } from "../structure/structuralModelService.js";
 import { compileProject } from "../compiler/index.js";
 import { ensureCompiledProjectRenderInputs } from "../compiler/compiledProjectRenderInputs.js";
 import { resolveArchitectureModelRegistry } from "../modelStepResolver.js";
@@ -5278,10 +5279,27 @@ function buildSelectedDesign(compiledProject, programme) {
 }
 
 function drawingTypeForPanel(panelType) {
+  if (
+    panelType === "foundation_plan" ||
+    panelType === "roof_framing_plan" ||
+    panelType === "structural_section" ||
+    panelType === "structural_notes" ||
+    panelType.startsWith("structural_")
+  ) {
+    return "structural";
+  }
   if (panelType.startsWith("floor_plan_")) return "floor_plan";
   if (panelType.startsWith("section_")) return "section";
   if (panelType.startsWith("elevation_")) return "elevation";
   return "diagram";
+}
+
+function structuralDrawingsEnabled(options = {}) {
+  return (
+    options.structuralDrawingsEnabled === true ||
+    String(process.env.STRUCTURAL_DRAWINGS_ENABLED || "").toLowerCase() ===
+      "true"
+  );
 }
 
 function buildDrawingSet(compiledProject, options = {}) {
@@ -5296,7 +5314,13 @@ function buildDrawingSet(compiledProject, options = {}) {
     layoutTemplate,
     vernacularPack: options.vernacularPack || null,
   });
-  const technicalPanels = technicalBuild.technicalPanels || {};
+  const structuralBuild = structuralDrawingsEnabled(options)
+    ? buildStructuralDrawingPanelsFromCompiledProject({ compiledProject })
+    : { structuralModel: null, structuralPanels: {} };
+  const technicalPanels = {
+    ...(technicalBuild.technicalPanels || {}),
+    ...(structuralBuild.structuralPanels || {}),
+  };
   const drawingViews = Object.entries(technicalPanels).map(
     ([panelType, panel]) => {
       const drawingType = drawingTypeForPanel(panelType);
@@ -5331,13 +5355,19 @@ function buildDrawingSet(compiledProject, options = {}) {
         layers: [
           {
             layer_id: `${panelType}-geometry`,
-            source: "compiled_project",
+            source:
+              drawingType === "structural"
+                ? "structural_model"
+                : "compiled_project",
             entity_ids: [
               ...(compiledProject.rooms || []).map(
                 (room) => room.sourceId || room.id,
               ),
               ...(compiledProject.walls || []).map((wall) => wall.id),
               ...(compiledProject.openings || []).map((opening) => opening.id),
+              ...(drawingType === "structural"
+                ? structuralBuild.structuralModel?.memberIds || []
+                : []),
             ],
           },
         ],
@@ -5401,12 +5431,21 @@ function buildDrawingSet(compiledProject, options = {}) {
               normalizedViewBox: panel.normalizedViewBox || null,
               viewBoxNormalization: panel.viewBoxNormalization || null,
               technicalQualityMetadata: panel.technicalQualityMetadata || null,
+              structuralModelHash:
+                panel.structuralModelHash ||
+                panel.metadata?.structuralModelHash ||
+                null,
+              reviewRequired: panel.reviewRequired || false,
             },
           },
         ];
       }),
     ),
-    technicalBuild,
+    technicalBuild: {
+      ...technicalBuild,
+      structuralModel: structuralBuild.structuralModel || null,
+      structuralPanels: structuralBuild.structuralPanels || {},
+    },
   };
 }
 

--- a/src/services/structure/structuralModelService.js
+++ b/src/services/structure/structuralModelService.js
@@ -1,0 +1,858 @@
+import {
+  buildBoundingBoxFromPolygon,
+  computeCentroid,
+  createStableHash,
+  createStableId,
+  rectangleToPolygon,
+  roundMetric,
+} from "../cad/projectGeometrySchema.js";
+import { buildStructuralGrid } from "./structuralGridService.js";
+
+export const STRUCTURAL_MODEL_VERSION = "structural-model-v1";
+export const STRUCTURAL_DRAWING_PANEL_VERSION = "structural-drawing-panel-v1";
+
+export const STRUCTURAL_REVIEW_DISCLAIMER =
+  "PRELIMINARY STRUCTURAL INFORMATION ONLY - not for construction. Review and calculations by a licensed structural engineer are required.";
+
+export const REQUIRED_STRUCTURAL_CAD_LAYERS = Object.freeze([
+  "S-FOUNDATION",
+  "S-COLUMN",
+  "S-BEAM",
+  "S-SLAB",
+  "S-ROOF",
+  "S-GRID",
+  "S-NOTES",
+  "S-DIMS",
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function point(value = {}) {
+  return {
+    x: roundMetric(value.x),
+    y: roundMetric(value.y),
+  };
+}
+
+function polygon(points = []) {
+  return toArray(points).map(point);
+}
+
+function hasPolygon(points = []) {
+  return Array.isArray(points) && points.length >= 3;
+}
+
+function sourceProjectGraphHashOf(compiledProject = {}) {
+  return (
+    compiledProject.sourceProjectGraphHash ||
+    compiledProject.projectGraphHash ||
+    compiledProject.project_graph_hash ||
+    compiledProject.metadata?.sourceProjectGraphHash ||
+    compiledProject.metadata?.projectGraphHash ||
+    compiledProject.geometryHash ||
+    null
+  );
+}
+
+function jurisdictionOf(compiledProject = {}) {
+  return (
+    compiledProject.jurisdiction ||
+    compiledProject.regulations?.jurisdiction ||
+    compiledProject.metadata?.jurisdiction ||
+    "generic"
+  );
+}
+
+function levelsOf(compiledProject = {}) {
+  return toArray(compiledProject.levels).length
+    ? toArray(compiledProject.levels)
+    : [{ id: "level-0", level_number: 0, name: "Ground", elevation_m: 0 }];
+}
+
+function levelIdOf(entry = {}) {
+  return entry.levelId || entry.level_id || entry.level || "level-0";
+}
+
+function levelName(level = {}, index = 0) {
+  if (Number(level.level_number) === 0 || index === 0) return "ground";
+  return `level${Number(level.level_number) || index}`;
+}
+
+function candidateFootprint(compiledProject = {}) {
+  const slab = toArray(compiledProject.slabs).find((entry) =>
+    hasPolygon(entry.polygon),
+  );
+  if (slab) return polygon(slab.polygon);
+  if (hasPolygon(compiledProject.footprint?.polygon)) {
+    return polygon(compiledProject.footprint.polygon);
+  }
+  if (hasPolygon(compiledProject.site?.buildable_polygon)) {
+    return polygon(compiledProject.site.buildable_polygon);
+  }
+  if (hasPolygon(compiledProject.site?.boundary_polygon)) {
+    return polygon(compiledProject.site.boundary_polygon);
+  }
+  return rectangleToPolygon(0, 0, 12, 8);
+}
+
+function bboxOf(compiledProject = {}) {
+  return buildBoundingBoxFromPolygon(candidateFootprint(compiledProject));
+}
+
+function expandedPolygonFromBbox(bbox = {}, offset = 0.35) {
+  return rectangleToPolygon(
+    Number(bbox.min_x || 0) - offset,
+    Number(bbox.min_y || 0) - offset,
+    Number(bbox.width || 12) + offset * 2,
+    Number(bbox.height || 8) + offset * 2,
+  );
+}
+
+function memberId(prefix, index) {
+  return `${prefix}-${String(index + 1).padStart(3, "0")}`;
+}
+
+function buildDesignBasis(compiledProject = {}) {
+  const storeyCount = levelsOf(compiledProject).length;
+  return {
+    status: "preliminary",
+    designStage: "concept_structural_coordination",
+    buildingUse:
+      compiledProject.buildingType ||
+      compiledProject.metadata?.buildingType ||
+      "residential",
+    storeyCount,
+    materialSystem:
+      compiledProject.materials?.structure?.primary ||
+      compiledProject.materials?.structural?.primary ||
+      "masonry / timber / reinforced concrete assumptions",
+    codeBasis:
+      "Jurisdiction-specific structural code checks have not been performed.",
+    loadingBasis:
+      "Indicative residential dead/live load assumptions only; no engineer calculations.",
+  };
+}
+
+function buildAssumptions(compiledProject = {}) {
+  return [
+    "Preliminary structural layout is derived deterministically from compiled ProjectGraph geometry.",
+    "Foundation sizes, reinforcement, bearing capacity, lateral stability, and member sizing are placeholders pending structural engineering.",
+    `Jurisdiction is ${jurisdictionOf(compiledProject)}; local code verification is required.`,
+    "Ground conditions, drainage, retaining requirements, wind, seismic, and snow loads are not calculated in this slice.",
+  ];
+}
+
+function buildFoundationSystem(
+  compiledProject = {},
+  bbox = bboxOf(compiledProject),
+) {
+  const explicitFoundations = toArray(compiledProject.foundations)
+    .filter((foundation) => hasPolygon(foundation.polygon))
+    .map((foundation, index) => ({
+      id: foundation.id || memberId("FND", index),
+      memberId: foundation.memberId || memberId("FND", index),
+      type: foundation.type || "strip_foundation",
+      polygon: polygon(foundation.polygon),
+      levelId: levelIdOf(foundation),
+      status: "preliminary",
+    }));
+  const foundations = explicitFoundations.length
+    ? explicitFoundations
+    : [
+        {
+          id: "foundation-derived-001",
+          memberId: "FND-001",
+          type: "preliminary_raft_or_strip_foundation_zone",
+          polygon: expandedPolygonFromBbox(bbox, 0.35),
+          levelId: "level-0",
+          status: "preliminary",
+        },
+      ];
+  return {
+    systemType: "preliminary strip/raft foundation coordination zone",
+    reviewRequired: true,
+    foundations,
+  };
+}
+
+function buildSlabs(compiledProject = {}) {
+  const footprint = candidateFootprint(compiledProject);
+  const levels = levelsOf(compiledProject);
+  const explicitSlabs = toArray(compiledProject.slabs)
+    .filter((slab) => hasPolygon(slab.polygon))
+    .map((slab, index) => ({
+      id: slab.id || memberId("SLAB", index),
+      memberId: slab.memberId || memberId("SLAB", index),
+      levelId: levelIdOf(slab),
+      type: slab.type || "preliminary_floor_slab",
+      polygon: polygon(slab.polygon),
+      thickness_m: Number(slab.thickness_m || 0.15),
+      status: "preliminary",
+    }));
+  if (explicitSlabs.length) return explicitSlabs;
+  return levels.map((level, index) => ({
+    id: `slab-derived-${index + 1}`,
+    memberId: memberId("SLAB", index),
+    levelId: level.id || `level-${index}`,
+    type: index === 0 ? "ground_bearing_slab" : "upper_floor_slab",
+    polygon: footprint,
+    thickness_m: 0.15,
+    status: "preliminary",
+  }));
+}
+
+function buildLoadBearingWalls(compiledProject = {}) {
+  return toArray(compiledProject.walls)
+    .filter((wall) => wall.exterior || wall.loadBearing || wall.structural)
+    .map((wall, index) => ({
+      id: wall.id || memberId("LBW", index),
+      memberId: wall.memberId || memberId("LBW", index),
+      levelId: levelIdOf(wall),
+      type: wall.exterior ? "external_load_bearing_wall" : "load_bearing_wall",
+      start: point(wall.start),
+      end: point(wall.end),
+      thickness_m: Number(wall.thickness_m || (wall.exterior ? 0.3 : 0.2)),
+      status: "preliminary",
+    }))
+    .filter((wall) => wall.start && wall.end);
+}
+
+function buildGrid(compiledProject = {}, bbox = bboxOf(compiledProject)) {
+  const projectGeometry = {
+    project_id:
+      compiledProject.project_id ||
+      compiledProject.projectId ||
+      compiledProject.geometryHash,
+    site: {
+      buildable_bbox: bbox,
+      boundary_bbox: bbox,
+    },
+    levels: levelsOf(compiledProject),
+  };
+  const grid =
+    compiledProject.structuralGrid || buildStructuralGrid(projectGeometry);
+  return {
+    ...grid,
+    source: compiledProject.structuralGrid
+      ? "compiled_project"
+      : "structuralModelService",
+  };
+}
+
+function buildColumns(compiledProject = {}, structuralGrid = {}) {
+  const explicitColumns = toArray(compiledProject.columns).map(
+    (column, index) => ({
+      id: column.id || memberId("COL", index),
+      memberId: column.memberId || memberId("COL", index),
+      levelId: levelIdOf(column),
+      type: column.type || "preliminary_column",
+      position: point(column.position || column.position_m),
+      width_m: Number(column.width_m || 0.3),
+      depth_m: Number(column.depth_m || column.width_m || 0.3),
+      status: "preliminary",
+    }),
+  );
+  if (explicitColumns.length) return explicitColumns;
+  return toArray(structuralGrid.suggested_columns)
+    .slice(0, 36)
+    .map((column, index) => ({
+      id: column.id || memberId("COL", index),
+      memberId: memberId("COL", index),
+      levelId: column.level_id || "level-0",
+      type: "preliminary_grid_column",
+      position: point(column),
+      width_m: 0.25,
+      depth_m: 0.25,
+      status: "preliminary",
+    }));
+}
+
+function buildBeams(
+  compiledProject = {},
+  structuralGrid = {},
+  bbox = bboxOf(compiledProject),
+) {
+  const explicitBeams = toArray(compiledProject.beams).map((beam, index) => ({
+    id: beam.id || memberId("BM", index),
+    memberId: beam.memberId || memberId("BM", index),
+    levelId: levelIdOf(beam),
+    type: beam.type || "preliminary_beam",
+    start: point(beam.start),
+    end: point(beam.end),
+    status: "preliminary",
+  }));
+  if (explicitBeams.length) return explicitBeams;
+  return toArray(structuralGrid.y_axes)
+    .slice(1, -1)
+    .map((axis, index) => ({
+      id: memberId("BM", index),
+      memberId: memberId("BM", index),
+      levelId: "level-0",
+      type: "preliminary_grid_beam",
+      start: { x: bbox.min_x, y: axis.position_m },
+      end: { x: bbox.max_x, y: axis.position_m },
+      status: "preliminary",
+    }));
+}
+
+function buildRoofFraming(
+  compiledProject = {},
+  bbox = bboxOf(compiledProject),
+) {
+  const roofOutline = toArray(compiledProject.roof_primitives).find((roof) =>
+    hasPolygon(roof.polygon),
+  );
+  const outline = roofOutline
+    ? polygon(roofOutline.polygon)
+    : candidateFootprint(compiledProject);
+  const roofBbox = buildBoundingBoxFromPolygon(outline);
+  const rafterCount = Math.max(
+    4,
+    Math.min(18, Math.ceil((roofBbox.width || 10) / 0.9)),
+  );
+  const rafters = Array.from({ length: rafterCount }, (_, index) => {
+    const x =
+      roofBbox.min_x +
+      ((index + 0.5) * (roofBbox.width || bbox.width || 10)) / rafterCount;
+    return {
+      id: memberId("RFT", index),
+      memberId: memberId("RFT", index),
+      type: "preliminary_rafter",
+      start: { x: roundMetric(x), y: roofBbox.min_y },
+      end: { x: roundMetric(x), y: roofBbox.max_y },
+      spacing_m: roundMetric((roofBbox.width || 10) / rafterCount),
+      status: "preliminary",
+    };
+  });
+  return {
+    id: roofOutline?.id || "roof-framing-derived-001",
+    memberId: "ROOF-001",
+    type: "preliminary_roof_framing",
+    outline,
+    rafters,
+    levelId: levelIdOf(
+      roofOutline || { levelId: levelsOf(compiledProject).at(-1)?.id },
+    ),
+    status: "preliminary",
+  };
+}
+
+function buildSchedules({
+  foundations,
+  slabs,
+  beams,
+  columns,
+  loadBearingWalls,
+  roofFraming,
+}) {
+  return {
+    foundations: foundations.map((member) => ({
+      memberId: member.memberId,
+      type: member.type,
+      status: member.status,
+    })),
+    slabs: slabs.map((member) => ({
+      memberId: member.memberId,
+      levelId: member.levelId,
+      type: member.type,
+      thickness_m: member.thickness_m,
+    })),
+    beams: beams.map((member) => ({
+      memberId: member.memberId,
+      levelId: member.levelId,
+      type: member.type,
+    })),
+    columns: columns.map((member) => ({
+      memberId: member.memberId,
+      levelId: member.levelId,
+      type: member.type,
+    })),
+    loadBearingWalls: loadBearingWalls.map((member) => ({
+      memberId: member.memberId,
+      levelId: member.levelId,
+      type: member.type,
+    })),
+    roofFraming: roofFraming.rafters.map((member) => ({
+      memberId: member.memberId,
+      type: member.type,
+      spacing_m: member.spacing_m,
+    })),
+  };
+}
+
+export function buildStructuralModelFromCompiledProject({
+  compiledProject,
+  jurisdiction = null,
+} = {}) {
+  if (!compiledProject?.geometryHash) {
+    throw new Error(
+      "Compiled project with geometryHash is required to build StructuralModel.",
+    );
+  }
+  const bbox = bboxOf(compiledProject);
+  const structuralGrid = buildGrid(compiledProject, bbox);
+  const foundationSystem = buildFoundationSystem(compiledProject, bbox);
+  const slabs = buildSlabs(compiledProject);
+  const columns = buildColumns(compiledProject, structuralGrid);
+  const beams = buildBeams(compiledProject, structuralGrid, bbox);
+  const loadBearingWalls = buildLoadBearingWalls(compiledProject);
+  const roofFraming = buildRoofFraming(compiledProject, bbox);
+  const foundations = foundationSystem.foundations;
+  const designBasis = buildDesignBasis(compiledProject);
+  const assumptions = buildAssumptions(compiledProject);
+  const preliminaryLoadPathNotes = [
+    "Loads conceptually transfer from roof framing to beams/load-bearing walls, then to slabs/foundations.",
+    "Column/grid coordination is indicative and must be rationalized by structural engineer calculations.",
+    "Lateral stability, uplift, disproportionate collapse, and movement joints are not calculated.",
+  ];
+  const partial = {
+    version: STRUCTURAL_MODEL_VERSION,
+    geometryHash: compiledProject.geometryHash,
+    sourceProjectGraphHash: sourceProjectGraphHashOf(compiledProject),
+    jurisdiction: jurisdiction || jurisdictionOf(compiledProject),
+    designBasis,
+    assumptions,
+    disclaimers: [STRUCTURAL_REVIEW_DISCLAIMER],
+    reviewRequired: true,
+    foundationSystem,
+    foundations,
+    slabs,
+    beams,
+    columns,
+    loadBearingWalls,
+    roofFraming,
+    structuralGrid,
+    memberIds: [
+      ...foundations,
+      ...slabs,
+      ...beams,
+      ...columns,
+      ...loadBearingWalls,
+      ...roofFraming.rafters,
+    ].map((member) => member.memberId),
+    preliminaryLoadPathNotes,
+    schedules: buildSchedules({
+      foundations,
+      slabs,
+      beams,
+      columns,
+      loadBearingWalls,
+      roofFraming,
+    }),
+    requiredCadLayers: [...REQUIRED_STRUCTURAL_CAD_LAYERS],
+    imageProviderUsed: "none",
+    technicalDrawing: true,
+  };
+  const structuralModelHash = createStableHash(JSON.stringify(partial));
+  return {
+    structuralModelId: createStableId(
+      "structural-model",
+      compiledProject.geometryHash,
+      structuralModelHash,
+    ),
+    structuralModelHash,
+    ...partial,
+  };
+}
+
+function structuralViewBox(structuralModel = {}) {
+  const points = [
+    ...toArray(structuralModel.foundationSystem?.foundations).flatMap(
+      (foundation) => foundation.polygon || [],
+    ),
+    ...toArray(structuralModel.slabs).flatMap((slab) => slab.polygon || []),
+    ...(structuralModel.roofFraming?.outline || []),
+  ];
+  const bbox = buildBoundingBoxFromPolygon(
+    points.length ? points : rectangleToPolygon(0, 0, 12, 8),
+  );
+  const pad = 1.5;
+  return {
+    bbox,
+    minX: bbox.min_x - pad,
+    minY: bbox.min_y - pad,
+    width: Math.max(1, bbox.width + pad * 2),
+    height: Math.max(1, bbox.height + pad * 2),
+  };
+}
+
+function svgPoint(pointValue = {}, viewBox = structuralViewBox()) {
+  const x =
+    ((Number(pointValue.x || 0) - viewBox.minX) / viewBox.width) * 860 + 70;
+  const y =
+    620 - ((Number(pointValue.y || 0) - viewBox.minY) / viewBox.height) * 520;
+  return { x: roundMetric(x, 2), y: roundMetric(y, 2) };
+}
+
+function svgPolyline(points = [], viewBox, className, extra = "") {
+  const coords = polygon(points)
+    .map((entry) => {
+      const p = svgPoint(entry, viewBox);
+      return `${p.x},${p.y}`;
+    })
+    .join(" ");
+  return `<polygon class="${className}" points="${coords}" ${extra}/>`;
+}
+
+function svgLine(start, end, viewBox, className, extra = "") {
+  const a = svgPoint(start, viewBox);
+  const b = svgPoint(end, viewBox);
+  return `<line class="${className}" x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}" ${extra}/>`;
+}
+
+function svgText(pointValue, viewBox, text, className = "s-note", dy = 0) {
+  const p = svgPoint(pointValue, viewBox);
+  return `<text class="${className}" x="${p.x}" y="${roundMetric(p.y + dy, 2)}">${String(text || "")}</text>`;
+}
+
+function gridSvg(structuralModel = {}, viewBox) {
+  const bbox = viewBox.bbox;
+  const xLines = toArray(structuralModel.structuralGrid?.x_axes)
+    .map((axis) => {
+      const top = svgPoint({ x: axis.position_m, y: bbox.max_y }, viewBox);
+      const bottom = svgPoint({ x: axis.position_m, y: bbox.min_y }, viewBox);
+      return `<line class="s-grid-line" x1="${top.x}" y1="${top.y}" x2="${bottom.x}" y2="${bottom.y}"/><circle class="s-grid-bubble" cx="${top.x}" cy="${top.y - 18}" r="12"/><text class="s-grid-label" x="${top.x - 4}" y="${top.y - 14}">${axis.label}</text>`;
+    })
+    .join("");
+  const yLines = toArray(structuralModel.structuralGrid?.y_axes)
+    .map((axis) => {
+      const left = svgPoint({ x: bbox.min_x, y: axis.position_m }, viewBox);
+      const right = svgPoint({ x: bbox.max_x, y: axis.position_m }, viewBox);
+      return `<line class="s-grid-line" x1="${left.x}" y1="${left.y}" x2="${right.x}" y2="${right.y}"/><circle class="s-grid-bubble" cx="${left.x - 18}" cy="${left.y}" r="12"/><text class="s-grid-label" x="${left.x - 22}" y="${left.y + 4}">${axis.label}</text>`;
+    })
+    .join("");
+  return `<g class="s-grid">${xLines}${yLines}</g>`;
+}
+
+function commonSvgShell({ panelType, title, structuralModel, body }) {
+  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="700" viewBox="0 0 1000 700" role="img" aria-label="${title}">
+<metadata>{"panelType":"${panelType}","geometryHash":"${structuralModel.geometryHash}","structuralModelHash":"${structuralModel.structuralModelHash}","technicalDrawing":true,"imageProviderUsed":"none"}</metadata>
+<style>
+.sheet{fill:#f8faf5;stroke:#263238;stroke-width:2}
+.title{font:700 24px Arial;fill:#1d2b21}
+.subtitle,.s-note{font:13px Arial;fill:#263238}
+.disclaimer{font:700 13px Arial;fill:#8a3b12}
+.s-foundation{fill:#d7ccc8;stroke:#5d4037;stroke-width:3}
+.s-slab{fill:#e8eef2;stroke:#455a64;stroke-width:2}
+.s-beam{stroke:#bf360c;stroke-width:5}
+.s-column{fill:#bf360c;stroke:#5d1f0d;stroke-width:2}
+.s-roof{fill:none;stroke:#6a1b9a;stroke-width:2}
+.s-rafter{stroke:#6a1b9a;stroke-width:1.5}
+.s-grid-line{stroke:#1565c0;stroke-width:1;stroke-dasharray:7 5}
+.s-grid-bubble{fill:#fff;stroke:#1565c0;stroke-width:2}
+.s-grid-label{font:700 11px Arial;fill:#1565c0}
+.member-tag{font:700 12px Arial;fill:#111}
+.s-note-box{fill:#fff8e1;stroke:#8a6d1d;stroke-width:1.5}
+</style>
+<rect class="sheet" x="10" y="10" width="980" height="680"/>
+<text class="title" x="36" y="46">${title}</text>
+<text class="subtitle" x="36" y="68">PRELIMINARY STRUCTURAL - ENGINEER REVIEW REQUIRED</text>
+${body}
+<text class="disclaimer" x="36" y="670">${STRUCTURAL_REVIEW_DISCLAIMER}</text>
+</svg>`;
+  return {
+    panelType,
+    drawingType: "structural",
+    width: 1000,
+    height: 700,
+    svgString,
+    svgHash: createStableHash(svgString),
+    status: "ready",
+    technicalDrawing: true,
+    imageProviderUsed: "none",
+    providerUsed: "deterministic_svg",
+    renderer: "deterministic_svg",
+    geometryHash: structuralModel.geometryHash,
+    sourceGeometryHash: structuralModel.geometryHash,
+    sourceProjectGraphHash: structuralModel.sourceProjectGraphHash,
+    structuralModelHash: structuralModel.structuralModelHash,
+    reviewRequired: true,
+    metadata: {
+      version: STRUCTURAL_DRAWING_PANEL_VERSION,
+      structuralModelHash: structuralModel.structuralModelHash,
+      reviewRequired: true,
+      disclaimer: STRUCTURAL_REVIEW_DISCLAIMER,
+      imageProviderUsed: "none",
+      technicalDrawing: true,
+    },
+    technicalQualityMetadata: {
+      version: STRUCTURAL_DRAWING_PANEL_VERSION,
+      panel_type: panelType,
+      geometryHash: structuralModel.geometryHash,
+      sourceGeometryHash: structuralModel.geometryHash,
+      structuralModelHash: structuralModel.structuralModelHash,
+      memberTags: structuralModel.memberIds,
+      gridAxisCount:
+        toArray(structuralModel.structuralGrid?.x_axes).length +
+        toArray(structuralModel.structuralGrid?.y_axes).length,
+      reviewRequired: true,
+      imageProviderUsed: "none",
+    },
+  };
+}
+
+function foundationPanel(structuralModel, viewBox) {
+  const body = [
+    gridSvg(structuralModel, viewBox),
+    ...toArray(structuralModel.foundationSystem?.foundations).map(
+      (foundation) => svgPolyline(foundation.polygon, viewBox, "s-foundation"),
+    ),
+    ...toArray(structuralModel.foundationSystem?.foundations).map(
+      (foundation) =>
+        svgText(
+          computeCentroid(foundation.polygon),
+          viewBox,
+          foundation.memberId,
+          "member-tag",
+        ),
+    ),
+  ].join("");
+  return commonSvgShell({
+    panelType: "foundation_plan",
+    title: "STRUCTURAL FOUNDATION PLAN",
+    structuralModel,
+    body,
+  });
+}
+
+function floorPanel(structuralModel, viewBox, levelId, panelType, title) {
+  const slabs = toArray(structuralModel.slabs).filter(
+    (slab) => slab.levelId === levelId,
+  );
+  const columns = toArray(structuralModel.columns).filter(
+    (column) =>
+      column.levelId === levelId || panelType === "structural_ground_floor",
+  );
+  const beams = toArray(structuralModel.beams).filter(
+    (beam) =>
+      beam.levelId === levelId || panelType === "structural_ground_floor",
+  );
+  const body = [
+    gridSvg(structuralModel, viewBox),
+    ...slabs.map((slab) => svgPolyline(slab.polygon, viewBox, "s-slab")),
+    ...beams.map((beam) => svgLine(beam.start, beam.end, viewBox, "s-beam")),
+    ...columns.map((column) => {
+      const p = svgPoint(column.position, viewBox);
+      return `<rect class="s-column" x="${p.x - 7}" y="${p.y - 7}" width="14" height="14"/><text class="member-tag" x="${p.x + 10}" y="${p.y - 8}">${column.memberId}</text>`;
+    }),
+    ...beams.map((beam) =>
+      svgText(
+        {
+          x: (beam.start.x + beam.end.x) / 2,
+          y: (beam.start.y + beam.end.y) / 2,
+        },
+        viewBox,
+        beam.memberId,
+        "member-tag",
+        -6,
+      ),
+    ),
+  ].join("");
+  return commonSvgShell({ panelType, title, structuralModel, body });
+}
+
+function roofPanel(structuralModel, viewBox) {
+  const body = [
+    gridSvg(structuralModel, viewBox),
+    svgPolyline(
+      structuralModel.roofFraming?.outline || [],
+      viewBox,
+      "s-roof",
+      'fill="none"',
+    ),
+    ...toArray(structuralModel.roofFraming?.rafters).map((rafter) =>
+      svgLine(rafter.start, rafter.end, viewBox, "s-rafter"),
+    ),
+    ...toArray(structuralModel.roofFraming?.rafters)
+      .slice(0, 6)
+      .map((rafter) =>
+        svgText(
+          {
+            x: (rafter.start.x + rafter.end.x) / 2,
+            y: (rafter.start.y + rafter.end.y) / 2,
+          },
+          viewBox,
+          rafter.memberId,
+          "member-tag",
+        ),
+      ),
+  ].join("");
+  return commonSvgShell({
+    panelType: "roof_framing_plan",
+    title: "STRUCTURAL ROOF FRAMING PLAN",
+    structuralModel,
+    body,
+  });
+}
+
+function sectionPanel(structuralModel) {
+  const body = `<g class="s-section">
+<line class="s-foundation" x1="120" y1="560" x2="880" y2="560"/>
+<line class="s-column" x1="230" y1="560" x2="230" y2="210"/>
+<line class="s-column" x1="770" y1="560" x2="770" y2="210"/>
+<line class="s-beam" x1="200" y1="300" x2="800" y2="300"/>
+<line class="s-roof" x1="160" y1="210" x2="500" y2="110"/>
+<line class="s-roof" x1="500" y1="110" x2="840" y2="210"/>
+<text class="member-tag" x="240" y="284">PRELIMINARY LOAD PATH</text>
+<text class="s-note" x="120" y="595">Loads: roof framing -> beams/walls/columns -> foundations. Engineer calculations required.</text>
+</g>`;
+  return commonSvgShell({
+    panelType: "structural_section",
+    title: "STRUCTURAL SECTION",
+    structuralModel,
+    body,
+  });
+}
+
+function notesPanel(structuralModel) {
+  const notes = [
+    ...structuralModel.preliminaryLoadPathNotes,
+    ...structuralModel.assumptions,
+  ];
+  const body = `<rect class="s-note-box" x="44" y="90" width="912" height="500"/>
+${notes
+  .slice(0, 10)
+  .map(
+    (note, index) =>
+      `<text class="s-note" x="68" y="${130 + index * 34}">${index + 1}. ${note}</text>`,
+  )
+  .join("")}
+<text class="member-tag" x="68" y="520">Structural model hash: ${structuralModel.structuralModelHash}</text>`;
+  return commonSvgShell({
+    panelType: "structural_notes",
+    title: "STRUCTURAL NOTES",
+    structuralModel,
+    body,
+  });
+}
+
+export function buildStructuralDrawingPanelsFromStructuralModel(
+  structuralModel = {},
+) {
+  const viewBox = structuralViewBox(structuralModel);
+  const levels = [
+    ...new Set(toArray(structuralModel.slabs).map((slab) => slab.levelId)),
+  ];
+  const panels = {
+    foundation_plan: foundationPanel(structuralModel, viewBox),
+    structural_ground_floor: floorPanel(
+      structuralModel,
+      viewBox,
+      levels[0] || "level-0",
+      "structural_ground_floor",
+      "STRUCTURAL GROUND FLOOR PLAN",
+    ),
+    roof_framing_plan: roofPanel(structuralModel, viewBox),
+    structural_section: sectionPanel(structuralModel),
+    structural_notes: notesPanel(structuralModel),
+  };
+  if (levels.length > 1) {
+    panels.structural_upper_floor = floorPanel(
+      structuralModel,
+      viewBox,
+      levels[1],
+      "structural_upper_floor",
+      "STRUCTURAL UPPER FLOOR PLAN",
+    );
+  }
+  return panels;
+}
+
+export function buildStructuralDrawingPanelsFromCompiledProject({
+  compiledProject,
+  jurisdiction = null,
+} = {}) {
+  const structuralModel = buildStructuralModelFromCompiledProject({
+    compiledProject,
+    jurisdiction,
+  });
+  return {
+    structuralModel,
+    structuralPanels:
+      buildStructuralDrawingPanelsFromStructuralModel(structuralModel),
+  };
+}
+
+export function validateStructuralModel(
+  structuralModel = {},
+  { compiledProject = null } = {},
+) {
+  const errors = [];
+  const warnings = [];
+  if (structuralModel.version !== STRUCTURAL_MODEL_VERSION) {
+    errors.push({ code: "STRUCTURAL_MODEL_VERSION_INVALID" });
+  }
+  if (!structuralModel.structuralModelHash) {
+    errors.push({ code: "STRUCTURAL_MODEL_HASH_MISSING" });
+  }
+  if (!structuralModel.geometryHash) {
+    errors.push({ code: "STRUCTURAL_MODEL_GEOMETRY_HASH_MISSING" });
+  }
+  if (
+    compiledProject?.geometryHash &&
+    structuralModel.geometryHash !== compiledProject.geometryHash
+  ) {
+    errors.push({ code: "STRUCTURAL_MODEL_GEOMETRY_HASH_MISMATCH" });
+  }
+  if (structuralModel.reviewRequired !== true) {
+    errors.push({ code: "STRUCTURAL_MODEL_REVIEW_REQUIRED_MISSING" });
+  }
+  if (
+    !toArray(structuralModel.disclaimers)
+      .join(" ")
+      .match(/licensed structural engineer/i)
+  ) {
+    errors.push({ code: "STRUCTURAL_MODEL_DISCLAIMER_MISSING" });
+  }
+  if (!toArray(structuralModel.foundationSystem?.foundations).length) {
+    errors.push({ code: "STRUCTURAL_MODEL_FOUNDATIONS_MISSING" });
+  }
+  if (!toArray(structuralModel.slabs).length) {
+    errors.push({ code: "STRUCTURAL_MODEL_SLABS_MISSING" });
+  }
+  if (!toArray(structuralModel.roofFraming?.rafters).length) {
+    errors.push({ code: "STRUCTURAL_MODEL_ROOF_FRAMING_MISSING" });
+  }
+  if (structuralModel.imageProviderUsed !== "none") {
+    errors.push({ code: "STRUCTURAL_MODEL_IMAGE_PROVIDER_FORBIDDEN" });
+  }
+  REQUIRED_STRUCTURAL_CAD_LAYERS.forEach((layerName) => {
+    if (!toArray(structuralModel.requiredCadLayers).includes(layerName)) {
+      errors.push({
+        code: "STRUCTURAL_MODEL_REQUIRED_LAYER_MISSING",
+        layerName,
+      });
+    }
+  });
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    checks: {
+      hasStructuralModelHash: Boolean(structuralModel.structuralModelHash),
+      reviewRequired: structuralModel.reviewRequired === true,
+      imageProviderUsed: structuralModel.imageProviderUsed || null,
+      foundationCount: toArray(structuralModel.foundationSystem?.foundations)
+        .length,
+      slabCount: toArray(structuralModel.slabs).length,
+      roofFramingCount: toArray(structuralModel.roofFraming?.rafters).length,
+    },
+  };
+}
+
+export default {
+  STRUCTURAL_MODEL_VERSION,
+  STRUCTURAL_DRAWING_PANEL_VERSION,
+  STRUCTURAL_REVIEW_DISCLAIMER,
+  REQUIRED_STRUCTURAL_CAD_LAYERS,
+  buildStructuralModelFromCompiledProject,
+  buildStructuralDrawingPanelsFromStructuralModel,
+  buildStructuralDrawingPanelsFromCompiledProject,
+  validateStructuralModel,
+};


### PR DESCRIPTION
## Summary

Adds an opt-in preliminary structural model and structural CAD drawing pipeline.

Structural outputs are disabled by default and only included when `STRUCTURAL_DRAWINGS_ENABLED=true` or `includeStructuralDrawings=true`.

All structural outputs are preliminary and require review by a licensed structural engineer.

## Changes

- Adds deterministic `StructuralModel` generation from compiled project geometry.
- Adds foundations, slabs, beams, columns/posts, load-bearing walls, roof framing, structural grid, member IDs, schedules, and preliminary load-path notes.
- Adds deterministic SVG structural panels:
  - foundation plan
  - structural ground floor
  - structural upper floor when applicable
  - roof framing plan
  - structural section
  - structural notes
- Adds optional ProjectGraph drawing-set integration behind `STRUCTURAL_DRAWINGS_ENABLED=true` or explicit option.
- Adds structural CAD entities/layers into CanonicalDrawingModel/DXF when structural output is enabled:
  - `S-FOUNDATION`
  - `S-COLUMN`
  - `S-BEAM`
  - `S-SLAB`
  - `S-ROOF`
  - `S-GRID`
  - `S-NOTES`
  - `S-DIMS`
- Adds structural QA checks for hash presence/match, review requirement, disclaimer, foundations, and no image provider.
- Updates roadmap to describe structural output as preliminary and opt-in.

## Validation

- Focused structural/CAD tests passed.
- `npm run lint`
- `git diff --check`
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Safety and scope

- No image-generation path added for structural technical drawings.
- Fake DWG remains disabled.
- Existing ProjectGraph/A1/CAD authority gates were not weakened.
- Default architectural CAD/DXF export remains architectural-only.
- Structural CAD/DXF is included only when structural drawings are enabled.

## Current limitations

- Preliminary coordination model only.
- No engineered member sizing.
- No reinforcement design.
- No structural calculations.
- No load combinations.
- No wind, snow, seismic, or lateral analysis.
- No geotechnical bearing/foundation verification.
- No jurisdiction-specific structural code compliance.
- Requires review by a licensed structural engineer before use for construction.