### PR TITLE
Add opt-in preliminary MEP model and CAD drawings

### DIFF
--- a/docs/roadmaps/professional-cad-bim-output-roadmap.md
+++ b/docs/roadmaps/professional-cad-bim-output-roadmap.md
@@ -162,6 +162,11 @@ Acceptance criteria:
 ## PR 4: MEP model and drawings
 
 Add deterministic `mepModel` derived from ProjectGraph / CompiledProject.
+This package is opt-in: MEP drawing panels and MEP CAD/DXF entities are included
+only when `MEP_DRAWINGS_ENABLED=true` or an explicit `includeMepDrawings` option
+is passed. Existing architectural CAD/DXF exports remain non-MEP by default.
+All MEP outputs are preliminary coordination information and require review by a
+qualified MEP engineer before construction or permit use.
 
 Deliverables:
 
@@ -169,15 +174,45 @@ Deliverables:
   drainage/waste plan, HVAC/ventilation plan, riser/shaft plan, legends, and
   schedules.
 - Fixture generation from room types.
-- Deterministic routing with clash avoidance.
-- MEP symbols as CAD blocks.
-- Preliminary / specialist-review-required status.
+- Deterministic preliminary routing and coordination notes derived from room
+  geometry, wet rooms, kitchens, habitable rooms, corridors, and service cores
+  where available.
+- MEP symbols as deterministic SVG/CAD blocks.
+- CAD/DXF MEP layers/entities (`E-LIGHT`, `E-POWER`, `E-SWITCH`, `E-DATA`,
+  `P-WATER`, `P-DRAIN`, `P-SANITARY`, `M-DUCT`, `M-VENT`, `M-EQUIP`,
+  `MEP-RISER`, `MEP-NOTES`, `MEP-DIMS`) when MEP drawings are enabled.
+- Preliminary / qualified-MEP-engineer-review-required status.
 
 Acceptance criteria:
 
 - Wet rooms generate plumbing and drainage.
 - Bedrooms, living rooms, and kitchens generate lighting and power layouts.
-- MEP drawings export to SVG and DXF.
+- MEP drawings export to deterministic SVG and DXF only when MEP drawings are
+  enabled.
+- Default CanonicalDrawingModel/DXF export remains architectural-only and does
+  not emit MEP model data or MEP layers/entities.
+- MEP model and drawings carry deterministic hashes, no image-provider technical
+  drawing path, and qualified MEP engineer review disclaimers.
+
+Current limitations after this slice:
+
+- Preliminary coordination model only.
+- No electrical circuit calculations, load schedules, cable sizing, protection
+  discrimination, or circuit schedules.
+- No pipe sizing, pressure/drop checks, pump sizing, drainage falls verification,
+  or fixture unit calculations.
+- No duct sizing, fan duty calculations, ventilation rate calculations, acoustic
+  checks, or heat/cooling load calculations.
+- No automated clash detection or construction-grade service coordination.
+- No jurisdiction-specific MEP code compliance yet.
+- DWG remains conversion-only and unavailable unless a real converter is
+  configured; DXF remains the guaranteed CAD output.
+
+Next MEP fidelity PR:
+
+- Add engineer-reviewed sizing/calculation models, circuit schedules, pipe and
+  duct sizing, pressure/drop checks, load schedules, and jurisdiction-specific
+  MEP code checks.
 
 ## PR 5: Detail library
 

--- a/src/__tests__/services/cad/canonicalDrawingModel.test.js
+++ b/src/__tests__/services/cad/canonicalDrawingModel.test.js
@@ -69,11 +69,24 @@ function fixtureCompiledProject() {
         id: "room-kitchen",
         levelId: "level-0",
         name: "Kitchen",
+        type: "kitchen",
         polygon: [
           { x: 8, y: 3 },
+          { x: 11, y: 3 },
+          { x: 11, y: 7 },
+          { x: 8, y: 7 },
+        ],
+      },
+      {
+        id: "room-bath",
+        levelId: "level-0",
+        name: "Bathroom",
+        type: "bathroom",
+        polygon: [
+          { x: 11, y: 3 },
           { x: 13, y: 3 },
-          { x: 13, y: 10 },
-          { x: 8, y: 10 },
+          { x: 13, y: 7 },
+          { x: 11, y: 7 },
         ],
       },
     ],
@@ -176,6 +189,22 @@ function entityTypes(entities) {
   return new Set(entities.map((entity) => entity.type));
 }
 
+const MEP_LAYER_NAMES = [
+  "E-LIGHT",
+  "E-POWER",
+  "E-SWITCH",
+  "E-DATA",
+  "P-WATER",
+  "P-DRAIN",
+  "P-SANITARY",
+  "M-DUCT",
+  "M-VENT",
+  "M-EQUIP",
+  "MEP-RISER",
+  "MEP-NOTES",
+  "MEP-DIMS",
+];
+
 describe("CanonicalDrawingModel", () => {
   test("throws when CompiledProject geometryHash is missing", () => {
     expect(() =>
@@ -218,9 +247,15 @@ describe("CanonicalDrawingModel", () => {
       }),
     );
     expect(model.structuralModel).toBeUndefined();
+    expect(model.mepModel).toBeUndefined();
     expect(
       model.modelSpace.entities.filter((entity) =>
         String(entity.layer || "").startsWith("S-"),
+      ),
+    ).toEqual([]);
+    expect(
+      model.modelSpace.entities.filter((entity) =>
+        MEP_LAYER_NAMES.includes(entity.layer),
       ),
     ).toEqual([]);
   });
@@ -318,20 +353,38 @@ describe("CanonicalDrawingModel", () => {
     });
     const layerNames = model.layers.map((layer) => layer.name);
     const architecturalLayerNames = REQUIRED_CANONICAL_CAD_LAYERS.filter(
-      (layerName) => !layerName.startsWith("S-"),
+      (layerName) =>
+        !layerName.startsWith("S-") && !MEP_LAYER_NAMES.includes(layerName),
     );
 
     expect(layerNames).toEqual(expect.arrayContaining(architecturalLayerNames));
     expect(layerNames).not.toEqual(
       expect.arrayContaining(["S-FOUNDATION", "S-BEAM", "S-GRID"]),
     );
+    expect(layerNames).not.toEqual(expect.arrayContaining(MEP_LAYER_NAMES));
 
     const structuralModel = buildCanonicalDrawingModelFromCompiledProject({
       compiledProject: fixtureCompiledProject(),
       includeStructuralDrawings: true,
     });
     expect(structuralModel.layers.map((layer) => layer.name)).toEqual(
-      expect.arrayContaining(REQUIRED_CANONICAL_CAD_LAYERS),
+      expect.arrayContaining(
+        REQUIRED_CANONICAL_CAD_LAYERS.filter(
+          (layerName) => !MEP_LAYER_NAMES.includes(layerName),
+        ),
+      ),
+    );
+
+    const mepModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeMepDrawings: true,
+    });
+    expect(mepModel.layers.map((layer) => layer.name)).toEqual(
+      expect.arrayContaining(
+        REQUIRED_CANONICAL_CAD_LAYERS.filter(
+          (layerName) => !layerName.startsWith("S-"),
+        ),
+      ),
     );
   });
 
@@ -408,6 +461,10 @@ describe("CanonicalDrawingModel", () => {
     expect(result.checks.hasStructuralDisclaimer).toBe(false);
     expect(result.checks.structuralReviewRequired).toBe(false);
     expect(result.checks.structuralImageProviderUsed).toBe(null);
+    expect(result.checks.hasMepModelHash).toBe(false);
+    expect(result.checks.hasMepDisclaimer).toBe(false);
+    expect(result.checks.mepReviewRequired).toBe(false);
+    expect(result.checks.mepImageProviderUsed).toBe(null);
   });
 
   test("adds structural CAD entities, dimensions, grid, and review notes", () => {
@@ -459,6 +516,108 @@ describe("CanonicalDrawingModel", () => {
       expect(entity.technicalDrawing).toBe(true);
       expect(entity.geometryHash).toBe(model.geometryHash);
     });
+  });
+
+  test("adds opt-in MEP CAD entities, symbols, routes, dimensions, and review notes", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeMepDrawings: true,
+    });
+
+    expect(model.mepModel).toEqual(
+      expect.objectContaining({
+        geometryHash: model.geometryHash,
+        sourceProjectGraphHash: model.sourceProjectGraphHash,
+        reviewRequired: true,
+        imageProviderUsed: "none",
+      }),
+    );
+    expect(model.mepModel.disclaimers.join(" ")).toMatch(
+      /qualified MEP engineer/i,
+    );
+
+    const mepEntities = model.modelSpace.entities.filter((entity) =>
+      MEP_LAYER_NAMES.includes(entity.layer),
+    );
+    const layers = new Set(mepEntities.map((entity) => entity.layer));
+    const roles = new Set(
+      mepEntities.map((entity) => entity.metadata?.role).filter(Boolean),
+    );
+
+    expect([...layers]).toEqual(expect.arrayContaining(MEP_LAYER_NAMES));
+    expect([...roles]).toEqual(
+      expect.arrayContaining([
+        "mep_light_fixture",
+        "mep_power_outlet",
+        "mep_switch",
+        "mep_plumbing_supply",
+        "mep_drainage_waste",
+        "mep_ventilation_route",
+        "mep_riser",
+        "mep_equipment",
+        "review_disclaimer",
+      ]),
+    );
+    mepEntities.forEach((entity) => {
+      expect(entity.imageProviderUsed).toBe("none");
+      expect(entity.technicalDrawing).toBe(true);
+      expect(entity.geometryHash).toBe(model.geometryHash);
+    });
+  });
+
+  test("CAD QA validates MEP only when a MepModel is present or required", () => {
+    const defaultModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const defaultResult = validateCanonicalDrawingModel(defaultModel);
+
+    expect(defaultModel.mepModel).toBeUndefined();
+    expect(defaultResult.valid).toBe(true);
+    expect(defaultResult.errors.map((error) => error.code)).not.toEqual(
+      expect.arrayContaining(["CAD_MODEL_MEP_MODEL_HASH_MISSING"]),
+    );
+
+    const mepModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeMepDrawings: true,
+    });
+    const brokenResult = validateCanonicalDrawingModel({
+      ...mepModel,
+      mepModel: {
+        ...mepModel.mepModel,
+        mepModelHash: null,
+        disclaimers: [],
+        drainageWasteLayout: {
+          ...mepModel.mepModel.drainageWasteLayout,
+          lines: [],
+        },
+        electricalLightingLayout: {
+          ...mepModel.mepModel.electricalLightingLayout,
+          fixtures: [],
+        },
+        imageProviderUsed: "openai",
+      },
+    });
+    const codes = brokenResult.errors.map((error) => error.code);
+
+    expect(brokenResult.valid).toBe(false);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        "CAD_MODEL_MEP_MODEL_HASH_MISSING",
+        "CAD_MODEL_MEP_DISCLAIMER_MISSING",
+        "CAD_MODEL_MEP_WET_ROOM_DRAINAGE_MISSING",
+        "CAD_MODEL_MEP_HABITABLE_LIGHTING_MISSING",
+        "CAD_MODEL_MEP_IMAGE_PROVIDER_FORBIDDEN",
+      ]),
+    );
+
+    const requiredResult = validateCanonicalDrawingModel(defaultModel, {
+      requireMepModel: true,
+    });
+    expect(requiredResult.valid).toBe(false);
+    expect(requiredResult.errors.map((error) => error.code)).toContain(
+      "CAD_MODEL_MEP_MODEL_HASH_MISSING",
+    );
   });
 
   test("CAD QA fails when title blocks are missing", () => {

--- a/src/__tests__/services/cad/canonicalDxfExporter.test.js
+++ b/src/__tests__/services/cad/canonicalDxfExporter.test.js
@@ -40,11 +40,36 @@ function fixtureCompiledProject() {
         id: "room-1",
         levelId: "level-0",
         name: "Living",
+        type: "living",
         polygon: [
           { x: 3, y: 3 },
-          { x: 13, y: 3 },
-          { x: 13, y: 10 },
+          { x: 8, y: 3 },
+          { x: 8, y: 10 },
           { x: 3, y: 10 },
+        ],
+      },
+      {
+        id: "room-2",
+        levelId: "level-0",
+        name: "Kitchen",
+        type: "kitchen",
+        polygon: [
+          { x: 8, y: 3 },
+          { x: 11, y: 3 },
+          { x: 11, y: 7 },
+          { x: 8, y: 7 },
+        ],
+      },
+      {
+        id: "room-3",
+        levelId: "level-0",
+        name: "Bathroom",
+        type: "bathroom",
+        polygon: [
+          { x: 11, y: 3 },
+          { x: 13, y: 3 },
+          { x: 13, y: 7 },
+          { x: 11, y: 7 },
         ],
       },
     ],
@@ -166,6 +191,12 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).not.toContain("S-BEAM");
     expect(dxf).not.toContain("S-GRID");
     expect(dxf).not.toContain("PRELIMINARY STRUCTURAL INFORMATION ONLY");
