### PR TITLE
Site boundary: AutoCAD-style length input and smoother editing

### DIFF
--- a/api/site/_lib/boundaryNormalize.js
+++ b/api/site/_lib/boundaryNormalize.js
@@ -31,8 +31,17 @@ export const BOUNDARY_SOURCE = Object.freeze({
   OVERPASS_BUILDING_CONTAINS: "openstreetmap-overpass-building-contains-point",
   OVERPASS_BUILDING_NEAREST: "openstreetmap-overpass-building-nearest",
   OVERPASS_PARCEL_CONTAINS: "openstreetmap-overpass-parcel-contains-point",
+  // Returned when no INSPIRE / Digital Land / Overpass parcel or building
+  // matches AND a follow-up Overpass highway-density probe also comes back
+  // empty within 200 m. Indicates a remote / desert / unmapped site —
+  // surfaced as a dashed-amber 50 m × 50 m placeholder so the user knows
+  // the polygon is a guess and they should refine it.
+  REMOTE_PLACEHOLDER: "Remote-site placeholder",
   NONE: null,
 });
+
+export const REMOTE_PLACEHOLDER_BOUNDARY_CONFIDENCE = 0.2;
+export const REMOTE_PLACEHOLDER_RECTANGLE_M = 50;
 
 const CONFIDENCE_BY_SOURCE = Object.freeze({
   // Digital Land's live API beats every other source because it is the
@@ -727,6 +736,76 @@ export function buildBoundaryResponse({
  * just on `polygon` being null. Returns a 200 from the endpoint, NOT a
  * 404, because "no boundary" is a valid (negative) result, not an error.
  */
+/**
+ * Build a "remote-site placeholder" response. Shape matches the canonical
+ * proxy response so the client only branches on `polygon` and `source`.
+ *
+ * Generates a `REMOTE_PLACEHOLDER_RECTANGLE_M`-square latitude-corrected
+ * rectangle around `(lat, lng)` so the editor has something to render
+ * without faking a real boundary. The combined `source` + low confidence
+ * + `placeholder: true` flag tell the UI to render dashed amber and show
+ * the "draw to refine" banner.
+ */
+export function buildRemoteSitePlaceholderResponse({
+  lat,
+  lng,
+  cached = false,
+  now = null,
+  queryRadiusM = 200,
+  rectangleM = REMOTE_PLACEHOLDER_RECTANGLE_M,
+} = {}) {
+  // Latitude-correct meters → degrees (mirrors the math used by
+  // generateRectangularLot in the legacy intelligent-fallback path).
+  const halfDepthDeg = rectangleM / 2 / 111320;
+  const halfWidthDeg =
+    rectangleM / 2 / (111320 * Math.cos((Number(lat) * Math.PI) / 180));
+  const polygon = [
+    { lat: Number(lat) + halfDepthDeg, lng: Number(lng) - halfWidthDeg },
+    { lat: Number(lat) + halfDepthDeg, lng: Number(lng) + halfWidthDeg },
+    { lat: Number(lat) - halfDepthDeg, lng: Number(lng) + halfWidthDeg },
+    { lat: Number(lat) - halfDepthDeg, lng: Number(lng) - halfWidthDeg },
+  ];
+
+  const measurements = buildBoundaryMeasurements(polygon);
+  const hash = hashBoundaryShape({
+    polygon,
+    source: BOUNDARY_SOURCE.REMOTE_PLACEHOLDER,
+  });
+
+  return {
+    schemaVersion: PROXY_RESPONSE_SCHEMA_VERSION,
+    policyVersion: BOUNDARY_POLICY_VERSION,
+    polygon,
+    source: BOUNDARY_SOURCE.REMOTE_PLACEHOLDER,
+    confidence: REMOTE_PLACEHOLDER_BOUNDARY_CONFIDENCE,
+    boundaryAuthoritative: false,
+    estimateReason: "remote_site_no_osm_evidence",
+    placeholder: true,
+    recommendation: "draw_manually",
+    areaM2: measurements.areaM2,
+    surfaceAreaM2: measurements.surfaceAreaM2,
+    perimeterM: measurements.perimeterM,
+    segments: measurements.segments,
+    angles: measurements.angles,
+    hash,
+    cached: Boolean(cached),
+    timestamp: now || new Date().toISOString(),
+    metadata: {
+      reason: "remote_site_no_osm_evidence",
+      overpassQueryRadiusM: queryRadiusM,
+      placeholder: true,
+      rectangleM,
+      siteMetrics: {
+        areaM2: measurements.areaM2,
+        surfaceAreaM2: measurements.surfaceAreaM2,
+        perimeterM: measurements.perimeterM,
+        segmentCount: measurements.segmentCount,
+        angleCount: measurements.angleCount,
+      },
+    },
+  };
+}
+
 export function buildEmptyResponse({
   reason = "no_polygon_found",
   cached = false,

--- a/api/site/_lib/overpassClient.js
+++ b/api/site/_lib/overpassClient.js
@@ -184,6 +184,52 @@ async function safeText(response) {
 }
 
 /**
+ * Build the Overpass query for highway count near `(lat, lng)`. Used as
+ * a "non-habitat" probe — when buildings + parcels both come back empty
+ * AND there are zero highways within the radius, the site is treated
+ * as a remote/desert location and the proxy returns a dashed-amber
+ * placeholder polygon instead of letting the browser fall through to
+ * the synthetic intelligent-fallback shape.
+ */
+export function buildHighwayDensityQuery({ lat, lng, radiusM = 200 }) {
+  return `[out:json][timeout:25];
+(
+  way["highway"](around:${radiusM},${lat},${lng});
+);
+out ids;
+`;
+}
+
+/**
+ * Run the highway-density probe. Returns the count of highway ways
+ * within the radius. On any error returns null (caller treats null as
+ * "do not assume remote site" — never falsely flag desert when the
+ * Overpass API misbehaved).
+ */
+export async function fetchHighwayDensity({
+  lat,
+  lng,
+  radiusM = 200,
+  url,
+  timeoutMs,
+  fetchImpl,
+  signal,
+}) {
+  try {
+    const result = await runOverpassQuery({
+      query: buildHighwayDensityQuery({ lat, lng, radiusM }),
+      url,
+      timeoutMs,
+      fetchImpl,
+      signal,
+    });
+    return Array.isArray(result?.elements) ? result.elements.length : null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+/**
  * Convenience wrapper: run building + parcel queries in parallel.
  * Either query failing independently does NOT throw — the caller can
  * still attempt to use whichever set of elements came back. Only when

--- a/api/site/boundary.js
+++ b/api/site/boundary.js
@@ -41,6 +41,7 @@
 import { setCorsHeaders, handlePreflight } from "../_shared/cors.js";
 import {
   fetchBuildingAndParcel,
+  fetchHighwayDensity,
   OverpassRateLimitError,
   OverpassTimeoutError,
 } from "./_lib/overpassClient.js";
@@ -48,6 +49,7 @@ import {
   BOUNDARY_POLICY_VERSION,
   buildBoundaryResponse,
   buildEmptyResponse,
+  buildRemoteSitePlaceholderResponse,
   selectBestBoundaryCandidate,
 } from "./_lib/boundaryNormalize.js";
 import { fetchInspireParcelsNear } from "./_lib/inspirePolygonsClient.js";
@@ -294,11 +296,43 @@ export async function resolveBoundaryRequest({
   });
 
   if (!best) {
-    body = buildEmptyResponse({
-      reason: "no_polygon_found",
-      cached: false,
-      queryRadiusM: buildingRadiusM,
-    });
+    // No INSPIRE / Digital Land / Overpass parcel or building match. Probe
+    // highway density before declaring "no polygon" so we can distinguish
+    // "rural addr but mapped" (don't flag) from "true desert / unmapped"
+    // (flag as remote-site placeholder so the editor renders dashed amber
+    // and prompts the user to draw). Skip the probe if Overpass already
+    // failed — re-running it would just hit the same error.
+    let highwayCount = null;
+    if (
+      !overpassError &&
+      buildingElements.length === 0 &&
+      parcelElements.length === 0
+    ) {
+      try {
+        highwayCount = await fetchHighwayDensity({
+          lat,
+          lng,
+          radiusM: 200,
+          fetchImpl,
+        });
+      } catch (_err) {
+        highwayCount = null;
+      }
+    }
+    if (highwayCount === 0) {
+      body = buildRemoteSitePlaceholderResponse({
+        lat,
+        lng,
+        cached: false,
+        queryRadiusM: 200,
+      });
+    } else {
+      body = buildEmptyResponse({
+        reason: "no_polygon_found",
+        cached: false,
+        queryRadiusM: buildingRadiusM,
+      });
+    }
   } else {
     body = buildBoundaryResponse({
       polygon: best.polygon,

--- a/src/__tests__/api/site-boundary.test.js
+++ b/src/__tests__/api/site-boundary.test.js
@@ -218,6 +218,66 @@ describe("api/site/boundary — empty / fallback paths", () => {
     expect(r.body.metadata.reason).toBe("overpass_unavailable");
   });
 
+  test("returns Remote-site placeholder when buildings + parcels + highways all empty", async () => {
+    // Three Overpass calls in order: building, parcel, highway-density.
+    // All come back with zero elements → genuinely remote/desert site.
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeOverpassResponse([])) // building
+      .mockResolvedValueOnce(makeOverpassResponse([])) // parcel
+      .mockResolvedValueOnce(makeOverpassResponse([])); // highway density
+
+    const r = await resolveBoundaryRequest({
+      ...OVERPASS_ONLY,
+      lat: 22.0,
+      lng: 53.0, // Empty Quarter / Rub' al Khali — no OSM coverage
+      fetchImpl,
+      useCache: false,
+    });
+
+    expect(r.status).toBe(200);
+    expect(r.body.source).toBe("Remote-site placeholder");
+    expect(r.body.polygon).toHaveLength(4);
+    expect(r.body.boundaryAuthoritative).toBe(false);
+    expect(r.body.confidence).toBeCloseTo(0.2, 2);
+    expect(r.body.placeholder).toBe(true);
+    expect(r.body.recommendation).toBe("draw_manually");
+    expect(r.body.metadata.reason).toBe("remote_site_no_osm_evidence");
+    // 50 m × 50 m → ~2500 m². Allow a little wiggle room for latitude
+    // correction at lat=22°.
+    expect(r.body.areaM2).toBeGreaterThan(2400);
+    expect(r.body.areaM2).toBeLessThan(2600);
+    // All three Overpass probes must have been issued (building, parcel,
+    // highway density).
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  test("returns no_polygon_found (NOT placeholder) when only OSM parcels/buildings are empty but roads exist", async () => {
+    const highwayWay = {
+      type: "way",
+      id: 999,
+      tags: { highway: "primary" },
+    };
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeOverpassResponse([])) // building
+      .mockResolvedValueOnce(makeOverpassResponse([])) // parcel
+      .mockResolvedValueOnce(makeOverpassResponse([highwayWay])); // highway
+
+    const r = await resolveBoundaryRequest({
+      ...OVERPASS_ONLY,
+      lat: POINT.lat,
+      lng: POINT.lng,
+      fetchImpl,
+      useCache: false,
+    });
+
+    expect(r.status).toBe(200);
+    expect(r.body.polygon).toBeNull();
+    expect(r.body.metadata.reason).toBe("no_polygon_found");
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
   test("never claims authoritative for empty / errored responses", async () => {
     const fetchImpl = jest
       .fn()

--- a/src/__tests__/components/SiteBoundaryEditorV2.boundaryMeasurements.test.js
+++ b/src/__tests__/components/SiteBoundaryEditorV2.boundaryMeasurements.test.js
@@ -221,7 +221,13 @@ describe("SiteBoundaryEditorV2 boundary measurements", () => {
     expect(container.textContent).toContain("Click to place corners");
     expect(container.textContent).toContain("Double-click or Enter to finish");
     expect(container.textContent).toContain("Esc/Backspace to undo last point");
-    expect(container.textContent).toContain("Shift = 45° snap");
+    // The default snap angle changed from 45° to 90° (ortho) in
+    // feat/boundary-cad-input. The help line is now built from the prop so
+    // we assert the new default text and the new "type a number" affordance.
+    expect(container.textContent).toContain("Shift = 90° snap");
+    expect(container.textContent).toContain(
+      "Type a number to place the next corner at exact distance",
+    );
 
     unmount();
   });

--- a/src/__tests__/components/SiteBoundaryEditorV2.boundaryMeasurements.test.js
+++ b/src/__tests__/components/SiteBoundaryEditorV2.boundaryMeasurements.test.js
@@ -195,13 +195,15 @@ describe("SiteBoundaryEditorV2 boundary measurements", () => {
     unmount();
   });
 
-  test("Edit mode instructions are visible", () => {
+  test("Edit mode instructions are visible immediately when polygon is present", () => {
+    // SELECT and EDIT collapsed into a single SELECTED state in
+    // feat/boundary-cad-input. When initialBoundaryPolygon is provided the
+    // editor lands in SELECTED + focused=true via the normalize effect, so
+    // the editing instructions render immediately — no toolbar click needed.
     const { container, unmount } = renderBoundaryEditor();
 
-    click(buttonByText(container, "Edit"));
-
     expect(container.textContent).toContain(
-      "Drag blue corner points to adjust the boundary",
+      "Drag blue corner points to reshape the boundary",
     );
     expect(container.textContent).toContain(
       "Click midpoint dots to add a corner",
@@ -209,6 +211,26 @@ describe("SiteBoundaryEditorV2 boundary measurements", () => {
     expect(container.textContent).toContain(
       "Select a corner and press Delete/Backspace to remove it",
     );
+    expect(container.textContent).toContain(
+      "Drag the polygon body to translate the whole site",
+    );
+
+    unmount();
+  });
+
+  test("clicking the focus toggle dims handles and hides instructions", () => {
+    const { container, unmount } = renderBoundaryEditor();
+    expect(container.textContent).toContain(
+      "Drag blue corner points to reshape the boundary",
+    );
+
+    click(buttonByText(container, "Editing"));
+
+    // Focus toggled off → instructions removed, toolbar copy flips to Focus.
+    expect(container.textContent).not.toContain(
+      "Drag blue corner points to reshape the boundary",
+    );
+    expect(container.textContent).toContain("Focus (E)");
 
     unmount();
   });
@@ -228,6 +250,26 @@ describe("SiteBoundaryEditorV2 boundary measurements", () => {
     expect(container.textContent).toContain(
       "Type a number to place the next corner at exact distance",
     );
+
+    unmount();
+  });
+
+  test("remote-site placeholder banner renders when boundarySource matches", () => {
+    const { container, unmount } = renderBoundaryEditor({
+      boundarySource: "Remote-site placeholder",
+    });
+
+    const banner = container.querySelector(
+      '[data-testid="boundary-remote-placeholder-banner"]',
+    );
+    expect(banner).toBeTruthy();
+    expect(container.textContent).toContain("No parcel data found");
+    expect(container.textContent).toContain("50 m × 50 m placeholder");
+    expect(
+      container.querySelector(
+        '[data-testid="boundary-remote-placeholder-draw"]',
+      ),
+    ).toBeTruthy();
 
     unmount();
   });

--- a/src/components/map/BoundaryDynamicInput.jsx
+++ b/src/components/map/BoundaryDynamicInput.jsx
@@ -106,6 +106,32 @@ export function BoundaryDynamicInput({
     }
   }, [visible, ref]);
 
+  // Position via `transform: translate3d` (GPU-composited, zero layout
+  // reflow per frame) instead of `left/top` (which forces a layout
+  // invalidation on every cursor-stream update at ~60 Hz and visibly
+  // flickers the map + page background while drawing). Computed before the
+  // early-return below so React's Rules of Hooks are honored — useMemo
+  // must be called unconditionally on every render.
+  const wrapperStyle = useMemo(() => {
+    if (!anchorPx) return null;
+    return {
+      position: "absolute",
+      left: 0,
+      top: 0,
+      transform: `translate3d(${Math.round(anchorPx.x + 12)}px, ${Math.round(
+        anchorPx.y + 12,
+      )}px, 0)`,
+      willChange: "transform",
+      pointerEvents: "none",
+      zIndex: 50,
+      direction: "ltr",
+    };
+    // Depend on the scalar x/y rather than the object reference so a fresh
+    // anchorPx object emitted with the same coordinates does not bust the
+    // memoized style (and re-trigger the inline-style assignment).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchorPx?.x, anchorPx?.y]);
+
   if (!visible || hideForTouch || !anchorPx) {
     return null;
   }
@@ -147,15 +173,6 @@ export function BoundaryDynamicInput({
     if (typeof onLengthChange === "function") {
       onLengthChange(event.target.value);
     }
-  };
-
-  const wrapperStyle = {
-    position: "absolute",
-    left: `${Math.round(anchorPx.x + 12)}px`,
-    top: `${Math.round(anchorPx.y + 12)}px`,
-    pointerEvents: "none",
-    zIndex: 50,
-    direction: "ltr",
   };
 
   const cardClassName = [

--- a/src/components/map/BoundaryDynamicInput.jsx
+++ b/src/components/map/BoundaryDynamicInput.jsx
@@ -1,0 +1,249 @@
+/**
+ * BoundaryDynamicInput.jsx
+ *
+ * AutoCAD-style "dynamic input" overlay for the site-boundary draw and edit
+ * surface. Anchored at a pixel position relative to the map container, the
+ * overlay shows:
+ *   - the current segment length (typed by the user in DRAW mode, or
+ *     measured from the previous vertex in DRAG mode);
+ *   - the live bearing (informational);
+ *   - a small snap badge (ORTHO / ENDPOINT) when a snap is active;
+ *   - error feedback when the typed length is non-positive or unparseable.
+ *
+ * Pure presentational. The host (SiteBoundaryEditorV2) owns the state and
+ * the keyboard routing; the host calls `onCommit(lengthM)` when the user
+ * presses Enter (DRAW mode only), and `onCancel()` for Escape.
+ *
+ * Guardrails:
+ *  - 3: rejects NaN, Infinity, zero, and negative values; accepts both '.'
+ *    and ',' as decimal separators.
+ *  - 9: hidden on coarse pointers (touch / mobile).
+ *  - Accessibility: aria-live="polite" status node; map keeps focus until
+ *    the user actually types into the input (host handles that handoff).
+ *
+ * @module BoundaryDynamicInput
+ */
+
+import React, { useEffect, useMemo, useRef } from "react";
+
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
+/**
+ * Parse a length string into a positive finite number. Returns null when the
+ * input is empty, contains junk, or fails the > 0 guardrail.
+ * Accepts comma or period as decimal separator (locale-friendly).
+ *
+ * @param {string} raw
+ * @returns {number | null}
+ */
+export function parseLengthMeters(raw) {
+  if (raw == null) return null;
+  const trimmed = String(raw).trim();
+  if (!trimmed) return null;
+  // Reject anything that isn't digits, separator, or sign — this is what
+  // protects us from things like "12.5.5" or "12abc".
+  if (!/^[+-]?\d*[.,]?\d*$/.test(trimmed)) return null;
+  const normalized = trimmed.replace(",", ".");
+  const value = Number(normalized);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+}
+
+function isCoarsePointer() {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  try {
+    return window.matchMedia(COARSE_POINTER_QUERY).matches;
+  } catch (e) {
+    return false;
+  }
+}
+
+function formatLength(value, units) {
+  if (!Number.isFinite(value)) return "";
+  return `${value.toFixed(2)} ${units}`;
+}
+
+function formatBearing(value) {
+  if (!Number.isFinite(value)) return "";
+  return `${value.toFixed(1)}°`;
+}
+
+const BADGE_LABELS = {
+  ortho: "ORTHO",
+  vertex: "ENDPOINT",
+};
+
+export function BoundaryDynamicInput({
+  visible = false,
+  anchorPx = null,
+  mode = "draw",
+  lengthValue = "",
+  liveLengthM = 0,
+  liveBearingDeg = 0,
+  snapHint = null,
+  units = "m",
+  onLengthChange,
+  onCommit,
+  onCancel,
+  inputRef = null,
+}) {
+  const internalRef = useRef(null);
+  const ref = inputRef || internalRef;
+
+  // Hide entirely on coarse pointers so touch users don't get a tiny float
+  // input. Bigger markers + RAF preview still apply on touch.
+  const hideForTouch = useMemo(() => isCoarsePointer(), []);
+
+  // When the host hides the overlay, also clear any browser focus.
+  useEffect(() => {
+    if (!visible && ref.current === document.activeElement) {
+      ref.current.blur();
+    }
+  }, [visible, ref]);
+
+  if (!visible || hideForTouch || !anchorPx) {
+    return null;
+  }
+
+  const parsed = parseLengthMeters(lengthValue);
+  const isInvalid = lengthValue.trim() !== "" && parsed === null;
+  const isReadOnly = mode === "drag";
+  const badge =
+    snapHint && BADGE_LABELS[snapHint] ? BADGE_LABELS[snapHint] : null;
+
+  const liveDisplay = formatLength(liveLengthM, units);
+  const bearingDisplay = formatBearing(liveBearingDeg);
+
+  const ariaStatus = isReadOnly
+    ? `Length ${liveDisplay}, bearing ${bearingDisplay}`
+    : `Length ${lengthValue || liveDisplay}, bearing ${bearingDisplay}${
+        isInvalid ? ", invalid value" : ""
+      }`;
+
+  const handleKeyDown = (event) => {
+    if (isReadOnly) return;
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (parsed !== null && typeof onCommit === "function") {
+        onCommit(parsed);
+      }
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (typeof onCancel === "function") {
+        onCancel();
+      }
+    }
+  };
+
+  const handleChange = (event) => {
+    if (isReadOnly) return;
+    if (typeof onLengthChange === "function") {
+      onLengthChange(event.target.value);
+    }
+  };
+
+  const wrapperStyle = {
+    position: "absolute",
+    left: `${Math.round(anchorPx.x + 12)}px`,
+    top: `${Math.round(anchorPx.y + 12)}px`,
+    pointerEvents: "none",
+    zIndex: 50,
+    direction: "ltr",
+  };
+
+  const cardClassName = [
+    "pointer-events-auto",
+    "select-none",
+    "bg-white/95",
+    "backdrop-blur",
+    "shadow-md",
+    "rounded-md",
+    "px-3",
+    "py-2",
+    "text-xs",
+    "font-mono",
+    "text-gray-800",
+    "border",
+    isInvalid ? "border-red-500" : "border-gray-300",
+  ].join(" ");
+
+  const inputClassName = [
+    "w-24",
+    "px-2",
+    "py-1",
+    "rounded",
+    "border",
+    "text-sm",
+    "font-mono",
+    "outline-none",
+    "focus:ring-2",
+    isInvalid
+      ? "border-red-500 focus:ring-red-200"
+      : "border-gray-300 focus:ring-blue-200",
+  ].join(" ");
+
+  return (
+    <div style={wrapperStyle} role="presentation">
+      <div className={cardClassName}>
+        <div className="flex items-center gap-2">
+          <span className="uppercase tracking-wide text-[10px] text-gray-500">
+            Length
+          </span>
+          {isReadOnly ? (
+            <span className="text-sm font-semibold text-gray-900">
+              {liveDisplay || "—"}
+            </span>
+          ) : (
+            <input
+              ref={ref}
+              type="text"
+              inputMode="decimal"
+              dir="ltr"
+              value={lengthValue}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              aria-label="Length in meters"
+              aria-invalid={isInvalid ? "true" : "false"}
+              className={inputClassName}
+              placeholder={liveDisplay || "0.00"}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          )}
+          <span className="text-[10px] text-gray-500">{units}</span>
+        </div>
+        <div className="mt-1 flex items-center gap-2 text-[10px] text-gray-500">
+          <span>Bearing</span>
+          <span className="font-semibold text-gray-700">
+            {bearingDisplay || "—"}
+          </span>
+          {badge ? (
+            <span
+              className="ml-auto px-1.5 py-0.5 rounded text-[10px] font-bold tracking-wide bg-emerald-600 text-white"
+              data-testid="boundary-dynamic-snap-badge"
+            >
+              {badge}
+            </span>
+          ) : null}
+        </div>
+        {isInvalid ? (
+          <div className="mt-1 text-[10px] text-red-600" role="alert">
+            Length must be a positive number.
+          </div>
+        ) : null}
+      </div>
+      <div className="sr-only" aria-live="polite">
+        {ariaStatus}
+      </div>
+    </div>
+  );
+}
+
+export default BoundaryDynamicInput;

--- a/src/components/map/BoundaryDynamicInput.jsx
+++ b/src/components/map/BoundaryDynamicInput.jsx
@@ -178,8 +178,12 @@ export function BoundaryDynamicInput({
   const cardClassName = [
     "pointer-events-auto",
     "select-none",
-    "bg-white/95",
-    "backdrop-blur",
+    // Solid white instead of `bg-white/95 + backdrop-blur` — backdrop-blur
+    // is GPU-recomputed on every cursor move (the overlay slides over the
+    // satellite tiles), which combined with marker/polygon updates flickers
+    // the map on mid-range hardware. The chip is small and floats above
+    // the map, so a fully-opaque card is visually fine.
+    "bg-white",
     "shadow-md",
     "rounded-md",
     "px-3",

--- a/src/components/map/BoundaryNumericEditor.jsx
+++ b/src/components/map/BoundaryNumericEditor.jsx
@@ -14,58 +14,10 @@ import {
   calculateAngles,
   calculateSegments,
   closeRing,
-  roundCoord,
+  destinationFromBearing,
+  normalizeBearing,
   validatePolygon,
 } from "./boundaryGeometry.js";
-
-const EARTH_RADIUS_METERS = 6371000;
-
-function toRadians(value) {
-  return (Number(value) * Math.PI) / 180;
-}
-
-function toDegrees(value) {
-  return (Number(value) * 180) / Math.PI;
-}
-
-function normalizeBearing(value) {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) return null;
-  return ((numeric % 360) + 360) % 360;
-}
-
-function destinationFromBearing(start, lengthM, bearingDeg) {
-  const distance = Number(lengthM);
-  const bearing = normalizeBearing(bearingDeg);
-  if (!Array.isArray(start) || !Number.isFinite(distance) || bearing === null) {
-    return null;
-  }
-
-  const lng1 = toRadians(start[0]);
-  const lat1 = toRadians(start[1]);
-  const theta = toRadians(bearing);
-  const delta = distance / EARTH_RADIUS_METERS;
-
-  const sinLat1 = Math.sin(lat1);
-  const cosLat1 = Math.cos(lat1);
-  const sinDelta = Math.sin(delta);
-  const cosDelta = Math.cos(delta);
-
-  const lat2 = Math.asin(
-    sinLat1 * cosDelta + cosLat1 * sinDelta * Math.cos(theta),
-  );
-  const lng2 =
-    lng1 +
-    Math.atan2(
-      Math.sin(theta) * sinDelta * cosLat1,
-      cosDelta - sinLat1 * Math.sin(lat2),
-    );
-
-  return [
-    roundCoord(((toDegrees(lng2) + 540) % 360) - 180),
-    roundCoord(toDegrees(lat2)),
-  ];
-}
 
 function buildDimensionRows(vertices = []) {
   if (!Array.isArray(vertices) || vertices.length < 3) return [];

--- a/src/components/map/PolygonDrawingManager.js
+++ b/src/components/map/PolygonDrawingManager.js
@@ -5,12 +5,14 @@
  *
  * Features:
  * - Click to place vertices
- * - Live preview line following cursor
+ * - Live preview line following cursor (RAF-throttled)
  * - Double-click or Enter to finish
  * - Auto-close when clicking near first point
- * - SHIFT for angle snapping (45° increments)
+ * - SHIFT for angle snapping (default 90° / ortho; configurable)
  * - ESC to cancel current drawing
  * - Real-time validation feedback
+ * - AutoCAD-style dynamic length input (type a number to place the next
+ *   vertex at exact distance along the snapped/cursor bearing)
  *
  * @module PolygonDrawingManager
  */
@@ -19,10 +21,12 @@ import {
   roundCoord,
   snapToVertex,
   constrainToAngle,
+  destinationFromBearing,
+  liveLengthAndBearing,
   validatePolygon,
   closeRing,
   SNAP_PIXEL_THRESHOLD,
-  ANGLE_SNAP_DEGREES,
+  ORTHO_SNAP_DEGREES,
 } from "./boundaryGeometry.js";
 
 /**
@@ -40,10 +44,15 @@ export class PolygonDrawingManager {
       onDrawingCancel: null, // () => void
       onValidationError: null, // (errors) => void
       onCursorMove: null, // (position) => void
+      // Dynamic-input callbacks — RAF-coalesced (one emit/frame max).
+      onDynamicCursor: null, // ({ anchorPx, lengthM, bearingDeg, locked, hasAnchor }) => void
+      onDynamicInputKey: null, // ({ key, ctrl, shift, meta, alt }) => boolean (true => consumed)
+      onSnapHint: null, // ('vertex' | 'ortho' | null) => void
       minVertices: 3,
       autoCloseThresholdPx: 15,
       snapThresholdPx: SNAP_PIXEL_THRESHOLD,
-      angleSnapDegrees: ANGLE_SNAP_DEGREES,
+      // Default to 90° ortho (AutoCAD-style). Callers can pass 45 to opt back.
+      angleSnapDegrees: ORTHO_SNAP_DEGREES,
       strokeColor: "#8B5CF6",
       fillColor: "#8B5CF6",
       previewStrokeColor: "#A78BFA",
@@ -55,10 +64,23 @@ export class PolygonDrawingManager {
     this.isDrawing = false;
     this.vertices = [];
     this.cursorPosition = null;
+    this.lastSnapHint = null;
 
     // Keyboard state
     this.shiftPressed = false;
     this.altPressed = false;
+
+    // RAF throttle state
+    this.rafHandle = null;
+    this.pendingMovePosition = null;
+
+    // Click suppression after a typed-length commit so the Enter keystroke's
+    // synthetic map click doesn't spawn a duplicate vertex.
+    this._suppressNextClick = false;
+    this._suppressClickTimeout = null;
+
+    // Cached projection (invalidated on bounds/zoom/projection changes).
+    this._projectionCache = null;
 
     // Google Maps objects
     this.polyline = null; // Committed edges
@@ -75,28 +97,49 @@ export class PolygonDrawingManager {
     this.mapClickListener = null;
     this.mapMoveListener = null;
     this.mapDblClickListener = null;
+    this.boundsListener = null;
+    this.zoomListener = null;
+    this.projectionListener = null;
     this.keydownHandler = null;
     this.keyupHandler = null;
+
+    // Test/host hook to ask "is the dynamic input pending non-empty input?"
+    // SiteBoundaryEditorV2 sets this at runtime so Enter/Esc gating is correct.
+    // Default: always false (legacy behavior).
+    this.isDynamicInputPending = () => false;
   }
 
   /**
-   * Initialize OverlayView for projection access
+   * Initialize OverlayView for projection access. `draw` is called by Google
+   * Maps whenever the projection changes (pan/zoom/etc.) — we use that signal
+   * to invalidate the projection cache cheaply.
    * @private
    */
   _initOverlayView() {
     this.overlayView = new this.google.maps.OverlayView();
     this.overlayView.onAdd = function () {};
-    this.overlayView.draw = function () {};
-    this.overlayView.onRemove = function () {};
+    const self = this;
+    this.overlayView.draw = function () {
+      self._projectionCache = null;
+    };
+    this.overlayView.onRemove = function () {
+      self._projectionCache = null;
+    };
     this.overlayView.setMap(this.map);
   }
 
   /**
-   * Get projection
+   * Get projection (cached). The cache is invalidated by `OverlayView.draw`
+   * and by the explicit map listeners attached in `_attachMapListeners`.
    * @private
    */
   _getProjection() {
-    return this.overlayView.getProjection();
+    if (this._projectionCache) return this._projectionCache;
+    const projection = this.overlayView.getProjection();
+    if (projection) {
+      this._projectionCache = projection;
+    }
+    return projection;
   }
 
   /**
@@ -133,7 +176,8 @@ export class PolygonDrawingManager {
   }
 
   /**
-   * Stop drawing mode
+   * Stop drawing mode (Guardrail 5: cancel pending RAF + drop the projection
+   * cache so we don't leak frames or stale projections after mode changes).
    */
   stop() {
     if (!this.isDrawing) return;
@@ -142,6 +186,31 @@ export class PolygonDrawingManager {
 
     // Restore cursor
     this.map.setOptions({ draggableCursor: null });
+
+    // Cancel any pending animation frame from the throttled mousemove path.
+    if (this.rafHandle != null) {
+      cancelAnimationFrame(this.rafHandle);
+      this.rafHandle = null;
+    }
+    this.pendingMovePosition = null;
+    if (this._suppressClickTimeout) {
+      clearTimeout(this._suppressClickTimeout);
+      this._suppressClickTimeout = null;
+    }
+    this._suppressNextClick = false;
+    this.lastSnapHint = null;
+    if (this.options.onSnapHint) {
+      this.options.onSnapHint(null);
+    }
+    if (this.options.onDynamicCursor) {
+      this.options.onDynamicCursor({
+        anchorPx: null,
+        lengthM: 0,
+        bearingDeg: 0,
+        locked: false,
+        hasAnchor: false,
+      });
+    }
 
     // Cleanup
     this._detachMapListeners();
@@ -232,6 +301,19 @@ export class PolygonDrawingManager {
       e.stop(); // Prevent zoom
       this.complete();
     });
+
+    // Invalidate the projection cache when the map view actually changes.
+    // OverlayView.draw also nulls it, but listening here is cheaper and
+    // covers the cases where draw is debounced.
+    const invalidate = () => {
+      this._projectionCache = null;
+    };
+    this.boundsListener = this.map.addListener("bounds_changed", invalidate);
+    this.zoomListener = this.map.addListener("zoom_changed", invalidate);
+    this.projectionListener = this.map.addListener(
+      "projection_changed",
+      invalidate,
+    );
   }
 
   _detachMapListeners() {
@@ -246,6 +328,18 @@ export class PolygonDrawingManager {
     if (this.mapDblClickListener) {
       this.google.maps.event.removeListener(this.mapDblClickListener);
       this.mapDblClickListener = null;
+    }
+    if (this.boundsListener) {
+      this.google.maps.event.removeListener(this.boundsListener);
+      this.boundsListener = null;
+    }
+    if (this.zoomListener) {
+      this.google.maps.event.removeListener(this.zoomListener);
+      this.zoomListener = null;
+    }
+    if (this.projectionListener) {
+      this.google.maps.event.removeListener(this.projectionListener);
+      this.projectionListener = null;
     }
   }
 
@@ -269,96 +363,201 @@ export class PolygonDrawingManager {
   }
 
   _handleMapClick(e) {
-    let coord = [roundCoord(e.latLng.lng()), roundCoord(e.latLng.lat())];
+    // Guardrail 8: typed-length commits trigger Enter, which Maps may relay as
+    // a click; skip exactly one click after a programmatic commit so we don't
+    // double-place a vertex.
+    if (this._suppressNextClick) {
+      this._suppressNextClick = false;
+      return;
+    }
 
-    // Apply snapping
-    if (!this.altPressed) {
-      // Check if clicking near first vertex to auto-close
-      if (this.vertices.length >= this.options.minVertices) {
-        const firstVertex = this.vertices[0];
-        const firstPixel = this.latLngToPixel(firstVertex);
-        const clickPixel = this.latLngToPixel(coord);
+    const rawCoord = [roundCoord(e.latLng.lng()), roundCoord(e.latLng.lat())];
+    const placement = this._resolvePlacement(rawCoord, { isClick: true });
+    if (placement.autoClosed) {
+      this.complete();
+      return;
+    }
+    this._appendVertex(placement.coord);
+  }
 
-        if (firstPixel && clickPixel) {
-          const dx = clickPixel.x - firstPixel.x;
-          const dy = clickPixel.y - firstPixel.y;
-          const distPx = Math.sqrt(dx * dx + dy * dy);
+  /**
+   * Compute the snapped/constrained position for a candidate coord, plus an
+   * optional auto-close flag for click handling. Used by both the click path
+   * and the RAF-driven preview path so the math stays in one place.
+   * @private
+   */
+  _resolvePlacement(rawCoord, { isClick = false } = {}) {
+    let coord = rawCoord;
+    let snapHint = null;
+    let lockedToOrtho = false;
 
-          if (distPx <= this.options.autoCloseThresholdPx) {
-            // Auto-close: complete the polygon
-            this.complete();
-            return;
-          }
-        }
-      }
+    if (this.altPressed || this.vertices.length === 0) {
+      return { coord, snapHint, lockedToOrtho, autoClosed: false };
+    }
 
-      // SHIFT = angle snapping
-      if (this.shiftPressed && this.vertices.length > 0) {
-        const lastVertex = this.vertices[this.vertices.length - 1];
-        coord = constrainToAngle(
-          lastVertex,
-          coord,
-          this.options.angleSnapDegrees,
-        );
-      }
-
-      // Vertex snapping
-      if (this.vertices.length > 0) {
-        const vertexSnap = snapToVertex(
-          coord,
-          this.vertices,
-          this._getSnapThresholdMeters(),
-        );
-        if (
-          vertexSnap.snapped &&
-          vertexSnap.snapIndex !== this.vertices.length - 1
-        ) {
-          coord = vertexSnap.point;
+    // Auto-close detection (click path only).
+    if (isClick && this.vertices.length >= this.options.minVertices) {
+      const firstVertex = this.vertices[0];
+      const firstPixel = this.latLngToPixel(firstVertex);
+      const clickPixel = this.latLngToPixel(coord);
+      if (firstPixel && clickPixel) {
+        const dx = clickPixel.x - firstPixel.x;
+        const dy = clickPixel.y - firstPixel.y;
+        const distPx = Math.sqrt(dx * dx + dy * dy);
+        if (distPx <= this.options.autoCloseThresholdPx) {
+          return { coord, snapHint: "vertex", lockedToOrtho, autoClosed: true };
         }
       }
     }
 
-    // Add vertex
+    // SHIFT = angle snapping (default 90° / ortho).
+    if (this.shiftPressed) {
+      const lastVertex = this.vertices[this.vertices.length - 1];
+      coord = constrainToAngle(
+        lastVertex,
+        coord,
+        this.options.angleSnapDegrees,
+      );
+      lockedToOrtho = true;
+      snapHint = "ortho";
+    }
+
+    // Vertex snapping.
+    const vertexSnap = snapToVertex(
+      coord,
+      this.vertices,
+      this._getSnapThresholdMeters(),
+    );
+    if (vertexSnap.snapped) {
+      const allowSnapToLast = !isClick;
+      const isLast = vertexSnap.snapIndex === this.vertices.length - 1;
+      if (!isLast || allowSnapToLast) {
+        coord = vertexSnap.point;
+        snapHint = "vertex";
+      }
+    }
+
+    return { coord, snapHint, lockedToOrtho, autoClosed: false };
+  }
+
+  _appendVertex(coord) {
     this.vertices.push(coord);
     this._updateVisuals();
-
     if (this.options.onVertexAdded) {
       this.options.onVertexAdded([...this.vertices]);
     }
   }
 
   _handleMapMove(e) {
-    let coord = [roundCoord(e.latLng.lng()), roundCoord(e.latLng.lat())];
+    // RAF throttle: store the latest cursor coord and schedule one frame.
+    // Discards every intermediate move event — only the most recent matters.
+    this.pendingMovePosition = [
+      roundCoord(e.latLng.lng()),
+      roundCoord(e.latLng.lat()),
+    ];
+    if (this.rafHandle != null) return;
+    this.rafHandle = requestAnimationFrame(() => {
+      this.rafHandle = null;
+      const pending = this.pendingMovePosition;
+      this.pendingMovePosition = null;
+      if (!pending || !this.isDrawing) return;
+      this._processMove(pending);
+    });
+  }
 
-    // Apply preview snapping
-    if (!this.altPressed && this.vertices.length > 0) {
-      // SHIFT = angle snapping
-      if (this.shiftPressed) {
-        const lastVertex = this.vertices[this.vertices.length - 1];
-        coord = constrainToAngle(
-          lastVertex,
-          coord,
-          this.options.angleSnapDegrees,
-        );
-      }
-
-      // Vertex snapping
-      const vertexSnap = snapToVertex(
-        coord,
-        this.vertices,
-        this._getSnapThresholdMeters(),
-      );
-      if (vertexSnap.snapped) {
-        coord = vertexSnap.point;
-      }
-    }
-
-    this.cursorPosition = coord;
+  _processMove(rawCoord) {
+    const placement = this._resolvePlacement(rawCoord, { isClick: false });
+    this.cursorPosition = placement.coord;
     this._updatePreviewLine();
 
     if (this.options.onCursorMove) {
-      this.options.onCursorMove(coord);
+      this.options.onCursorMove(placement.coord);
     }
+    this._emitDynamicCursor(placement);
+    this._emitSnapHint(placement.snapHint);
+  }
+
+  _emitDynamicCursor(placement) {
+    if (!this.options.onDynamicCursor) return;
+    const anchorPx = this.latLngToPixel(placement.coord);
+    const hasAnchor = this.vertices.length > 0;
+    let lengthM = 0;
+    let bearingDeg = 0;
+    if (hasAnchor) {
+      const prev = this.vertices[this.vertices.length - 1];
+      const live = liveLengthAndBearing(prev, placement.coord);
+      lengthM = live.lengthM;
+      bearingDeg = live.bearingDeg;
+    }
+    this.options.onDynamicCursor({
+      anchorPx: anchorPx ? { x: anchorPx.x, y: anchorPx.y } : null,
+      lengthM,
+      bearingDeg,
+      locked: placement.lockedToOrtho,
+      hasAnchor,
+    });
+  }
+
+  _emitSnapHint(hint) {
+    if (this.lastSnapHint === hint) return;
+    this.lastSnapHint = hint;
+    if (this.options.onSnapHint) {
+      this.options.onSnapHint(hint);
+    }
+  }
+
+  /**
+   * Programmatically place the next vertex at exactly `lengthM` meters from
+   * the previous vertex, along either (a) the Shift-snapped ortho bearing, or
+   * (b) the live cursor bearing. Routes through the same `onVertexAdded`
+   * callback as a normal map click so undo/redo history is identical.
+   *
+   * Guardrail 3: rejects non-finite, zero, or negative lengths.
+   * Guardrail 4: returns/emits `[lng, lat]`, never lat/lng-swapped.
+   * Guardrail 8: shares the click commit path (`_appendVertex`).
+   *
+   * @param {number} lengthM
+   * @returns {boolean} true on commit, false on validation failure
+   */
+  commitLength(lengthM) {
+    const distance = Number(lengthM);
+    if (!Number.isFinite(distance) || distance <= 0) {
+      if (this.options.onValidationError) {
+        this.options.onValidationError([
+          "Length must be a positive number greater than zero.",
+        ]);
+      }
+      return false;
+    }
+    if (this.vertices.length === 0) return false;
+    if (!this.cursorPosition) return false;
+
+    const prev = this.vertices[this.vertices.length - 1];
+    let bearingDeg;
+    if (this.shiftPressed) {
+      const constrained = constrainToAngle(
+        prev,
+        this.cursorPosition,
+        this.options.angleSnapDegrees,
+      );
+      bearingDeg = liveLengthAndBearing(prev, constrained).bearingDeg;
+    } else {
+      bearingDeg = liveLengthAndBearing(prev, this.cursorPosition).bearingDeg;
+    }
+
+    const next = destinationFromBearing(prev, distance, bearingDeg);
+    if (!next) return false;
+
+    // Suppress the synthetic click that Maps may fire after the Enter keystroke.
+    this._suppressNextClick = true;
+    if (this._suppressClickTimeout) clearTimeout(this._suppressClickTimeout);
+    this._suppressClickTimeout = setTimeout(() => {
+      this._suppressNextClick = false;
+      this._suppressClickTimeout = null;
+    }, 100);
+
+    this._appendVertex(next);
+    return true;
   }
 
   _handleKeyDown(e) {
@@ -371,29 +570,85 @@ export class PolygonDrawingManager {
       e.preventDefault();
     }
 
-    // Enter to complete
-    if (e.key === "Enter") {
-      e.preventDefault();
-      this.complete();
+    // Modifier-bearing keystrokes (Ctrl/Cmd-anything) are not draw input —
+    // let the host page (e.g. Ctrl+Z undo) handle them.
+    const hasModifier = e.ctrlKey || e.metaKey;
+    const targetTag = e.target?.tagName || "";
+    const focusInForm = targetTag === "INPUT" || targetTag === "TEXTAREA";
+
+    // Route numeric/decimal/sign characters to the dynamic-input overlay so
+    // the user can start typing without first clicking the floating field.
+    if (
+      !hasModifier &&
+      this.vertices.length > 0 &&
+      this.options.onDynamicInputKey &&
+      this._isDynamicInputCharacter(e.key) &&
+      !focusInForm
+    ) {
+      const consumed = this.options.onDynamicInputKey({
+        key: e.key,
+        ctrl: e.ctrlKey,
+        shift: e.shiftKey,
+        meta: e.metaKey,
+        alt: e.altKey,
+      });
+      if (consumed) {
+        e.preventDefault();
+        return;
+      }
     }
 
-    // Escape to cancel
+    // Enter: if the dynamic input has a pending value, the host has already
+    // handled it (and called `commitLength`). Otherwise fall through to the
+    // legacy "finish polygon" behavior.
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (this.isDynamicInputPending && this.isDynamicInputPending()) {
+        return;
+      }
+      this.complete();
+      return;
+    }
+
+    // Escape: if the dynamic input has a pending value, host clears it; we
+    // skip the undo/cancel chain so the user doesn't accidentally lose
+    // vertices while editing the length field.
     if (e.key === "Escape") {
       e.preventDefault();
+      if (this.isDynamicInputPending && this.isDynamicInputPending()) {
+        return;
+      }
       if (this.vertices.length > 0) {
         this.undoLastVertex();
       } else {
         this.cancel();
       }
+      return;
     }
 
-    // Backspace/Delete to undo last vertex
+    // Backspace/Delete to undo last vertex (unless typing in a real form
+    // field, or the dynamic input has a pending value).
     if (e.key === "Backspace" || e.key === "Delete") {
-      if (e.target.tagName !== "INPUT" && e.target.tagName !== "TEXTAREA") {
-        e.preventDefault();
-        this.undoLastVertex();
+      if (focusInForm) return;
+      if (this.isDynamicInputPending && this.isDynamicInputPending()) {
+        // Let the dynamic-input overlay handle the keystroke itself.
+        return;
       }
+      e.preventDefault();
+      this.undoLastVertex();
     }
+  }
+
+  /**
+   * Whether a key would meaningfully contribute to a length value.
+   * @private
+   */
+  _isDynamicInputCharacter(key) {
+    if (!key) return false;
+    if (key.length === 1) {
+      return /[0-9.,]/.test(key);
+    }
+    return key === "Backspace" || key === "Delete";
   }
 
   _handleKeyUp(e) {
@@ -589,10 +844,32 @@ export class PolygonDrawingManager {
   }
 
   /**
-   * Clean up resources
+   * Clean up resources. Idempotent — safe to call after `stop()` or on a
+   * never-started instance. Guardrail 5: ensures no listeners, RAF, or
+   * timers outlive the instance.
    */
   destroy() {
+    // `stop()` only runs its body when isDrawing; force the cleanup path to
+    // run regardless so callers that never started drawing still tear down
+    // cleanly.
+    this.isDrawing = true;
     this.stop();
+    this.isDrawing = false;
+
+    // Defensive: if stop() short-circuited for some reason, ensure listeners
+    // and timers are gone.
+    this._detachMapListeners();
+    this._detachKeyboardListeners();
+    if (this.rafHandle != null) {
+      cancelAnimationFrame(this.rafHandle);
+      this.rafHandle = null;
+    }
+    if (this._suppressClickTimeout) {
+      clearTimeout(this._suppressClickTimeout);
+      this._suppressClickTimeout = null;
+    }
+    this._projectionCache = null;
+    this.isDynamicInputPending = () => false;
 
     if (this.overlayView) {
       this.overlayView.setMap(null);

--- a/src/components/map/PrecisionPolygonEditor.js
+++ b/src/components/map/PrecisionPolygonEditor.js
@@ -20,11 +20,12 @@ import {
   snapToVertex,
   snapToEdge,
   constrainToAngle,
+  liveLengthAndBearing,
   wouldCauseSelfIntersection,
   closeRing,
   roundCoord,
   SNAP_PIXEL_THRESHOLD,
-  ANGLE_SNAP_DEGREES,
+  ORTHO_SNAP_DEGREES,
 } from "./boundaryGeometry.js";
 
 /**
@@ -44,9 +45,13 @@ export class PrecisionPolygonEditor {
       onDragEnd: null, // (index, polygon) => void
       onSelectionChange: null, // (selectedIndex) => void
       onValidationWarning: null, // (message) => void
+      // Live drag tooltip + snap badge — RAF-coalesced (one emit/frame max).
+      onDragLiveDimension: null, // ({ index, lengthM, bearingDeg, anchorPx }) => void
+      onSnapHint: null, // ('vertex' | 'ortho' | null) => void
       minVertices: 3,
       snapThresholdPx: SNAP_PIXEL_THRESHOLD,
-      angleSnapDegrees: ANGLE_SNAP_DEGREES,
+      // Default to 90° ortho (AutoCAD-style). Pass 45 to restore legacy snap.
+      angleSnapDegrees: ORTHO_SNAP_DEGREES,
       preventSelfIntersection: true,
       ...options,
     };
@@ -59,6 +64,7 @@ export class PrecisionPolygonEditor {
     this.selectedIndex = null;
     this.hoveredIndex = null;
     this.hoveredEdgeIndex = null;
+    this.lastSnapHint = null;
 
     // Keyboard state
     this.shiftPressed = false;
@@ -165,7 +171,9 @@ export class PrecisionPolygonEditor {
   }
 
   /**
-   * Disable editing mode
+   * Disable editing mode. Guardrail 5: also clears any pending RAF and emits
+   * a final null snap-hint / drag-dimension so host overlays don't keep stale
+   * state after the user leaves EDIT mode.
    */
   disable() {
     if (!this.isEnabled) return;
@@ -175,6 +183,10 @@ export class PrecisionPolygonEditor {
     this._removePolygonOverlay();
     this._detachKeyboardListeners();
     this._cancelDrag();
+    this._emitSnapHint(null);
+    if (this.options.onDragLiveDimension) {
+      this.options.onDragLiveDimension(null);
+    }
   }
 
   /**
@@ -255,47 +267,64 @@ export class PrecisionPolygonEditor {
     this._clearVertexMarkers();
 
     this.vertexMarkers = this.vertices.map((vertex, index) => {
-      const marker = new this.google.maps.Marker({
-        position: { lat: vertex[1], lng: vertex[0] },
+      const position = { lat: vertex[1], lng: vertex[0] };
+
+      // Visible marker: pure visual, never draggable, never clickable.
+      // The hit-shadow marker (below) owns all pointer events so the user
+      // gets a generously sized hit target without changing the visible dot.
+      const visible = new this.google.maps.Marker({
+        position,
         map: this.map,
         icon: this._getVertexIcon(index),
-        draggable: true,
-        cursor: "move",
+        draggable: false,
+        clickable: false,
+        cursor: "default",
         zIndex: 1000 + index,
       });
 
-      // Drag start
-      const dragStartListener = marker.addListener("dragstart", () => {
+      // Hit-shadow marker: invisible (opacity 0.001), bigger than the visible
+      // marker, and on top so all clicks/drags resolve here. Forwards every
+      // event to the same handlers the visible marker used to own.
+      const hit = new this.google.maps.Marker({
+        position,
+        map: this.map,
+        icon: this._getVertexHitIcon(),
+        draggable: true,
+        clickable: true,
+        cursor: "move",
+        zIndex: 2000 + index,
+      });
+
+      const dragStartListener = hit.addListener("dragstart", () => {
         this._handleDragStart(index);
       });
 
-      // Drag (throttled with RAF)
-      const dragListener = marker.addListener("drag", (e) => {
+      // Mirror the hit position to the visible marker so the user can see the
+      // drag without waiting for the RAF-driven polygon repaint.
+      const dragListener = hit.addListener("drag", (e) => {
+        if (visible) visible.setPosition(e.latLng);
         this._handleDrag(index, e.latLng);
       });
 
-      // Drag end
-      const dragEndListener = marker.addListener("dragend", () => {
+      const dragEndListener = hit.addListener("dragend", () => {
         this._handleDragEnd(index);
       });
 
-      // Click to select
-      const clickListener = marker.addListener("click", () => {
+      const clickListener = hit.addListener("click", () => {
         this._handleVertexClick(index);
       });
 
-      // Hover
-      const mouseoverListener = marker.addListener("mouseover", () => {
+      const mouseoverListener = hit.addListener("mouseover", () => {
         if (!this.isDragging) {
           this.hoveredIndex = index;
-          marker.setIcon(this._getVertexIcon(index, true));
+          if (visible) visible.setIcon(this._getVertexIcon(index, true));
         }
       });
 
-      const mouseoutListener = marker.addListener("mouseout", () => {
+      const mouseoutListener = hit.addListener("mouseout", () => {
         if (!this.isDragging) {
           this.hoveredIndex = null;
-          marker.setIcon(this._getVertexIcon(index));
+          if (visible) visible.setIcon(this._getVertexIcon(index));
         }
       });
 
@@ -308,12 +337,15 @@ export class PrecisionPolygonEditor {
         mouseoutListener,
       );
 
-      return marker;
+      return { visible, hit };
     });
   }
 
   _clearVertexMarkers() {
-    this.vertexMarkers.forEach((m) => m.setMap(null));
+    this.vertexMarkers.forEach((pair) => {
+      if (pair?.visible) pair.visible.setMap(null);
+      if (pair?.hit) pair.hit.setMap(null);
+    });
     this.vertexMarkers = [];
   }
 
@@ -321,10 +353,12 @@ export class PrecisionPolygonEditor {
     const isSelected = index === this.selectedIndex;
     const isDragging = index === this.draggedIndex;
 
+    // Bumped from 10 → 12 default; hover/selected/dragging all bumped to 15
+    // so the visible dot is comfortably sized at typical site zoom levels.
     let fillColor = "#2563EB"; // Blue
     let strokeColor = "#FFFFFF";
     let strokeWeight = 3;
-    let scale = 10;
+    let scale = 12;
 
     if (isDragging) {
       fillColor = "#EF4444"; // Red
@@ -335,12 +369,12 @@ export class PrecisionPolygonEditor {
       fillColor = "#F59E0B"; // Amber
       strokeColor = "#1E3A8A";
       strokeWeight = 4;
-      scale = 13;
+      scale = 15;
     } else if (isHovered) {
       fillColor = "#10B981"; // Green
       strokeColor = "#064E3B";
       strokeWeight = 4;
-      scale = 12;
+      scale = 15;
     }
 
     return {
@@ -350,6 +384,25 @@ export class PrecisionPolygonEditor {
       fillOpacity: 1,
       strokeColor,
       strokeWeight,
+      anchor: new this.google.maps.Point(0, 0),
+    };
+  }
+
+  /**
+   * Hit-shadow icon: invisible to the user (opacity 0.001) but ~22 px wide so
+   * the click/drag target is much larger than the visible dot. The hit marker
+   * is layered above the visible marker with a higher zIndex.
+   * @private
+   */
+  _getVertexHitIcon() {
+    return {
+      path: this.google.maps.SymbolPath.CIRCLE,
+      scale: 22,
+      fillColor: "#FFFFFF",
+      fillOpacity: 0.001,
+      strokeColor: "#FFFFFF",
+      strokeOpacity: 0,
+      strokeWeight: 0,
       anchor: new this.google.maps.Point(0, 0),
     };
   }
@@ -433,8 +486,9 @@ export class PrecisionPolygonEditor {
     this.draggedIndex = index;
 
     // Update marker appearance
-    if (this.vertexMarkers[index]) {
-      this.vertexMarkers[index].setIcon(this._getVertexIcon(index));
+    const pair = this.vertexMarkers[index];
+    if (pair?.visible) {
+      pair.visible.setIcon(this._getVertexIcon(index));
     }
 
     // Hide midpoint markers during drag
@@ -470,6 +524,8 @@ export class PrecisionPolygonEditor {
     this.pendingDragPosition = null;
 
     let newCoord = [roundCoord(lng), roundCoord(lat)];
+    let orthoSnapped = false;
+    let vertexSnapped = false;
 
     // Apply snapping based on keyboard state
     if (!this.altPressed) {
@@ -481,6 +537,7 @@ export class PrecisionPolygonEditor {
           newCoord,
           this.options.angleSnapDegrees,
         );
+        orthoSnapped = true;
       }
 
       // Vertex snapping (to other vertices)
@@ -492,6 +549,7 @@ export class PrecisionPolygonEditor {
       );
       if (vertexSnap.snapped) {
         newCoord = vertexSnap.point;
+        vertexSnapped = true;
       }
     }
 
@@ -511,13 +569,13 @@ export class PrecisionPolygonEditor {
           );
         }
 
-        // Revert marker position
-        if (this.vertexMarkers[index]) {
+        // Revert BOTH marker positions (visible and hit) so they stay in sync.
+        const pair = this.vertexMarkers[index];
+        if (pair) {
           const currentVertex = this.vertices[index];
-          this.vertexMarkers[index].setPosition({
-            lat: currentVertex[1],
-            lng: currentVertex[0],
-          });
+          const revertPos = { lat: currentVertex[1], lng: currentVertex[0] };
+          if (pair.visible) pair.visible.setPosition(revertPos);
+          if (pair.hit) pair.hit.setPosition(revertPos);
         }
         return;
       }
@@ -529,9 +587,53 @@ export class PrecisionPolygonEditor {
     // Update polygon overlay
     this._updatePolygonOverlay();
 
+    // Live dimension tooltip (read-only): segment from previous vertex.
+    this._emitDragLiveDimension(index, newCoord);
+
+    // Snap hint priority: vertex snap wins over ortho lock (shows 'ENDPOINT'
+    // even if the user is also holding Shift, because endpoint snap is the
+    // higher-fidelity action).
+    let hint = null;
+    if (vertexSnapped) hint = "vertex";
+    else if (orthoSnapped) hint = "ortho";
+    this._emitSnapHint(hint);
+
     // Notify (transient update)
     if (this.options.onVertexUpdate) {
       this.options.onVertexUpdate(index, newCoord, [...this.vertices]);
+    }
+  }
+
+  _emitDragLiveDimension(index, newCoord) {
+    if (!this.options.onDragLiveDimension) return;
+    if (index <= 0) {
+      // No "previous" vertex for the first index — emit zeros so the overlay
+      // can still show a placeholder anchored on the dragged marker.
+      const anchorPx = this.latLngToPixel(newCoord);
+      this.options.onDragLiveDimension({
+        index,
+        lengthM: 0,
+        bearingDeg: 0,
+        anchorPx: anchorPx ? { x: anchorPx.x, y: anchorPx.y } : null,
+      });
+      return;
+    }
+    const prev = this.vertices[index - 1];
+    const live = liveLengthAndBearing(prev, newCoord);
+    const anchorPx = this.latLngToPixel(newCoord);
+    this.options.onDragLiveDimension({
+      index,
+      lengthM: live.lengthM,
+      bearingDeg: live.bearingDeg,
+      anchorPx: anchorPx ? { x: anchorPx.x, y: anchorPx.y } : null,
+    });
+  }
+
+  _emitSnapHint(hint) {
+    if (this.lastSnapHint === hint) return;
+    this.lastSnapHint = hint;
+    if (this.options.onSnapHint) {
+      this.options.onSnapHint(hint);
     }
   }
 
@@ -545,10 +647,12 @@ export class PrecisionPolygonEditor {
       this.rafHandle = null;
     }
 
-    // Final position from marker
-    const marker = this.vertexMarkers[index];
-    if (marker) {
-      const position = marker.getPosition();
+    // Read final position from the hit marker (the one Google Maps was
+    // dragging); fall back to the visible marker if the pair is malformed.
+    const pair = this.vertexMarkers[index];
+    const sourceMarker = pair?.hit || pair?.visible;
+    if (sourceMarker) {
+      const position = sourceMarker.getPosition();
       let finalCoord = [roundCoord(position.lng()), roundCoord(position.lat())];
 
       // Apply final snapping
@@ -575,7 +679,15 @@ export class PrecisionPolygonEditor {
 
       // Update to snapped position
       this.vertices[index] = finalCoord;
-      marker.setPosition({ lat: finalCoord[1], lng: finalCoord[0] });
+      const finalLatLng = { lat: finalCoord[1], lng: finalCoord[0] };
+      if (pair?.visible) pair.visible.setPosition(finalLatLng);
+      if (pair?.hit) pair.hit.setPosition(finalLatLng);
+    }
+
+    // Clear the live drag hint state once the drag finishes.
+    this._emitSnapHint(null);
+    if (this.options.onDragLiveDimension) {
+      this.options.onDragLiveDimension(null);
     }
 
     // Refresh UI
@@ -624,9 +736,9 @@ export class PrecisionPolygonEditor {
       this.selectedIndex = index;
     }
 
-    // Update marker appearance
-    this.vertexMarkers.forEach((marker, i) => {
-      marker.setIcon(this._getVertexIcon(i));
+    // Update visible-marker appearance for every vertex.
+    this.vertexMarkers.forEach((pair, i) => {
+      if (pair?.visible) pair.visible.setIcon(this._getVertexIcon(i));
     });
 
     if (this.options.onSelectionChange) {
@@ -728,8 +840,8 @@ export class PrecisionPolygonEditor {
     // Escape to deselect
     if (e.key === "Escape") {
       this.selectedIndex = null;
-      this.vertexMarkers.forEach((marker, i) => {
-        marker.setIcon(this._getVertexIcon(i));
+      this.vertexMarkers.forEach((pair, i) => {
+        if (pair?.visible) pair.visible.setIcon(this._getVertexIcon(i));
       });
 
       if (this.options.onSelectionChange) {
@@ -826,11 +938,11 @@ export class PrecisionPolygonEditor {
     if (this.isEnabled) {
       this._updatePolygonOverlay();
 
-      if (this.vertexMarkers[index]) {
-        this.vertexMarkers[index].setPosition({
-          lat: newCoord[1],
-          lng: newCoord[0],
-        });
+      const pair = this.vertexMarkers[index];
+      if (pair) {
+        const latLng = { lat: newCoord[1], lng: newCoord[0] };
+        if (pair.visible) pair.visible.setPosition(latLng);
+        if (pair.hit) pair.hit.setPosition(latLng);
       }
     }
 
@@ -857,8 +969,8 @@ export class PrecisionPolygonEditor {
    */
   selectVertex(index) {
     this.selectedIndex = index;
-    this.vertexMarkers.forEach((marker, i) => {
-      marker.setIcon(this._getVertexIcon(i));
+    this.vertexMarkers.forEach((pair, i) => {
+      if (pair?.visible) pair.visible.setIcon(this._getVertexIcon(i));
     });
 
     if (this.options.onSelectionChange) {

--- a/src/components/map/PrecisionPolygonEditor.js
+++ b/src/components/map/PrecisionPolygonEditor.js
@@ -28,6 +28,45 @@ import {
   ORTHO_SNAP_DEGREES,
 } from "./boundaryGeometry.js";
 
+const TRANSPARENT_PIXEL_DATA_URL =
+  "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%221%22%20height%3D%221%22%2F%3E";
+
+const EDGE_LABEL_STYLE_ID = "ppe-edge-label-style";
+
+function ensureEdgeLabelStyleInjected() {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(EDGE_LABEL_STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = EDGE_LABEL_STYLE_ID;
+  style.textContent = `.ppe-edge-label{
+    text-shadow:
+      0 0 3px #ffffff,
+      0 0 3px #ffffff,
+      0 0 4px #ffffff;
+    pointer-events: none;
+    white-space: nowrap;
+  }`;
+  document.head.appendChild(style);
+}
+
+function formatEdgeLength(lengthM) {
+  if (!Number.isFinite(lengthM) || lengthM <= 0) return "";
+  if (lengthM < 1) return `${(lengthM * 100).toFixed(0)} cm`;
+  if (lengthM < 100) return `${lengthM.toFixed(2)} m`;
+  if (lengthM < 1000) return `${lengthM.toFixed(1)} m`;
+  return `${(lengthM / 1000).toFixed(3)} km`;
+}
+
+function midpointBearingCursor(bearingDeg) {
+  // Map a 0-360° bearing to one of four resize cursors based on the closest
+  // 45°-step angle. NS = vertical edge → ns-resize, etc.
+  const normalized = ((bearingDeg % 180) + 180) % 180;
+  if (normalized < 22.5 || normalized >= 157.5) return "ns-resize";
+  if (normalized < 67.5) return "nesw-resize";
+  if (normalized < 112.5) return "ew-resize";
+  return "nwse-resize";
+}
+
 /**
  * Precision Polygon Editor Class
  */
@@ -48,6 +87,23 @@ export class PrecisionPolygonEditor {
       // Live drag tooltip + snap badge — RAF-coalesced (one emit/frame max).
       onDragLiveDimension: null, // ({ index, lengthM, bearingDeg, anchorPx }) => void
       onSnapHint: null, // ('vertex' | 'ortho' | null) => void
+      // When the user clicks the polygon body (not on a vertex/edge) while
+      // it is not focused, the host can promote it to focused state — this
+      // is what lets auto-detected boundaries be selected with a single click.
+      onPolygonBodyClick: null, // (latLng) => void
+      // Body-translate (drag whole polygon).
+      onTranslateStart: null, // () => void
+      onTranslateEnd: null, // (polygon) => void
+      // When true the editor renders vertex/midpoint/edge-label markers and
+      // wires drag/translate. When false the polygon is rendered dimmed and
+      // is only clickable to fire onPolygonBodyClick.
+      focused: true,
+      // When true the polygon is rendered as a dashed amber placeholder
+      // (no parcel data found, e.g. desert site). Body interactions remain
+      // available; the styling is the only change.
+      placeholder: false,
+      // Toggle always-visible edge length labels on focused polygons.
+      showEdgeLabels: true,
       minVertices: 3,
       snapThresholdPx: SNAP_PIXEL_THRESHOLD,
       // Default to 90° ortho (AutoCAD-style). Pass 45 to restore legacy snap.
@@ -55,6 +111,8 @@ export class PrecisionPolygonEditor {
       preventSelfIntersection: true,
       ...options,
     };
+
+    ensureEdgeLabelStyleInjected();
 
     // State
     this.vertices = []; // [lng, lat] format
@@ -79,7 +137,17 @@ export class PrecisionPolygonEditor {
     this.polygonOverlay = null;
     this.vertexMarkers = [];
     this.midpointMarkers = [];
+    this.edgeLabelMarkers = [];
     this.edgeHighlight = null;
+
+    // Body-translate state (drag whole polygon).
+    this.isTranslating = false;
+    this.translateStartLatLng = null;
+    this.translateOriginalVertices = null;
+    this.translateMapListeners = [];
+    this.translateRafHandle = null;
+    this.pendingTranslateLatLng = null;
+    this.previousMapDraggable = null;
 
     // Event listeners
     this.listeners = [];
@@ -158,6 +226,52 @@ export class PrecisionPolygonEditor {
   }
 
   /**
+   * Set focused state. When focused, vertex/midpoint/edge-label markers are
+   * shown and dragging is enabled. When not focused, the polygon is rendered
+   * dimmed and is only clickable (fires onPolygonBodyClick).
+   * @param {boolean} focused
+   */
+  setFocused(focused) {
+    const next = Boolean(focused);
+    if (this.options.focused === next) return;
+    this.options.focused = next;
+    if (this.isEnabled) {
+      // End any in-progress translate before defocusing.
+      if (!next && this.isTranslating) {
+        this._cancelTranslate();
+      }
+      this._refresh();
+    }
+  }
+
+  /**
+   * Set placeholder state. When true, the polygon renders dashed amber to
+   * indicate "no parcel data found — please refine".
+   * @param {boolean} placeholder
+   */
+  setPlaceholder(placeholder) {
+    const next = Boolean(placeholder);
+    if (this.options.placeholder === next) return;
+    this.options.placeholder = next;
+    if (this.isEnabled) {
+      this._refresh();
+    }
+  }
+
+  /**
+   * Toggle always-visible edge length labels.
+   * @param {boolean} visible
+   */
+  setEdgeLabelsVisible(visible) {
+    const next = Boolean(visible);
+    if (this.options.showEdgeLabels === next) return;
+    this.options.showEdgeLabels = next;
+    if (this.isEnabled) {
+      this._refresh();
+    }
+  }
+
+  /**
    * Enable editing mode
    */
   enable() {
@@ -167,6 +281,7 @@ export class PrecisionPolygonEditor {
     this._createPolygonOverlay();
     this._createVertexMarkers();
     this._createMidpointMarkers();
+    this._createEdgeLabelMarkers();
     this._attachKeyboardListeners();
   }
 
@@ -179,6 +294,7 @@ export class PrecisionPolygonEditor {
     if (!this.isEnabled) return;
 
     this.isEnabled = false;
+    this._cancelTranslate();
     this._clearAllMarkers();
     this._removePolygonOverlay();
     this._detachKeyboardListeners();
@@ -198,11 +314,64 @@ export class PrecisionPolygonEditor {
     this._updatePolygonOverlay();
     this._createVertexMarkers();
     this._createMidpointMarkers();
+    this._createEdgeLabelMarkers();
   }
 
   // ============================================================
   // POLYGON OVERLAY
   // ============================================================
+
+  _getPolygonOverlayStyle() {
+    const { focused, placeholder } = this.options;
+    if (placeholder) {
+      // Dashed amber outline used when no parcel data was found within
+      // 200 m of the site. Conveys low confidence at a glance and prompts
+      // the user to refine via Draw mode.
+      return {
+        strokeColor: "#F59E0B",
+        strokeOpacity: 0,
+        strokeWeight: 2,
+        fillColor: "#F59E0B",
+        fillOpacity: 0.08,
+        icons: [
+          {
+            icon: {
+              path: "M 0,-1 0,1",
+              strokeColor: "#F59E0B",
+              strokeOpacity: 0.95,
+              strokeWeight: 2,
+              scale: 3,
+            },
+            offset: "0",
+            repeat: "10px",
+          },
+        ],
+        cursor: focused ? "move" : "pointer",
+      };
+    }
+    if (focused) {
+      return {
+        strokeColor: "#10B981",
+        strokeOpacity: 1,
+        strokeWeight: 2,
+        fillColor: "#10B981",
+        fillOpacity: 0.15,
+        icons: undefined,
+        cursor: "move",
+      };
+    }
+    // Latent — boundary present but not the user's current focus. Polygon
+    // stays clickable so a single click promotes it back to focused.
+    return {
+      strokeColor: "#10B981",
+      strokeOpacity: 0.55,
+      strokeWeight: 2,
+      fillColor: "#10B981",
+      fillOpacity: 0.08,
+      icons: undefined,
+      cursor: "pointer",
+    };
+  }
 
   _createPolygonOverlay() {
     if (this.polygonOverlay) {
@@ -212,14 +381,16 @@ export class PrecisionPolygonEditor {
     if (this.vertices.length < 3) return;
 
     const path = this.vertices.map((v) => ({ lat: v[1], lng: v[0] }));
+    const style = this._getPolygonOverlayStyle();
 
     this.polygonOverlay = new this.google.maps.Polygon({
       paths: path,
-      strokeColor: "#10B981",
-      strokeOpacity: 1,
-      strokeWeight: 2,
-      fillColor: "#10B981",
-      fillOpacity: 0.15,
+      strokeColor: style.strokeColor,
+      strokeOpacity: style.strokeOpacity,
+      strokeWeight: style.strokeWeight,
+      fillColor: style.fillColor,
+      fillOpacity: style.fillOpacity,
+      icons: style.icons,
       clickable: true,
       draggable: false,
       editable: false,
@@ -227,14 +398,46 @@ export class PrecisionPolygonEditor {
       map: this.map,
       zIndex: 100,
     });
+    if (style.cursor) {
+      try {
+        this.polygonOverlay.setOptions({ cursor: style.cursor });
+      } catch (_e) {
+        // setOptions on a Polygon supports cursor in modern Maps API; fall
+        // back silently if a stub doesn't.
+      }
+    }
 
-    // Click on polygon edge to add vertex
+    // Click on polygon edge to add vertex (focused) OR promote to focused
+    // (latent). The handler branches on this.options.focused. We also
+    // suppress the trailing click that fires immediately after a
+    // body-translate mouseup, otherwise releasing a translate inside the
+    // polygon would insert a stray vertex.
     const clickListener = this.polygonOverlay.addListener("click", (e) => {
-      if (this.isDragging) return;
+      if (this.isDragging || this.isTranslating) return;
+      if (
+        this._lastTranslateEndAt &&
+        Date.now() - this._lastTranslateEndAt < 80
+      ) {
+        return;
+      }
       this._handlePolygonClick(e);
     });
-
     this.listeners.push(clickListener);
+
+    // Body-translate via mousedown on the polygon body. Only active when
+    // focused and not placeholder; vertex/midpoint markers have higher
+    // zIndex so they capture mousedown when hit-tested.
+    const mouseDownListener = this.polygonOverlay.addListener(
+      "mousedown",
+      (e) => {
+        if (!this.options.focused) return;
+        if (this.isDragging || this.isTranslating) return;
+        if (this.hoveredIndex !== null) return;
+        if (this.hoveredEdgeIndex !== null) return;
+        this._handleBodyMouseDown(e);
+      },
+    );
+    this.listeners.push(mouseDownListener);
   }
 
   _updatePolygonOverlay() {
@@ -250,6 +453,20 @@ export class PrecisionPolygonEditor {
 
     const path = this.vertices.map((v) => ({ lat: v[1], lng: v[0] }));
     this.polygonOverlay.setPath(path);
+    const style = this._getPolygonOverlayStyle();
+    try {
+      this.polygonOverlay.setOptions({
+        strokeColor: style.strokeColor,
+        strokeOpacity: style.strokeOpacity,
+        strokeWeight: style.strokeWeight,
+        fillColor: style.fillColor,
+        fillOpacity: style.fillOpacity,
+        icons: style.icons,
+        cursor: style.cursor,
+      });
+    } catch (_e) {
+      // Older Maps API stubs may not implement setOptions on Polygon.
+    }
   }
 
   _removePolygonOverlay() {
@@ -265,6 +482,12 @@ export class PrecisionPolygonEditor {
 
   _createVertexMarkers() {
     this._clearVertexMarkers();
+
+    // Vertex handles are only rendered when the polygon is the user's
+    // current focus. A latent (clicked-to-promote) polygon shows no dots;
+    // dashed-amber placeholders also suppress vertex markers because the
+    // user is expected to use Draw to define the boundary.
+    if (!this.options.focused || this.options.placeholder) return;
 
     this.vertexMarkers = this.vertices.map((vertex, index) => {
       const position = { lat: vertex[1], lng: vertex[0] };
@@ -415,6 +638,9 @@ export class PrecisionPolygonEditor {
     this._clearMidpointMarkers();
 
     if (this.vertices.length < 2) return;
+    // Midpoints (insert-vertex affordance) are gated on focus + non-placeholder
+    // for the same reason vertex markers are.
+    if (!this.options.focused || this.options.placeholder) return;
 
     this.midpointMarkers = this.vertices.map((vertex, index) => {
       const nextIndex = (index + 1) % this.vertices.length;
@@ -425,11 +651,18 @@ export class PrecisionPolygonEditor {
         lng: (vertex[0] + nextVertex[0]) / 2,
       };
 
+      // Compute resize cursor from edge bearing so the midpoint signals
+      // "drag to add a vertex perpendicular to this edge".
+      const dLng = nextVertex[0] - vertex[0];
+      const dLat = nextVertex[1] - vertex[1];
+      const bearingDeg = (Math.atan2(dLng, dLat) * 180) / Math.PI;
+      const cursor = midpointBearingCursor(bearingDeg);
+
       const marker = new this.google.maps.Marker({
         position: midpoint,
         map: this.map,
         icon: this._getMidpointIcon(),
-        cursor: "pointer",
+        cursor,
         zIndex: 500,
       });
 
@@ -475,6 +708,123 @@ export class PrecisionPolygonEditor {
   _clearAllMarkers() {
     this._clearVertexMarkers();
     this._clearMidpointMarkers();
+    this._clearEdgeLabelMarkers();
+  }
+
+  // ============================================================
+  // EDGE LENGTH LABELS (always visible while focused)
+  // ============================================================
+
+  _createEdgeLabelMarkers() {
+    this._clearEdgeLabelMarkers();
+
+    if (this.vertices.length < 2) return;
+    if (!this.options.focused || this.options.placeholder) return;
+    if (!this.options.showEdgeLabels) return;
+
+    const count = this.vertices.length;
+    this.edgeLabelMarkers = new Array(count);
+    for (let i = 0; i < count; i++) {
+      this.edgeLabelMarkers[i] = this._createEdgeLabelMarker(i);
+    }
+  }
+
+  _createEdgeLabelMarker(index) {
+    const start = this.vertices[index];
+    const end = this.vertices[(index + 1) % this.vertices.length];
+    if (!start || !end) return null;
+
+    const live = liveLengthAndBearing(start, end);
+    const text = formatEdgeLength(live.lengthM);
+
+    const midpoint = {
+      lat: (start[1] + end[1]) / 2,
+      lng: (start[0] + end[0]) / 2,
+    };
+
+    const marker = new this.google.maps.Marker({
+      position: midpoint,
+      map: this.map,
+      clickable: false,
+      cursor: "default",
+      zIndex: 600,
+      icon: {
+        url: TRANSPARENT_PIXEL_DATA_URL,
+        size: new this.google.maps.Size(1, 1),
+        anchor: new this.google.maps.Point(0, 0),
+        labelOrigin: new this.google.maps.Point(0, 0),
+      },
+      label: {
+        text: text || " ",
+        color: "#0F172A",
+        fontSize: "11px",
+        fontWeight: "700",
+        className: "ppe-edge-label",
+      },
+    });
+
+    return marker;
+  }
+
+  _clearEdgeLabelMarkers() {
+    this.edgeLabelMarkers.forEach((m) => {
+      if (m) m.setMap(null);
+    });
+    this.edgeLabelMarkers = [];
+  }
+
+  /**
+   * Re-position and re-text the edge-label markers adjacent to a vertex
+   * during drag. Two edges share the dragged vertex (incoming + outgoing).
+   * @private
+   */
+  _updateEdgeLabelsForVertex(vertexIndex) {
+    if (!this.edgeLabelMarkers || this.edgeLabelMarkers.length === 0) return;
+    const count = this.vertices.length;
+    const incoming = (vertexIndex - 1 + count) % count;
+    const outgoing = vertexIndex;
+    [incoming, outgoing].forEach((edgeIndex) => {
+      const marker = this.edgeLabelMarkers[edgeIndex];
+      if (!marker) return;
+      const start = this.vertices[edgeIndex];
+      const end = this.vertices[(edgeIndex + 1) % count];
+      if (!start || !end) return;
+      marker.setPosition({
+        lat: (start[1] + end[1]) / 2,
+        lng: (start[0] + end[0]) / 2,
+      });
+      const live = liveLengthAndBearing(start, end);
+      const text = formatEdgeLength(live.lengthM);
+      const currentLabel = marker.getLabel();
+      marker.setLabel({
+        text: text || " ",
+        color: currentLabel?.color || "#0F172A",
+        fontSize: currentLabel?.fontSize || "11px",
+        fontWeight: currentLabel?.fontWeight || "700",
+        className: currentLabel?.className || "ppe-edge-label",
+      });
+    });
+  }
+
+  /**
+   * Re-position every edge label without recreating markers. Used during
+   * body-translate where every edge moves by the same delta.
+   * @private
+   */
+  _updateAllEdgeLabelPositions() {
+    if (!this.edgeLabelMarkers || this.edgeLabelMarkers.length === 0) return;
+    const count = this.vertices.length;
+    for (let i = 0; i < count; i++) {
+      const marker = this.edgeLabelMarkers[i];
+      if (!marker) continue;
+      const start = this.vertices[i];
+      const end = this.vertices[(i + 1) % count];
+      if (!start || !end) continue;
+      marker.setPosition({
+        lat: (start[1] + end[1]) / 2,
+        lng: (start[0] + end[0]) / 2,
+      });
+    }
   }
 
   // ============================================================
@@ -586,6 +936,9 @@ export class PrecisionPolygonEditor {
 
     // Update polygon overlay
     this._updatePolygonOverlay();
+
+    // Live-update the two edge-length labels adjacent to the dragged vertex.
+    this._updateEdgeLabelsForVertex(index);
 
     // Live dimension tooltip (read-only): segment from previous vertex.
     this._emitDragLiveDimension(index, newCoord);
@@ -767,6 +1120,16 @@ export class PrecisionPolygonEditor {
   }
 
   _handlePolygonClick(e) {
+    // When the polygon is not the user's current focus, a body click promotes
+    // it to focused state instead of inserting a vertex. This is the seam
+    // that lets auto-detected boundaries be selected with one click.
+    if (!this.options.focused) {
+      if (this.options.onPolygonBodyClick && e?.latLng) {
+        this.options.onPolygonBodyClick(e.latLng);
+      }
+      return;
+    }
+
     // Find nearest edge and add vertex
     const clickCoord = [e.latLng.lng(), e.latLng.lat()];
     const ring = closeRing(this.vertices);
@@ -787,6 +1150,200 @@ export class PrecisionPolygonEditor {
       if (this.options.onPolygonChange) {
         this.options.onPolygonChange([...this.vertices]);
       }
+    }
+  }
+
+  // ============================================================
+  // BODY TRANSLATE (drag whole polygon)
+  // ============================================================
+
+  /**
+   * Begin a body-translate. Captures the start latLng + a clone of the
+   * current vertices so we can compute deltas without losing precision,
+   * disables map panning so the gesture doesn't fight the map drag, and
+   * binds map mousemove + mouseup listeners.
+   * @private
+   */
+  _handleBodyMouseDown(e) {
+    if (!e?.latLng) return;
+    this.isTranslating = true;
+    this.translateStartLatLng = {
+      lat: e.latLng.lat(),
+      lng: e.latLng.lng(),
+    };
+    this.translateOriginalVertices = this.vertices.map((v) => [v[0], v[1]]);
+
+    // Disable map drag so the user's cursor controls the polygon, not the
+    // map pan. Restored on mouseup or cancel.
+    if (this.map && typeof this.map.get === "function") {
+      try {
+        this.previousMapDraggable = this.map.get("draggable");
+      } catch (_e) {
+        this.previousMapDraggable = null;
+      }
+    } else {
+      this.previousMapDraggable = null;
+    }
+    if (this.map && typeof this.map.setOptions === "function") {
+      try {
+        this.map.setOptions({ draggable: false });
+      } catch (_e) {
+        // No-op for stubs
+      }
+    }
+
+    // Hide vertex/midpoint markers during translate so they don't lag behind
+    // the polygon body. Edge labels stay visible and reposition each frame.
+    this.vertexMarkers.forEach((pair) => {
+      if (pair?.visible) pair.visible.setVisible(false);
+      if (pair?.hit) pair.hit.setVisible(false);
+    });
+    this.midpointMarkers.forEach((m) => m.setVisible(false));
+
+    if (this.map && this.google?.maps?.event) {
+      const moveListener = this.google.maps.event.addListener(
+        this.map,
+        "mousemove",
+        (ev) => this._handleBodyMouseMove(ev),
+      );
+      const upListener = this.google.maps.event.addListener(
+        this.map,
+        "mouseup",
+        () => this._handleBodyMouseUp(),
+      );
+      this.translateMapListeners.push(moveListener, upListener);
+    }
+
+    if (this.options.onTranslateStart) {
+      this.options.onTranslateStart();
+    }
+  }
+
+  _handleBodyMouseMove(e) {
+    if (!this.isTranslating || !e?.latLng) return;
+    this.pendingTranslateLatLng = {
+      lat: e.latLng.lat(),
+      lng: e.latLng.lng(),
+    };
+    if (!this.translateRafHandle) {
+      this.translateRafHandle = requestAnimationFrame(() =>
+        this._processTranslate(),
+      );
+    }
+  }
+
+  _processTranslate() {
+    this.translateRafHandle = null;
+    if (!this.isTranslating || !this.pendingTranslateLatLng) return;
+
+    const { lat, lng } = this.pendingTranslateLatLng;
+    this.pendingTranslateLatLng = null;
+
+    let dLat = lat - this.translateStartLatLng.lat;
+    let dLng = lng - this.translateStartLatLng.lng;
+
+    // Shift constrains body translate to a single axis (ortho), matching
+    // the snap behavior of the AutoCAD-style draw + vertex drag.
+    if (this.shiftPressed) {
+      if (Math.abs(dLng) >= Math.abs(dLat)) {
+        dLat = 0;
+      } else {
+        dLng = 0;
+      }
+    }
+
+    const original = this.translateOriginalVertices;
+    for (let i = 0; i < original.length; i++) {
+      this.vertices[i] = [
+        roundCoord(original[i][0] + dLng),
+        roundCoord(original[i][1] + dLat),
+      ];
+    }
+
+    this._updatePolygonOverlay();
+    this._updateAllEdgeLabelPositions();
+
+    this._emitSnapHint(this.shiftPressed ? "ortho" : null);
+  }
+
+  _handleBodyMouseUp() {
+    if (!this.isTranslating) return;
+    if (this.translateRafHandle) {
+      cancelAnimationFrame(this.translateRafHandle);
+      this.translateRafHandle = null;
+    }
+    // Apply any final pending position one last time so we commit at the
+    // exact mouseup location, not the last RAF-coalesced sample.
+    if (this.pendingTranslateLatLng) {
+      this._processTranslate();
+    }
+    this._endTranslate({ committed: true });
+  }
+
+  _cancelTranslate() {
+    if (!this.isTranslating) return;
+    if (this.translateRafHandle) {
+      cancelAnimationFrame(this.translateRafHandle);
+      this.translateRafHandle = null;
+    }
+    // Revert vertices to their pre-translate clone so a cancel leaves no
+    // visual artifact.
+    if (this.translateOriginalVertices) {
+      this.vertices = this.translateOriginalVertices.map((v) => [v[0], v[1]]);
+    }
+    this._endTranslate({ committed: false });
+  }
+
+  _endTranslate({ committed }) {
+    this.isTranslating = false;
+    this.pendingTranslateLatLng = null;
+    this.translateStartLatLng = null;
+    this._lastTranslateEndAt = Date.now();
+
+    // Detach map listeners.
+    if (this.translateMapListeners.length && this.google?.maps?.event) {
+      this.translateMapListeners.forEach((listener) => {
+        this.google.maps.event.removeListener(listener);
+      });
+    }
+    this.translateMapListeners = [];
+
+    // Restore map dragging.
+    if (this.map && typeof this.map.setOptions === "function") {
+      try {
+        this.map.setOptions({
+          draggable:
+            this.previousMapDraggable === false
+              ? false
+              : this.previousMapDraggable !== null
+                ? Boolean(this.previousMapDraggable)
+                : true,
+        });
+      } catch (_e) {
+        // No-op for stubs
+      }
+    }
+    this.previousMapDraggable = null;
+
+    this._emitSnapHint(null);
+
+    // Refresh markers regardless of commit/cancel; vertex positions have
+    // either moved or been reverted, but in both cases we need to rebuild
+    // marker visuals from `this.vertices`.
+    if (this.isEnabled) {
+      this._refresh();
+    }
+
+    if (committed) {
+      this.translateOriginalVertices = null;
+      if (this.options.onPolygonChange) {
+        this.options.onPolygonChange([...this.vertices]);
+      }
+      if (this.options.onTranslateEnd) {
+        this.options.onTranslateEnd([...this.vertices]);
+      }
+    } else {
+      this.translateOriginalVertices = null;
     }
   }
 
@@ -837,8 +1394,12 @@ export class PrecisionPolygonEditor {
       this.removeVertex(this.selectedIndex);
     }
 
-    // Escape to deselect
+    // Escape to cancel any in-progress translate, otherwise deselect
     if (e.key === "Escape") {
+      if (this.isTranslating) {
+        this._cancelTranslate();
+        return;
+      }
       this.selectedIndex = null;
       this.vertexMarkers.forEach((pair, i) => {
         if (pair?.visible) pair.visible.setIcon(this._getVertexIcon(i));

--- a/src/components/map/PrecisionPolygonEditor.js
+++ b/src/components/map/PrecisionPolygonEditor.js
@@ -451,8 +451,32 @@ export class PrecisionPolygonEditor {
       return;
     }
 
+    this._updatePolygonOverlayPath();
+    this._updatePolygonOverlayStyle();
+  }
+
+  /**
+   * Hot-path setter — called from _processDrag / _processTranslate at RAF
+   * frequency. Only `paths` mutates per frame; the visual style does not.
+   * Splitting this out of `_updatePolygonOverlay` removes a `setOptions`
+   * call per frame that was forcing Google Maps to recomposite the overlay
+   * layer (the visible flicker on the map + page background).
+   * @private
+   */
+  _updatePolygonOverlayPath() {
+    if (!this.polygonOverlay) return;
+    if (this.vertices.length < 3) return;
     const path = this.vertices.map((v) => ({ lat: v[1], lng: v[0] }));
     this.polygonOverlay.setPath(path);
+  }
+
+  /**
+   * Cold-path setter — called only when focus / placeholder state changes,
+   * not per drag frame.
+   * @private
+   */
+  _updatePolygonOverlayStyle() {
+    if (!this.polygonOverlay) return;
     const style = this._getPolygonOverlayStyle();
     try {
       this.polygonOverlay.setOptions({
@@ -762,6 +786,11 @@ export class PrecisionPolygonEditor {
         className: "ppe-edge-label",
       },
     });
+    // Cache the last-emitted text on the marker so per-frame updates can
+    // skip `setLabel` when the rounded text is unchanged. setLabel forces
+    // Google Maps to recreate the marker's label DOM, which compounds the
+    // per-frame overlay-recompose cost during drag.
+    marker.__lastLabelText = text || " ";
 
     return marker;
   }
@@ -794,10 +823,16 @@ export class PrecisionPolygonEditor {
         lng: (start[0] + end[0]) / 2,
       });
       const live = liveLengthAndBearing(start, end);
-      const text = formatEdgeLength(live.lengthM);
+      const text = formatEdgeLength(live.lengthM) || " ";
+      // Only re-issue setLabel when the rendered text actually changes —
+      // setLabel forces Google Maps to rebuild the marker's label DOM,
+      // which is one of the per-frame mutations contributing to flicker
+      // during corner drag.
+      if (marker.__lastLabelText === text) return;
+      marker.__lastLabelText = text;
       const currentLabel = marker.getLabel();
       marker.setLabel({
-        text: text || " ",
+        text,
         color: currentLabel?.color || "#0F172A",
         fontSize: currentLabel?.fontSize || "11px",
         fontWeight: currentLabel?.fontWeight || "700",
@@ -934,8 +969,8 @@ export class PrecisionPolygonEditor {
     // Update internal state
     this.vertices[index] = newCoord;
 
-    // Update polygon overlay
-    this._updatePolygonOverlay();
+    // Update polygon overlay (path only — style is unchanged during drag).
+    this._updatePolygonOverlayPath();
 
     // Live-update the two edge-length labels adjacent to the dragged vertex.
     this._updateEdgeLabelsForVertex(index);
@@ -1260,7 +1295,7 @@ export class PrecisionPolygonEditor {
       ];
     }
 
-    this._updatePolygonOverlay();
+    this._updatePolygonOverlayPath();
     this._updateAllEdgeLabelPositions();
 
     this._emitSnapHint(this.shiftPressed ? "ortho" : null);

--- a/src/components/map/SiteBoundaryEditorV2.jsx
+++ b/src/components/map/SiteBoundaryEditorV2.jsx
@@ -46,12 +46,14 @@ import {
 import { buildManualVerifiedBoundary } from "../../services/site/boundaryPolicy.js";
 import logger from "../../utils/logger.js";
 
-// Editor modes
+// Editor modes. SELECTED is the unified "polygon present" state — auto-detect
+// and fresh-draw both land here. Inside SELECTED, `isPolygonFocused` controls
+// whether vertex/midpoint/edge-label markers are visible. DRAW is the active
+// drawing state. IDLE means no polygon yet.
 const MODES = {
-  SELECT: "select",
-  EDIT: "edit",
+  IDLE: "idle",
+  SELECTED: "selected",
   DRAW: "draw",
-  TABLE: "table",
 };
 
 /**
@@ -81,6 +83,13 @@ export function SiteBoundaryEditorV2({
     typeof boundarySource === "string" &&
     (boundarySource.startsWith("hm-land-registry-inspire") ||
       boundarySource.startsWith("digital-land-title-boundary"));
+  // When the property-boundary service falls through to a remote-site
+  // placeholder (no parcel + no buildings + no roads within 200 m), the
+  // editor renders the polygon dashed amber and surfaces a banner asking
+  // the user to draw or refine the boundary manually.
+  const isBoundaryRemotePlaceholder =
+    typeof boundarySource === "string" &&
+    /remote-site placeholder/i.test(boundarySource);
   // Refs
   const mapContainerRef = useRef(null);
   const polygonEditorRef = useRef(null);
@@ -89,7 +98,10 @@ export function SiteBoundaryEditorV2({
   const contextualBoundaryOverlayRef = useRef(null);
 
   // State
-  const [mode, setMode] = useState(MODES.SELECT);
+  const [mode, setMode] = useState(MODES.IDLE);
+  // When SELECTED, controls whether the polygon is the user's current focus
+  // (markers visible, drag enabled) or latent (dimmed, click-to-promote).
+  const [isPolygonFocused, setIsPolygonFocused] = useState(false);
   const [isLoadingBoundary, setIsLoadingBoundary] = useState(false);
   const [selectedVertexIndex, setSelectedVertexIndex] = useState(null);
   const [showDiagnostics, setShowDiagnostics] = useState(true);
@@ -260,7 +272,10 @@ export function SiteBoundaryEditorV2({
         }
       }
 
-      setMode(MODES.SELECT);
+      // Auto-detected boundary lands focused so the user can immediately
+      // drag a corner — no toolbar dance required.
+      setMode(MODES.SELECTED);
+      setIsPolygonFocused(true);
     } catch (err) {
       logger.error("Auto-detect failed:", err);
       setValidationWarning(
@@ -325,6 +340,22 @@ export function SiteBoundaryEditorV2({
     map,
     polygonLength,
   ]);
+
+  // Normalize mode based on polygon presence. Picks up the case where
+  // `initialBoundaryPolygon` is provided as a prop (the user already had
+  // a boundary from a previous session) — without this effect the editor
+  // would stay in IDLE and the polygon would never get rendered with
+  // markers. Conversely, when the polygon is cleared from outside, fall
+  // back to IDLE so the editor doesn't sit in SELECTED with no shape.
+  useEffect(() => {
+    if (polygonLength >= 3 && mode === MODES.IDLE) {
+      setMode(MODES.SELECTED);
+      setIsPolygonFocused(true);
+    } else if (polygonLength === 0 && mode === MODES.SELECTED) {
+      setMode(MODES.IDLE);
+      setIsPolygonFocused(false);
+    }
+  }, [polygonLength, mode]);
 
   // ============================================================
   // NOTIFY PARENT OF CHANGES
@@ -571,41 +602,22 @@ export function SiteBoundaryEditorV2({
     polygonLength,
   ]);
 
+  // The PrecisionPolygonEditor now renders ANY present polygon (auto-detected
+  // or freshly drawn). The previous SELECT-mode latent google.maps.Polygon
+  // (clickable: false) has been removed — it created the asymmetry where
+  // auto-detected boundaries could not be dragged.
   useEffect(() => {
-    if (!map || !google || !isLoaded) return;
-
-    // Remove existing overlay
+    if (!map || !google || !isLoaded) return undefined;
     if (polygonOverlayRef.current) {
       polygonOverlayRef.current.setMap(null);
       polygonOverlayRef.current = null;
     }
-
-    // Create new overlay if polygon exists and not in edit/draw mode
-    if (polygonLength >= 3 && mode === MODES.SELECT) {
-      polygonOverlayRef.current = new google.maps.Polygon({
-        paths: polygon,
-        strokeColor: "#3B82F6",
-        strokeOpacity: 1,
-        strokeWeight: 3,
-        fillColor: "#3B82F6",
-        fillOpacity: 0.2,
-        clickable: false,
-        zIndex: 2,
-        map,
-      });
-    }
-
-    return () => {
-      if (polygonOverlayRef.current) {
-        polygonOverlayRef.current.setMap(null);
-        polygonOverlayRef.current = null;
-      }
-    };
-  }, [google, isLoaded, map, mode, polygon, polygonLength]);
+    return undefined;
+  }, [google, isLoaded, map]);
 
   // Fit bounds when polygon changes significantly
   useEffect(() => {
-    if (map && google && fitBoundaryLength >= 3 && mode === MODES.SELECT) {
+    if (map && google && fitBoundaryLength >= 3 && mode === MODES.SELECTED) {
       const bounds = calculateBounds(fitBoundaryPolygon);
       if (bounds) {
         const googleBounds = boundsToGoogleBounds(bounds, google);
@@ -627,7 +639,7 @@ export function SiteBoundaryEditorV2({
       polygonEditorRef.current = null;
     }
 
-    if (mode === MODES.EDIT && vertices.length >= 3) {
+    if (mode === MODES.SELECTED && vertices.length >= 3) {
       polygonEditorRef.current = createPrecisionPolygonEditor(map, google, {
         onPolygonChange: (newVertices) => {
           // Convert from [lng, lat] to {lat, lng} and update state
@@ -694,6 +706,14 @@ export function SiteBoundaryEditorV2({
         onSnapHint: (hint) => {
           setDynamicInput((prev) => ({ ...prev, snapHint: hint }));
         },
+        // Click on the polygon body when latent promotes the polygon to
+        // focused so the user can immediately drag a vertex. This is the
+        // seam that lets auto-detected boundaries be edited without
+        // clicking a toolbar button.
+        onPolygonBodyClick: () => setIsPolygonFocused(true),
+        focused: isPolygonFocused,
+        placeholder: isBoundaryRemotePlaceholder,
+        showEdgeLabels: true,
         angleSnapDegrees: orthoSnapDegrees,
         preventSelfIntersection: true,
         minVertices: 3,
@@ -717,6 +737,11 @@ export function SiteBoundaryEditorV2({
         snapHint: null,
       }));
     };
+    // isPolygonFocused / isBoundaryRemotePlaceholder are intentionally omitted
+    // from the dep array — they are forwarded to the editor via setFocused /
+    // setPlaceholder below without tearing the editor down. Including them
+    // here would rebuild markers on every focus toggle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     google,
     isLoaded,
@@ -730,10 +755,41 @@ export function SiteBoundaryEditorV2({
 
   // Update editor vertices when they change externally (e.g., from table)
   useEffect(() => {
-    if (polygonEditorRef.current && mode === MODES.EDIT) {
+    if (polygonEditorRef.current && mode === MODES.SELECTED) {
       polygonEditorRef.current.setVertices(vertices);
     }
   }, [vertices, mode]);
+
+  // Sync focused / placeholder state to the editor without tearing it down.
+  useEffect(() => {
+    if (polygonEditorRef.current && mode === MODES.SELECTED) {
+      polygonEditorRef.current.setFocused(isPolygonFocused);
+    }
+  }, [isPolygonFocused, mode]);
+
+  useEffect(() => {
+    if (polygonEditorRef.current && mode === MODES.SELECTED) {
+      polygonEditorRef.current.setPlaceholder(isBoundaryRemotePlaceholder);
+    }
+  }, [isBoundaryRemotePlaceholder, mode]);
+
+  // Click on the map outside any polygon defocuses the polygon (markers
+  // dim, drag affordance hides). Click on the polygon itself promotes it
+  // back to focused — handled inside PrecisionPolygonEditor via
+  // onPolygonBodyClick. The map-level listener fires for any click that
+  // does NOT hit a polygon/marker (Google Maps fires polygon click first
+  // when overlapping, so this only triggers on truly-outside clicks).
+  useEffect(() => {
+    if (!map || !google || !isLoaded) return undefined;
+    const listener = google.maps.event.addListener(map, "click", () => {
+      if (mode !== MODES.SELECTED) return;
+      if (!isPolygonFocused) return;
+      setIsPolygonFocused(false);
+    });
+    return () => {
+      google.maps.event.removeListener(listener);
+    };
+  }, [google, isLoaded, isPolygonFocused, map, mode]);
 
   // ============================================================
   // DRAWING MANAGER (Draw Mode)
@@ -753,12 +809,20 @@ export function SiteBoundaryEditorV2({
         onDrawingComplete: (newVertices) => {
           const newRing = closeRing(newVertices);
           setRing(newRing);
-          setMode(MODES.EDIT); // Switch to edit mode after drawing
+          // Fresh-draw lands focused so the user can immediately drag a
+          // corner to refine — same as auto-detect.
+          setMode(MODES.SELECTED);
+          setIsPolygonFocused(true);
         },
         onDrawingCancel: () => {
-          // If we had a polygon before, stay in select mode
+          // If we had a polygon before, return to SELECTED with focus
+          // restored. If not, fall back to IDLE.
           if (polygonLength >= 3) {
-            setMode(MODES.SELECT);
+            setMode(MODES.SELECTED);
+            setIsPolygonFocused(true);
+          } else {
+            setMode(MODES.IDLE);
+            setIsPolygonFocused(false);
           }
         },
         onValidationError: (errors) => {
@@ -864,8 +928,16 @@ export function SiteBoundaryEditorV2({
 
       setMode(newMode);
       setSelectedVertexIndex(null);
+      // Returning to SELECTED from DRAW restores focus (the user just
+      // finished drawing, they want the polygon active).
+      if (newMode === MODES.SELECTED && polygonLength >= 3) {
+        setIsPolygonFocused(true);
+      }
+      if (newMode === MODES.IDLE) {
+        setIsPolygonFocused(false);
+      }
     },
-    [mode],
+    [mode, polygonLength],
   );
 
   const handleFitBounds = useCallback(() => {
@@ -883,8 +955,8 @@ export function SiteBoundaryEditorV2({
       const newRing = closeRing(newVertices);
       setRing(newRing);
 
-      // Update editor if in edit mode
-      if (polygonEditorRef.current && mode === MODES.EDIT) {
+      // Update editor if a polygon is loaded
+      if (polygonEditorRef.current && mode === MODES.SELECTED) {
         polygonEditorRef.current.setVertices(newVertices);
       }
     },
@@ -894,7 +966,8 @@ export function SiteBoundaryEditorV2({
   const handleClear = useCallback(() => {
     if (window.confirm("Clear the boundary? This cannot be undone.")) {
       clearPolygon();
-      setMode(MODES.SELECT);
+      setMode(MODES.IDLE);
+      setIsPolygonFocused(false);
     }
   }, [clearPolygon]);
 
@@ -924,14 +997,18 @@ export function SiteBoundaryEditorV2({
         redo();
       }
 
-      // E = Toggle edit mode
+      // E = Toggle polygon focus (when a polygon is present). Promotes a
+      // latent polygon to focused (markers + drag) or dims a focused one.
       if (e.key === "e" && !e.ctrlKey && !e.metaKey) {
-        handleModeChange(mode === MODES.EDIT ? MODES.SELECT : MODES.EDIT);
+        if (mode === MODES.SELECTED && polygonLength >= 3) {
+          setIsPolygonFocused((prev) => !prev);
+        }
       }
 
       // D = Toggle draw mode
       if (e.key === "d" && !e.ctrlKey && !e.metaKey) {
-        handleModeChange(mode === MODES.DRAW ? MODES.SELECT : MODES.DRAW);
+        const fallback = polygonLength >= 3 ? MODES.SELECTED : MODES.IDLE;
+        handleModeChange(mode === MODES.DRAW ? fallback : MODES.DRAW);
       }
 
       // T = Toggle table editor
@@ -942,7 +1019,7 @@ export function SiteBoundaryEditorV2({
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [mode, undo, redo, handleModeChange]);
+  }, [mode, polygonLength, undo, redo, handleModeChange]);
 
   // ============================================================
   // RENDER
@@ -975,28 +1052,31 @@ export function SiteBoundaryEditorV2({
             {isLoadingBoundary ? "Detecting..." : "🔍 Auto-Detect"}
           </button>
 
-          {/* Mode buttons */}
+          {/* Mode buttons. SELECT+EDIT are collapsed into a single Focus
+              toggle that's only meaningful when a polygon is present.
+              Drawing is the only state-machine transition the user makes
+              explicitly via toolbar. */}
           <div className="flex rounded-lg border border-slate-300 overflow-hidden">
             <button
-              onClick={() => handleModeChange(MODES.SELECT)}
+              onClick={() => setIsPolygonFocused((prev) => !prev)}
+              disabled={mode !== MODES.SELECTED || polygon.length < 3}
               className={`px-3 py-2 text-sm font-medium transition-colors ${
-                mode === MODES.SELECT
-                  ? "bg-slate-700 text-white"
-                  : "bg-white text-slate-700 hover:bg-slate-100"
-              }`}
-            >
-              👆 Select
-            </button>
-            <button
-              onClick={() => handleModeChange(MODES.EDIT)}
-              disabled={polygon.length < 3}
-              className={`px-3 py-2 text-sm font-medium transition-colors border-l border-slate-300 ${
-                mode === MODES.EDIT
+                mode === MODES.SELECTED && isPolygonFocused
                   ? "bg-green-600 text-white"
                   : "bg-white text-slate-700 hover:bg-slate-100 disabled:bg-slate-100 disabled:text-slate-400"
               }`}
+              title={
+                mode === MODES.SELECTED
+                  ? isPolygonFocused
+                    ? "Polygon focused — click to dim and pan map freely"
+                    : "Click polygon body or press E to focus and edit"
+                  : "Auto-detect or draw a polygon first"
+              }
+              data-testid="focus-toggle"
             >
-              ✏️ Edit (E)
+              {mode === MODES.SELECTED && isPolygonFocused
+                ? "✏️ Editing (E)"
+                : "👆 Focus (E)"}
             </button>
             <button
               onClick={() => handleModeChange(MODES.DRAW)}
@@ -1091,7 +1171,7 @@ export function SiteBoundaryEditorV2({
 
         {/* Mode instructions */}
         <AnimatePresence>
-          {mode === MODES.EDIT && (
+          {mode === MODES.SELECTED && isPolygonFocused && (
             <motion.div
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: "auto" }}
@@ -1099,17 +1179,22 @@ export function SiteBoundaryEditorV2({
               className="mt-3 p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-900"
               data-testid="edit-mode-instructions"
             >
-              <strong className="block mb-1">Edit Mode</strong>
+              <strong className="block mb-1">Editing site boundary</strong>
               <ul className="grid gap-1 sm:grid-cols-2">
-                <li>Drag blue corner points to adjust the boundary</li>
+                <li>Drag blue corner points to reshape the boundary</li>
+                <li>Drag the polygon body to translate the whole site</li>
                 <li>Click midpoint dots to add a corner</li>
                 <li>Select a corner and press Delete/Backspace to remove it</li>
                 <li>
                   <span className="font-mono">Shift</span> = {orthoSnapDegrees}°
-                  snap (ortho)
+                  snap (ortho) — works during drag and translate
                 </li>
                 <li>
                   <span className="font-mono">Alt</span> = free movement
+                </li>
+                <li className="sm:col-span-2">
+                  Click outside the polygon to dim handles; click the polygon
+                  body to focus again.
                 </li>
               </ul>
             </motion.div>
@@ -1137,6 +1222,38 @@ export function SiteBoundaryEditorV2({
                   <span className="font-mono">Esc</span> cancels.
                 </li>
               </ul>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Remote-site placeholder banner — surfaced when the proxy
+            returned a 50 m × 50 m amber placeholder because no OSM
+            buildings + parcels + highways were found within 200 m of
+            the site (true desert / unmapped area). The user is prompted
+            to draw or refine the boundary manually. */}
+        <AnimatePresence>
+          {isBoundaryRemotePlaceholder && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              className="mt-3 p-3 bg-amber-50 border border-amber-300 rounded-lg text-sm text-amber-900 flex flex-wrap items-center gap-3"
+              data-testid="boundary-remote-placeholder-banner"
+            >
+              <span className="flex-1 min-w-[200px]">
+                <strong className="block mb-0.5">No parcel data found</strong>
+                The dashed amber outline is a 50 m × 50 m placeholder centred on
+                this address. Draw or drag corners to refine the real site
+                boundary.
+              </span>
+              <button
+                type="button"
+                onClick={() => handleModeChange(MODES.DRAW)}
+                className="px-3 py-1.5 bg-amber-600 text-white rounded hover:bg-amber-700 text-xs font-semibold"
+                data-testid="boundary-remote-placeholder-draw"
+              >
+                🖊️ Draw boundary
+              </button>
             </motion.div>
           )}
         </AnimatePresence>

--- a/src/components/map/SiteBoundaryEditorV2.jsx
+++ b/src/components/map/SiteBoundaryEditorV2.jsx
@@ -31,6 +31,7 @@ import { createPrecisionPolygonEditor } from "./PrecisionPolygonEditor.js";
 import { createPolygonDrawingManager } from "./PolygonDrawingManager.js";
 import { BoundaryNumericEditor } from "./BoundaryNumericEditor.jsx";
 import { BoundaryDiagnostics } from "./BoundaryDiagnostics.jsx";
+import { BoundaryDynamicInput } from "./BoundaryDynamicInput.jsx";
 import {
   fetchAutoBoundary,
   calculateBounds,
@@ -69,6 +70,7 @@ export function SiteBoundaryEditorV2({
   boundarySource = null,
   contextualBoundarySource = null,
   contextualBoundaryRole = null,
+  orthoSnapDegrees = 90,
 }) {
   // OGL v3.0 attribution: when the boundary comes from HM Land Registry
   // (via either the bundled INSPIRE fixture or Digital Land's
@@ -104,10 +106,67 @@ export function SiteBoundaryEditorV2({
   const brownfieldMarkersRef = useRef([]);
   const brownfieldInfoWindowRef = useRef(null);
 
+  // AutoCAD-style dynamic-input overlay state. The drawing manager and
+  // precision editor stream cursor / live-dimension events here via
+  // RAF-coalesced callbacks (Guardrail 7). Keeping length state in the host
+  // is what lets the manager's `_handleKeyDown` route digit keystrokes
+  // through `onDynamicInputKey` without having to know about React.
+  const [dynamicInput, setDynamicInput] = useState({
+    visible: false,
+    anchorPx: null,
+    mode: "draw", // 'draw' | 'drag'
+    lengthValue: "",
+    liveLengthM: 0,
+    liveBearingDeg: 0,
+    snapHint: null,
+  });
+  const dynamicInputRef = useRef(null);
+  const dynamicInputPendingRef = useRef(false);
+  const dynamicInputModeRef = useRef("draw");
+
   const handleMapContainerRef = useCallback((element) => {
     mapContainerRef.current = element;
     setMapContainerElement(element);
   }, []);
+
+  const handleDynamicInputChange = useCallback((next) => {
+    const value = String(next ?? "");
+    dynamicInputPendingRef.current = value.trim() !== "";
+    setDynamicInput((prev) => ({ ...prev, lengthValue: value }));
+  }, []);
+
+  const clearDynamicInput = useCallback(() => {
+    dynamicInputPendingRef.current = false;
+    setDynamicInput((prev) => ({ ...prev, lengthValue: "" }));
+  }, []);
+
+  const handleDynamicInputCommit = useCallback(
+    (lengthM) => {
+      const parsed = Number(lengthM);
+      if (!Number.isFinite(parsed) || parsed <= 0) return;
+      const manager = drawingManagerRef.current;
+      if (!manager || typeof manager.commitLength !== "function") return;
+      manager.commitLength(parsed);
+      // Clear the field after a successful commit so the user can keep
+      // chaining vertices without manually deleting digits each time.
+      clearDynamicInput();
+    },
+    [clearDynamicInput],
+  );
+
+  const handleDynamicInputCancel = useCallback(() => {
+    clearDynamicInput();
+    if (
+      mapContainerRef.current &&
+      typeof mapContainerRef.current.focus === "function"
+    ) {
+      try {
+        mapContainerRef.current.focus({ preventScroll: true });
+      } catch (e) {
+        // older browsers
+      }
+    }
+  }, [clearDynamicInput]);
 
   // Google Maps hook
   const {
@@ -583,6 +642,14 @@ export function SiteBoundaryEditorV2({
           // Commit to history after drag
           const newRing = closeRing(allVertices);
           setRing(newRing);
+          // Hide the live-dimension overlay once the drag commits.
+          dynamicInputModeRef.current = "draw";
+          setDynamicInput((prev) => ({
+            ...prev,
+            visible: false,
+            anchorPx: null,
+            snapHint: null,
+          }));
         },
         onVertexAdd: (index, position, allVertices) => {
           const newRing = closeRing(allVertices);
@@ -599,6 +666,35 @@ export function SiteBoundaryEditorV2({
           setValidationWarning(message);
           setTimeout(() => setValidationWarning(null), 3000);
         },
+        // AutoCAD-style live dimension tooltip while dragging a corner. Read-only
+        // in v1 — the host renders the same overlay component used for DRAW
+        // mode but switches it into 'drag' mode (no input field).
+        onDragLiveDimension: (info) => {
+          if (!info) {
+            setDynamicInput((prev) => ({
+              ...prev,
+              visible: false,
+              anchorPx: null,
+            }));
+            return;
+          }
+          dynamicInputModeRef.current = "drag";
+          setDynamicInput((prev) => ({
+            ...prev,
+            visible: true,
+            anchorPx: info.anchorPx,
+            mode: "drag",
+            lengthValue: "",
+            liveLengthM: Number.isFinite(info.lengthM) ? info.lengthM : 0,
+            liveBearingDeg: Number.isFinite(info.bearingDeg)
+              ? info.bearingDeg
+              : 0,
+          }));
+        },
+        onSnapHint: (hint) => {
+          setDynamicInput((prev) => ({ ...prev, snapHint: hint }));
+        },
+        angleSnapDegrees: orthoSnapDegrees,
         preventSelfIntersection: true,
         minVertices: 3,
       });
@@ -612,8 +708,25 @@ export function SiteBoundaryEditorV2({
         polygonEditorRef.current.destroy();
         polygonEditorRef.current = null;
       }
+      // Drop overlay visibility on mode-change cleanup so a stale anchor from
+      // a previous drag never sticks around.
+      setDynamicInput((prev) => ({
+        ...prev,
+        visible: false,
+        anchorPx: null,
+        snapHint: null,
+      }));
     };
-  }, [google, isLoaded, map, mode, setRing, updateVertexTransient, vertices]);
+  }, [
+    google,
+    isLoaded,
+    map,
+    mode,
+    orthoSnapDegrees,
+    setRing,
+    updateVertexTransient,
+    vertices,
+  ]);
 
   // Update editor vertices when they change externally (e.g., from table)
   useEffect(() => {
@@ -656,8 +769,66 @@ export function SiteBoundaryEditorV2({
           setValidationWarning(errors.join("; "));
           setTimeout(() => setValidationWarning(null), 15000);
         },
+        // RAF-coalesced cursor stream from the manager. Fires at most once
+        // per frame regardless of mousemove rate (Guardrail 7).
+        onDynamicCursor: ({ anchorPx, lengthM, bearingDeg, hasAnchor }) => {
+          dynamicInputModeRef.current = "draw";
+          setDynamicInput((prev) => ({
+            ...prev,
+            visible: hasAnchor && Boolean(anchorPx),
+            anchorPx: anchorPx || null,
+            mode: "draw",
+            liveLengthM: Number.isFinite(lengthM) ? lengthM : 0,
+            liveBearingDeg: Number.isFinite(bearingDeg) ? bearingDeg : 0,
+          }));
+        },
+        // Manager routes digit/dot/comma/Backspace keystrokes here so the user
+        // can start typing without first clicking the floating input.
+        onDynamicInputKey: ({ key }) => {
+          if (dynamicInputModeRef.current !== "draw") return false;
+          if (key === "Backspace" || key === "Delete") {
+            setDynamicInput((prev) => {
+              const next = prev.lengthValue.slice(0, -1);
+              dynamicInputPendingRef.current = next.trim() !== "";
+              return { ...prev, lengthValue: next };
+            });
+            // Focus the input so subsequent native keystrokes flow naturally.
+            if (
+              dynamicInputRef.current &&
+              document.activeElement !== dynamicInputRef.current
+            ) {
+              dynamicInputRef.current.focus({ preventScroll: true });
+            }
+            return true;
+          }
+          if (key && key.length === 1 && /[0-9.,]/.test(key)) {
+            setDynamicInput((prev) => {
+              const next = (prev.lengthValue || "") + key;
+              dynamicInputPendingRef.current = next.trim() !== "";
+              return { ...prev, lengthValue: next };
+            });
+            if (
+              dynamicInputRef.current &&
+              document.activeElement !== dynamicInputRef.current
+            ) {
+              dynamicInputRef.current.focus({ preventScroll: true });
+            }
+            return true;
+          }
+          return false;
+        },
+        onSnapHint: (hint) => {
+          setDynamicInput((prev) => ({ ...prev, snapHint: hint }));
+        },
+        angleSnapDegrees: orthoSnapDegrees,
         minVertices: 3,
       });
+
+      // Manager peeks at this on Enter/Esc so it doesn't fight the dynamic
+      // input over keystrokes (Guardrail 8: typed-length commits route
+      // through the same `_appendVertex` path as a normal click).
+      drawingManagerRef.current.isDynamicInputPending = () =>
+        dynamicInputPendingRef.current;
 
       drawingManagerRef.current.start();
     }
@@ -667,8 +838,18 @@ export function SiteBoundaryEditorV2({
         drawingManagerRef.current.destroy();
         drawingManagerRef.current = null;
       }
+      dynamicInputPendingRef.current = false;
+      setDynamicInput({
+        visible: false,
+        anchorPx: null,
+        mode: "draw",
+        lengthValue: "",
+        liveLengthM: 0,
+        liveBearingDeg: 0,
+        snapHint: null,
+      });
     };
-  }, [google, isLoaded, map, mode, polygonLength, setRing]);
+  }, [google, isLoaded, map, mode, orthoSnapDegrees, polygonLength, setRing]);
 
   // ============================================================
   // EVENT HANDLERS
@@ -924,7 +1105,8 @@ export function SiteBoundaryEditorV2({
                 <li>Click midpoint dots to add a corner</li>
                 <li>Select a corner and press Delete/Backspace to remove it</li>
                 <li>
-                  <span className="font-mono">Shift</span> = angle snap
+                  <span className="font-mono">Shift</span> = {orthoSnapDegrees}°
+                  snap (ortho)
                 </li>
                 <li>
                   <span className="font-mono">Alt</span> = free movement
@@ -946,7 +1128,13 @@ export function SiteBoundaryEditorV2({
                 <li>Double-click or Enter to finish</li>
                 <li>Esc/Backspace to undo last point</li>
                 <li>
-                  <span className="font-mono">Shift</span> = 45° snap
+                  <span className="font-mono">Shift</span> = {orthoSnapDegrees}°
+                  snap
+                </li>
+                <li className="sm:col-span-2">
+                  Type a number to place the next corner at exact distance —
+                  <span className="font-mono">Enter</span> places,{" "}
+                  <span className="font-mono">Esc</span> cancels.
                 </li>
               </ul>
             </motion.div>
@@ -1018,6 +1206,23 @@ export function SiteBoundaryEditorV2({
             ref={handleMapContainerRef}
             className="h-[320px] w-full bg-slate-100 md:h-[390px]"
             style={{ minHeight: "300px" }}
+          />
+
+          {/* AutoCAD-style dynamic length / live-dimension overlay. Anchored
+              to the cursor while drawing, anchored to the dragged corner
+              while editing. Hidden on coarse pointers. */}
+          <BoundaryDynamicInput
+            visible={dynamicInput.visible}
+            anchorPx={dynamicInput.anchorPx}
+            mode={dynamicInput.mode}
+            lengthValue={dynamicInput.lengthValue}
+            liveLengthM={dynamicInput.liveLengthM}
+            liveBearingDeg={dynamicInput.liveBearingDeg}
+            snapHint={dynamicInput.snapHint}
+            inputRef={dynamicInputRef}
+            onLengthChange={handleDynamicInputChange}
+            onCommit={handleDynamicInputCommit}
+            onCancel={handleDynamicInputCancel}
           />
         </div>
 

--- a/src/components/map/SiteBoundaryEditorV2.jsx
+++ b/src/components/map/SiteBoundaryEditorV2.jsx
@@ -96,6 +96,7 @@ export function SiteBoundaryEditorV2({
   const drawingManagerRef = useRef(null);
   const polygonOverlayRef = useRef(null);
   const contextualBoundaryOverlayRef = useRef(null);
+  const contextualBoundaryClickListenerRef = useRef(null);
 
   // State
   const [mode, setMode] = useState(MODES.IDLE);
@@ -573,6 +574,10 @@ export function SiteBoundaryEditorV2({
       // stroke + lower fill opacity than the authoritative blue overlay so
       // the user can tell at a glance it is non-authoritative — colour
       // matches the A1 site-plan boundary for end-to-end consistency.
+      // Clickable: a confirm dialog lets the user *adopt* the contextual
+      // outline as their editable site boundary so they don't need to
+      // redraw it from scratch. Adoption is opt-in (never silent) because
+      // the contextual shape is non-authoritative.
       contextualBoundaryOverlayRef.current = new google.maps.Polygon({
         paths: contextualBoundaryPolygon,
         strokeColor: "#1976D2",
@@ -580,13 +585,38 @@ export function SiteBoundaryEditorV2({
         strokeWeight: 2,
         fillColor: "#1976D2",
         fillOpacity: 0.08,
-        clickable: false,
+        clickable: true,
+        cursor: "pointer",
         zIndex: 1,
         map,
       });
+      contextualBoundaryClickListenerRef.current =
+        contextualBoundaryOverlayRef.current.addListener("click", () => {
+          if (
+            !Array.isArray(contextualBoundaryPolygon) ||
+            contextualBoundaryPolygon.length < 3
+          ) {
+            return;
+          }
+          const ok = window.confirm(
+            "Adopt this contextual outline as your site boundary?\n\n" +
+              "It becomes a draggable polygon you can refine corner-by-corner. " +
+              "The original detection is preserved for context.",
+          );
+          if (!ok) return;
+          setPolygon(contextualBoundaryPolygon);
+          setMode(MODES.SELECTED);
+          setIsPolygonFocused(true);
+        });
     }
 
     return () => {
+      if (contextualBoundaryClickListenerRef.current && google?.maps?.event) {
+        google.maps.event.removeListener(
+          contextualBoundaryClickListenerRef.current,
+        );
+        contextualBoundaryClickListenerRef.current = null;
+      }
       if (contextualBoundaryOverlayRef.current) {
         contextualBoundaryOverlayRef.current.setMap(null);
         contextualBoundaryOverlayRef.current = null;
@@ -600,6 +630,7 @@ export function SiteBoundaryEditorV2({
     map,
     polygon,
     polygonLength,
+    setPolygon,
   ]);
 
   // The PrecisionPolygonEditor now renders ANY present polygon (auto-detected

--- a/src/components/map/__tests__/PolygonDrawingManager.dynamicInput.test.js
+++ b/src/components/map/__tests__/PolygonDrawingManager.dynamicInput.test.js
@@ -1,0 +1,369 @@
+/**
+ * PolygonDrawingManager.dynamicInput.test.js
+ *
+ * Tests the AutoCAD-style "type a length" drawing flow added in
+ * feat/boundary-cad-input. Covers Guardrails 3 (validation), 4 (lng/lat
+ * order), 5 (lifecycle / RAF cleanup), and 8 (typed-length commits share
+ * the click history path).
+ *
+ * Google Maps is mocked at minimum-surface fidelity — just enough for the
+ * drawing manager to construct, attach listeners, route mouse/key events,
+ * and emit its callbacks deterministically.
+ */
+
+import { createPolygonDrawingManager } from "../PolygonDrawingManager.js";
+
+let __raf_callbacks = [];
+
+function flushRAF() {
+  const queue = __raf_callbacks.slice();
+  __raf_callbacks = [];
+  queue.forEach((cb) => cb(performance.now()));
+}
+
+beforeEach(() => {
+  __raf_callbacks = [];
+  global.requestAnimationFrame = (cb) => {
+    __raf_callbacks.push(cb);
+    return __raf_callbacks.length;
+  };
+  global.cancelAnimationFrame = (handle) => {
+    if (handle != null) {
+      __raf_callbacks[handle - 1] = () => {};
+    }
+  };
+});
+
+function createMaps() {
+  const listenersByMap = new Map();
+  let lastMap = null;
+
+  class Marker {
+    constructor(opts = {}) {
+      this.opts = opts;
+      this.position = opts.position || null;
+      this.icon = opts.icon || null;
+      this.map = opts.map || null;
+    }
+    setPosition(p) {
+      this.position = p;
+    }
+    setIcon(icon) {
+      this.icon = icon;
+    }
+    setMap(map) {
+      this.map = map;
+    }
+    getPosition() {
+      return this.position;
+    }
+    addListener(_event, _handler) {
+      return { __event: _event, remove() {} };
+    }
+  }
+
+  class Polyline {
+    constructor(opts = {}) {
+      this.opts = opts;
+      this.path = opts.path || [];
+      this.map = opts.map || null;
+    }
+    setPath(p) {
+      this.path = p;
+    }
+    setMap(map) {
+      this.map = map;
+    }
+  }
+
+  class Point {
+    constructor(x, y) {
+      this.x = x;
+      this.y = y;
+    }
+  }
+
+  class LatLng {
+    constructor(lat, lng) {
+      this._lat = lat;
+      this._lng = lng;
+    }
+    lat() {
+      return this._lat;
+    }
+    lng() {
+      return this._lng;
+    }
+  }
+
+  class OverlayView {
+    constructor() {
+      this.onAdd = () => {};
+      this.draw = () => {};
+      this.onRemove = () => {};
+    }
+    setMap(map) {
+      this.map = map;
+    }
+    getProjection() {
+      return {
+        // Simple "1 unit lng = 1 px" projection so cursor positions become
+        // predictable pixel anchors in the test.
+        fromLatLngToDivPixel(latLng) {
+          return new Point(latLng.lng() * 100, -latLng.lat() * 100);
+        },
+        fromDivPixelToLatLng(pt) {
+          return new LatLng(-pt.y / 100, pt.x / 100);
+        },
+      };
+    }
+  }
+
+  function createMap() {
+    const listeners = new Map();
+    const map = {
+      __listeners: listeners,
+      __removed: [],
+      addListener(event, handler) {
+        const id = `${event}-${Math.random()}`;
+        const ref = { __event: event, __handler: handler, __id: id };
+        if (!listeners.has(event)) listeners.set(event, []);
+        listeners.get(event).push(ref);
+        return ref;
+      },
+      setOptions: () => {},
+      getZoom: () => 18,
+      getDiv: () => ({ focus: () => {} }),
+    };
+    listenersByMap.set(map, listeners);
+    lastMap = map;
+    return map;
+  }
+
+  return {
+    createMap,
+    google: {
+      maps: {
+        Marker,
+        Polyline,
+        OverlayView,
+        Point,
+        LatLng,
+        SymbolPath: { CIRCLE: "CIRCLE" },
+        event: {
+          removeListener(ref) {
+            if (!ref) return;
+            for (const list of listenersByMap.values()) {
+              for (const arr of list.values()) {
+                const idx = arr.indexOf(ref);
+                if (idx !== -1) {
+                  arr.splice(idx, 1);
+                  if (lastMap) lastMap.__removed.push(ref);
+                }
+              }
+            }
+          },
+        },
+      },
+    },
+  };
+}
+
+function fireMapEvent(map, eventName, payload) {
+  const handlers = (map.__listeners.get(eventName) || []).slice();
+  handlers.forEach((ref) => ref.__handler(payload));
+}
+
+function makeLatLng(google, lng, lat) {
+  return new google.maps.LatLng(lat, lng);
+}
+
+describe("PolygonDrawingManager dynamic length input", () => {
+  test("RAF-throttled mousemove emits a single dynamic-cursor event per frame", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+
+    const cursorCalls = [];
+    const manager = createPolygonDrawingManager(map, google, {
+      onDynamicCursor: (info) => cursorCalls.push(info),
+      angleSnapDegrees: 90,
+    });
+    manager.start();
+
+    // Place an anchor first so liveLengthAndBearing has a previous vertex.
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 0, 0) });
+
+    // Spam several mousemove events; only the last one should win.
+    fireMapEvent(map, "mousemove", { latLng: makeLatLng(google, 0.0001, 0) });
+    fireMapEvent(map, "mousemove", { latLng: makeLatLng(google, 0.0002, 0) });
+    fireMapEvent(map, "mousemove", { latLng: makeLatLng(google, 0.0003, 0) });
+
+    // RAF hasn't fired yet — no emits.
+    expect(cursorCalls.length).toBe(0);
+
+    flushRAF();
+
+    // Exactly one emit even though we dispatched three mousemoves.
+    expect(cursorCalls.length).toBe(1);
+    expect(cursorCalls[0].hasAnchor).toBe(true);
+    expect(cursorCalls[0].lengthM).toBeGreaterThan(0);
+
+    manager.destroy();
+  });
+
+  test("typing a digit routes through onDynamicInputKey and consumes it", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+
+    const keystrokes = [];
+    const manager = createPolygonDrawingManager(map, google, {
+      onDynamicInputKey: (info) => {
+        keystrokes.push(info.key);
+        return true;
+      },
+    });
+    manager.start();
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 0, 0) });
+
+    const digit = new KeyboardEvent("keydown", { key: "1" });
+    let prevented = false;
+    digit.preventDefault = () => {
+      prevented = true;
+    };
+    Object.defineProperty(digit, "target", {
+      value: document.body,
+      configurable: true,
+    });
+    document.dispatchEvent(digit);
+
+    expect(keystrokes).toEqual(["1"]);
+    expect(prevented).toBe(true);
+
+    manager.destroy();
+  });
+
+  test("Enter is suppressed when isDynamicInputPending() returns true", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+
+    const completeCalls = [];
+    const manager = createPolygonDrawingManager(map, google, {
+      onDrawingComplete: (verts) => completeCalls.push(verts),
+      minVertices: 3,
+    });
+    manager.start();
+    // Place 3 vertices so complete() would otherwise succeed.
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 0, 0) });
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 0.001, 0) });
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 0.001, 0.001) });
+
+    // Mark the dynamic input as pending — Enter should NOT finish the polygon.
+    manager.isDynamicInputPending = () => true;
+    const enter = new KeyboardEvent("keydown", { key: "Enter" });
+    Object.defineProperty(enter, "target", {
+      value: document.body,
+      configurable: true,
+    });
+    document.dispatchEvent(enter);
+    expect(completeCalls.length).toBe(0);
+
+    // Now clear pending; Enter completes.
+    manager.isDynamicInputPending = () => false;
+    const enter2 = new KeyboardEvent("keydown", { key: "Enter" });
+    Object.defineProperty(enter2, "target", {
+      value: document.body,
+      configurable: true,
+    });
+    document.dispatchEvent(enter2);
+    expect(completeCalls.length).toBe(1);
+  });
+
+  test("commitLength rejects non-positive / non-finite values (Guardrail 3)", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+
+    const added = [];
+    const validation = [];
+    const manager = createPolygonDrawingManager(map, google, {
+      onVertexAdded: (verts) => added.push(verts),
+      onValidationError: (errs) => validation.push(errs),
+    });
+    manager.start();
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 0, 0) });
+    // Set a cursor so commitLength can resolve a bearing.
+    fireMapEvent(map, "mousemove", { latLng: makeLatLng(google, 0.001, 0) });
+    flushRAF();
+
+    expect(manager.commitLength(0)).toBe(false);
+    expect(manager.commitLength(-5)).toBe(false);
+    expect(manager.commitLength(NaN)).toBe(false);
+    expect(manager.commitLength(Infinity)).toBe(false);
+
+    // No vertex past the first click should have been added.
+    expect(added.length).toBe(1); // only the click
+    expect(validation.length).toBeGreaterThanOrEqual(4);
+
+    manager.destroy();
+  });
+
+  test("commitLength shares the click history path (Guardrail 8) and emits [lng, lat] (Guardrail 4)", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+
+    const added = [];
+    const manager = createPolygonDrawingManager(map, google, {
+      onVertexAdded: (verts) => added.push(verts.slice()),
+    });
+    manager.start();
+    // Anchor at lng=10, lat=20 so the lng/lat order is unambiguous.
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 10, 20) });
+    fireMapEvent(map, "mousemove", { latLng: makeLatLng(google, 11, 20) });
+    flushRAF();
+
+    const ok = manager.commitLength(50);
+    expect(ok).toBe(true);
+
+    // Two onVertexAdded calls: one from the click, one from commitLength.
+    expect(added.length).toBe(2);
+    const last = added[1];
+    const newest = last[last.length - 1];
+    // Vertex order is [lng, lat]: lng > 10 (moved east), lat ≈ 20.
+    expect(newest[0]).toBeGreaterThan(10);
+    expect(Math.abs(newest[1] - 20)).toBeLessThan(0.01);
+
+    manager.destroy();
+  });
+
+  test("destroy cancels any pending RAF and removes map listeners (Guardrail 5)", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+
+    let cursorCalls = 0;
+    const manager = createPolygonDrawingManager(map, google, {
+      onDynamicCursor: () => {
+        cursorCalls += 1;
+      },
+    });
+    manager.start();
+    fireMapEvent(map, "click", { latLng: makeLatLng(google, 0, 0) });
+    fireMapEvent(map, "mousemove", { latLng: makeLatLng(google, 0.001, 0) });
+
+    // RAF queued but not flushed; destroy should cancel it.
+    expect(__raf_callbacks.length).toBeGreaterThan(0);
+    manager.destroy();
+    flushRAF();
+
+    // The post-destroy RAF must NOT call back into the (destroyed) manager
+    // emitting a stale cursor event. We reset cursorCalls earlier; only the
+    // post-destroy "null" cleanup emit from stop() may have fired. Either way
+    // it must not be > 1 (no leaked frames).
+    expect(cursorCalls).toBeLessThanOrEqual(1);
+
+    // Map listeners were removed.
+    const remaining = Array.from(map.__listeners.values()).reduce(
+      (sum, arr) => sum + arr.length,
+      0,
+    );
+    expect(remaining).toBe(0);
+  });
+});

--- a/src/components/map/__tests__/PrecisionPolygonEditor.dragHints.test.js
+++ b/src/components/map/__tests__/PrecisionPolygonEditor.dragHints.test.js
@@ -38,6 +38,7 @@ function createMaps() {
       this.opts = opts;
       this.position = opts.position || null;
       this.icon = opts.icon || null;
+      this.label = opts.label || null;
       this.map = opts.map || null;
       this._listeners = new Map();
       allMarkers.add(this);
@@ -47,6 +48,12 @@ function createMaps() {
     }
     setIcon(icon) {
       this.icon = icon;
+    }
+    setLabel(label) {
+      this.label = label;
+    }
+    getLabel() {
+      return this.label;
     }
     setMap(map) {
       this.map = map;
@@ -82,6 +89,9 @@ function createMaps() {
     setPath(p) {
       this.path = p;
     }
+    setOptions(o) {
+      this.opts = { ...this.opts, ...o };
+    }
     setMap(map) {
       this.map = map;
     }
@@ -90,6 +100,17 @@ function createMaps() {
       if (!this._listeners.has(event)) this._listeners.set(event, []);
       this._listeners.get(event).push(ref);
       return ref;
+    }
+    fire(event, payload) {
+      const arr = this._listeners.get(event) || [];
+      arr.slice().forEach((ref) => ref.__handler(payload));
+    }
+  }
+
+  class Size {
+    constructor(w, h) {
+      this.width = w;
+      this.height = h;
     }
   }
 
@@ -138,6 +159,7 @@ function createMaps() {
     const handlers = new Map();
     return {
       __handlers: handlers,
+      __opts: {},
       addListener(event, handler) {
         const ref = { __event: event, __handler: handler };
         if (!handlers.has(event)) handlers.set(event, []);
@@ -145,7 +167,16 @@ function createMaps() {
         return ref;
       },
       addListenerOnce: () => ({}),
-      setOptions: () => {},
+      setOptions(o) {
+        this.__opts = { ...this.__opts, ...o };
+      },
+      get(key) {
+        return this.__opts[key];
+      },
+      fire(event, payload) {
+        const arr = handlers.get(event) || [];
+        arr.slice().forEach((ref) => ref.__handler(payload));
+      },
       getZoom: () => 18,
       getDiv: () => ({ focus: () => {} }),
     };
@@ -161,10 +192,14 @@ function createMaps() {
         OverlayView,
         Point,
         LatLng,
+        Size,
         SymbolPath: { CIRCLE: "CIRCLE" },
         event: {
           addListenerOnce: () => ({}),
           removeListener: () => {},
+          addListener(target, event, handler) {
+            return target.addListener(event, handler);
+          },
         },
       },
     },
@@ -179,7 +214,7 @@ const SQUARE = [
 ];
 
 describe("PrecisionPolygonEditor drag hints", () => {
-  test("creates a hit-shadow marker per visible marker (Guardrail 6 pairing)", () => {
+  test("creates a hit-shadow marker per visible marker plus edge labels", () => {
     const { google, createMap, allMarkers } = createMaps();
     const map = createMap();
     const editor = createPrecisionPolygonEditor(map, google);
@@ -187,8 +222,8 @@ describe("PrecisionPolygonEditor drag hints", () => {
     editor.enable();
 
     // 4 vertices × 2 markers each (visible + hit) = 8 markers, plus the
-    // 4 midpoint markers between them = 12 total.
-    expect(allMarkers.size).toBe(12);
+    // 4 midpoint markers between them = 12, plus 4 edge-length labels = 16.
+    expect(allMarkers.size).toBe(16);
 
     editor.destroy();
 
@@ -308,5 +343,222 @@ describe("PrecisionPolygonEditor drag hints", () => {
     // Final emits ensure the host overlay can hide its tooltip + badge.
     expect(snapHints[snapHints.length - 1]).toBeNull();
     expect(dragSamples[dragSamples.length - 1]).toBeNull();
+  });
+});
+
+describe("PrecisionPolygonEditor focused state", () => {
+  test("focused: false renders polygon clickable but creates no markers", () => {
+    const { google, createMap, allMarkers } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google, {
+      focused: false,
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+
+    // Polygon overlay still exists and is clickable; vertex/midpoint/edge
+    // labels are all suppressed.
+    expect(allMarkers.size).toBe(0);
+    expect(editor.polygonOverlay).toBeDefined();
+    expect(editor.polygonOverlay.opts.clickable).toBe(true);
+
+    editor.destroy();
+  });
+
+  test("clicking the polygon body when latent fires onPolygonBodyClick", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const calls = [];
+    const editor = createPrecisionPolygonEditor(map, google, {
+      focused: false,
+      onPolygonBodyClick: (latLng) => calls.push(latLng),
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+
+    editor.polygonOverlay.fire("click", {
+      latLng: new google.maps.LatLng(37.705, -122.395),
+    });
+
+    expect(calls.length).toBe(1);
+    expect(typeof calls[0].lat).toBe("function");
+    editor.destroy();
+  });
+
+  test("setFocused(true) after construction creates markers via _refresh", () => {
+    const { google, createMap, allMarkers } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google, {
+      focused: false,
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+    expect(allMarkers.size).toBe(0);
+
+    editor.setFocused(true);
+    // 8 paired vertex markers + 4 midpoints + 4 edge labels = 16.
+    expect(allMarkers.size).toBe(16);
+
+    editor.destroy();
+  });
+
+  test("placeholder: true suppresses vertex/midpoint markers", () => {
+    const { google, createMap, allMarkers } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google, {
+      placeholder: true,
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+    // Placeholder suppresses all markers (vertex + midpoint + edge labels).
+    expect(allMarkers.size).toBe(0);
+    editor.destroy();
+  });
+});
+
+describe("PrecisionPolygonEditor edge labels", () => {
+  test("creates one edge label per edge with a length string", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google);
+    editor.setVertices(SQUARE);
+    editor.enable();
+
+    expect(editor.edgeLabelMarkers.length).toBe(4);
+    editor.edgeLabelMarkers.forEach((m) => {
+      expect(m).toBeDefined();
+      expect(m.label?.text).toEqual(expect.any(String));
+      expect(m.label.text.length).toBeGreaterThan(0);
+    });
+
+    editor.destroy();
+  });
+
+  test("showEdgeLabels: false suppresses edge labels", () => {
+    const { google, createMap, allMarkers } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google, {
+      showEdgeLabels: false,
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+    // 4 visible + 4 hit + 4 midpoint = 12 (no edge labels).
+    expect(allMarkers.size).toBe(12);
+    expect(editor.edgeLabelMarkers.length).toBe(0);
+    editor.destroy();
+  });
+
+  test("dragging a vertex updates the two adjacent edge labels", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google);
+    editor.setVertices(SQUARE);
+    editor.enable();
+
+    const beforeIncoming = editor.edgeLabelMarkers[0].label.text;
+    const beforeOutgoing = editor.edgeLabelMarkers[1].label.text;
+
+    const pair = editor.vertexMarkers[1];
+    pair.hit.fire("dragstart");
+    pair.hit.fire("drag", {
+      latLng: new google.maps.LatLng(37.72, -122.398),
+    });
+    flushRAF();
+
+    expect(editor.edgeLabelMarkers[0].label.text).not.toBe(beforeIncoming);
+    expect(editor.edgeLabelMarkers[1].label.text).not.toBe(beforeOutgoing);
+
+    editor.destroy();
+  });
+});
+
+describe("PrecisionPolygonEditor body translate", () => {
+  test("polygon body mousedown + map mousemove translates every vertex", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const polyChanges = [];
+    const editor = createPrecisionPolygonEditor(map, google, {
+      onPolygonChange: (verts) => polyChanges.push(verts),
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+    const original = editor.getVertices();
+
+    editor.polygonOverlay.fire("mousedown", {
+      latLng: new google.maps.LatLng(37.705, -122.395),
+    });
+    map.fire("mousemove", {
+      latLng: new google.maps.LatLng(37.715, -122.385),
+    });
+    flushRAF();
+
+    // Every vertex should have moved by the same delta.
+    const after = editor.getVertices();
+    const dLng = after[0][0] - original[0][0];
+    const dLat = after[0][1] - original[0][1];
+    expect(dLng).toBeCloseTo(0.01, 5);
+    expect(dLat).toBeCloseTo(0.01, 5);
+    after.forEach((v, i) => {
+      expect(v[0] - original[i][0]).toBeCloseTo(dLng, 5);
+      expect(v[1] - original[i][1]).toBeCloseTo(dLat, 5);
+    });
+
+    map.fire("mouseup");
+    expect(polyChanges.length).toBe(1);
+
+    editor.destroy();
+  });
+
+  test("Shift held during translate constrains delta to one axis", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google);
+    editor.setVertices(SQUARE);
+    editor.enable();
+    const original = editor.getVertices();
+
+    editor.shiftPressed = true;
+    editor.polygonOverlay.fire("mousedown", {
+      latLng: new google.maps.LatLng(37.705, -122.395),
+    });
+    // dLat = 0.001, dLng = 0.005 → |dLng| dominates, so dLat should be zeroed.
+    map.fire("mousemove", {
+      latLng: new google.maps.LatLng(37.706, -122.39),
+    });
+    flushRAF();
+
+    const after = editor.getVertices();
+    expect(after[0][0]).not.toBeCloseTo(original[0][0], 6);
+    expect(after[0][1]).toBeCloseTo(original[0][1], 6);
+
+    map.fire("mouseup");
+    editor.destroy();
+  });
+
+  test("body click after translate does NOT insert a stray vertex", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google);
+    editor.setVertices(SQUARE);
+    editor.enable();
+    const before = editor.getVertices().length;
+
+    editor.polygonOverlay.fire("mousedown", {
+      latLng: new google.maps.LatLng(37.705, -122.395),
+    });
+    map.fire("mousemove", {
+      latLng: new google.maps.LatLng(37.706, -122.394),
+    });
+    flushRAF();
+    map.fire("mouseup");
+
+    // Trailing click that fires immediately after mouseup must be ignored.
+    editor.polygonOverlay.fire("click", {
+      latLng: new google.maps.LatLng(37.706, -122.394),
+    });
+
+    expect(editor.getVertices().length).toBe(before);
+
+    editor.destroy();
   });
 });

--- a/src/components/map/__tests__/PrecisionPolygonEditor.dragHints.test.js
+++ b/src/components/map/__tests__/PrecisionPolygonEditor.dragHints.test.js
@@ -1,0 +1,312 @@
+/**
+ * PrecisionPolygonEditor.dragHints.test.js
+ *
+ * Validates the corner-drag UX upgrades added in feat/boundary-cad-input:
+ * - Hit-shadow markers paired with visible markers (Guardrail 6).
+ * - onDragLiveDimension and onSnapHint callbacks emitted from _processDrag.
+ * - All marker pairs torn down on disable() / destroy() (Guardrail 5/6).
+ */
+
+import { createPrecisionPolygonEditor } from "../PrecisionPolygonEditor.js";
+
+let __raf_callbacks = [];
+
+function flushRAF() {
+  const queue = __raf_callbacks.slice();
+  __raf_callbacks = [];
+  queue.forEach((cb) => cb(performance.now()));
+}
+
+beforeEach(() => {
+  __raf_callbacks = [];
+  global.requestAnimationFrame = (cb) => {
+    __raf_callbacks.push(cb);
+    return __raf_callbacks.length;
+  };
+  global.cancelAnimationFrame = (handle) => {
+    if (handle != null) {
+      __raf_callbacks[handle - 1] = () => {};
+    }
+  };
+});
+
+function createMaps() {
+  const allMarkers = new Set();
+
+  class Marker {
+    constructor(opts = {}) {
+      this.opts = opts;
+      this.position = opts.position || null;
+      this.icon = opts.icon || null;
+      this.map = opts.map || null;
+      this._listeners = new Map();
+      allMarkers.add(this);
+    }
+    setPosition(p) {
+      this.position = p;
+    }
+    setIcon(icon) {
+      this.icon = icon;
+    }
+    setMap(map) {
+      this.map = map;
+      if (map === null) allMarkers.delete(this);
+    }
+    setVisible() {}
+    getPosition() {
+      const p = this.position || { lat: 0, lng: 0 };
+      return {
+        lat: () => (typeof p.lat === "function" ? p.lat() : p.lat),
+        lng: () => (typeof p.lng === "function" ? p.lng() : p.lng),
+      };
+    }
+    addListener(event, handler) {
+      const ref = { __event: event, __handler: handler };
+      if (!this._listeners.has(event)) this._listeners.set(event, []);
+      this._listeners.get(event).push(ref);
+      return ref;
+    }
+    fire(event, payload) {
+      const arr = this._listeners.get(event) || [];
+      arr.slice().forEach((ref) => ref.__handler(payload));
+    }
+  }
+
+  class Polygon {
+    constructor(opts = {}) {
+      this.opts = opts;
+      this.path = opts.paths || [];
+      this.map = opts.map || null;
+      this._listeners = new Map();
+    }
+    setPath(p) {
+      this.path = p;
+    }
+    setMap(map) {
+      this.map = map;
+    }
+    addListener(event, handler) {
+      const ref = { __event: event, __handler: handler };
+      if (!this._listeners.has(event)) this._listeners.set(event, []);
+      this._listeners.get(event).push(ref);
+      return ref;
+    }
+  }
+
+  class Point {
+    constructor(x, y) {
+      this.x = x;
+      this.y = y;
+    }
+  }
+
+  class LatLng {
+    constructor(lat, lng) {
+      this._lat = lat;
+      this._lng = lng;
+    }
+    lat() {
+      return this._lat;
+    }
+    lng() {
+      return this._lng;
+    }
+  }
+
+  class OverlayView {
+    constructor() {
+      this.onAdd = () => {};
+      this.draw = () => {};
+      this.onRemove = () => {};
+    }
+    setMap(map) {
+      this.map = map;
+    }
+    getProjection() {
+      return {
+        fromLatLngToDivPixel(latLng) {
+          return new Point(latLng.lng() * 100, -latLng.lat() * 100);
+        },
+        fromDivPixelToLatLng(pt) {
+          return new LatLng(-pt.y / 100, pt.x / 100);
+        },
+      };
+    }
+  }
+
+  function createMap() {
+    const handlers = new Map();
+    return {
+      __handlers: handlers,
+      addListener(event, handler) {
+        const ref = { __event: event, __handler: handler };
+        if (!handlers.has(event)) handlers.set(event, []);
+        handlers.get(event).push(ref);
+        return ref;
+      },
+      addListenerOnce: () => ({}),
+      setOptions: () => {},
+      getZoom: () => 18,
+      getDiv: () => ({ focus: () => {} }),
+    };
+  }
+
+  return {
+    createMap,
+    allMarkers,
+    google: {
+      maps: {
+        Marker,
+        Polygon,
+        OverlayView,
+        Point,
+        LatLng,
+        SymbolPath: { CIRCLE: "CIRCLE" },
+        event: {
+          addListenerOnce: () => ({}),
+          removeListener: () => {},
+        },
+      },
+    },
+  };
+}
+
+const SQUARE = [
+  [-122.4, 37.7],
+  [-122.4, 37.71],
+  [-122.39, 37.71],
+  [-122.39, 37.7],
+];
+
+describe("PrecisionPolygonEditor drag hints", () => {
+  test("creates a hit-shadow marker per visible marker (Guardrail 6 pairing)", () => {
+    const { google, createMap, allMarkers } = createMaps();
+    const map = createMap();
+    const editor = createPrecisionPolygonEditor(map, google);
+    editor.setVertices(SQUARE);
+    editor.enable();
+
+    // 4 vertices × 2 markers each (visible + hit) = 8 markers, plus the
+    // 4 midpoint markers between them = 12 total.
+    expect(allMarkers.size).toBe(12);
+
+    editor.destroy();
+
+    // After destroy(): every marker setMap(null), set should be empty.
+    expect(allMarkers.size).toBe(0);
+  });
+
+  test("dragging a hit marker emits live dimension + ortho snap hint", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const dragSamples = [];
+    const snapHints = [];
+
+    const editor = createPrecisionPolygonEditor(map, google, {
+      onDragLiveDimension: (info) => dragSamples.push(info),
+      onSnapHint: (hint) => snapHints.push(hint),
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+
+    // Find the hit marker for index 2 (the one whose previous vertex exists).
+    // vertexMarkers[2] = { visible, hit } — fire dragstart + drag on the hit.
+    const pair = editor.vertexMarkers[2];
+    expect(pair?.hit).toBeDefined();
+    expect(pair?.visible).toBeDefined();
+
+    // Simulate Shift held so ortho snap engages.
+    editor.shiftPressed = true;
+
+    pair.hit.fire("dragstart");
+    pair.hit.fire("drag", {
+      latLng: new google.maps.LatLng(37.71, -122.388),
+    });
+
+    // The drag listener queues a RAF; flush it.
+    flushRAF();
+
+    expect(dragSamples.length).toBeGreaterThan(0);
+    expect(dragSamples[0]).toMatchObject({
+      index: 2,
+      lengthM: expect.any(Number),
+      bearingDeg: expect.any(Number),
+    });
+    expect(dragSamples[0].lengthM).toBeGreaterThan(0);
+
+    // 'ortho' was emitted because Shift was held and the new coord differed
+    // from the raw cursor (snap engaged).
+    expect(snapHints).toContain("ortho");
+
+    editor.destroy();
+  });
+
+  test("dragend nulls out the live overlay (Guardrail 5 cleanup)", () => {
+    const { google, createMap } = createMaps();
+    const map = createMap();
+    const dragSamples = [];
+    const snapHints = [];
+
+    const editor = createPrecisionPolygonEditor(map, google, {
+      onDragLiveDimension: (info) => dragSamples.push(info),
+      onSnapHint: (hint) => snapHints.push(hint),
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+
+    // Hold Shift so the drag actually emits an "ortho" snap hint we can then
+    // verify gets cleared on dragend (the de-duplication guard inside
+    // _emitSnapHint only fires when the hint actually changes value).
+    editor.shiftPressed = true;
+
+    const pair = editor.vertexMarkers[1];
+    pair.hit.fire("dragstart");
+    pair.hit.fire("drag", {
+      latLng: new google.maps.LatLng(37.715, -122.388),
+    });
+    flushRAF();
+    expect(snapHints).toContain("ortho");
+
+    pair.hit.fire("dragend");
+
+    // After dragend the editor should emit a `null` to the live-dimension
+    // sink so the overlay can hide.
+    const nullDimEmits = dragSamples.filter((sample) => sample === null);
+    expect(nullDimEmits.length).toBe(1);
+    // Snap hint cleared too.
+    expect(snapHints[snapHints.length - 1]).toBeNull();
+
+    editor.destroy();
+  });
+
+  test("disable() clears every paired marker and emits null overlay state", () => {
+    const { google, createMap, allMarkers } = createMaps();
+    const map = createMap();
+    const dragSamples = [];
+    const snapHints = [];
+    const editor = createPrecisionPolygonEditor(map, google, {
+      onDragLiveDimension: (info) => dragSamples.push(info),
+      onSnapHint: (hint) => snapHints.push(hint),
+    });
+    editor.setVertices(SQUARE);
+    editor.enable();
+    expect(allMarkers.size).toBeGreaterThan(0);
+
+    // Establish a non-null hint first so disable() emits a real "null"
+    // transition (the de-dup guard would skip null-after-null).
+    editor.shiftPressed = true;
+    const pair = editor.vertexMarkers[1];
+    pair.hit.fire("dragstart");
+    pair.hit.fire("drag", {
+      latLng: new google.maps.LatLng(37.715, -122.388),
+    });
+    flushRAF();
+    expect(snapHints).toContain("ortho");
+
+    editor.disable();
+    expect(allMarkers.size).toBe(0);
+    // Final emits ensure the host overlay can hide its tooltip + badge.
+    expect(snapHints[snapHints.length - 1]).toBeNull();
+    expect(dragSamples[dragSamples.length - 1]).toBeNull();
+  });
+});

--- a/src/components/map/__tests__/boundaryGeometry.test.js
+++ b/src/components/map/__tests__/boundaryGeometry.test.js
@@ -485,3 +485,92 @@ describe("Format Conversion", () => {
     expect(latLngArray[0]).toEqual({ lat: 37.7, lng: -122.4 });
   });
 });
+
+// ============================================================
+// AutoCAD-style draw helpers (added in feat/boundary-cad-input)
+// ============================================================
+
+describe("AutoCAD-style helpers", () => {
+  test("ORTHO_SNAP_DEGREES is 90 and ANGLE_SNAP_DEGREES still 45", async () => {
+    const mod = await import("../boundaryGeometry.js");
+    expect(mod.ORTHO_SNAP_DEGREES).toBe(90);
+    expect(mod.ANGLE_SNAP_DEGREES).toBe(45);
+  });
+
+  test("constrainToAngle(prev, target, 90) snaps near-east cursor to true east", async () => {
+    const { constrainToAngle: constrain } =
+      await import("../boundaryGeometry.js");
+    // Prev at origin, target ~3° north of east. With 90° snap that should
+    // collapse to due east (bearing 90°), so the y component returns to ~prev.y.
+    const prev = [0, 0];
+    const target = [0.001, 0.00005];
+    const snapped = constrain(prev, target, 90);
+    expect(Math.abs(snapped[1])).toBeLessThan(1e-6);
+    expect(snapped[0]).toBeGreaterThan(0);
+  });
+
+  test("normalizeBearing maps angles into [0, 360) and rejects junk", async () => {
+    const { normalizeBearing } = await import("../boundaryGeometry.js");
+    expect(normalizeBearing(0)).toBe(0);
+    expect(normalizeBearing(360)).toBe(0);
+    expect(normalizeBearing(-90)).toBe(270);
+    expect(normalizeBearing(450)).toBe(90);
+    expect(normalizeBearing(NaN)).toBeNull();
+    expect(normalizeBearing("not-a-number")).toBeNull();
+  });
+
+  test("destinationFromBearing places a point ~1m east at small distance", async () => {
+    const { destinationFromBearing } = await import("../boundaryGeometry.js");
+    const start = [0, 0];
+    const result = destinationFromBearing(start, 1, 90);
+    expect(result).not.toBeNull();
+    expect(result[0]).toBeGreaterThan(0); // moved east → +lng
+    expect(Math.abs(result[1])).toBeLessThan(1e-5); // stays on equator
+  });
+
+  test("destinationFromBearing returns the same vertex order PR #98 expected", async () => {
+    // Regression for the import swap: numeric output must match the previous
+    // local implementation exactly for a known fixture so PR #98's tests
+    // continue to pass.
+    const { destinationFromBearing, roundCoord: round } =
+      await import("../boundaryGeometry.js");
+    const start = [-122.4, 37.7];
+    const out = destinationFromBearing(start, 50, 45);
+    expect(out).not.toBeNull();
+    // Order is [lng, lat] (Guardrail 4 — same order callers receive).
+    expect(out[0]).toBeGreaterThan(start[0]);
+    expect(out[1]).toBeGreaterThan(start[1]);
+    expect(out[0]).toBe(round(out[0]));
+    expect(out[1]).toBe(round(out[1]));
+  });
+
+  test("destinationFromBearing rejects bad inputs", async () => {
+    const { destinationFromBearing } = await import("../boundaryGeometry.js");
+    expect(destinationFromBearing(null, 5, 90)).toBeNull();
+    expect(destinationFromBearing([0, 0], "abc", 90)).toBeNull();
+    expect(destinationFromBearing([0, 0], 5, NaN)).toBeNull();
+  });
+
+  test("liveLengthAndBearing returns positive length and a bearing in [0, 360)", async () => {
+    const { liveLengthAndBearing } = await import("../boundaryGeometry.js");
+    const prev = [0, 0];
+    const cursor = [0.0001, 0]; // ~11.1 m east at the equator
+    const live = liveLengthAndBearing(prev, cursor);
+    expect(live.lengthM).toBeGreaterThan(10);
+    expect(live.lengthM).toBeLessThan(13);
+    expect(live.bearingDeg).toBeGreaterThanOrEqual(0);
+    expect(live.bearingDeg).toBeLessThan(360);
+  });
+
+  test("liveLengthAndBearing returns zeros for invalid inputs", async () => {
+    const { liveLengthAndBearing } = await import("../boundaryGeometry.js");
+    expect(liveLengthAndBearing(null, null)).toEqual({
+      lengthM: 0,
+      bearingDeg: 0,
+    });
+    expect(liveLengthAndBearing([0, 0], ["nope", "nope"])).toEqual({
+      lengthM: 0,
+      bearingDeg: 0,
+    });
+  });
+});

--- a/src/components/map/boundaryGeometry.js
+++ b/src/components/map/boundaryGeometry.js
@@ -21,7 +21,30 @@ export const EARTH_RADIUS_METERS = 6371000;
 export const COORDINATE_PRECISION = 7; // ~1cm precision
 export const MIN_VERTICES = 3;
 export const SNAP_PIXEL_THRESHOLD = 12;
+// Legacy diagonal snap (kept for back-compat; new editors default to ORTHO).
 export const ANGLE_SNAP_DEGREES = 45;
+// AutoCAD-style orthogonal snap used by the dynamic-input draw / drag UX.
+export const ORTHO_SNAP_DEGREES = 90;
+
+function toRadians(value) {
+  return (Number(value) * Math.PI) / 180;
+}
+
+function toDegrees(value) {
+  return (Number(value) * 180) / Math.PI;
+}
+
+/**
+ * Normalize a bearing into the [0, 360) range. Returns null for non-finite
+ * inputs so callers can branch deterministically.
+ * @param {number} value
+ * @returns {number | null}
+ */
+export function normalizeBearing(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return ((numeric % 360) + 360) % 360;
+}
 
 function toFiniteNumber(value) {
   const numeric = Number(value);
@@ -631,6 +654,85 @@ export function constrainToAngle(
   return destination.geometry.coordinates;
 }
 
+/**
+ * Compute the geodesic destination [lng, lat] from a start point given a
+ * length (meters) and bearing (degrees). Uses the spherical-Earth haversine
+ * formula. Returns null when inputs are invalid.
+ *
+ * Single source of truth for AutoCAD-style "type a length to place the next
+ * vertex" placements and for the existing numeric-tab length/bearing edits in
+ * BoundaryNumericEditor.
+ *
+ * @param {[number, number]} start - [lng, lat]
+ * @param {number} lengthM - distance in meters
+ * @param {number} bearingDeg - bearing in degrees (will be normalized into [0, 360))
+ * @returns {[number, number] | null}
+ */
+export function destinationFromBearing(start, lengthM, bearingDeg) {
+  const distance = Number(lengthM);
+  const bearing = normalizeBearing(bearingDeg);
+  if (!Array.isArray(start) || !Number.isFinite(distance) || bearing === null) {
+    return null;
+  }
+
+  const lng1 = toRadians(start[0]);
+  const lat1 = toRadians(start[1]);
+  const theta = toRadians(bearing);
+  const delta = distance / EARTH_RADIUS_METERS;
+
+  const sinLat1 = Math.sin(lat1);
+  const cosLat1 = Math.cos(lat1);
+  const sinDelta = Math.sin(delta);
+  const cosDelta = Math.cos(delta);
+
+  const lat2 = Math.asin(
+    sinLat1 * cosDelta + cosLat1 * sinDelta * Math.cos(theta),
+  );
+  const lng2 =
+    lng1 +
+    Math.atan2(
+      Math.sin(theta) * sinDelta * cosLat1,
+      cosDelta - sinLat1 * Math.sin(lat2),
+    );
+
+  return [
+    roundCoord(((toDegrees(lng2) + 540) % 360) - 180),
+    roundCoord(toDegrees(lat2)),
+  ];
+}
+
+/**
+ * Compute live length (meters) and forward bearing (degrees) from a previous
+ * vertex to the current cursor position. Used by the dynamic-input draw
+ * overlay and by the corner-drag length tooltip. Returns zeros when inputs
+ * are invalid so the overlay can render placeholders without branching.
+ *
+ * @param {[number, number]} prev - [lng, lat] previous vertex
+ * @param {[number, number]} cursor - [lng, lat] cursor position
+ * @returns {{ lengthM: number, bearingDeg: number }}
+ */
+export function liveLengthAndBearing(prev, cursor) {
+  if (
+    !Array.isArray(prev) ||
+    !Array.isArray(cursor) ||
+    !Number.isFinite(Number(prev[0])) ||
+    !Number.isFinite(Number(prev[1])) ||
+    !Number.isFinite(Number(cursor[0])) ||
+    !Number.isFinite(Number(cursor[1]))
+  ) {
+    return { lengthM: 0, bearingDeg: 0 };
+  }
+  const from = turf.point(prev);
+  const to = turf.point(cursor);
+  const lengthM = turf.distance(from, to, { units: "meters" });
+  const rawBearing = turf.bearing(from, to);
+  const bearingDeg = normalizeBearing(rawBearing) ?? 0;
+  return {
+    lengthM: roundCoord(lengthM, 3),
+    bearingDeg: roundCoord(bearingDeg, 2),
+  };
+}
+
 // ============================================================
 // VALIDATION SUITE
 // ============================================================
@@ -907,6 +1009,11 @@ export default {
   snapBearing,
   constrainToAngle,
 
+  // Bearing math
+  normalizeBearing,
+  destinationFromBearing,
+  liveLengthAndBearing,
+
   // Format conversion
   toGeoJSON,
   fromGeoJSON,
@@ -923,4 +1030,5 @@ export default {
   MIN_VERTICES,
   SNAP_PIXEL_THRESHOLD,
   ANGLE_SNAP_DEGREES,
+  ORTHO_SNAP_DEGREES,
 };

--- a/src/services/propertyBoundaryService.js
+++ b/src/services/propertyBoundaryService.js
@@ -30,6 +30,25 @@ export const SITE_BOUNDARY_PROXY_TIMEOUT_MS = 9000;
 export const INTELLIGENT_FALLBACK_BOUNDARY_SOURCE = "Intelligent Fallback";
 export const INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE = 0.4;
 
+// Surfaced by `/api/site/boundary` when buildings + parcels both come back
+// empty AND a highway-density probe finds zero ways within 200 m of the
+// site. Indicates a remote / desert / unmapped location — the polygon
+// returned is a 50 m × 50 m latitude-corrected placeholder, not a real
+// boundary, so the UI renders it dashed amber and prompts the user to
+// draw a real boundary.
+export const REMOTE_PLACEHOLDER_BOUNDARY_SOURCE = "Remote-site placeholder";
+export const REMOTE_PLACEHOLDER_BOUNDARY_CONFIDENCE = 0.2;
+
+export function isRemoteSitePlaceholderResult(result = {}) {
+  if (!result) return false;
+  if (result.placeholder === true) return true;
+  if (result.metadata?.placeholder === true) return true;
+  const source = String(
+    result?.boundarySource || result?.source || result?.metadata?.source || "",
+  );
+  return /remote-site placeholder/i.test(source);
+}
+
 export function buildEstimatedBoundaryMetadata({
   source = INTELLIGENT_FALLBACK_BOUNDARY_SOURCE,
   confidence = INTELLIGENT_FALLBACK_BOUNDARY_CONFIDENCE,
@@ -223,6 +242,11 @@ export async function fetchSiteBoundaryFromProxy({
       boundarySource: json.source,
       estimateReason: json.estimateReason || null,
       estimatedOnly: json.boundaryAuthoritative !== true,
+      // Forward placeholder + recommendation fields from the proxy so the
+      // editor can render dashed amber and surface the "draw to refine"
+      // banner. Only set when the proxy explicitly flagged the polygon.
+      placeholder: json.placeholder === true ? true : undefined,
+      recommendation: json.recommendation || undefined,
       policyVersion: json.policyVersion || BOUNDARY_POLICY_VERSION,
       hash: json.hash || null,
       metadata: {

--- a/src/services/siteBoundaryAutoDetectPolicy.js
+++ b/src/services/siteBoundaryAutoDetectPolicy.js
@@ -30,7 +30,32 @@ function hasEstimatedBoundarySource(locationData = {}) {
       "",
   );
 
-  return /intelligent fallback|fallback/i.test(source);
+  return /intelligent fallback|fallback|remote-site placeholder/i.test(source);
+}
+
+/**
+ * True when the site boundary is the dashed-amber 50 m × 50 m placeholder
+ * surfaced by `/api/site/boundary` for remote/desert/unmapped locations.
+ * Distinct from the "intelligent fallback" path because this placeholder
+ * is generated server-side after both OSM evidence AND a highway-density
+ * probe come back empty — strongest signal we have for "no data here".
+ */
+export function hasRemoteSitePlaceholder(locationData = {}) {
+  if (!locationData) return false;
+  if (
+    locationData.placeholder === true ||
+    locationData.siteAnalysis?.placeholder === true ||
+    locationData.metadata?.placeholder === true
+  ) {
+    return true;
+  }
+  const source = String(
+    locationData.boundarySource ||
+      locationData.siteAnalysis?.boundarySource ||
+      locationData.metadata?.boundarySource ||
+      "",
+  );
+  return /remote-site placeholder/i.test(source);
 }
 
 export function shouldEnableBoundaryAutoDetect(locationData = null) {


### PR DESCRIPTION
## Summary

Improves the Site Boundary Editor with AutoCAD-style draw/edit interactions.

## Changes

- Collapses old select/edit modes into simpler `IDLE`, `SELECTED`, and `DRAW`.
- Auto-detected and freshly drawn boundaries now land in focused/drag-editable state.
- Adds click-to-focus and click-outside defocus behaviour.
- Adds smoother manual drawing with RAF-throttled preview updates.
- Adds bigger corner drag targets.
- Adds always-visible edge length labels.
- Adds cursor feedback for vertices, edges, and polygon body.
- Adds body-translate: hold/drag the whole boundary polygon.
- Adds Shift orthographic constraint during translate.
- Adds remote/desert placeholder handling when Overpass finds no buildings/parcels/roads.
- Shows amber placeholder banner and Draw Boundary CTA for remote-site placeholder cases.

## Validation

- Focused tests: 113/113 passed.
- Added 14 PrecisionPolygonEditor tests.
- Added 2 site-boundary proxy tests.
- Added 2 SiteBoundaryEditorV2 tests.
- `npm run lint` passed.
- `npm run build:active` passed.

## Scope

UI/site-boundary only.

No ProjectGraph, A1, CAD/DXF, structural, MEP, backend generation, image2, or authority-gate changes.

## Not yet done

Browser smoke test still required before marking ready for review.

## Manual smoke checklist

- Auto-detect a real boundary.
- Confirm it lands focused/editable.
- Drag a corner.
- Drag the whole polygon body.
- Hold Shift and confirm orthographic movement.
- Confirm edge labels update live.
- Click outside to defocus.
- Press E to toggle focus.
- Draw a new boundary and confirm preview is smooth.
- Test remote/desert placeholder and Draw Boundary CTA.

## Before merge

Run:

```
npm start
```

Then manually test:

- [ ] Auto-detected boundary is editable on first click.
- [ ] Corner drag is easy with bigger hit target.
- [ ] Whole polygon body can be held and dragged.
- [ ] Shift constrains body drag orthogonally.
- [ ] Edge length labels show and update.
- [ ] Draw mode preview is smooth at zoom 18-20.
- [ ] Remote placeholder banner appears only when appropriate.
- [ ] Draw Boundary CTA works.
- [ ] Existing numeric Dimensions tab still works.
- [ ] No A1/CAD/ProjectGraph files changed.

If the browser smoke passes, mark the PR ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)