+    expect(dxf).not.toContain("E-LIGHT");
+    expect(dxf).not.toContain("P-WATER");
+    expect(dxf).not.toContain("P-DRAIN");
+    expect(dxf).not.toContain("M-VENT");
+    expect(dxf).not.toContain("MEP-NOTES");
+    expect(dxf).not.toContain("PRELIMINARY MEP INFORMATION ONLY");
   });
 
   test("emits structural CAD layers, grid, foundations, roof framing, notes, and no raster entities", () => {
@@ -188,6 +219,38 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).toContain("PRELIMINARY STRUCTURAL INFORMATION ONLY");
     expect(dxf).toContain("FND-001");
     expect(dxf).toContain("RFT-001");
+    expect(dxf).not.toMatch(/  0\nIMAGE\n/);
+    expect(dxf).not.toMatch(/  0\nRASTER\n/);
+  });
+
+  test("emits opt-in MEP CAD layers, symbols, routes, notes, and no raster entities", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeMepDrawings: true,
+    });
+    const dxf = exportCanonicalDrawingModelToDXF({
+      canonicalDrawingModel: model,
+    });
+
+    expect(dxf).toContain("E-LIGHT");
+    expect(dxf).toContain("E-POWER");
+    expect(dxf).toContain("E-SWITCH");
+    expect(dxf).toContain("E-DATA");
+    expect(dxf).toContain("P-WATER");
+    expect(dxf).toContain("P-DRAIN");
+    expect(dxf).toContain("P-SANITARY");
+    expect(dxf).toContain("M-DUCT");
+    expect(dxf).toContain("M-VENT");
+    expect(dxf).toContain("M-EQUIP");
+    expect(dxf).toContain("MEP-RISER");
+    expect(dxf).toContain("MEP-NOTES");
+    expect(dxf).toContain("MEP-DIMS");
+    expect(dxf).toContain("MEP_LIGHT_CEILING");
+    expect(dxf).toContain("MEP_SOCKET");
+    expect(dxf).toContain("MEP_SANITARY_FIXTURE");
+    expect(dxf).toContain("MEP_EXTRACT_FAN");
+    expect(dxf).toContain("PRELIMINARY MEP INFORMATION ONLY");
+    expect(dxf).toContain("MEP coordination route");
     expect(dxf).not.toMatch(/  0\nIMAGE\n/);
     expect(dxf).not.toMatch(/  0\nRASTER\n/);
   });

--- a/src/__tests__/services/mep/mepDrawingSetIntegration.test.js
+++ b/src/__tests__/services/mep/mepDrawingSetIntegration.test.js
@@ -1,0 +1,170 @@
+import { __projectGraphVerticalSliceInternals } from "../../../services/project/projectGraphVerticalSliceService.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geometry-hash-mep-drawing-set-001",
+    projectGraphHash: "project-graph-hash-mep-drawing-set-001",
+    site: {
+      boundary_polygon: [
+        { x: 0, y: 0 },
+        { x: 18, y: 0 },
+        { x: 18, y: 12 },
+        { x: 0, y: 12 },
+      ],
+    },
+    levels: [{ id: "level-0", level_number: 0, name: "Ground", height_m: 3.2 }],
+    slabs: [
+      {
+        id: "slab-0",
+        levelId: "level-0",
+        polygon: [
+          { x: 2, y: 2 },
+          { x: 15, y: 2 },
+          { x: 15, y: 10 },
+          { x: 2, y: 10 },
+        ],
+      },
+    ],
+    rooms: [
+      {
+        id: "room-living",
+        levelId: "level-0",
+        name: "Living",
+        type: "living",
+        polygon: [
+          { x: 2, y: 2 },
+          { x: 8, y: 2 },
+          { x: 8, y: 10 },
+          { x: 2, y: 10 },
+        ],
+      },
+      {
+        id: "room-kitchen",
+        levelId: "level-0",
+        name: "Kitchen",
+        type: "kitchen",
+        polygon: [
+          { x: 8, y: 2 },
+          { x: 12, y: 2 },
+          { x: 12, y: 6 },
+          { x: 8, y: 6 },
+        ],
+      },
+      {
+        id: "room-bath",
+        levelId: "level-0",
+        name: "Bathroom",
+        type: "bathroom",
+        polygon: [
+          { x: 12, y: 2 },
+          { x: 15, y: 2 },
+          { x: 15, y: 6 },
+          { x: 12, y: 6 },
+        ],
+      },
+    ],
+  };
+}
+
+describe("MEP drawing-set integration", () => {
+  test("keeps MEP sheets disabled by default", () => {
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+      {
+        layoutTemplate: "presentation-v3",
+      },
+    );
+    const panelTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(panelTypes).not.toContain("mep_lighting_plan");
+    expect(panelTypes).not.toContain("mep_power_plan");
+    expect(panelTypes).not.toContain("mep_plumbing_plan");
+    expect(result.technicalBuild.mepModel).toBeNull();
+  });
+
+  test("adds MEP drawing sheets and manifest entries when explicitly enabled", () => {
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+      {
+        layoutTemplate: "presentation-v3",
+        includeMepDrawings: true,
+      },
+    );
+    const panelTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+    const mepArtifacts = Object.values(result.drawingArtifacts).filter(
+      (artifact) => artifact.drawingType === "mep",
+    );
+
+    expect(panelTypes).toEqual(
+      expect.arrayContaining([
+        "mep_lighting_plan",
+        "mep_power_plan",
+        "mep_plumbing_plan",
+        "mep_drainage_plan",
+        "mep_ventilation_plan",
+        "mep_schematic_notes",
+      ]),
+    );
+    expect(result.technicalBuild.mepModel?.mepModelHash).toBeTruthy();
+    expect(mepArtifacts.length).toBeGreaterThan(0);
+    mepArtifacts.forEach((artifact) => {
+      expect(artifact.technicalDrawing).toBe(true);
+      expect(artifact.imageProviderUsed).toBe("none");
+      expect(artifact.metadata.mepModelHash).toBeTruthy();
+      expect(artifact.metadata.reviewRequired).toBe(true);
+      expect(artifact.svgString).toContain(
+        "QUALIFIED MEP ENGINEER REVIEW REQUIRED",
+      );
+    });
+  });
+});
+
+describe("MEP drawing set environment gating", () => {
+  const originalMepEnv = process.env.MEP_DRAWINGS_ENABLED;
+
+  afterEach(() => {
+    if (originalMepEnv === undefined) {
+      delete process.env.MEP_DRAWINGS_ENABLED;
+    } else {
+      process.env.MEP_DRAWINGS_ENABLED = originalMepEnv;
+    }
+  });
+
+  test("includes MEP panels when MEP_DRAWINGS_ENABLED=true", () => {
+    process.env.MEP_DRAWINGS_ENABLED = "true";
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+    );
+    const drawingTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(drawingTypes).toEqual(
+      expect.arrayContaining([
+        "mep_lighting_plan",
+        "mep_power_plan",
+        "mep_plumbing_plan",
+        "mep_drainage_plan",
+        "mep_ventilation_plan",
+      ]),
+    );
+  });
+
+  test("keeps MEP panels absent when MEP_DRAWINGS_ENABLED=false", () => {
+    process.env.MEP_DRAWINGS_ENABLED = "false";
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+    );
+    const drawingTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(drawingTypes).not.toEqual(
+      expect.arrayContaining(["mep_lighting_plan", "mep_power_plan"]),
+    );
+  });
+});

--- a/src/__tests__/services/mep/mepModelService.test.js
+++ b/src/__tests__/services/mep/mepModelService.test.js
@@ -1,0 +1,218 @@
+import {
+  MEP_REVIEW_DISCLAIMER,
+  REQUIRED_MEP_CAD_LAYERS,
+  buildMepDrawingPanelsFromCompiledProject,
+  buildMepModelFromCompiledProject,
+  validateMepModel,
+} from "../../../services/mep/mepModelService.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geometry-hash-mep-001",
+    projectGraphHash: "project-graph-hash-mep-001",
+    projectName: "MEP Fixture",
+    jurisdiction: "uk",
+    buildingType: "residential",
+    site: {
+      boundary_polygon: [
+        { x: 0, y: 0 },
+        { x: 18, y: 0 },
+        { x: 18, y: 12 },
+        { x: 0, y: 12 },
+      ],
+    },
+    levels: [
+      {
+        id: "level-0",
+        level_number: 0,
+        name: "Ground",
+        elevation_m: 0,
+        height_m: 3.2,
+      },
+    ],
+    slabs: [
+      {
+        id: "slab-0",
+        levelId: "level-0",
+        polygon: [
+          { x: 2, y: 2 },
+          { x: 15, y: 2 },
+          { x: 15, y: 10 },
+          { x: 2, y: 10 },
+        ],
+      },
+    ],
+    rooms: [
+      {
+        id: "room-living",
+        levelId: "level-0",
+        name: "Living",
+        type: "living",
+        polygon: [
+          { x: 2, y: 2 },
+          { x: 8, y: 2 },
+          { x: 8, y: 10 },
+          { x: 2, y: 10 },
+        ],
+      },
+      {
+        id: "room-kitchen",
+        levelId: "level-0",
+        name: "Kitchen",
+        type: "kitchen",
+        polygon: [
+          { x: 8, y: 2 },
+          { x: 12, y: 2 },
+          { x: 12, y: 6 },
+          { x: 8, y: 6 },
+        ],
+      },
+      {
+        id: "room-bath",
+        levelId: "level-0",
+        name: "Bathroom",
+        type: "bathroom",
+        polygon: [
+          { x: 12, y: 2 },
+          { x: 15, y: 2 },
+          { x: 15, y: 6 },
+          { x: 12, y: 6 },
+        ],
+      },
+      {
+        id: "room-hall",
+        levelId: "level-0",
+        name: "Hall",
+        type: "corridor",
+        polygon: [
+          { x: 8, y: 6 },
+          { x: 15, y: 6 },
+          { x: 15, y: 10 },
+          { x: 8, y: 10 },
+        ],
+      },
+    ],
+  };
+}
+
+describe("mepModelService", () => {
+  test("builds a deterministic preliminary MepModel with authority hashes", () => {
+    const first = buildMepModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const second = buildMepModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+
+    expect(first.geometryHash).toBe("geometry-hash-mep-001");
+    expect(first.sourceProjectGraphHash).toBe("project-graph-hash-mep-001");
+    expect(first.mepModelHash).toBe(second.mepModelHash);
+    expect(first.mepModelId).toBe(second.mepModelId);
+    expect(first.reviewRequired).toBe(true);
+    expect(first.disclaimers).toContain(MEP_REVIEW_DISCLAIMER);
+    expect(first.imageProviderUsed).toBe("none");
+    expect(first.requiredCadLayers).toEqual(REQUIRED_MEP_CAD_LAYERS);
+  });
+
+  test("derives wet-room plumbing, drainage, and ventilation routes", () => {
+    const model = buildMepModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+
+    expect(model.roomFixtureMapping.wetRooms).toContain("room-bath");
+    expect(model.roomFixtureMapping.kitchens).toContain("room-kitchen");
+    expect(model.plumbingSupplyLayout.lines.length).toBeGreaterThan(0);
+    expect(model.drainageWasteLayout.lines.length).toBeGreaterThan(0);
+    expect(model.ventilationHvacLayout.routes.length).toBeGreaterThan(0);
+    expect(model.ventilationHvacLayout.extractFans.length).toBeGreaterThan(0);
+  });
+
+  test("derives habitable-room lighting, power, and data layouts", () => {
+    const model = buildMepModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+
+    expect(model.roomFixtureMapping.habitableRooms).toContain("room-living");
+    expect(model.electricalLightingLayout.fixtures.length).toBeGreaterThan(0);
+    expect(model.electricalPowerSocketLayout.outlets.length).toBeGreaterThan(0);
+    expect(model.electricalPowerSocketLayout.switches.length).toBeGreaterThan(
+      0,
+    );
+    expect(model.schedules.lightingSchedule.length).toBeGreaterThan(0);
+    expect(model.schedules.powerSchedule.length).toBeGreaterThan(0);
+  });
+
+  test("generates deterministic SVG MEP panels without image providers", () => {
+    const { mepModel, mepPanels } = buildMepDrawingPanelsFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+
+    expect(Object.keys(mepPanels)).toEqual(
+      expect.arrayContaining([
+        "mep_lighting_plan",
+        "mep_power_plan",
+        "mep_plumbing_plan",
+        "mep_drainage_plan",
+        "mep_ventilation_plan",
+        "mep_schematic_notes",
+      ]),
+    );
+    Object.values(mepPanels).forEach((panel) => {
+      expect(panel.svgString).toContain("<svg");
+      expect(panel.svgString).toContain("MEP LEGEND");
+      expect(panel.svgString).toContain(
+        "QUALIFIED MEP ENGINEER REVIEW REQUIRED",
+      );
+      expect(panel.svgString).toContain('data-image-provider-used="none"');
+      expect(panel.technicalDrawing).toBe(true);
+      expect(panel.imageProviderUsed).toBe("none");
+      expect(panel.reviewRequired).toBe(true);
+      expect(panel.geometryHash).toBe(mepModel.geometryHash);
+      expect(panel.sourceGeometryHash).toBe(mepModel.geometryHash);
+    });
+    expect(mepPanels.mep_lighting_plan.svgString).toContain("mep-light-symbol");
+    expect(mepPanels.mep_power_plan.svgString).toContain("mep-socket-symbol");
+    expect(mepPanels.mep_plumbing_plan.svgString).toContain("mep-water-route");
+    expect(mepPanels.mep_drainage_plan.svgString).toContain("mep-drain-route");
+    expect(mepPanels.mep_ventilation_plan.svgString).toContain(
+      "mep-vent-route",
+    );
+  });
+
+  test("validates MEP QA failures for missing hashes, review data, routes, and image providers", () => {
+    const model = buildMepModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    expect(
+      validateMepModel(model, { compiledProject: fixtureCompiledProject() })
+        .valid,
+    ).toBe(true);
+
+    const broken = validateMepModel(
+      {
+        ...model,
+        mepModelHash: null,
+        disclaimers: [],
+        drainageWasteLayout: { ...model.drainageWasteLayout, lines: [] },
+        electricalLightingLayout: {
+          ...model.electricalLightingLayout,
+          fixtures: [],
+        },
+        imageProviderUsed: "openai",
+      },
+      { compiledProject: fixtureCompiledProject() },
+    );
+    const codes = broken.errors.map((error) => error.code);
+
+    expect(broken.valid).toBe(false);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        "MEP_MODEL_HASH_MISSING",
+        "MEP_MODEL_DISCLAIMER_MISSING",
+        "MEP_MODEL_WET_ROOM_DRAINAGE_MISSING",
+        "MEP_MODEL_HABITABLE_LIGHTING_MISSING",
+        "MEP_MODEL_IMAGE_PROVIDER_FORBIDDEN",
+      ]),
+    );
+  });
+});

--- a/src/services/cad/canonicalDrawingModel.js
+++ b/src/services/cad/canonicalDrawingModel.js
@@ -6,6 +6,7 @@ import {
   roundMetric,
 } from "./projectGeometrySchema.js";
 import { buildStructuralModelFromCompiledProject } from "../structure/structuralModelService.js";
+import { buildMepModelFromCompiledProject } from "../mep/mepModelService.js";
 
 export const CANONICAL_DRAWING_MODEL_VERSION = "canonical-drawing-model-v1";
 
@@ -44,12 +45,18 @@ export const REQUIRED_CANONICAL_CAD_LAYERS = Object.freeze([
   "S-NOTES",
   "S-DIMS",
   "M-DUCT",
-  "M-PIPE",
   "P-DRAIN",
   "E-LIGHT",
   "E-POWER",
   "E-SWITCH",
-  "F-FIRE",
+  "E-DATA",
+  "P-WATER",
+  "P-SANITARY",
+  "M-VENT",
+  "M-EQUIP",
+  "MEP-RISER",
+  "MEP-NOTES",
+  "MEP-DIMS",
 ]);
 
 const STRUCTURAL_CANONICAL_CAD_LAYER_NAMES = new Set([
@@ -61,6 +68,24 @@ const STRUCTURAL_CANONICAL_CAD_LAYER_NAMES = new Set([
   "S-GRID",
   "S-NOTES",
   "S-DIMS",
+]);
+
+const MEP_CANONICAL_CAD_LAYER_NAMES = new Set([
+  "M-DUCT",
+  "M-PIPE",
+  "P-DRAIN",
+  "E-LIGHT",
+  "E-POWER",
+  "E-SWITCH",
+  "E-DATA",
+  "P-WATER",
+  "P-SANITARY",
+  "M-VENT",
+  "M-EQUIP",
+  "MEP-RISER",
+  "MEP-NOTES",
+  "MEP-DIMS",
+  "F-FIRE",
 ]);
 
 export const DEFAULT_CANONICAL_CAD_LAYERS = Object.freeze([
@@ -249,6 +274,62 @@ export const DEFAULT_CANONICAL_CAD_LAYERS = Object.freeze([
   {
     name: "E-SWITCH",
     discipline: "electrical",
+    color: 2,
+    lineweight: 18,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "E-DATA",
+    discipline: "electrical",
+    color: 4,
+    lineweight: 18,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "P-WATER",
+    discipline: "plumbing",
+    color: 5,
+    lineweight: 25,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "P-SANITARY",
+    discipline: "plumbing",
+    color: 6,
+    lineweight: 25,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "M-VENT",
+    discipline: "mechanical",
+    color: 5,
+    lineweight: 25,
+    linetype: "DASHED",
+  },
+  {
+    name: "M-EQUIP",
+    discipline: "mechanical",
+    color: 7,
+    lineweight: 25,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "MEP-RISER",
+    discipline: "mep",
+    color: 4,
+    lineweight: 35,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "MEP-NOTES",
+    discipline: "mep",
+    color: 7,
+    lineweight: 18,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "MEP-DIMS",
+    discipline: "mep",
     color: 2,
     lineweight: 18,
     linetype: "CONTINUOUS",
@@ -1543,6 +1624,396 @@ function buildStructuralPrimitiveEntities(
   return entities;
 }
 
+function buildMepModelEntities(mepModel = {}, geometryHash) {
+  const entities = [];
+  const mepModelHash = mepModel.mepModelHash;
+  const addTag = ({
+    text,
+    point,
+    sourceId,
+    viewType,
+    viewId,
+    layer = "MEP-NOTES",
+    role = "mep_tag",
+  }) => {
+    entities.push(
+      textEntity({
+        text,
+        point,
+        height: 0.18,
+        layer,
+        viewType,
+        viewId,
+        geometryHash,
+        sourceId,
+        metadata: {
+          role,
+          mepModelHash,
+        },
+      }),
+    );
+  };
+
+  toArray(mepModel.electricalLightingLayout?.fixtures).forEach(
+    (fixture, index) => {
+      const point = fixture.point || { x: 0, y: 0 };
+      entities.push(
+        insertEntity({
+          blockName: "MEP_LIGHT_CEILING",
+          point,
+          layer: "E-LIGHT",
+          viewType: "mep_lighting_plan",
+          viewId: fixture.levelId || "mep_lighting_plan",
+          geometryHash,
+          sourceId: fixture.id || `mep-light-${index + 1}`,
+          metadata: {
+            role: "mep_light_fixture",
+            fixtureId: fixture.id || null,
+            roomId: fixture.roomId || null,
+            mepModelHash,
+          },
+        }),
+      );
+      addTag({
+        text: fixture.tag || fixture.id || `L${index + 1}`,
+        point: { x: point.x + 0.25, y: point.y + 0.25 },
+        sourceId: `${fixture.id || `mep-light-${index + 1}`}-tag`,
+        viewType: "mep_lighting_plan",
+        viewId: fixture.levelId || "mep_lighting_plan",
+        role: "mep_light_fixture_tag",
+      });
+    },
+  );
+
+  toArray(mepModel.electricalPowerSocketLayout?.switches).forEach(
+    (switchPoint, index) => {
+      entities.push(
+        insertEntity({
+          blockName: "MEP_SWITCH",
+          point: switchPoint.point || { x: 0, y: 0 },
+          layer: "E-SWITCH",
+          viewType: "mep_power_plan",
+          viewId: switchPoint.levelId || "mep_power_plan",
+          geometryHash,
+          sourceId: switchPoint.id || `mep-switch-${index + 1}`,
+          metadata: {
+            role: "mep_switch",
+            switchId: switchPoint.id || null,
+            roomId: switchPoint.roomId || null,
+            mepModelHash,
+          },
+        }),
+      );
+    },
+  );
+
+  toArray(mepModel.electricalPowerSocketLayout?.outlets).forEach(
+    (outlet, index) => {
+      const point = outlet.point || { x: 0, y: 0 };
+      entities.push(
+        insertEntity({
+          blockName: "MEP_SOCKET",
+          point,
+          layer: "E-POWER",
+          viewType: "mep_power_plan",
+          viewId: outlet.levelId || "mep_power_plan",
+          geometryHash,
+          sourceId: outlet.id || `mep-socket-${index + 1}`,
+          metadata: {
+            role: "mep_power_outlet",
+            outletId: outlet.id || null,
+            roomId: outlet.roomId || null,
+            mepModelHash,
+          },
+        }),
+      );
+    },
+  );
+
+  toArray(mepModel.electricalPowerSocketLayout?.dataPoints).forEach(
+    (dataPoint, index) => {
+      entities.push(
+        insertEntity({
+          blockName: "MEP_DATA_POINT",
+          point: dataPoint.point || { x: 0, y: 0 },
+          layer: "E-DATA",
+          viewType: "mep_power_plan",
+          viewId: dataPoint.levelId || "mep_power_plan",
+          geometryHash,
+          sourceId: dataPoint.id || `mep-data-${index + 1}`,
+          metadata: {
+            role: "mep_data_point",
+            dataPointId: dataPoint.id || null,
+            roomId: dataPoint.roomId || null,
+            mepModelHash,
+          },
+        }),
+      );
+    },
+  );
+
+  toArray(mepModel.plumbingSupplyLayout?.lines).forEach((line, index) => {
+    entities.push(
+      lineEntity({
+        start: line.start || { x: 0, y: 0 },
+        end: line.end || { x: 0, y: 0 },
+        layer: "P-WATER",
+        viewType: "mep_plumbing_plan",
+        viewId: line.levelId || "mep_plumbing_plan",
+        geometryHash,
+        sourceId: line.id || `mep-water-${index + 1}`,
+        metadata: {
+          role: "mep_plumbing_supply",
+          lineId: line.id || null,
+          roomId: line.roomId || null,
+          mepModelHash,
+        },
+      }),
+    );
+  });
+
+  toArray(mepModel.plumbingSupplyLayout?.fixtures).forEach((fixture, index) => {
+    entities.push(
+      insertEntity({
+        blockName: "MEP_SANITARY_FIXTURE",
+        point: fixture.point || { x: 0, y: 0 },
+        layer: "P-SANITARY",
+        viewType: "mep_plumbing_plan",
+        viewId: fixture.levelId || "mep_plumbing_plan",
+        geometryHash,
+        sourceId: fixture.id || `mep-sanitary-${index + 1}`,
+        metadata: {
+          role: "mep_sanitary_fixture",
+          fixtureId: fixture.id || null,
+          roomId: fixture.roomId || null,
+          mepModelHash,
+        },
+      }),
+    );
+  });
+
+  toArray(mepModel.drainageWasteLayout?.lines).forEach((line, index) => {
+    entities.push(
+      lineEntity({
+        start: line.start || { x: 0, y: 0 },
+        end: line.end || { x: 0, y: 0 },
+        layer: "P-DRAIN",
+        viewType: "mep_drainage_plan",
+        viewId: line.levelId || "mep_drainage_plan",
+        geometryHash,
+        sourceId: line.id || `mep-drain-${index + 1}`,
+        metadata: {
+          role: "mep_drainage_waste",
+          lineId: line.id || null,
+          roomId: line.roomId || null,
+          mepModelHash,
+        },
+      }),
+    );
+  });
+
+  toArray(mepModel.drainageWasteLayout?.fixtures).forEach((fixture, index) => {
+    entities.push(
+      insertEntity({
+        blockName: "MEP_SANITARY_FIXTURE",
+        point: fixture.point || { x: 0, y: 0 },
+        layer: "P-SANITARY",
+        viewType: "mep_drainage_plan",
+        viewId: fixture.levelId || "mep_drainage_plan",
+        geometryHash,
+        sourceId: fixture.id || `mep-drain-fixture-${index + 1}`,
+        metadata: {
+          role: "mep_drainage_fixture",
+          fixtureId: fixture.id || null,
+          roomId: fixture.roomId || null,
+          mepModelHash,
+        },
+      }),
+    );
+  });
+
+  toArray(mepModel.ventilationHvacLayout?.routes).forEach((route, index) => {
+    entities.push(
+      lineEntity({
+        start: route.start || { x: 0, y: 0 },
+        end: route.end || { x: 0, y: 0 },
+        layer: "M-VENT",
+        viewType: "mep_ventilation_plan",
+        viewId: route.levelId || "mep_ventilation_plan",
+        geometryHash,
+        sourceId: route.id || `mep-vent-${index + 1}`,
+        metadata: {
+          role: "mep_ventilation_route",
+          routeId: route.id || null,
+          roomId: route.roomId || null,
+          mepModelHash,
+        },
+      }),
+    );
+    entities.push(
+      lineEntity({
+        start: {
+          x: (route.start?.x || 0) + 0.08,
+          y: (route.start?.y || 0) + 0.08,
+        },
+        end: {
+          x: (route.end?.x || 0) + 0.08,
+          y: (route.end?.y || 0) + 0.08,
+        },
+        layer: "M-DUCT",
+        viewType: "mep_ventilation_plan",
+        viewId: route.levelId || "mep_ventilation_plan",
+        geometryHash,
+        sourceId: `${route.id || `mep-vent-${index + 1}`}-duct`,
+        metadata: {
+          role: "mep_duct_route",
+          routeId: route.id || null,
+          roomId: route.roomId || null,
+          mepModelHash,
+        },
+      }),
+    );
+  });
+
+  toArray(mepModel.ventilationHvacLayout?.extractFans).forEach((fan, index) => {
+    entities.push(
+      insertEntity({
+        blockName: "MEP_EXTRACT_FAN",
+        point: fan.point || { x: 0, y: 0 },
+        layer: "M-VENT",
+        viewType: "mep_ventilation_plan",
+        viewId: fan.levelId || "mep_ventilation_plan",
+        geometryHash,
+        sourceId: fan.id || `mep-extract-${index + 1}`,
+        metadata: {
+          role: "mep_extract_fan",
+          fanId: fan.id || null,
+          roomId: fan.roomId || null,
+          mepModelHash,
+        },
+      }),
+    );
+  });
+
+  toArray(mepModel.risersShafts).forEach((riser, index) => {
+    const point = riser.position || riser.point || { x: 0, y: 0 };
+    entities.push(
+      insertEntity({
+        blockName: "MEP_RISER",
+        point,
+        layer: "MEP-RISER",
+        viewType: "mep_plumbing_plan",
+        viewId: riser.levelId || "mep_plumbing_plan",
+        geometryHash,
+        sourceId: riser.id || `mep-riser-${index + 1}`,
+        metadata: {
+          role: "mep_riser",
+          riserId: riser.id || null,
+          mepModelHash,
+        },
+      }),
+    );
+    addTag({
+      text: riser.tag || riser.id || `R${index + 1}`,
+      point: { x: point.x + 0.3, y: point.y + 0.3 },
+      sourceId: `${riser.id || `mep-riser-${index + 1}`}-tag`,
+      viewType: "mep_plumbing_plan",
+      viewId: riser.levelId || "mep_plumbing_plan",
+      role: "mep_riser_tag",
+    });
+  });
+
+  toArray(mepModel.equipmentPlantLocations).forEach((equipment, index) => {
+    const point = equipment.position || equipment.point || { x: 0, y: 0 };
+    entities.push(
+      insertEntity({
+        blockName: "MEP_EQUIPMENT",
+        point,
+        layer: "M-EQUIP",
+        viewType: "mep_schematic_notes",
+        viewId: equipment.levelId || "mep_schematic_notes",
+        geometryHash,
+        sourceId: equipment.id || `mep-equipment-${index + 1}`,
+        metadata: {
+          role: "mep_equipment",
+          equipmentId: equipment.id || null,
+          mepModelHash,
+        },
+      }),
+    );
+    addTag({
+      text: equipment.tag || equipment.id || `EQ${index + 1}`,
+      point: { x: point.x + 0.35, y: point.y + 0.25 },
+      sourceId: `${equipment.id || `mep-equipment-${index + 1}`}-tag`,
+      viewType: "mep_schematic_notes",
+      viewId: equipment.levelId || "mep_schematic_notes",
+      role: "mep_equipment_tag",
+    });
+  });
+
+  toArray(mepModel.coordinationNotes).forEach((note, index) => {
+    addTag({
+      text: note,
+      point: { x: 1, y: -1 - index * 0.28 },
+      sourceId: `mep-coordination-note-${index + 1}`,
+      viewType: "mep_schematic_notes",
+      viewId: "mep_schematic_notes",
+      role: "mep_coordination_note",
+    });
+  });
+
+  toArray(mepModel.disclaimers).forEach((disclaimer, index) => {
+    addTag({
+      text: disclaimer,
+      point: { x: 1, y: -2.25 - index * 0.28 },
+      sourceId: `mep-review-disclaimer-${index + 1}`,
+      viewType: "mep_schematic_notes",
+      viewId: "mep_schematic_notes",
+      role: "review_disclaimer",
+    });
+  });
+
+  const firstSupplyLine = toArray(mepModel.plumbingSupplyLayout?.lines)[0];
+  if (firstSupplyLine?.start && firstSupplyLine?.end) {
+    entities.push(
+      dimensionEntity({
+        start: firstSupplyLine.start,
+        end: firstSupplyLine.end,
+        offset: {
+          x: firstSupplyLine.start.x,
+          y: firstSupplyLine.start.y - 0.35,
+        },
+        text: "MEP coordination route",
+        layer: "MEP-DIMS",
+        viewType: "mep_plumbing_plan",
+        viewId: firstSupplyLine.levelId || "mep_plumbing_plan",
+        geometryHash,
+        sourceId: "mep-primary-route-dim",
+        metadata: {
+          role: "mep_clearance_dimension",
+          mepModelHash,
+        },
+      }),
+    );
+  }
+
+  return entities;
+}
+
+function buildMepPrimitiveEntities(
+  compiledProject = {},
+  geometryHash,
+  includeMepDrawings = false,
+) {
+  if (!includeMepDrawings) {
+    return [];
+  }
+  const mepModel = buildMepModelFromCompiledProject({
+    compiledProject,
+  });
+  return buildMepModelEntities(mepModel, geometryHash);
+}
+
 function defaultBlocks(geometryHash) {
   const block = (name, description, entities = []) => ({
     name,
@@ -1619,6 +2090,14 @@ function defaultBlocks(geometryHash) {
     block("SANITARY_WC", "Sanitary WC symbol", []),
     block("ELECTRICAL_LIGHT", "Electrical light symbol", []),
     block("ELECTRICAL_SOCKET", "Electrical socket symbol", []),
+    block("MEP_LIGHT_CEILING", "MEP ceiling light symbol", []),
+    block("MEP_SWITCH", "MEP switch symbol", []),
+    block("MEP_SOCKET", "MEP socket outlet symbol", []),
+    block("MEP_DATA_POINT", "MEP data point symbol", []),
+    block("MEP_SANITARY_FIXTURE", "MEP sanitary fixture symbol", []),
+    block("MEP_EXTRACT_FAN", "MEP extract fan symbol", []),
+    block("MEP_RISER", "MEP riser symbol", []),
+    block("MEP_EQUIPMENT", "MEP equipment symbol", []),
   ];
 }
 
@@ -2056,6 +2535,8 @@ export function buildCanonicalDrawingModelFromCompiledProject({
   units = "meters",
   includeStructuralDrawings = false,
   structuralDrawingsEnabled = false,
+  includeMepDrawings = false,
+  mepDrawingsEnabled = false,
 } = {}) {
   if (!compiledProject?.geometryHash) {
     throw new Error(
@@ -2069,8 +2550,16 @@ export function buildCanonicalDrawingModelFromCompiledProject({
   const sourceProjectGraphHash = sourceProjectGraphHashOf(compiledProject);
   const shouldIncludeStructuralDrawings =
     includeStructuralDrawings === true || structuralDrawingsEnabled === true;
+  const shouldIncludeMepDrawings =
+    includeMepDrawings === true || mepDrawingsEnabled === true;
   const structuralModel = shouldIncludeStructuralDrawings
     ? buildStructuralModelFromCompiledProject({
+        compiledProject,
+        jurisdiction: resolvedJurisdiction,
+      })
+    : null;
+  const mepModel = shouldIncludeMepDrawings
+    ? buildMepModelFromCompiledProject({
         compiledProject,
         jurisdiction: resolvedJurisdiction,
       })
@@ -2084,6 +2573,11 @@ export function buildCanonicalDrawingModelFromCompiledProject({
       compiledProject,
       geometryHash,
       shouldIncludeStructuralDrawings,
+    ),
+    ...buildMepPrimitiveEntities(
+      compiledProject,
+      geometryHash,
+      shouldIncludeMepDrawings,
     ),
   ];
   const sheets = buildPaperSpaceSheets({
@@ -2115,10 +2609,13 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     },
     plotStyleMetadata: clone(DEFAULT_PLOT_STYLE_METADATA),
     ...(structuralModel ? { structuralModel } : {}),
+    ...(mepModel ? { mepModel } : {}),
     layers: clone(DEFAULT_CANONICAL_CAD_LAYERS).filter(
       (layer) =>
-        shouldIncludeStructuralDrawings ||
-        !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layer.name),
+        (shouldIncludeStructuralDrawings ||
+          !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layer.name)) &&
+        (shouldIncludeMepDrawings ||
+          !MEP_CANONICAL_CAD_LAYER_NAMES.has(layer.name)),
     ),
     blocks: defaultBlocks(geometryHash),
     hatches: clone(DEFAULT_HATCHES),
@@ -2199,6 +2696,8 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
   const dimensionPolicy = options.dimensionPolicy || "warn";
   const shouldValidateStructuralModel =
     Boolean(model.structuralModel) || options.requireStructuralModel === true;
+  const shouldValidateMepModel =
+    Boolean(model.mepModel) || options.requireMepModel === true;
 
   if (model.schema_version !== CANONICAL_DRAWING_MODEL_VERSION) {
     errors.push(
@@ -2354,8 +2853,9 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
   const layerNames = new Set(toArray(model.layers).map((layer) => layer.name));
   const requiredLayerNames = REQUIRED_CANONICAL_CAD_LAYERS.filter(
     (layerName) =>
-      shouldValidateStructuralModel ||
-      !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layerName),
+      (shouldValidateStructuralModel ||
+        !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layerName)) &&
+      (shouldValidateMepModel || !MEP_CANONICAL_CAD_LAYER_NAMES.has(layerName)),
   );
   requiredLayerNames.forEach((layerName) => {
     if (!layerNames.has(layerName)) {
@@ -2514,6 +3014,85 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
     );
   }
 
+  if (shouldValidateMepModel && !model.mepModel?.mepModelHash) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_MEP_MODEL_HASH_MISSING",
+        "CanonicalDrawingModel requires mepModel.mepModelHash when MEP output is enabled.",
+      ),
+    );
+  }
+  if (
+    shouldValidateMepModel &&
+    model.mepModel?.geometryHash &&
+    model.geometryHash &&
+    model.mepModel.geometryHash !== model.geometryHash
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_MEP_GEOMETRY_HASH_MISMATCH",
+        "MepModel geometryHash must match CanonicalDrawingModel geometryHash.",
+        {
+          mepGeometryHash: model.mepModel.geometryHash,
+          geometryHash: model.geometryHash,
+        },
+      ),
+    );
+  }
+  if (shouldValidateMepModel && model.mepModel?.reviewRequired !== true) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_MEP_REVIEW_REQUIRED_MISSING",
+        "MepModel must be marked reviewRequired=true.",
+      ),
+    );
+  }
+  if (
+    shouldValidateMepModel &&
+    !toArray(model.mepModel?.disclaimers)
+      .join(" ")
+      .match(/qualified MEP engineer/i)
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_MEP_DISCLAIMER_MISSING",
+        "MepModel requires qualified MEP engineer review disclaimer.",
+      ),
+    );
+  }
+  if (
+    shouldValidateMepModel &&
+    toArray(model.mepModel?.roomFixtureMapping?.wetRooms).length > 0 &&
+    !toArray(model.mepModel?.drainageWasteLayout?.lines).length
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_MEP_WET_ROOM_DRAINAGE_MISSING",
+        "MepModel requires drainage/waste routes when wet rooms are present.",
+      ),
+    );
+  }
+  if (
+    shouldValidateMepModel &&
+    toArray(model.mepModel?.roomFixtureMapping?.habitableRooms).length > 0 &&
+    !toArray(model.mepModel?.electricalLightingLayout?.fixtures).length
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_MEP_HABITABLE_LIGHTING_MISSING",
+        "MepModel requires lighting fixtures when habitable rooms are present.",
+      ),
+    );
+  }
+  if (shouldValidateMepModel && model.mepModel?.imageProviderUsed !== "none") {
+    errors.push(
+      validationError(
+        "CAD_MODEL_MEP_IMAGE_PROVIDER_FORBIDDEN",
+        "MepModel must not use image generation.",
+      ),
+    );
+  }
+
   const hasNativeLayouts =
     sheets.length > 0 &&
     sheets.every((sheet) => sheet.nativeLayout?.className === "AcDbLayout");
@@ -2539,6 +3118,10 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
   const hasStructuralDisclaimer = toArray(model.structuralModel?.disclaimers)
     .join(" ")
     .match(/licensed structural engineer/i);
+  const hasMepModelHash = Boolean(model.mepModel?.mepModelHash);
+  const hasMepDisclaimer = toArray(model.mepModel?.disclaimers)
+    .join(" ")
+    .match(/qualified MEP engineer/i);
 
   return {
     valid: errors.length === 0,
@@ -2564,6 +3147,10 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
       structuralReviewRequired: model.structuralModel?.reviewRequired === true,
       structuralImageProviderUsed:
         model.structuralModel?.imageProviderUsed || null,
+      hasMepModelHash,
+      hasMepDisclaimer: Boolean(hasMepDisclaimer),
+      mepReviewRequired: model.mepModel?.reviewRequired === true,
+      mepImageProviderUsed: model.mepModel?.imageProviderUsed || null,
     },
   };
 }

--- a/src/services/mep/mepModelService.js
+++ b/src/services/mep/mepModelService.js
@@ -1,0 +1,875 @@
+import {
+  buildBoundingBoxFromPolygon,
+  computeCentroid,
+  createStableHash,
+  createStableId,
+  roundMetric,
+} from "../cad/projectGeometrySchema.js";
+
+export const MEP_MODEL_VERSION = "mep-model-v1";
+export const MEP_DRAWING_PANEL_VERSION = "mep-drawing-panel-v1";
+
+export const MEP_REVIEW_DISCLAIMER =
+  "PRELIMINARY MEP INFORMATION ONLY - not for construction. Review, sizing, calculations, and coordination by a qualified MEP engineer are required.";
+
+export const REQUIRED_MEP_CAD_LAYERS = Object.freeze([
+  "E-LIGHT",
+  "E-POWER",
+  "E-SWITCH",
+  "E-DATA",
+  "P-WATER",
+  "P-DRAIN",
+  "P-SANITARY",
+  "M-DUCT",
+  "M-VENT",
+  "M-EQUIP",
+  "MEP-RISER",
+  "MEP-NOTES",
+  "MEP-DIMS",
+]);
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function finiteMetric(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? roundMetric(numeric, 3) : fallback;
+}
+
+function point(value = {}) {
+  return {
+    x: finiteMetric(value.x ?? value.x_m ?? value.left ?? 0),
+    y: finiteMetric(value.y ?? value.y_m ?? value.top ?? 0),
+  };
+}
+
+function polygon(value) {
+  return toArray(value).map(point);
+}
+
+function hasPolygon(value) {
+  return polygon(value).length >= 3;
+}
+
+function sourceProjectGraphHashOf(compiledProject = {}) {
+  return (
+    compiledProject.sourceProjectGraphHash ||
+    compiledProject.projectGraphHash ||
+    compiledProject.projectGraph?.hash ||
+    compiledProject.metadata?.sourceProjectGraphHash ||
+    compiledProject.metadata?.projectGraphHash ||
+    compiledProject.geometryHash ||
+    null
+  );
+}
+
+function jurisdictionOf(compiledProject = {}, jurisdiction = null) {
+  return (
+    jurisdiction ||
+    compiledProject.jurisdiction ||
+    compiledProject.project?.jurisdiction ||
+    compiledProject.metadata?.jurisdiction ||
+    "generic"
+  );
+}
+
+function roomName(room = {}) {
+  return String(
+    room.name || room.type || room.roomType || room.label || room.id || "",
+  );
+}
+
+function roomKind(room = {}) {
+  return String(
+    room.type || room.roomType || room.category || roomName(room),
+  ).toLowerCase();
+}
+
+function isKitchen(room = {}) {
+  return /kitchen|cuisine/.test(
+    `${roomKind(room)} ${roomName(room).toLowerCase()}`,
+  );
+}
+
+function isWetRoom(room = {}) {
+  return /bath|wc|toilet|shower|ensuite|utility|laundry|wet|sanitary/.test(
+    `${roomKind(room)} ${roomName(room).toLowerCase()}`,
+  );
+}
+
+function isHabitableRoom(room = {}) {
+  const text = `${roomKind(room)} ${roomName(room).toLowerCase()}`;
+  return /living|bed|dining|study|office|kitchen|lounge|family|habitable/.test(
+    text,
+  );
+}
+
+function isCirculation(room = {}) {
+  return /corridor|hall|landing|stair|circulation/.test(
+    `${roomKind(room)} ${roomName(room).toLowerCase()}`,
+  );
+}
+
+function levelIdOf(room = {}) {
+  return room.levelId || room.level_id || room.level || "level-0";
+}
+
+function roomPolygon(room = {}) {
+  if (hasPolygon(room.polygon)) return polygon(room.polygon);
+  if (hasPolygon(room.boundary)) return polygon(room.boundary);
+  if (room.center || room.position || room.position_m) {
+    const center = point(room.center || room.position || room.position_m);
+    const w = finiteMetric(room.width_m || room.width || 3, 3);
+    const d = finiteMetric(room.depth_m || room.height_m || room.depth || 3, 3);
+    return [
+      { x: center.x - w / 2, y: center.y - d / 2 },
+      { x: center.x + w / 2, y: center.y - d / 2 },
+      { x: center.x + w / 2, y: center.y + d / 2 },
+      { x: center.x - w / 2, y: center.y + d / 2 },
+    ];
+  }
+  return [];
+}
+
+function roomCenter(room = {}) {
+  const poly = roomPolygon(room);
+  if (poly.length >= 3) return computeCentroid(poly);
+  return point(room.center || room.position || room.position_m || {});
+}
+
+function roomBBox(room = {}) {
+  const poly = roomPolygon(room);
+  if (poly.length >= 3) return buildBoundingBoxFromPolygon(poly);
+  const center = roomCenter(room);
+  return {
+    min_x: center.x - 1,
+    max_x: center.x + 1,
+    min_y: center.y - 1,
+    max_y: center.y + 1,
+    width: 2,
+    height: 2,
+  };
+}
+
+function collectProjectPoints(compiledProject = {}) {
+  const points = [];
+  toArray(compiledProject.rooms).forEach((room) =>
+    points.push(...roomPolygon(room)),
+  );
+  toArray(compiledProject.slabs).forEach((slab) =>
+    points.push(...polygon(slab.polygon)),
+  );
+  points.push(...polygon(compiledProject.site?.buildable_polygon));
+  points.push(...polygon(compiledProject.site?.boundary_polygon));
+  return points;
+}
+
+function projectBBox(compiledProject = {}) {
+  const points = collectProjectPoints(compiledProject);
+  if (points.length >= 2) return buildBoundingBoxFromPolygon(points);
+  return { min_x: 0, min_y: 0, max_x: 12, max_y: 8, width: 12, height: 8 };
+}
+
+function makeFixtureId(prefix, index) {
+  return `${prefix}-${String(index + 1).padStart(3, "0")}`;
+}
+
+function offsetPoint(base, dx, dy) {
+  return {
+    x: roundMetric((base?.x || 0) + dx, 3),
+    y: roundMetric((base?.y || 0) + dy, 3),
+  };
+}
+
+function buildRoomInventory(compiledProject = {}) {
+  const rooms = toArray(compiledProject.rooms).map((room, index) => ({
+    id: room.id || room.sourceId || `room-${index + 1}`,
+    name: roomName(room) || `Room ${index + 1}`,
+    type: roomKind(room) || "room",
+    levelId: levelIdOf(room),
+    center: roomCenter(room),
+    bbox: roomBBox(room),
+    polygon: roomPolygon(room),
+    isWetRoom: isWetRoom(room),
+    isKitchen: isKitchen(room),
+    isHabitable: isHabitableRoom(room),
+    isCirculation: isCirculation(room),
+  }));
+
+  if (rooms.length) return rooms;
+
+  const bbox = projectBBox(compiledProject);
+  return [
+    {
+      id: "room-default-living",
+      name: "Living",
+      type: "living",
+      levelId: "level-0",
+      center: {
+        x: roundMetric(bbox.min_x + bbox.width / 2),
+        y: roundMetric(bbox.min_y + bbox.height / 2),
+      },
+      bbox,
+      polygon: [
+        { x: bbox.min_x, y: bbox.min_y },
+        { x: bbox.max_x, y: bbox.min_y },
+        { x: bbox.max_x, y: bbox.max_y },
+        { x: bbox.min_x, y: bbox.max_y },
+      ],
+      isWetRoom: false,
+      isKitchen: false,
+      isHabitable: true,
+      isCirculation: false,
+    },
+  ];
+}
+
+function buildRisers(compiledProject, rooms) {
+  const bbox = projectBBox(compiledProject);
+  const serviceRoom =
+    rooms.find((room) => room.isWetRoom || room.isKitchen) || rooms[0];
+  const center = serviceRoom?.center || {
+    x: bbox.min_x + bbox.width * 0.85,
+    y: bbox.min_y + bbox.height * 0.25,
+  };
+  return [
+    {
+      id: "MEP-RISER-001",
+      tag: "RS-001",
+      levelId: serviceRoom?.levelId || "level-0",
+      position: offsetPoint(center, 0.45, 0.45),
+      serves: ["water", "drainage", "ventilation"],
+      reviewRequired: true,
+    },
+  ];
+}
+
+function buildElectricalLayouts(rooms) {
+  const lightingFixtures = [];
+  const powerOutlets = [];
+  const switches = [];
+  const dataPoints = [];
+
+  rooms.forEach((room, index) => {
+    if (room.isHabitable || room.isCirculation || room.isKitchen) {
+      lightingFixtures.push({
+        id: makeFixtureId("LT", lightingFixtures.length),
+        tag: makeFixtureId("LT", lightingFixtures.length),
+        roomId: room.id,
+        roomName: room.name,
+        levelId: room.levelId,
+        point: room.center,
+        fixtureType: room.isKitchen ? "linear_kitchen_task" : "ceiling_light",
+      });
+      powerOutlets.push({
+        id: makeFixtureId("PWR", powerOutlets.length),
+        tag: makeFixtureId("PWR", powerOutlets.length),
+        roomId: room.id,
+        roomName: room.name,
+        levelId: room.levelId,
+        point: offsetPoint(room.center, -0.45, -0.35),
+        outletType: room.isKitchen ? "kitchen_counter_socket" : "double_socket",
+      });
+      switches.push({
+        id: makeFixtureId("SW", switches.length),
+        tag: makeFixtureId("SW", switches.length),
+        roomId: room.id,
+        roomName: room.name,
+        levelId: room.levelId,
+        point: { x: room.bbox.min_x + 0.35, y: room.bbox.min_y + 0.35 },
+        switchType: "one_way_switch",
+      });
+      if (/study|office|bed|living/i.test(`${room.type} ${room.name}`)) {
+        dataPoints.push({
+          id: makeFixtureId("DATA", dataPoints.length),
+          tag: makeFixtureId("DATA", dataPoints.length),
+          roomId: room.id,
+          roomName: room.name,
+          levelId: room.levelId,
+          point: offsetPoint(room.center, 0.45, -0.35),
+          outletType: "data_point",
+        });
+      }
+    }
+  });
+
+  return {
+    lightingLayout: { fixtures: lightingFixtures },
+    powerSocketLayout: { outlets: powerOutlets, switches, dataPoints },
+  };
+}
+
+function routeToRiser(room, riser, idPrefix, index) {
+  return {
+    id: makeFixtureId(idPrefix, index),
+    roomId: room.id,
+    roomName: room.name,
+    levelId: room.levelId,
+    start: room.center,
+    end: riser.position,
+    riserId: riser.id,
+  };
+}
+
+function buildPlumbingAndDrainage(rooms, risers) {
+  const riser = risers[0];
+  const serviceRooms = rooms.filter((room) => room.isWetRoom || room.isKitchen);
+  const plumbingFixtures = [];
+  const drainageFixtures = [];
+  const supplyLines = [];
+  const wasteLines = [];
+
+  serviceRooms.forEach((room) => {
+    const fixtureTag = room.isKitchen
+      ? "SK"
+      : room.name.match(/wc|toilet/i)
+        ? "WC"
+        : "SAN";
+    plumbingFixtures.push({
+      id: makeFixtureId("HW", plumbingFixtures.length),
+      tag: `${fixtureTag}-${String(plumbingFixtures.length + 1).padStart(3, "0")}`,
+      roomId: room.id,
+      roomName: room.name,
+      levelId: room.levelId,
+      point: offsetPoint(room.center, -0.25, 0.25),
+      fixtureType: room.isKitchen ? "sink_supply" : "sanitary_supply",
+    });
+    drainageFixtures.push({
+      id: makeFixtureId("DR", drainageFixtures.length),
+      tag: `DR-${String(drainageFixtures.length + 1).padStart(3, "0")}`,
+      roomId: room.id,
+      roomName: room.name,
+      levelId: room.levelId,
+      point: offsetPoint(room.center, 0.25, 0.25),
+      fixtureType: room.isKitchen ? "sink_waste" : "sanitary_waste",
+    });
+    supplyLines.push(routeToRiser(room, riser, "WTR", supplyLines.length));
+    wasteLines.push(routeToRiser(room, riser, "WST", wasteLines.length));
+  });
+
+  return {
+    plumbingSupplyLayout: { fixtures: plumbingFixtures, lines: supplyLines },
+    drainageWasteLayout: { fixtures: drainageFixtures, lines: wasteLines },
+  };
+}
+
+function buildVentilation(rooms, risers) {
+  const riser = risers[0];
+  const extractRooms = rooms.filter((room) => room.isWetRoom || room.isKitchen);
+  const habitableRooms = rooms.filter(
+    (room) => room.isHabitable && !room.isWetRoom,
+  );
+  const extractFans = extractRooms.map((room, index) => ({
+    id: makeFixtureId("EF", index),
+    tag: makeFixtureId("EF", index),
+    roomId: room.id,
+    roomName: room.name,
+    levelId: room.levelId,
+    point: offsetPoint(room.center, 0, -0.45),
+    fanType: "extract_fan",
+  }));
+  const routes = extractRooms.map((room, index) =>
+    routeToRiser(room, riser, "VENT", index),
+  );
+  const supplyMarkers = habitableRooms.map((room, index) => ({
+    id: makeFixtureId("SA", index),
+    tag: makeFixtureId("SA", index),
+    roomId: room.id,
+    roomName: room.name,
+    levelId: room.levelId,
+    point: offsetPoint(room.center, 0, 0.45),
+    markerType: "background_ventilation",
+  }));
+  return {
+    ventilationHvacLayout: {
+      extractFans,
+      routes,
+      supplyMarkers,
+      notes: [
+        "Ventilation routes are indicative only.",
+        "Fan duties, pressure drops, acoustic limits, and duct sizes are not calculated.",
+      ],
+    },
+  };
+}
+
+function buildEquipment(compiledProject, risers) {
+  const bbox = projectBBox(compiledProject);
+  return [
+    {
+      id: "MEP-EQ-001",
+      tag: "EQ-001",
+      equipmentType: "domestic_plant_allowance",
+      position: risers[0]?.position || { x: bbox.max_x - 1, y: bbox.min_y + 1 },
+      levelId: risers[0]?.levelId || "level-0",
+      note: "Indicative plant location pending engineer coordination.",
+    },
+  ];
+}
+
+function buildRoomFixtureMapping(rooms) {
+  return {
+    wetRooms: rooms.filter((room) => room.isWetRoom).map((room) => room.id),
+    kitchens: rooms.filter((room) => room.isKitchen).map((room) => room.id),
+    habitableRooms: rooms
+      .filter((room) => room.isHabitable)
+      .map((room) => room.id),
+    circulationRooms: rooms
+      .filter((room) => room.isCirculation)
+      .map((room) => room.id),
+  };
+}
+
+function buildSchedules(mepModelDraft) {
+  return {
+    lightingSchedule: mepModelDraft.electricalLightingLayout.fixtures.map(
+      (fixture) => ({
+        id: fixture.id,
+        tag: fixture.tag,
+        type: fixture.fixtureType,
+        roomId: fixture.roomId,
+      }),
+    ),
+    powerSchedule: mepModelDraft.electricalPowerSocketLayout.outlets.map(
+      (outlet) => ({
+        id: outlet.id,
+        tag: outlet.tag,
+        type: outlet.outletType,
+        roomId: outlet.roomId,
+      }),
+    ),
+    plumbingSchedule: [
+      ...mepModelDraft.plumbingSupplyLayout.fixtures,
+      ...mepModelDraft.drainageWasteLayout.fixtures,
+    ].map((fixture) => ({
+      id: fixture.id,
+      tag: fixture.tag,
+      type: fixture.fixtureType,
+      roomId: fixture.roomId,
+    })),
+    ventilationSchedule: mepModelDraft.ventilationHvacLayout.extractFans.map(
+      (fan) => ({
+        id: fan.id,
+        tag: fan.tag,
+        type: fan.fanType,
+        roomId: fan.roomId,
+      }),
+    ),
+  };
+}
+
+export function buildMepModelFromCompiledProject({
+  compiledProject,
+  jurisdiction = null,
+} = {}) {
+  if (!compiledProject?.geometryHash) {
+    throw new Error(
+      "Compiled project with geometryHash is required to build MepModel.",
+    );
+  }
+
+  const rooms = buildRoomInventory(compiledProject);
+  const risers = buildRisers(compiledProject, rooms);
+  const electrical = buildElectricalLayouts(rooms);
+  const hydraulic = buildPlumbingAndDrainage(rooms, risers);
+  const ventilation = buildVentilation(rooms, risers);
+  const draft = {
+    version: MEP_MODEL_VERSION,
+    geometryHash: compiledProject.geometryHash,
+    sourceProjectGraphHash: sourceProjectGraphHashOf(compiledProject),
+    jurisdiction: jurisdictionOf(compiledProject, jurisdiction),
+    designBasis: {
+      status: "preliminary",
+      outputType: "coordination_model",
+      units: "meters",
+      reviewRequired: true,
+      standardsBasis: "generic preliminary MEP coordination assumptions",
+    },
+    assumptions: [
+      "MEP layouts are deterministic coordination diagrams derived from compiled project room geometry.",
+      "No pipe sizing, pressure drop, ventilation duty, circuit loading, discrimination, or code compliance calculations are performed.",
+      "Fixture counts and routes are preliminary placeholders for qualified MEP engineer review.",
+    ],
+    disclaimers: [MEP_REVIEW_DISCLAIMER],
+    reviewRequired: true,
+    imageProviderUsed: "none",
+    technicalDrawing: true,
+    electricalLightingLayout: electrical.lightingLayout,
+    electricalPowerSocketLayout: electrical.powerSocketLayout,
+    plumbingSupplyLayout: hydraulic.plumbingSupplyLayout,
+    drainageWasteLayout: hydraulic.drainageWasteLayout,
+    ventilationHvacLayout: ventilation.ventilationHvacLayout,
+    risersShafts: risers,
+    equipmentPlantLocations: buildEquipment(compiledProject, risers),
+    roomFixtureMapping: buildRoomFixtureMapping(rooms),
+    mepLegends: [
+      { code: "LT", label: "Light fitting" },
+      { code: "SW", label: "Switch" },
+      { code: "PWR", label: "Power/socket outlet" },
+      { code: "DATA", label: "Data point" },
+      { code: "WTR", label: "Plumbing supply route" },
+      { code: "DR", label: "Drainage/waste route" },
+      { code: "EF", label: "Extract fan" },
+      { code: "RS", label: "Riser/shaft" },
+    ],
+    coordinationNotes: [
+      "Coordinate risers with structural openings and fire/acoustic compartmentation.",
+      "Coordinate wet room drainage falls, pipe zones, and access panels before construction.",
+      "Coordinate electrical points with furniture layouts and final client requirements.",
+    ],
+    preliminaryClashNotes: [
+      "No automated clash detection is performed in this slice.",
+      "Riser and plant locations are indicative and must be coordinated with structure and architecture.",
+    ],
+    requiredCadLayers: [...REQUIRED_MEP_CAD_LAYERS],
+  };
+
+  const schedules = buildSchedules(draft);
+  const partial = { ...draft, schedules };
+  const mepModelHash = createStableHash(JSON.stringify(partial));
+  return {
+    ...partial,
+    mepModelId: createStableId(
+      "mep-model",
+      compiledProject.geometryHash,
+      mepModelHash,
+    ),
+    mepModelHash,
+    memberIds: [
+      ...partial.electricalLightingLayout.fixtures,
+      ...partial.electricalPowerSocketLayout.outlets,
+      ...partial.electricalPowerSocketLayout.switches,
+      ...partial.electricalPowerSocketLayout.dataPoints,
+      ...partial.plumbingSupplyLayout.fixtures,
+      ...partial.drainageWasteLayout.fixtures,
+      ...partial.ventilationHvacLayout.extractFans,
+      ...partial.risersShafts,
+      ...partial.equipmentPlantLocations,
+    ].map((item) => item.tag || item.id),
+  };
+}
+
+function svgEscape(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function transformPointFactory(mepModel) {
+  const allPoints = [
+    ...mepModel.electricalLightingLayout.fixtures.map((item) => item.point),
+    ...mepModel.electricalPowerSocketLayout.outlets.map((item) => item.point),
+    ...mepModel.plumbingSupplyLayout.lines.flatMap((line) => [
+      line.start,
+      line.end,
+    ]),
+    ...mepModel.drainageWasteLayout.lines.flatMap((line) => [
+      line.start,
+      line.end,
+    ]),
+    ...mepModel.ventilationHvacLayout.routes.flatMap((line) => [
+      line.start,
+      line.end,
+    ]),
+  ];
+  const bbox =
+    allPoints.length >= 2
+      ? buildBoundingBoxFromPolygon(allPoints)
+      : { min_x: 0, min_y: 0, width: 12, height: 8 };
+  const margin = 70;
+  const width = 760;
+  const height = 560;
+  const scale = Math.min(
+    (width - margin * 2) / Math.max(bbox.width || 1, 1),
+    (height - margin * 2) / Math.max(bbox.height || 1, 1),
+  );
+  return (pt) => ({
+    x: roundMetric(margin + (Number(pt?.x || 0) - bbox.min_x) * scale, 2),
+    y: roundMetric(
+      height - margin - (Number(pt?.y || 0) - bbox.min_y) * scale,
+      2,
+    ),
+  });
+}
+
+function svgSymbol({ point: pt, className, label, shape = "circle" }) {
+  const tag = svgEscape(label);
+  if (shape === "rect") {
+    return `<rect class="${className}" x="${pt.x - 8}" y="${pt.y - 8}" width="16" height="16" /><text class="fixture-tag" x="${pt.x + 12}" y="${pt.y - 8}">${tag}</text>`;
+  }
+  if (shape === "triangle") {
+    return `<path class="${className}" d="M ${pt.x} ${pt.y - 10} L ${pt.x + 10} ${pt.y + 8} L ${pt.x - 10} ${pt.y + 8} Z" /><text class="fixture-tag" x="${pt.x + 12}" y="${pt.y - 8}">${tag}</text>`;
+  }
+  return `<circle class="${className}" cx="${pt.x}" cy="${pt.y}" r="8" /><text class="fixture-tag" x="${pt.x + 12}" y="${pt.y - 8}">${tag}</text>`;
+}
+
+function svgRoute({ start, end, className, label }) {
+  return `<line class="${className}" x1="${start.x}" y1="${start.y}" x2="${end.x}" y2="${end.y}" /><text class="route-tag" x="${(start.x + end.x) / 2}" y="${(start.y + end.y) / 2 - 6}">${svgEscape(label)}</text>`;
+}
+
+function buildPanel({ mepModel, panelType, title, body }) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="820" height="620" viewBox="0 0 820 620" role="img" data-panel-type="${panelType}" data-technical-drawing="true" data-image-provider-used="none">
+<style>
+.sheet{fill:#f8fbff;stroke:#1f3552;stroke-width:2}.title{font:700 24px monospace;fill:#13263f}.subtitle,.note{font:13px monospace;fill:#28415f}.mep-light-symbol{fill:#fff7b0;stroke:#8a6d00;stroke-width:2}.mep-socket-symbol{fill:#e7f0ff;stroke:#0050a4;stroke-width:2}.mep-switch-symbol{fill:#eef;stroke:#334;stroke-width:2}.mep-water-route{stroke:#1078d4;stroke-width:3;fill:none}.mep-drain-route{stroke:#7247a8;stroke-width:3;stroke-dasharray:8 5;fill:none}.mep-vent-route{stroke:#0b8f6a;stroke-width:3;fill:none}.mep-riser-symbol{fill:#fff;stroke:#c43;stroke-width:3}.mep-equipment-symbol{fill:#f6f1ea;stroke:#704214;stroke-width:2}.fixture-tag,.route-tag{font:11px monospace;fill:#13263f}.mep-legend{fill:#fff;stroke:#7b8da8;stroke-width:1}.review{font:700 13px monospace;fill:#9b2c2c}
+</style>
+<rect class="sheet" x="16" y="16" width="788" height="588" />
+<text class="title" x="36" y="44">${svgEscape(title)}</text>
+<text class="subtitle" x="36" y="68">PRELIMINARY MEP - QUALIFIED MEP ENGINEER REVIEW REQUIRED</text>
+<metadata>{"panelType":"${panelType}","geometryHash":"${mepModel.geometryHash}","mepModelHash":"${mepModel.mepModelHash}","technicalDrawing":true,"imageProviderUsed":"none"}</metadata>
+${body}
+<g class="mep-legend"><rect x="560" y="420" width="220" height="150" /><text class="note" x="574" y="444">MEP LEGEND</text><text class="note" x="574" y="466">LT light fitting</text><text class="note" x="574" y="488">PWR socket outlet</text><text class="note" x="574" y="510">WTR water route</text><text class="note" x="574" y="532">DR drain/waste route</text><text class="note" x="574" y="554">EF extract fan / vent route</text></g>
+<text class="review" x="36" y="590">${svgEscape(MEP_REVIEW_DISCLAIMER)}</text>
+</svg>`;
+  const svgHash = createStableHash(svg);
+  return {
+    panelType,
+    drawingType: "mep",
+    version: MEP_DRAWING_PANEL_VERSION,
+    title,
+    svgString: svg,
+    svgHash,
+    width: 820,
+    height: 620,
+    renderer: "deterministic_svg",
+    providerUsed: "deterministic_svg",
+    imageProviderUsed: "none",
+    technicalDrawing: true,
+    geometryHash: mepModel.geometryHash,
+    sourceGeometryHash: mepModel.geometryHash,
+    sourceProjectGraphHash: mepModel.sourceProjectGraphHash,
+    mepModelHash: mepModel.mepModelHash,
+    reviewRequired: true,
+    status: "ready",
+    metadata: {
+      panelType,
+      drawingType: "mep",
+      mepModelHash: mepModel.mepModelHash,
+      reviewRequired: true,
+      imageProviderUsed: "none",
+      renderer: "deterministic_svg",
+    },
+  };
+}
+
+export function buildMepDrawingPanelsFromMepModel(mepModel = {}) {
+  const mapPoint = transformPointFactory(mepModel);
+  const riserSymbols = toArray(mepModel.risersShafts)
+    .map((riser) =>
+      svgSymbol({
+        point: mapPoint(riser.position),
+        className: "mep-riser-symbol",
+        label: riser.tag || riser.id,
+        shape: "rect",
+      }),
+    )
+    .join("");
+  const lighting = toArray(mepModel.electricalLightingLayout?.fixtures)
+    .map((fixture) =>
+      svgSymbol({
+        point: mapPoint(fixture.point),
+        className: "mep-light-symbol",
+        label: fixture.tag,
+      }),
+    )
+    .join("");
+  const sockets = [
+    ...toArray(mepModel.electricalPowerSocketLayout?.outlets).map((outlet) =>
+      svgSymbol({
+        point: mapPoint(outlet.point),
+        className: "mep-socket-symbol",
+        label: outlet.tag,
+        shape: "rect",
+      }),
+    ),
+    ...toArray(mepModel.electricalPowerSocketLayout?.switches).map((sw) =>
+      svgSymbol({
+        point: mapPoint(sw.point),
+        className: "mep-switch-symbol",
+        label: sw.tag,
+        shape: "triangle",
+      }),
+    ),
+  ].join("");
+  const waterRoutes = toArray(mepModel.plumbingSupplyLayout?.lines)
+    .map((line) =>
+      svgRoute({
+        start: mapPoint(line.start),
+        end: mapPoint(line.end),
+        className: "mep-water-route",
+        label: line.id,
+      }),
+    )
+    .join("");
+  const drainRoutes = toArray(mepModel.drainageWasteLayout?.lines)
+    .map((line) =>
+      svgRoute({
+        start: mapPoint(line.start),
+        end: mapPoint(line.end),
+        className: "mep-drain-route",
+        label: line.id,
+      }),
+    )
+    .join("");
+  const ventRoutes = toArray(mepModel.ventilationHvacLayout?.routes)
+    .map((line) =>
+      svgRoute({
+        start: mapPoint(line.start),
+        end: mapPoint(line.end),
+        className: "mep-vent-route",
+        label: line.id,
+      }),
+    )
+    .join("");
+  const extractFans = toArray(mepModel.ventilationHvacLayout?.extractFans)
+    .map((fan) =>
+      svgSymbol({
+        point: mapPoint(fan.point),
+        className: "mep-vent-route",
+        label: fan.tag,
+        shape: "triangle",
+      }),
+    )
+    .join("");
+  const equipment = toArray(mepModel.equipmentPlantLocations)
+    .map((item) =>
+      svgSymbol({
+        point: mapPoint(item.position),
+        className: "mep-equipment-symbol",
+        label: item.tag,
+        shape: "rect",
+      }),
+    )
+    .join("");
+  const notes = [
+    ...toArray(mepModel.coordinationNotes),
+    ...toArray(mepModel.preliminaryClashNotes),
+  ]
+    .slice(0, 8)
+    .map(
+      (note, index) =>
+        `<text class="note" x="56" y="${130 + index * 24}">${svgEscape(note)}</text>`,
+    )
+    .join("");
+
+  const mepPanels = {
+    mep_lighting_plan: buildPanel({
+      mepModel,
+      panelType: "mep_lighting_plan",
+      title: "MEP Lighting Plan",
+      body: `<g>${lighting}${riserSymbols}</g>`,
+    }),
+    mep_power_plan: buildPanel({
+      mepModel,
+      panelType: "mep_power_plan",
+      title: "MEP Power and Data Plan",
+      body: `<g>${sockets}${riserSymbols}</g>`,
+    }),
+    mep_plumbing_plan: buildPanel({
+      mepModel,
+      panelType: "mep_plumbing_plan",
+      title: "MEP Plumbing Supply Plan",
+      body: `<g>${waterRoutes}${riserSymbols}</g>`,
+    }),
+    mep_drainage_plan: buildPanel({
+      mepModel,
+      panelType: "mep_drainage_plan",
+      title: "MEP Drainage and Waste Plan",
+      body: `<g>${drainRoutes}${riserSymbols}</g>`,
+    }),
+    mep_ventilation_plan: buildPanel({
+      mepModel,
+      panelType: "mep_ventilation_plan",
+      title: "MEP Ventilation Plan",
+      body: `<g>${ventRoutes}${extractFans}${riserSymbols}</g>`,
+    }),
+    mep_schematic_notes: buildPanel({
+      mepModel,
+      panelType: "mep_schematic_notes",
+      title: "MEP Schematic Notes",
+      body: `<g>${equipment}${notes}</g>`,
+    }),
+  };
+
+  return { mepModel, mepPanels };
+}
+
+export function buildMepDrawingPanelsFromCompiledProject({
+  compiledProject,
+  jurisdiction = null,
+} = {}) {
+  const mepModel = buildMepModelFromCompiledProject({
+    compiledProject,
+    jurisdiction,
+  });
+  return buildMepDrawingPanelsFromMepModel(mepModel);
+}
+
+export function validateMepModel(
+  mepModel = {},
+  { compiledProject = null } = {},
+) {
+  const errors = [];
+  if (!mepModel.mepModelHash) errors.push({ code: "MEP_MODEL_HASH_MISSING" });
+  if (!mepModel.geometryHash)
+    errors.push({ code: "MEP_MODEL_GEOMETRY_HASH_MISSING" });
+  if (
+    compiledProject?.geometryHash &&
+    mepModel.geometryHash &&
+    mepModel.geometryHash !== compiledProject.geometryHash
+  ) {
+    errors.push({ code: "MEP_MODEL_GEOMETRY_HASH_MISMATCH" });
+  }
+  if (mepModel.reviewRequired !== true)
+    errors.push({ code: "MEP_MODEL_REVIEW_REQUIRED_MISSING" });
+  if (
+    !toArray(mepModel.disclaimers)
+      .join(" ")
+      .match(/qualified MEP engineer/i)
+  ) {
+    errors.push({ code: "MEP_MODEL_DISCLAIMER_MISSING" });
+  }
+  const wetRooms = toArray(mepModel.roomFixtureMapping?.wetRooms);
+  const habitableRooms = toArray(mepModel.roomFixtureMapping?.habitableRooms);
+  if (wetRooms.length && !toArray(mepModel.drainageWasteLayout?.lines).length) {
+    errors.push({ code: "MEP_MODEL_WET_ROOM_DRAINAGE_MISSING" });
+  }
+  if (
+    habitableRooms.length &&
+    !toArray(mepModel.electricalLightingLayout?.fixtures).length
+  ) {
+    errors.push({ code: "MEP_MODEL_HABITABLE_LIGHTING_MISSING" });
+  }
+  if (mepModel.imageProviderUsed !== "none")
+    errors.push({ code: "MEP_MODEL_IMAGE_PROVIDER_FORBIDDEN" });
+  return {
+    valid: errors.length === 0,
+    errors,
+    checks: {
+      hasMepModelHash: Boolean(mepModel.mepModelHash),
+      geometryHashMatches:
+        !compiledProject?.geometryHash ||
+        mepModel.geometryHash === compiledProject.geometryHash,
+      reviewRequired: mepModel.reviewRequired === true,
+      imageProviderUsed: mepModel.imageProviderUsed || null,
+      wetRoomCount: wetRooms.length,
+      habitableRoomCount: habitableRooms.length,
+      lightingFixtureCount: toArray(mepModel.electricalLightingLayout?.fixtures)
+        .length,
+      drainageRouteCount: toArray(mepModel.drainageWasteLayout?.lines).length,
+    },
+  };
+}
+
+export default {
+  MEP_MODEL_VERSION,
+  MEP_DRAWING_PANEL_VERSION,
+  MEP_REVIEW_DISCLAIMER,
+  REQUIRED_MEP_CAD_LAYERS,
+  buildMepModelFromCompiledProject,
+  buildMepDrawingPanelsFromMepModel,
+  buildMepDrawingPanelsFromCompiledProject,
+  validateMepModel,
+};

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -13,6 +13,7 @@ import {
 } from "../cad/projectGeometrySchema.js";
 import { buildCompiledProjectTechnicalPanels } from "../canonical/compiledProjectTechnicalPackBuilder.js";
 import { buildStructuralDrawingPanelsFromCompiledProject } from "../structure/structuralModelService.js";
+import { buildMepDrawingPanelsFromCompiledProject } from "../mep/mepModelService.js";
 import { compileProject } from "../compiler/index.js";
 import { ensureCompiledProjectRenderInputs } from "../compiler/compiledProjectRenderInputs.js";
 import { resolveArchitectureModelRegistry } from "../modelStepResolver.js";
@@ -5288,6 +5289,7 @@ function drawingTypeForPanel(panelType) {
   ) {
     return "structural";
   }
+  if (panelType.startsWith("mep_")) return "mep";
   if (panelType.startsWith("floor_plan_")) return "floor_plan";
   if (panelType.startsWith("section_")) return "section";
   if (panelType.startsWith("elevation_")) return "elevation";
@@ -5297,8 +5299,17 @@ function drawingTypeForPanel(panelType) {
 function structuralDrawingsEnabled(options = {}) {
   return (
     options.structuralDrawingsEnabled === true ||
+    options.includeStructuralDrawings === true ||
     String(process.env.STRUCTURAL_DRAWINGS_ENABLED || "").toLowerCase() ===
       "true"
+  );
+}
+
+function mepDrawingsEnabled(options = {}) {
+  return (
+    options.mepDrawingsEnabled === true ||
+    options.includeMepDrawings === true ||
+    String(process.env.MEP_DRAWINGS_ENABLED || "").toLowerCase() === "true"
   );
 }
 
@@ -5317,9 +5328,13 @@ function buildDrawingSet(compiledProject, options = {}) {
   const structuralBuild = structuralDrawingsEnabled(options)
     ? buildStructuralDrawingPanelsFromCompiledProject({ compiledProject })
     : { structuralModel: null, structuralPanels: {} };
+  const mepBuild = mepDrawingsEnabled(options)
+    ? buildMepDrawingPanelsFromCompiledProject({ compiledProject })
+    : { mepModel: null, mepPanels: {} };
   const technicalPanels = {
     ...(technicalBuild.technicalPanels || {}),
     ...(structuralBuild.structuralPanels || {}),
+    ...(mepBuild.mepPanels || {}),
   };
   const drawingViews = Object.entries(technicalPanels).map(
     ([panelType, panel]) => {
@@ -5358,7 +5373,9 @@ function buildDrawingSet(compiledProject, options = {}) {
             source:
               drawingType === "structural"
                 ? "structural_model"
-                : "compiled_project",
+                : drawingType === "mep"
+                  ? "mep_model"
+                  : "compiled_project",
             entity_ids: [
               ...(compiledProject.rooms || []).map(
                 (room) => room.sourceId || room.id,
@@ -5367,6 +5384,9 @@ function buildDrawingSet(compiledProject, options = {}) {
               ...(compiledProject.openings || []).map((opening) => opening.id),
               ...(drawingType === "structural"
                 ? structuralBuild.structuralModel?.memberIds || []
+                : []),
+              ...(drawingType === "mep"
+                ? mepBuild.mepModel?.memberIds || []
                 : []),
             ],
           },
@@ -5435,6 +5455,8 @@ function buildDrawingSet(compiledProject, options = {}) {
                 panel.structuralModelHash ||
                 panel.metadata?.structuralModelHash ||
                 null,
+              mepModelHash:
+                panel.mepModelHash || panel.metadata?.mepModelHash || null,
               reviewRequired: panel.reviewRequired || false,
             },
           },
@@ -5445,6 +5467,8 @@ function buildDrawingSet(compiledProject, options = {}) {
       ...technicalBuild,
       structuralModel: structuralBuild.structuralModel || null,
       structuralPanels: structuralBuild.structuralPanels || {},
+      mepModel: mepBuild.mepModel || null,
+      mepPanels: mepBuild.mepPanels || {},
     },
   };
 }


### PR DESCRIPTION
## Summary

Adds an opt-in preliminary MEP model and MEP CAD drawing pipeline.

MEP outputs are disabled by default and only included when `MEP_DRAWINGS_ENABLED=true` or `includeMepDrawings=true`.

All MEP outputs are preliminary and require review by a qualified MEP engineer.

## Changes

- Adds deterministic `MepModel` generation from compiled project geometry.
- Adds lighting, power/socket, plumbing supply, drainage/waste, ventilation/HVAC, risers/shafts, equipment/plant, schedules, legends, and coordination notes.
- Adds deterministic SVG MEP panels:
  - lighting plan
  - power plan
  - plumbing plan
  - drainage plan
  - ventilation plan
  - schematic notes
- Adds optional ProjectGraph drawing-set integration behind `MEP_DRAWINGS_ENABLED=true` or explicit option.
- Adds MEP CAD entities/layers into CanonicalDrawingModel/DXF when MEP output is enabled:
  - `E-LIGHT`
  - `E-POWER`
  - `E-SWITCH`
  - `E-DATA`
  - `P-WATER`
  - `P-DRAIN`
  - `P-SANITARY`
  - `M-DUCT`
  - `M-VENT`
  - `M-EQUIP`
  - `MEP-RISER`
  - `MEP-NOTES`
  - `MEP-DIMS`
- Adds MEP QA checks for hash presence/match, review requirement, qualified engineer disclaimer, wet-room plumbing/drainage, habitable-room lighting, and no image provider.
- Updates roadmap to describe MEP output as preliminary and opt-in.

## Validation

- Focused audit tests: 5 suites passed
- 44 tests passed
- `npm run lint`
- `git diff --check`
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Safety and scope

- No image-generation path added for MEP technical drawings.
- Fake DWG remains disabled.
- Existing ProjectGraph/A1/CAD/structural authority gates were not weakened.
- Default CAD/DXF export remains non-MEP unless MEP is enabled.
- MEP CAD/DXF is included only when MEP drawings are enabled.

## Current limitations

- Preliminary coordination model only.
- No electrical load calculations.
- No circuit schedules or protective-device sizing.
- No pipe sizing or pressure/drop calculations.
- No duct sizing or airflow calculations.
- No plant sizing.
- No clash detection beyond preliminary coordination notes.
- No jurisdiction-specific MEP code compliance yet.
- Requires review by a qualified MEP engineer before use for construction.
