### PR TITLE
Add opt-in construction detail library and CAD detail sheets

### DIFF
--- a/api/project/export/dxf.js
+++ b/api/project/export/dxf.js
@@ -10,8 +10,18 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { compiledProject, projectName = "ArchiAI_Project" } = req.body || {};
-    const dxf = exportCompiledProjectToDXF({ compiledProject, projectName });
+    const {
+      compiledProject,
+      projectName = "ArchiAI_Project",
+      includeDetailDrawings = false,
+      detailDrawingsEnabled = false,
+    } = req.body || {};
+    const dxf = exportCompiledProjectToDXF({
+      compiledProject,
+      projectName,
+      includeDetailDrawings,
+      detailDrawingsEnabled,
+    });
     const safeName = String(projectName)
       .replace(/[^a-zA-Z0-9_-]/g, "_")
       .slice(0, 80);

--- a/docs/roadmaps/professional-cad-bim-output-roadmap.md
+++ b/docs/roadmaps/professional-cad-bim-output-roadmap.md
@@ -217,6 +217,12 @@ Next MEP fidelity PR:
 ## PR 5: Detail library
 
 Add a deterministic construction detail library.
+This package is opt-in: construction detail drawing panels and CAD/DXF detail
+entities are included only when `DETAIL_DRAWINGS_ENABLED=true` or an explicit
+`includeDetailDrawings` option is passed. Existing architectural, structural,
+and MEP CAD/DXF exports remain unchanged by default. All details are
+preliminary coordination information and require responsible architect/engineer
+review before construction, tender, permit, or code-compliance use.
 
 Deliverables:
 
@@ -230,8 +236,33 @@ Deliverables:
 Acceptance criteria:
 
 - Detail sheets contain expected details.
-- Details export to DXF.
+- Details export to deterministic SVG and DXF only when detail drawings are
+  enabled.
+- Default CanonicalDrawingModel/DXF export does not emit detail library data,
+  detail sheets, detail callouts, or detail layers/entities.
+- Detail library and detail sheets carry deterministic hashes, no image-provider
+  technical drawing path, and architect/engineer review disclaimers.
+- Detail QA requires required detail types, detail hashes, matching geometry
+  hash, material hatches, dimensions, callouts, review disclaimer, and no false
+  code-compliance or construction-approval claims.
 - No image generation is used for details.
+
+Current limitations after this slice:
+
+- Preliminary construction-detail coordination library only.
+- Details are not code-certified or approved for construction.
+- No jurisdiction-specific construction detail packs yet.
+- No fire/acoustic/thermal/waterproofing calculations or product-certified
+  assembly data.
+- No engineer-sealed structural connections, reinforcement, or fixings design.
+- DWG remains conversion-only and unavailable unless a real converter is
+  configured; DXF remains the guaranteed CAD output.
+
+Next detail fidelity PR:
+
+- Add jurisdiction-specific detail packs for UK, France, and Algeria with
+  reviewable code assumptions, localized notations, and material/assembly
+  variants.
 
 ## PR 6: Jurisdiction packs
 

--- a/src/__tests__/services/cad/canonicalDrawingModel.test.js
+++ b/src/__tests__/services/cad/canonicalDrawingModel.test.js
@@ -205,6 +205,22 @@ const MEP_LAYER_NAMES = [
   "MEP-DIMS",
 ];
 
+const DETAIL_LAYER_NAMES = [
+  "A-DETAIL",
+  "A-DETAIL-DIMS",
+  "A-DETAIL-TEXT",
+  "A-DETAIL-HATCH",
+  "A-CALLOUT",
+  "D-CONCRETE",
+  "D-MASONRY",
+  "D-INSULATION",
+  "D-TIMBER",
+  "D-MEMBRANE",
+  "D-EARTH",
+  "D-GLAZING",
+  "D-METAL",
+];
+
 describe("CanonicalDrawingModel", () => {
   test("throws when CompiledProject geometryHash is missing", () => {
     expect(() =>
@@ -248,6 +264,7 @@ describe("CanonicalDrawingModel", () => {
     );
     expect(model.structuralModel).toBeUndefined();
     expect(model.mepModel).toBeUndefined();
+    expect(model.detailLibrary).toBeUndefined();
     expect(
       model.modelSpace.entities.filter((entity) =>
         String(entity.layer || "").startsWith("S-"),
@@ -256,6 +273,11 @@ describe("CanonicalDrawingModel", () => {
     expect(
       model.modelSpace.entities.filter((entity) =>
         MEP_LAYER_NAMES.includes(entity.layer),
+      ),
+    ).toEqual([]);
+    expect(
+      model.modelSpace.entities.filter((entity) =>
+        DETAIL_LAYER_NAMES.includes(entity.layer),
       ),
     ).toEqual([]);
   });
@@ -354,7 +376,9 @@ describe("CanonicalDrawingModel", () => {
     const layerNames = model.layers.map((layer) => layer.name);
     const architecturalLayerNames = REQUIRED_CANONICAL_CAD_LAYERS.filter(
       (layerName) =>
-        !layerName.startsWith("S-") && !MEP_LAYER_NAMES.includes(layerName),
+        !layerName.startsWith("S-") &&
+        !MEP_LAYER_NAMES.includes(layerName) &&
+        !DETAIL_LAYER_NAMES.includes(layerName),
     );
 
     expect(layerNames).toEqual(expect.arrayContaining(architecturalLayerNames));
@@ -362,6 +386,7 @@ describe("CanonicalDrawingModel", () => {
       expect.arrayContaining(["S-FOUNDATION", "S-BEAM", "S-GRID"]),
     );
     expect(layerNames).not.toEqual(expect.arrayContaining(MEP_LAYER_NAMES));
+    expect(layerNames).not.toEqual(expect.arrayContaining(DETAIL_LAYER_NAMES));
 
     const structuralModel = buildCanonicalDrawingModelFromCompiledProject({
       compiledProject: fixtureCompiledProject(),
@@ -370,7 +395,9 @@ describe("CanonicalDrawingModel", () => {
     expect(structuralModel.layers.map((layer) => layer.name)).toEqual(
       expect.arrayContaining(
         REQUIRED_CANONICAL_CAD_LAYERS.filter(
-          (layerName) => !MEP_LAYER_NAMES.includes(layerName),
+          (layerName) =>
+            !MEP_LAYER_NAMES.includes(layerName) &&
+            !DETAIL_LAYER_NAMES.includes(layerName),
         ),
       ),
     );
@@ -382,7 +409,22 @@ describe("CanonicalDrawingModel", () => {
     expect(mepModel.layers.map((layer) => layer.name)).toEqual(
       expect.arrayContaining(
         REQUIRED_CANONICAL_CAD_LAYERS.filter(
-          (layerName) => !layerName.startsWith("S-"),
+          (layerName) =>
+            !layerName.startsWith("S-") &&
+            !DETAIL_LAYER_NAMES.includes(layerName),
+        ),
+      ),
+    );
+
+    const detailModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeDetailDrawings: true,
+    });
+    expect(detailModel.layers.map((layer) => layer.name)).toEqual(
+      expect.arrayContaining(
+        REQUIRED_CANONICAL_CAD_LAYERS.filter(
+          (layerName) =>
+            !layerName.startsWith("S-") && !MEP_LAYER_NAMES.includes(layerName),
         ),
       ),
     );
@@ -465,6 +507,10 @@ describe("CanonicalDrawingModel", () => {
     expect(result.checks.hasMepDisclaimer).toBe(false);
     expect(result.checks.mepReviewRequired).toBe(false);
     expect(result.checks.mepImageProviderUsed).toBe(null);
+    expect(result.checks.hasDetailLibraryHash).toBe(false);
+    expect(result.checks.hasDetailDisclaimer).toBe(false);
+    expect(result.checks.detailReviewRequired).toBe(false);
+    expect(result.checks.detailImageProviderUsed).toBe(null);
   });
 
   test("adds structural CAD entities, dimensions, grid, and review notes", () => {
@@ -617,6 +663,118 @@ describe("CanonicalDrawingModel", () => {
     expect(requiredResult.valid).toBe(false);
     expect(requiredResult.errors.map((error) => error.code)).toContain(
       "CAD_MODEL_MEP_MODEL_HASH_MISSING",
+    );
+  });
+
+  test("adds opt-in construction detail CAD entities, sheets, callouts, hatches, dimensions, and review notes", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeDetailDrawings: true,
+    });
+
+    expect(model.detailLibrary).toEqual(
+      expect.objectContaining({
+        geometryHash: model.geometryHash,
+        sourceProjectGraphHash: model.sourceProjectGraphHash,
+        reviewRequired: true,
+        imageProviderUsed: "none",
+      }),
+    );
+    expect(model.detailLibrary.disclaimers.join(" ")).toMatch(
+      /architect and engineer/i,
+    );
+    expect(model.paperSpace.sheets.map((sheet) => sheet.sheetId)).toEqual(
+      expect.arrayContaining(["D-501", "D-502", "D-503", "D-504"]),
+    );
+
+    const detailEntities = model.modelSpace.entities.filter((entity) =>
+      DETAIL_LAYER_NAMES.includes(entity.layer),
+    );
+    const layers = new Set(detailEntities.map((entity) => entity.layer));
+    const roles = new Set(
+      detailEntities.map((entity) => entity.metadata?.role).filter(Boolean),
+    );
+
+    expect([...layers]).toEqual(expect.arrayContaining(DETAIL_LAYER_NAMES));
+    expect([...roles]).toEqual(
+      expect.arrayContaining([
+        "detail_title",
+        "detail_material_hatch",
+        "detail_dimension",
+        "detail_callout",
+        "detail_callout_marker",
+        "detail_callout_reference",
+        "review_disclaimer",
+      ]),
+    );
+    detailEntities.forEach((entity) => {
+      expect(entity.imageProviderUsed).toBe("none");
+      expect(entity.technicalDrawing).toBe(true);
+      expect(entity.geometryHash).toBe(model.geometryHash);
+    });
+  });
+
+  test("CAD QA validates construction details only when detail library is present or required", () => {
+    const defaultModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const defaultResult = validateCanonicalDrawingModel(defaultModel);
+
+    expect(defaultModel.detailLibrary).toBeUndefined();
+    expect(defaultResult.valid).toBe(true);
+    expect(defaultResult.errors.map((error) => error.code)).not.toEqual(
+      expect.arrayContaining(["CAD_MODEL_DETAIL_LIBRARY_HASH_MISSING"]),
+    );
+
+    const detailModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeDetailDrawings: true,
+    });
+    const brokenResult = validateCanonicalDrawingModel({
+      ...detailModel,
+      detailLibrary: {
+        ...detailModel.detailLibrary,
+        detailLibraryHash: null,
+        disclaimers: [],
+        imageProviderUsed: "openai",
+        details: detailModel.detailLibrary.details
+          .filter((detail) => detail.detailType !== "wall_foundation_junction")
+          .map((detail, index) =>
+            index === 0
+              ? {
+                  ...detail,
+                  detailHash: null,
+                  hatches: [],
+                  dimensions: [],
+                  dxfEntities: [],
+                  imageProviderUsed: "openai",
+                }
+              : detail,
+          ),
+      },
+    });
+    const codes = brokenResult.errors.map((error) => error.code);
+
+    expect(brokenResult.valid).toBe(false);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        "CAD_MODEL_DETAIL_LIBRARY_HASH_MISSING",
+        "CAD_MODEL_DETAIL_DISCLAIMER_MISSING",
+        "CAD_MODEL_DETAIL_REQUIRED_TYPE_MISSING",
+        "CAD_MODEL_DETAIL_HASH_MISSING",
+        "CAD_MODEL_DETAIL_HATCHES_MISSING",
+        "CAD_MODEL_DETAIL_DIMENSIONS_MISSING",
+        "CAD_MODEL_DETAIL_CALLOUTS_MISSING",
+        "CAD_MODEL_DETAIL_IMAGE_PROVIDER_FORBIDDEN",
+      ]),
+    );
+
+    const requiredResult = validateCanonicalDrawingModel(defaultModel, {
+      requireDetailLibrary: true,
+    });
+    expect(requiredResult.valid).toBe(false);
+    expect(requiredResult.errors.map((error) => error.code)).toContain(
+      "CAD_MODEL_DETAIL_LIBRARY_HASH_MISSING",
     );
   });
 

--- a/src/__tests__/services/cad/canonicalDxfExporter.test.js
+++ b/src/__tests__/services/cad/canonicalDxfExporter.test.js
@@ -197,6 +197,12 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).not.toContain("M-VENT");
     expect(dxf).not.toContain("MEP-NOTES");
     expect(dxf).not.toContain("PRELIMINARY MEP INFORMATION ONLY");
+    expect(dxf).not.toContain("A-DETAIL");
+    expect(dxf).not.toContain("D-CONCRETE");
+    expect(dxf).not.toContain("Wall/Foundation Junction");
+    expect(dxf).not.toContain(
+      "PRELIMINARY CONSTRUCTION DETAIL INFORMATION ONLY",
+    );
   });
 
   test("emits structural CAD layers, grid, foundations, roof framing, notes, and no raster entities", () => {
@@ -251,6 +257,41 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).toContain("MEP_EXTRACT_FAN");
     expect(dxf).toContain("PRELIMINARY MEP INFORMATION ONLY");
     expect(dxf).toContain("MEP coordination route");
+    expect(dxf).not.toMatch(/  0\nIMAGE\n/);
+    expect(dxf).not.toMatch(/  0\nRASTER\n/);
+  });
+
+  test("emits opt-in construction detail CAD layers, hatches, dimensions, sheets, callouts, and no raster entities", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+      includeDetailDrawings: true,
+    });
+    const dxf = exportCanonicalDrawingModelToDXF({
+      canonicalDrawingModel: model,
+    });
+
+    expect(dxf).toContain("A-DETAIL");
+    expect(dxf).toContain("A-DETAIL-DIMS");
+    expect(dxf).toContain("A-DETAIL-TEXT");
+    expect(dxf).toContain("A-DETAIL-HATCH");
+    expect(dxf).toContain("A-CALLOUT");
+    expect(dxf).toContain("D-CONCRETE");
+    expect(dxf).toContain("D-MASONRY");
+    expect(dxf).toContain("D-INSULATION");
+    expect(dxf).toContain("D-TIMBER");
+    expect(dxf).toContain("D-MEMBRANE");
+    expect(dxf).toContain("D-EARTH");
+    expect(dxf).toContain("D-GLAZING");
+    expect(dxf).toContain("D-METAL");
+    expect(dxf).toContain("DETAIL_CALLOUT");
+    expect(dxf).toContain("Wall/Foundation Junction");
+    expect(dxf).toContain("Roof Eaves Detail");
+    expect(dxf).toContain("Drainage Inspection Chamber");
+    expect(dxf).toContain("PAPER_SPACE_LAYOUT: D-501");
+    expect(dxf).toContain("CALLOUT construction-detail");
+    expect(dxf).toContain("PRELIMINARY CONSTRUCTION DETAIL INFORMATION ONLY");
+    expect(dxf).toContain("DIMENSION");
+    expect(dxf).toContain("HATCH");
     expect(dxf).not.toMatch(/  0\nIMAGE\n/);
     expect(dxf).not.toMatch(/  0\nRASTER\n/);
   });

--- a/src/__tests__/services/details/constructionDetailDrawingSetIntegration.test.js
+++ b/src/__tests__/services/details/constructionDetailDrawingSetIntegration.test.js
@@ -1,0 +1,124 @@
+import { __projectGraphVerticalSliceInternals } from "../../../services/project/projectGraphVerticalSliceService.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geometry-hash-detail-drawing-set-001",
+    projectGraphHash: "project-graph-hash-detail-drawing-set-001",
+    site: {
+      boundary_polygon: [
+        { x: 0, y: 0 },
+        { x: 18, y: 0 },
+        { x: 18, y: 12 },
+        { x: 0, y: 12 },
+      ],
+    },
+    levels: [{ id: "level-0", level_number: 0, name: "Ground", height_m: 3.2 }],
+    rooms: [{ id: "room-1", name: "Bathroom", type: "bathroom" }],
+    walls: [{ id: "wall-1" }],
+    openings: [{ id: "door-1", type: "door" }],
+    roof_primitives: [{ id: "roof-1" }],
+  };
+}
+
+describe("construction detail drawing-set integration", () => {
+  test("keeps detail sheets disabled by default", () => {
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+      {
+        layoutTemplate: "presentation-v3",
+      },
+    );
+    const panelTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(panelTypes).not.toContain("detail_sheet_architectural");
+    expect(panelTypes).not.toContain("detail_sheet_envelope");
+    expect(result.technicalBuild.detailLibrary).toBeNull();
+  });
+
+  test("adds detail drawing sheets and manifest entries when explicitly enabled", () => {
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+      {
+        layoutTemplate: "presentation-v3",
+        includeDetailDrawings: true,
+      },
+    );
+    const panelTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+    const detailArtifacts = Object.values(result.drawingArtifacts).filter(
+      (artifact) => artifact.drawingType === "detail",
+    );
+
+    expect(panelTypes).toEqual(
+      expect.arrayContaining([
+        "detail_sheet_architectural",
+        "detail_sheet_envelope",
+        "detail_sheet_wetroom_drainage",
+        "detail_sheet_mep_riser",
+        "detail_notes",
+      ]),
+    );
+    expect(result.technicalBuild.detailLibrary?.detailLibraryHash).toBeTruthy();
+    expect(detailArtifacts.length).toBeGreaterThan(0);
+    detailArtifacts.forEach((artifact) => {
+      expect(artifact.technicalDrawing).toBe(true);
+      expect(artifact.imageProviderUsed).toBe("none");
+      expect(artifact.metadata.detailLibraryHash).toBeTruthy();
+      expect(artifact.metadata.detailHashes.length).toBeGreaterThan(0);
+      expect(artifact.metadata.reviewRequired).toBe(true);
+      expect(artifact.svgString).toContain(
+        "ARCHITECT / ENGINEER REVIEW REQUIRED",
+      );
+    });
+  });
+});
+
+describe("construction detail drawing set environment gating", () => {
+  const originalDetailEnv = process.env.DETAIL_DRAWINGS_ENABLED;
+
+  afterEach(() => {
+    if (originalDetailEnv === undefined) {
+      delete process.env.DETAIL_DRAWINGS_ENABLED;
+    } else {
+      process.env.DETAIL_DRAWINGS_ENABLED = originalDetailEnv;
+    }
+  });
+
+  test("includes detail panels when DETAIL_DRAWINGS_ENABLED=true", () => {
+    process.env.DETAIL_DRAWINGS_ENABLED = "true";
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+    );
+    const drawingTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(drawingTypes).toEqual(
+      expect.arrayContaining([
+        "detail_sheet_architectural",
+        "detail_sheet_envelope",
+        "detail_sheet_wetroom_drainage",
+      ]),
+    );
+  });
+
+  test("keeps detail panels absent when DETAIL_DRAWINGS_ENABLED=false", () => {
+    process.env.DETAIL_DRAWINGS_ENABLED = "false";
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+    );
+    const drawingTypes = result.drawingSet.drawings.map(
+      (drawing) => drawing.panel_type,
+    );
+
+    expect(drawingTypes).not.toEqual(
+      expect.arrayContaining([
+        "detail_sheet_architectural",
+        "detail_sheet_envelope",
+      ]),
+    );
+  });
+});

--- a/src/__tests__/services/details/constructionDetailLibrary.test.js
+++ b/src/__tests__/services/details/constructionDetailLibrary.test.js
@@ -1,0 +1,159 @@
+import {
+  DETAIL_REVIEW_DISCLAIMER,
+  REQUIRED_CONSTRUCTION_DETAIL_TYPES,
+  buildConstructionDetailLibraryFromCompiledProject,
+  buildConstructionDetailPanelsFromCompiledProject,
+  validateConstructionDetailLibrary,
+} from "../../../services/details/constructionDetailLibrary.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geometry-hash-detail-001",
+    projectGraphHash: "project-graph-hash-detail-001",
+    projectName: "Detail Fixture",
+    jurisdiction: "uk",
+    site: {
+      boundary_polygon: [
+        { x: 0, y: 0 },
+        { x: 18, y: 0 },
+        { x: 18, y: 12 },
+        { x: 0, y: 12 },
+      ],
+    },
+    levels: [
+      { id: "level-0", level_number: 0, name: "Ground", height_m: 3.2 },
+      { id: "level-1", level_number: 1, name: "First", height_m: 3.2 },
+    ],
+    rooms: [
+      { id: "living", name: "Living", type: "living" },
+      { id: "bath", name: "Bathroom", type: "bathroom" },
+    ],
+    walls: [{ id: "wall-1" }],
+    openings: [{ id: "window-1", type: "window" }],
+    stairs: [{ id: "stair-1" }],
+    roof_primitives: [{ id: "roof-1" }],
+  };
+}
+
+describe("constructionDetailLibrary", () => {
+  test("builds deterministic required construction details with authority hashes", () => {
+    const first = buildConstructionDetailLibraryFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const second = buildConstructionDetailLibraryFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    const detailTypes = first.details.map((detail) => detail.detailType);
+
+    expect(first.geometryHash).toBe("geometry-hash-detail-001");
+    expect(first.sourceProjectGraphHash).toBe("project-graph-hash-detail-001");
+    expect(first.detailLibraryHash).toBe(second.detailLibraryHash);
+    expect(detailTypes).toEqual(
+      expect.arrayContaining(REQUIRED_CONSTRUCTION_DETAIL_TYPES),
+    );
+    first.details.forEach((detail) => {
+      expect(detail.detailHash).toBeTruthy();
+      expect(detail.geometryHash).toBe(first.geometryHash);
+      expect(detail.sourceProjectGraphHash).toBe(first.sourceProjectGraphHash);
+      expect(detail.reviewRequired).toBe(true);
+      expect(detail.disclaimer).toBe(DETAIL_REVIEW_DISCLAIMER);
+      expect(detail.svgString).toContain('data-image-provider-used="none"');
+      expect(detail.dxfEntities.length).toBeGreaterThan(0);
+    });
+  });
+
+  test("generates deterministic SVG detail panels with hatches, dimensions, callouts, and disclaimer", () => {
+    const { detailLibrary, detailPanels } =
+      buildConstructionDetailPanelsFromCompiledProject({
+        compiledProject: fixtureCompiledProject(),
+      });
+
+    expect(Object.keys(detailPanels)).toEqual(
+      expect.arrayContaining([
+        "detail_sheet_architectural",
+        "detail_sheet_envelope",
+        "detail_sheet_wetroom_drainage",
+        "detail_sheet_mep_riser",
+        "detail_notes",
+      ]),
+    );
+    Object.values(detailPanels).forEach((panel) => {
+      expect(panel.svgString).toContain("<svg");
+      expect(panel.svgString).toContain("hatch-concrete");
+      expect(panel.svgString).toContain("hatch-masonry");
+      expect(panel.svgString).toContain("hatch-insulation");
+      expect(panel.svgString).toContain("detail-dimension");
+      expect(panel.svgString).toContain("callout");
+      expect(panel.svgString).toContain("ARCHITECT / ENGINEER REVIEW REQUIRED");
+      expect(panel.technicalDrawing).toBe(true);
+      expect(panel.imageProviderUsed).toBe("none");
+      expect(panel.renderer).toBe("deterministic_svg");
+      expect(panel.reviewRequired).toBe(true);
+      expect(panel.geometryHash).toBe(detailLibrary.geometryHash);
+      expect(panel.sourceGeometryHash).toBe(detailLibrary.geometryHash);
+    });
+    expect(detailPanels.detail_sheet_architectural.svgString).toContain(
+      "Wall/Foundation Junction",
+    );
+    expect(detailPanels.detail_sheet_envelope.svgString).toContain(
+      "Roof Eaves Detail",
+    );
+    expect(detailPanels.detail_sheet_wetroom_drainage.svgString).toContain(
+      "Drainage Inspection Chamber",
+    );
+    expect(detailPanels.detail_sheet_mep_riser.svgString).toContain(
+      "MEP Riser Detail",
+    );
+  });
+
+  test("validates detail QA failures for missing hash, disclaimer, required type, hatches, dimensions, callouts, and image provider", () => {
+    const detailLibrary = buildConstructionDetailLibraryFromCompiledProject({
+      compiledProject: fixtureCompiledProject(),
+    });
+    expect(
+      validateConstructionDetailLibrary(detailLibrary, {
+        compiledProject: fixtureCompiledProject(),
+      }).valid,
+    ).toBe(true);
+
+    const broken = validateConstructionDetailLibrary(
+      {
+        ...detailLibrary,
+        detailLibraryHash: null,
+        disclaimers: [],
+        imageProviderUsed: "openai",
+        details: detailLibrary.details
+          .filter((detail) => detail.detailType !== "wall_foundation_junction")
+          .map((detail, index) =>
+            index === 0
+              ? {
+                  ...detail,
+                  detailHash: null,
+                  hatches: [],
+                  dimensions: [],
+                  dxfEntities: [],
+                  imageProviderUsed: "openai",
+                }
+              : detail,
+          ),
+      },
+      { compiledProject: fixtureCompiledProject() },
+    );
+    const codes = broken.errors.map((error) => error.code);
+
+    expect(broken.valid).toBe(false);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        "DETAIL_LIBRARY_HASH_MISSING",
+        "DETAIL_LIBRARY_DISCLAIMER_MISSING",
+        "DETAIL_LIBRARY_REQUIRED_DETAIL_MISSING",
+        "DETAIL_HASH_MISSING",
+        "DETAIL_HATCHES_MISSING",
+        "DETAIL_DIMENSIONS_MISSING",
+        "DETAIL_CALLOUTS_MISSING",
+        "DETAIL_IMAGE_PROVIDER_FORBIDDEN",
+        "DETAIL_LIBRARY_IMAGE_PROVIDER_FORBIDDEN",
+      ]),
+    );
+  });
+});

--- a/src/services/cad/canonicalDrawingModel.js
+++ b/src/services/cad/canonicalDrawingModel.js
@@ -7,6 +7,10 @@ import {
 } from "./projectGeometrySchema.js";
 import { buildStructuralModelFromCompiledProject } from "../structure/structuralModelService.js";
 import { buildMepModelFromCompiledProject } from "../mep/mepModelService.js";
+import {
+  buildConstructionDetailLibraryFromCompiledProject,
+  REQUIRED_CONSTRUCTION_DETAIL_TYPES,
+} from "../details/constructionDetailLibrary.js";
 
 export const CANONICAL_DRAWING_MODEL_VERSION = "canonical-drawing-model-v1";
 
@@ -57,6 +61,19 @@ export const REQUIRED_CANONICAL_CAD_LAYERS = Object.freeze([
   "MEP-RISER",
   "MEP-NOTES",
   "MEP-DIMS",
+  "A-DETAIL",
+  "A-DETAIL-DIMS",
+  "A-DETAIL-TEXT",
+  "A-DETAIL-HATCH",
+  "A-CALLOUT",
+  "D-CONCRETE",
+  "D-MASONRY",
+  "D-INSULATION",
+  "D-TIMBER",
+  "D-MEMBRANE",
+  "D-EARTH",
+  "D-GLAZING",
+  "D-METAL",
 ]);
 
 const STRUCTURAL_CANONICAL_CAD_LAYER_NAMES = new Set([
@@ -86,6 +103,22 @@ const MEP_CANONICAL_CAD_LAYER_NAMES = new Set([
   "MEP-NOTES",
   "MEP-DIMS",
   "F-FIRE",
+]);
+
+const DETAIL_CANONICAL_CAD_LAYER_NAMES = new Set([
+  "A-DETAIL",
+  "A-DETAIL-DIMS",
+  "A-DETAIL-TEXT",
+  "A-DETAIL-HATCH",
+  "A-CALLOUT",
+  "D-CONCRETE",
+  "D-MASONRY",
+  "D-INSULATION",
+  "D-TIMBER",
+  "D-MEMBRANE",
+  "D-EARTH",
+  "D-GLAZING",
+  "D-METAL",
 ]);
 
 export const DEFAULT_CANONICAL_CAD_LAYERS = Object.freeze([
@@ -339,6 +372,97 @@ export const DEFAULT_CANONICAL_CAD_LAYERS = Object.freeze([
     discipline: "fire",
     color: 1,
     lineweight: 25,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "A-DETAIL",
+    discipline: "architectural_detail",
+    color: 7,
+    lineweight: 35,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "A-DETAIL-DIMS",
+    discipline: "architectural_detail",
+    color: 2,
+    lineweight: 18,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "A-DETAIL-TEXT",
+    discipline: "architectural_detail",
+    color: 7,
+    lineweight: 18,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "A-DETAIL-HATCH",
+    discipline: "architectural_detail",
+    color: 9,
+    lineweight: 13,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "A-CALLOUT",
+    discipline: "architectural_detail",
+    color: 4,
+    lineweight: 25,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "D-CONCRETE",
+    discipline: "detail_material",
+    color: 8,
+    lineweight: 13,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "D-MASONRY",
+    discipline: "detail_material",
+    color: 30,
+    lineweight: 13,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "D-INSULATION",
+    discipline: "detail_material",
+    color: 6,
+    lineweight: 13,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "D-TIMBER",
+    discipline: "detail_material",
+    color: 40,
+    lineweight: 13,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "D-MEMBRANE",
+    discipline: "detail_material",
+    color: 1,
+    lineweight: 13,
+    linetype: "DASHED",
+  },
+  {
+    name: "D-EARTH",
+    discipline: "detail_material",
+    color: 32,
+    lineweight: 13,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "D-GLAZING",
+    discipline: "detail_material",
+    color: 5,
+    lineweight: 13,
+    linetype: "CONTINUOUS",
+  },
+  {
+    name: "D-METAL",
+    discipline: "detail_material",
+    color: 8,
+    lineweight: 18,
     linetype: "CONTINUOUS",
   },
 ]);
@@ -2014,6 +2138,170 @@ function buildMepPrimitiveEntities(
   return buildMepModelEntities(mepModel, geometryHash);
 }
 
+function buildConstructionDetailEntities(detailLibrary = {}, geometryHash) {
+  const entities = [];
+  toArray(detailLibrary.details).forEach((detail) => {
+    toArray(detail.dxfEntities).forEach((sourceEntity, index) => {
+      const sourceId = `${detail.detailId}-${sourceEntity.role || sourceEntity.type}-${index + 1}`;
+      const metadata = {
+        role: sourceEntity.role || "detail_entity",
+        detailId: detail.detailId,
+        detailType: detail.detailType,
+        detailHash: detail.detailHash,
+        detailLibraryHash: detailLibrary.detailLibraryHash,
+        relatedDrawingRefs: detail.relatedDrawingRefs || [],
+      };
+      const common = {
+        layer: sourceEntity.layer || "A-DETAIL",
+        viewType: "detail",
+        viewId: detail.detailType,
+        geometryHash,
+        sourceId,
+        metadata,
+      };
+
+      if (sourceEntity.type === "LWPOLYLINE") {
+        entities.push(
+          polylineEntity({
+            points: sourceEntity.points || [],
+            closed: sourceEntity.closed === true,
+            ...common,
+          }),
+        );
+      } else if (sourceEntity.type === "LINE") {
+        entities.push(
+          lineEntity({
+            start: sourceEntity.start || { x: 0, y: 0 },
+            end: sourceEntity.end || { x: 0, y: 0 },
+            ...common,
+          }),
+        );
+      } else if (sourceEntity.type === "HATCH") {
+        entities.push(
+          hatchEntity({
+            points: sourceEntity.points || [],
+            pattern: sourceEntity.material || "detail",
+            ...common,
+          }),
+        );
+      } else if (sourceEntity.type === "DIMENSION") {
+        entities.push(
+          dimensionEntity({
+            start: sourceEntity.start || { x: 0, y: 0 },
+            end: sourceEntity.end || { x: 0, y: 0 },
+            offset: sourceEntity.offset || { x: 0, y: 0 },
+            text: sourceEntity.text || detail.detailScale,
+            ...common,
+          }),
+        );
+      } else if (sourceEntity.type === "INSERT") {
+        entities.push(
+          insertEntity({
+            blockName: sourceEntity.blockName || "DETAIL_CALLOUT",
+            point: sourceEntity.point || { x: 0, y: 0 },
+            ...common,
+          }),
+        );
+      } else {
+        entities.push(
+          textEntity({
+            text: sourceEntity.text || detail.detailTitle,
+            point: sourceEntity.point || { x: 0, y: 0 },
+            height: sourceEntity.height || 0.16,
+            ...common,
+          }),
+        );
+      }
+    });
+  });
+
+  toArray(detailLibrary.details).forEach((detail, index) => {
+    const x = roundMetric(1.2 + index * 0.32);
+    const y = roundMetric(12.4 - index * 0.18);
+    entities.push(
+      insertEntity({
+        blockName: "DETAIL_CALLOUT",
+        point: { x, y },
+        layer: "A-CALLOUT",
+        viewType:
+          detail.detailType === "drainage_inspection_chamber"
+            ? "site_plan"
+            : detail.detailType === "mep_riser_detail"
+              ? "mep_plumbing_plan"
+              : detail.detailType.includes("roof") ||
+                  detail.detailType.includes("window")
+                ? "elevation"
+                : detail.detailType.includes("wet_room")
+                  ? "floor_plan"
+                  : "section",
+        viewId: `callout-${detail.detailType}`,
+        geometryHash,
+        sourceId: `detail-callout-${detail.detailType}`,
+        metadata: {
+          role: "detail_callout_marker",
+          detailId: detail.detailId,
+          detailType: detail.detailType,
+          detailHash: detail.detailHash,
+          detailLibraryHash: detailLibrary.detailLibraryHash,
+          relatedDrawingRefs: detail.relatedDrawingRefs || [],
+        },
+      }),
+      textEntity({
+        text: `DETAIL ${detail.relatedDrawingRefs?.[0] || detail.detailId}`,
+        point: { x: roundMetric(x + 0.18), y: roundMetric(y + 0.18) },
+        height: 0.14,
+        layer: "A-CALLOUT",
+        viewType: "detail_callout",
+        viewId: `callout-${detail.detailType}`,
+        geometryHash,
+        sourceId: `detail-callout-label-${detail.detailType}`,
+        metadata: {
+          role: "detail_callout_reference",
+          detailId: detail.detailId,
+          detailType: detail.detailType,
+          detailHash: detail.detailHash,
+          detailLibraryHash: detailLibrary.detailLibraryHash,
+        },
+      }),
+    );
+  });
+
+  toArray(detailLibrary.disclaimers).forEach((disclaimer, index) => {
+    entities.push(
+      textEntity({
+        text: disclaimer,
+        point: { x: 0.5, y: roundMetric(-5 - index * 0.3) },
+        height: 0.16,
+        layer: "A-DETAIL-TEXT",
+        viewType: "detail_notes",
+        viewId: "detail_notes",
+        geometryHash,
+        sourceId: `detail-review-disclaimer-${index + 1}`,
+        metadata: {
+          role: "review_disclaimer",
+          detailLibraryHash: detailLibrary.detailLibraryHash,
+        },
+      }),
+    );
+  });
+
+  return entities;
+}
+
+function buildConstructionDetailPrimitiveEntities(
+  compiledProject = {},
+  geometryHash,
+  includeDetailDrawings = false,
+) {
+  if (!includeDetailDrawings) {
+    return [];
+  }
+  const detailLibrary = buildConstructionDetailLibraryFromCompiledProject({
+    compiledProject,
+  });
+  return buildConstructionDetailEntities(detailLibrary, geometryHash);
+}
+
 function defaultBlocks(geometryHash) {
   const block = (name, description, entities = []) => ({
     name,
@@ -2098,6 +2386,19 @@ function defaultBlocks(geometryHash) {
     block("MEP_EXTRACT_FAN", "MEP extract fan symbol", []),
     block("MEP_RISER", "MEP riser symbol", []),
     block("MEP_EQUIPMENT", "MEP equipment symbol", []),
+    block("DETAIL_CALLOUT", "Construction detail callout marker", [
+      {
+        type: "LINE",
+        layer: "A-CALLOUT",
+        geometry: { start: { x: -0.15, y: 0 }, end: { x: 0.15, y: 0 } },
+      },
+      {
+        type: "LINE",
+        layer: "A-CALLOUT",
+        geometry: { start: { x: 0, y: -0.15 }, end: { x: 0, y: 0.15 } },
+      },
+    ]),
+    block("DETAIL_TITLE", "Construction detail title block symbol", []),
   ];
 }
 
@@ -2528,6 +2829,138 @@ function buildDrawingScales() {
   ];
 }
 
+function buildDetailPaperSpaceSheets({
+  baseSheet,
+  detailLibrary,
+  geometryHash,
+  sourceProjectGraphHash,
+  jurisdiction,
+  units,
+} = {}) {
+  if (!baseSheet || !detailLibrary) {
+    return [];
+  }
+  const detailSheets = [
+    {
+      sheetId: "D-501",
+      panelType: "detail_sheet_architectural",
+      title: "Architectural Details",
+      scale: "1:10",
+    },
+    {
+      sheetId: "D-502",
+      panelType: "detail_sheet_envelope",
+      title: "Envelope Details",
+      scale: "1:5",
+    },
+    {
+      sheetId: "D-503",
+      panelType: "detail_sheet_wetroom_drainage",
+      title: "Wet Room and Drainage Details",
+      scale: "1:10",
+    },
+    {
+      sheetId: "D-504",
+      panelType: "detail_sheet_mep_riser",
+      title: "MEP Riser Detail",
+      scale: "1:10",
+    },
+  ];
+
+  return detailSheets.map((sheet, index) => {
+    const layoutName = sheet.sheetId;
+    const viewportHandle = cadHandle(
+      "detail-viewport",
+      layoutName,
+      geometryHash,
+    );
+    const layoutHandle = cadHandle("detail-layout", layoutName, geometryHash);
+    const blockRecordHandle = cadHandle(
+      "detail-block-record",
+      layoutName,
+      geometryHash,
+    );
+    const plotSettingsHandle = cadHandle(
+      "detail-plot-settings",
+      layoutName,
+      geometryHash,
+    );
+    return {
+      ...clone(baseSheet),
+      sheetId: sheet.sheetId,
+      sheetNumber: sheet.sheetId,
+      drawingNumber: sheet.sheetId,
+      layoutName,
+      title: sheet.title,
+      scale: sheet.scale,
+      discipline: "detail",
+      geometryHash,
+      sourceProjectGraphHash,
+      jurisdiction,
+      units,
+      modelViews: [sheet.panelType],
+      detailLibraryHash: detailLibrary.detailLibraryHash,
+      detailIds: toArray(detailLibrary.details)
+        .filter((detail) =>
+          sheet.panelType === "detail_sheet_architectural"
+            ? detail.group === "architectural"
+            : sheet.panelType === "detail_sheet_envelope"
+              ? detail.group === "envelope"
+              : sheet.panelType === "detail_sheet_wetroom_drainage"
+                ? detail.group === "wetroom_drainage"
+                : detail.group === "mep_riser",
+        )
+        .map((detail) => detail.detailId),
+      drawingIndex: {
+        ...(baseSheet.drawingIndex || {}),
+        sheetNumber: sheet.sheetId,
+        title: sheet.title,
+        scale: sheet.scale,
+        discipline: "detail",
+        detailLibraryHash: detailLibrary.detailLibraryHash,
+      },
+      nativeLayout: {
+        ...(baseSheet.nativeLayout || {}),
+        layoutName,
+        layoutHandle,
+        blockRecordHandle,
+        plotSettingsHandle,
+        ownerHandle: cadHandle("detail-layout-owner", layoutName),
+      },
+      plotSettings: {
+        ...(baseSheet.plotSettings || {}),
+        plotSettingsHandle,
+        plotStyleTable: "archiai-monochrome.ctb",
+      },
+      viewports: [
+        {
+          ...(toArray(baseSheet.viewports)[0] || {}),
+          viewportId: `vp-${sheet.panelType}`,
+          viewId: sheet.panelType,
+          viewType: "detail",
+          layoutName,
+          scale: sheet.scale,
+          geometryHash,
+          sourceProjectGraphHash,
+          nativeViewport: {
+            ...((toArray(baseSheet.viewports)[0] || {}).nativeViewport || {}),
+            entityType: "VIEWPORT",
+            className: "AcDbViewport",
+            viewportHandle,
+            layoutName,
+            ownerHandle: blockRecordHandle,
+          },
+          metadata: {
+            detailLibraryHash: detailLibrary.detailLibraryHash,
+            paperSpace: true,
+          },
+        },
+      ],
+      order: (baseSheet.order || 0) + index + 10,
+    };
+  });
+}
+
 export function buildCanonicalDrawingModelFromCompiledProject({
   compiledProject,
   projectName = null,
@@ -2537,6 +2970,8 @@ export function buildCanonicalDrawingModelFromCompiledProject({
   structuralDrawingsEnabled = false,
   includeMepDrawings = false,
   mepDrawingsEnabled = false,
+  includeDetailDrawings = false,
+  detailDrawingsEnabled = false,
 } = {}) {
   if (!compiledProject?.geometryHash) {
     throw new Error(
@@ -2552,6 +2987,8 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     includeStructuralDrawings === true || structuralDrawingsEnabled === true;
   const shouldIncludeMepDrawings =
     includeMepDrawings === true || mepDrawingsEnabled === true;
+  const shouldIncludeDetailDrawings =
+    includeDetailDrawings === true || detailDrawingsEnabled === true;
   const structuralModel = shouldIncludeStructuralDrawings
     ? buildStructuralModelFromCompiledProject({
         compiledProject,
@@ -2560,6 +2997,12 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     : null;
   const mepModel = shouldIncludeMepDrawings
     ? buildMepModelFromCompiledProject({
+        compiledProject,
+        jurisdiction: resolvedJurisdiction,
+      })
+    : null;
+  const detailLibrary = shouldIncludeDetailDrawings
+    ? buildConstructionDetailLibraryFromCompiledProject({
         compiledProject,
         jurisdiction: resolvedJurisdiction,
       })
@@ -2579,8 +3022,13 @@ export function buildCanonicalDrawingModelFromCompiledProject({
       geometryHash,
       shouldIncludeMepDrawings,
     ),
+    ...buildConstructionDetailPrimitiveEntities(
+      compiledProject,
+      geometryHash,
+      shouldIncludeDetailDrawings,
+    ),
   ];
-  const sheets = buildPaperSpaceSheets({
+  const architecturalSheets = buildPaperSpaceSheets({
     compiledProject,
     geometryHash,
     sourceProjectGraphHash,
@@ -2588,6 +3036,17 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     units,
     projectName: resolvedProjectName,
   });
+  const sheets = [
+    ...architecturalSheets,
+    ...buildDetailPaperSpaceSheets({
+      baseSheet: architecturalSheets[0],
+      detailLibrary,
+      geometryHash,
+      sourceProjectGraphHash,
+      jurisdiction: resolvedJurisdiction,
+      units,
+    }),
+  ];
 
   return {
     schema_version: CANONICAL_DRAWING_MODEL_VERSION,
@@ -2610,12 +3069,15 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     plotStyleMetadata: clone(DEFAULT_PLOT_STYLE_METADATA),
     ...(structuralModel ? { structuralModel } : {}),
     ...(mepModel ? { mepModel } : {}),
+    ...(detailLibrary ? { detailLibrary } : {}),
     layers: clone(DEFAULT_CANONICAL_CAD_LAYERS).filter(
       (layer) =>
         (shouldIncludeStructuralDrawings ||
           !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layer.name)) &&
         (shouldIncludeMepDrawings ||
-          !MEP_CANONICAL_CAD_LAYER_NAMES.has(layer.name)),
+          !MEP_CANONICAL_CAD_LAYER_NAMES.has(layer.name)) &&
+        (shouldIncludeDetailDrawings ||
+          !DETAIL_CANONICAL_CAD_LAYER_NAMES.has(layer.name)),
     ),
     blocks: defaultBlocks(geometryHash),
     hatches: clone(DEFAULT_HATCHES),
@@ -2698,6 +3160,8 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
     Boolean(model.structuralModel) || options.requireStructuralModel === true;
   const shouldValidateMepModel =
     Boolean(model.mepModel) || options.requireMepModel === true;
+  const shouldValidateDetailLibrary =
+    Boolean(model.detailLibrary) || options.requireDetailLibrary === true;
 
   if (model.schema_version !== CANONICAL_DRAWING_MODEL_VERSION) {
     errors.push(
@@ -2855,7 +3319,10 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
     (layerName) =>
       (shouldValidateStructuralModel ||
         !STRUCTURAL_CANONICAL_CAD_LAYER_NAMES.has(layerName)) &&
-      (shouldValidateMepModel || !MEP_CANONICAL_CAD_LAYER_NAMES.has(layerName)),
+      (shouldValidateMepModel ||
+        !MEP_CANONICAL_CAD_LAYER_NAMES.has(layerName)) &&
+      (shouldValidateDetailLibrary ||
+        !DETAIL_CANONICAL_CAD_LAYER_NAMES.has(layerName)),
   );
   requiredLayerNames.forEach((layerName) => {
     if (!layerNames.has(layerName)) {
@@ -3093,6 +3560,137 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
     );
   }
 
+  const detailLibraryDetails = toArray(model.detailLibrary?.details);
+  const detailTypes = new Set(
+    detailLibraryDetails.map((detail) => detail.detailType),
+  );
+  if (shouldValidateDetailLibrary && !model.detailLibrary?.detailLibraryHash) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_DETAIL_LIBRARY_HASH_MISSING",
+        "CanonicalDrawingModel requires detailLibrary.detailLibraryHash when detail drawings are enabled.",
+      ),
+    );
+  }
+  if (
+    shouldValidateDetailLibrary &&
+    model.detailLibrary?.geometryHash &&
+    model.geometryHash &&
+    model.detailLibrary.geometryHash !== model.geometryHash
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_DETAIL_GEOMETRY_HASH_MISMATCH",
+        "Construction detail library geometryHash must match CanonicalDrawingModel geometryHash.",
+        {
+          detailGeometryHash: model.detailLibrary.geometryHash,
+          geometryHash: model.geometryHash,
+        },
+      ),
+    );
+  }
+  if (
+    shouldValidateDetailLibrary &&
+    model.detailLibrary?.reviewRequired !== true
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_DETAIL_REVIEW_REQUIRED_MISSING",
+        "Construction detail library must be marked reviewRequired=true.",
+      ),
+    );
+  }
+  if (
+    shouldValidateDetailLibrary &&
+    !toArray(model.detailLibrary?.disclaimers)
+      .join(" ")
+      .match(/architect and engineer/i)
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_DETAIL_DISCLAIMER_MISSING",
+        "Construction detail library requires architect and engineer review disclaimer.",
+      ),
+    );
+  }
+  if (shouldValidateDetailLibrary) {
+    REQUIRED_CONSTRUCTION_DETAIL_TYPES.forEach((detailType) => {
+      if (!detailTypes.has(detailType)) {
+        errors.push(
+          validationError(
+            "CAD_MODEL_DETAIL_REQUIRED_TYPE_MISSING",
+            `Construction detail library is missing ${detailType}.`,
+            { detailType },
+          ),
+        );
+      }
+    });
+    detailLibraryDetails.forEach((detail) => {
+      if (!detail.detailHash) {
+        errors.push(
+          validationError(
+            "CAD_MODEL_DETAIL_HASH_MISSING",
+            "Construction detail is missing detailHash.",
+            { detailId: detail.detailId, detailType: detail.detailType },
+          ),
+        );
+      }
+      if (!toArray(detail.hatches).length) {
+        errors.push(
+          validationError(
+            "CAD_MODEL_DETAIL_HATCHES_MISSING",
+            "Construction detail is missing material hatches.",
+            { detailId: detail.detailId, detailType: detail.detailType },
+          ),
+        );
+      }
+      if (!toArray(detail.dimensions).length) {
+        errors.push(
+          validationError(
+            "CAD_MODEL_DETAIL_DIMENSIONS_MISSING",
+            "Construction detail is missing dimensions.",
+            { detailId: detail.detailId, detailType: detail.detailType },
+          ),
+        );
+      }
+      if (
+        !toArray(detail.dxfEntities).some((entity) =>
+          String(entity.role || "").includes("callout"),
+        )
+      ) {
+        errors.push(
+          validationError(
+            "CAD_MODEL_DETAIL_CALLOUTS_MISSING",
+            "Construction detail is missing callout references.",
+            { detailId: detail.detailId, detailType: detail.detailType },
+          ),
+        );
+      }
+      if (detail.imageProviderUsed && detail.imageProviderUsed !== "none") {
+        errors.push(
+          validationError(
+            "CAD_MODEL_DETAIL_IMAGE_PROVIDER_FORBIDDEN",
+            "Construction details must not use image generation.",
+            { detailId: detail.detailId, detailType: detail.detailType },
+          ),
+        );
+      }
+      if (
+        `${detail.disclaimer || ""} ${toArray(detail.annotations).join(" ")}`.match(
+          /approved for construction|code compliant|certified/i,
+        )
+      ) {
+        errors.push(
+          validationError(
+            "CAD_MODEL_DETAIL_FALSE_APPROVAL_CLAIM",
+            "Construction details must not claim construction approval or code certification.",
+            { detailId: detail.detailId, detailType: detail.detailType },
+          ),
+        );
+      }
+    });
+  }
+
   const hasNativeLayouts =
     sheets.length > 0 &&
     sheets.every((sheet) => sheet.nativeLayout?.className === "AcDbLayout");
@@ -3122,6 +3720,10 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
   const hasMepDisclaimer = toArray(model.mepModel?.disclaimers)
     .join(" ")
     .match(/qualified MEP engineer/i);
+  const hasDetailLibraryHash = Boolean(model.detailLibrary?.detailLibraryHash);
+  const hasDetailDisclaimer = toArray(model.detailLibrary?.disclaimers)
+    .join(" ")
+    .match(/architect and engineer/i);
 
   return {
     valid: errors.length === 0,
@@ -3151,6 +3753,11 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
       hasMepDisclaimer: Boolean(hasMepDisclaimer),
       mepReviewRequired: model.mepModel?.reviewRequired === true,
       mepImageProviderUsed: model.mepModel?.imageProviderUsed || null,
+      hasDetailLibraryHash,
+      hasDetailDisclaimer: Boolean(hasDetailDisclaimer),
+      detailReviewRequired: model.detailLibrary?.reviewRequired === true,
+      detailImageProviderUsed: model.detailLibrary?.imageProviderUsed || null,
+      detailCount: detailLibraryDetails.length,
     },
   };
 }

--- a/src/services/details/constructionDetailLibrary.js
+++ b/src/services/details/constructionDetailLibrary.js
@@ -1,0 +1,674 @@
+import {
+  createStableHash,
+  createStableId,
+  roundMetric,
+} from "../cad/projectGeometrySchema.js";
+
+export const CONSTRUCTION_DETAIL_LIBRARY_VERSION =
+  "construction-detail-library-v1";
+export const CONSTRUCTION_DETAIL_PANEL_VERSION = "construction-detail-panel-v1";
+
+export const DETAIL_REVIEW_DISCLAIMER =
+  "PRELIMINARY CONSTRUCTION DETAIL INFORMATION ONLY - not for construction. Review, coordination, code compliance, and approval by the responsible architect and engineer are required.";
+
+export const REQUIRED_CONSTRUCTION_DETAIL_TYPES = Object.freeze([
+  "wall_foundation_junction",
+  "floor_wall_junction",
+  "roof_eaves_detail",
+  "roof_ridge_detail",
+  "window_head_sill_jamb",
+  "door_threshold_detail",
+  "stair_detail",
+  "wet_room_floor_wall_detail",
+  "drainage_inspection_chamber",
+  "mep_riser_detail",
+]);
+
+export const REQUIRED_DETAIL_CAD_LAYERS = Object.freeze([
+  "A-DETAIL",
+  "A-DETAIL-DIMS",
+  "A-DETAIL-TEXT",
+  "A-DETAIL-HATCH",
+  "A-CALLOUT",
+  "D-CONCRETE",
+  "D-MASONRY",
+  "D-INSULATION",
+  "D-TIMBER",
+  "D-MEMBRANE",
+  "D-EARTH",
+  "D-GLAZING",
+  "D-METAL",
+]);
+
+const DETAIL_DEFINITIONS = Object.freeze([
+  {
+    detailType: "wall_foundation_junction",
+    detailTitle: "Wall/Foundation Junction",
+    detailScale: "1:10",
+    group: "architectural",
+    materialLayers: ["earth", "concrete", "masonry", "insulation", "membrane"],
+    sourceElements: ["foundations", "walls", "slabs"],
+  },
+  {
+    detailType: "floor_wall_junction",
+    detailTitle: "Floor/Wall Junction",
+    detailScale: "1:10",
+    group: "architectural",
+    materialLayers: ["concrete", "masonry", "insulation", "timber"],
+    sourceElements: ["slabs", "walls"],
+  },
+  {
+    detailType: "roof_eaves_detail",
+    detailTitle: "Roof Eaves Detail",
+    detailScale: "1:5",
+    group: "envelope",
+    materialLayers: ["timber", "insulation", "membrane", "masonry"],
+    sourceElements: ["roof", "walls"],
+  },
+  {
+    detailType: "roof_ridge_detail",
+    detailTitle: "Roof Ridge Detail",
+    detailScale: "1:5",
+    group: "envelope",
+    materialLayers: ["timber", "insulation", "membrane", "metal"],
+    sourceElements: ["roof"],
+  },
+  {
+    detailType: "window_head_sill_jamb",
+    detailTitle: "Window Head/Sill/Jamb",
+    detailScale: "1:5",
+    group: "envelope",
+    materialLayers: ["masonry", "insulation", "glazing", "membrane", "metal"],
+    sourceElements: ["openings", "walls"],
+  },
+  {
+    detailType: "door_threshold_detail",
+    detailTitle: "Door Threshold Detail",
+    detailScale: "1:5",
+    group: "architectural",
+    materialLayers: ["concrete", "masonry", "timber", "membrane", "metal"],
+    sourceElements: ["openings", "slabs"],
+  },
+  {
+    detailType: "stair_detail",
+    detailTitle: "Stair Detail",
+    detailScale: "1:10",
+    group: "architectural",
+    materialLayers: ["timber", "metal", "concrete"],
+    sourceElements: ["stairs", "levels"],
+  },
+  {
+    detailType: "wet_room_floor_wall_detail",
+    detailTitle: "Wet Room Floor/Wall Detail",
+    detailScale: "1:5",
+    group: "wetroom_drainage",
+    materialLayers: ["concrete", "membrane", "insulation", "masonry"],
+    sourceElements: ["rooms", "slabs"],
+  },
+  {
+    detailType: "drainage_inspection_chamber",
+    detailTitle: "Drainage Inspection Chamber",
+    detailScale: "1:20",
+    group: "wetroom_drainage",
+    materialLayers: ["earth", "concrete", "masonry", "membrane"],
+    sourceElements: ["site", "rooms"],
+  },
+  {
+    detailType: "mep_riser_detail",
+    detailTitle: "MEP Riser Detail",
+    detailScale: "1:10",
+    group: "mep_riser",
+    materialLayers: ["masonry", "metal", "membrane", "insulation"],
+    sourceElements: ["rooms", "levels"],
+  },
+]);
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function sourceProjectGraphHashOf(compiledProject = {}) {
+  return (
+    compiledProject.sourceProjectGraphHash ||
+    compiledProject.projectGraphHash ||
+    compiledProject.projectGraph?.hash ||
+    compiledProject.metadata?.sourceProjectGraphHash ||
+    compiledProject.metadata?.projectGraphHash ||
+    compiledProject.geometryHash ||
+    null
+  );
+}
+
+function jurisdictionOf(compiledProject = {}, jurisdiction = null) {
+  return (
+    jurisdiction ||
+    compiledProject.jurisdiction ||
+    compiledProject.project?.jurisdiction ||
+    compiledProject.metadata?.jurisdiction ||
+    "generic"
+  );
+}
+
+function projectContext(compiledProject = {}) {
+  return {
+    levelCount: toArray(compiledProject.levels).length || 1,
+    roomCount: toArray(compiledProject.rooms).length,
+    wallCount: toArray(compiledProject.walls).length,
+    openingCount: toArray(compiledProject.openings).length,
+    hasWetRooms: toArray(compiledProject.rooms).some((room) =>
+      /bath|wc|toilet|shower|wet|utility|laundry/i.test(
+        `${room.type || ""} ${room.roomType || ""} ${room.name || ""}`,
+      ),
+    ),
+    hasStairs: toArray(compiledProject.stairs).length > 0,
+    hasRoof:
+      toArray(compiledProject.roof_primitives).length > 0 ||
+      Boolean(compiledProject.roof),
+  };
+}
+
+function layerForMaterial(material) {
+  return (
+    {
+      concrete: "D-CONCRETE",
+      masonry: "D-MASONRY",
+      insulation: "D-INSULATION",
+      timber: "D-TIMBER",
+      membrane: "D-MEMBRANE",
+      earth: "D-EARTH",
+      glazing: "D-GLAZING",
+      metal: "D-METAL",
+    }[material] || "A-DETAIL-HATCH"
+  );
+}
+
+function detailBasePoint(index) {
+  const column = index % 2;
+  const row = Math.floor(index / 2);
+  return {
+    x: roundMetric(column * 5.2),
+    y: roundMetric(row * -3.4),
+  };
+}
+
+function buildDetailDxfEntities(definition, index) {
+  const base = detailBasePoint(index);
+  const id = definition.detailType;
+  const materialHatches = definition.materialLayers.map(
+    (material, layerIndex) => {
+      const x0 = roundMetric(base.x + 0.25 + layerIndex * 0.34);
+      const y0 = roundMetric(base.y + 0.35);
+      return {
+        type: "HATCH",
+        layer: layerForMaterial(material),
+        points: [
+          { x: x0, y: y0 },
+          { x: roundMetric(x0 + 0.28), y: y0 },
+          { x: roundMetric(x0 + 0.28), y: roundMetric(y0 + 1.3) },
+          { x: x0, y: roundMetric(y0 + 1.3) },
+        ],
+        material,
+        role: "detail_material_hatch",
+      };
+    },
+  );
+
+  return [
+    {
+      type: "LWPOLYLINE",
+      layer: "A-DETAIL",
+      points: [
+        { x: base.x, y: base.y },
+        { x: roundMetric(base.x + 4.4), y: base.y },
+        { x: roundMetric(base.x + 4.4), y: roundMetric(base.y + 2.6) },
+        { x: base.x, y: roundMetric(base.y + 2.6) },
+      ],
+      closed: true,
+      role: "detail_outline",
+    },
+    {
+      type: "HATCH",
+      layer: "A-DETAIL-HATCH",
+      points: [
+        { x: roundMetric(base.x + 2.65), y: roundMetric(base.y + 0.35) },
+        { x: roundMetric(base.x + 3.15), y: roundMetric(base.y + 0.35) },
+        { x: roundMetric(base.x + 3.15), y: roundMetric(base.y + 1.3) },
+        { x: roundMetric(base.x + 2.65), y: roundMetric(base.y + 1.3) },
+      ],
+      material: "generic_detail",
+      role: "detail_material_hatch",
+    },
+    ...materialHatches,
+    {
+      type: "LINE",
+      layer: "A-DETAIL",
+      start: { x: roundMetric(base.x + 0.3), y: roundMetric(base.y + 1.9) },
+      end: { x: roundMetric(base.x + 4.05), y: roundMetric(base.y + 1.9) },
+      role: "detail_section_line",
+    },
+    {
+      type: "DIMENSION",
+      layer: "A-DETAIL-DIMS",
+      start: { x: base.x, y: base.y },
+      end: { x: roundMetric(base.x + 4.4), y: base.y },
+      offset: { x: base.x, y: roundMetric(base.y - 0.35) },
+      text: `${definition.detailScale} coordination dimension`,
+      role: "detail_dimension",
+    },
+    {
+      type: "TEXT",
+      layer: "A-DETAIL-TEXT",
+      point: { x: base.x, y: roundMetric(base.y + 2.9) },
+      text: `${definition.detailTitle} ${definition.detailScale}`,
+      height: 0.18,
+      role: "detail_title",
+    },
+    {
+      type: "TEXT",
+      layer: "A-CALLOUT",
+      point: { x: roundMetric(base.x + 3.1), y: roundMetric(base.y + 2.35) },
+      text: `CALLOUT ${id}`,
+      height: 0.14,
+      role: "detail_callout_reference",
+    },
+    {
+      type: "INSERT",
+      layer: "A-CALLOUT",
+      blockName: "DETAIL_CALLOUT",
+      point: { x: roundMetric(base.x + 3.85), y: roundMetric(base.y + 2.15) },
+      role: "detail_callout",
+    },
+  ];
+}
+
+function svgEscape(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function materialPatternDefinitions() {
+  return `<defs>
+<pattern id="hatch-concrete" width="8" height="8" patternUnits="userSpaceOnUse"><path d="M0 8 L8 0" stroke="#57606a" stroke-width="1"/></pattern>
+<pattern id="hatch-masonry" width="12" height="8" patternUnits="userSpaceOnUse"><path d="M0 0 H12 M0 4 H12 M0 8 H12 M6 0 V4 M0 4 V8" stroke="#784421" stroke-width="1"/></pattern>
+<pattern id="hatch-insulation" width="12" height="8" patternUnits="userSpaceOnUse"><path d="M0 4 C3 0 6 8 9 4 S12 4 12 4" stroke="#c084fc" stroke-width="1" fill="none"/></pattern>
+<pattern id="hatch-timber" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M0 2 H10 M0 7 H10" stroke="#8b5a2b" stroke-width="1"/></pattern>
+<pattern id="hatch-earth" width="10" height="10" patternUnits="userSpaceOnUse"><circle cx="2" cy="2" r="1" fill="#6b4f2a"/><circle cx="8" cy="6" r="1" fill="#6b4f2a"/></pattern>
+<pattern id="hatch-glazing" width="8" height="8" patternUnits="userSpaceOnUse"><path d="M0 8 L8 0" stroke="#2563eb" stroke-width="1"/></pattern>
+<pattern id="hatch-membrane" width="6" height="6" patternUnits="userSpaceOnUse"><path d="M0 3 H6" stroke="#dc2626" stroke-width="1"/></pattern>
+</defs>`;
+}
+
+function hatchClass(material) {
+  return `hatch-${material}`;
+}
+
+function buildDetailSvg(definition, index, detailId) {
+  const x = 28 + (index % 2) * 250;
+  const y = 54 + Math.floor(index / 2) * 170;
+  const hatches = definition.materialLayers
+    .map((material, layerIndex) => {
+      const fill = `url(#hatch-${material})`;
+      return `<rect class="${hatchClass(material)} detail-hatch" x="${x + 14 + layerIndex * 24}" y="${y + 36}" width="22" height="86" fill="${fill}" stroke="#1f2937"/>`;
+    })
+    .join("");
+  return `<g class="construction-detail" data-detail-id="${svgEscape(detailId)}" data-detail-type="${svgEscape(definition.detailType)}">
+<rect class="detail-frame" x="${x}" y="${y}" width="220" height="142"/>
+<text class="detail-title" x="${x + 10}" y="${y + 20}">${svgEscape(definition.detailTitle)}</text>
+<text class="detail-scale" x="${x + 10}" y="${y + 38}">Scale ${svgEscape(definition.detailScale)}</text>
+${hatches}
+<line class="detail-line" x1="${x + 16}" y1="${y + 122}" x2="${x + 196}" y2="${y + 122}"/>
+<line class="detail-dimension" x1="${x + 16}" y1="${y + 132}" x2="${x + 196}" y2="${y + 132}"/>
+<text class="dimension-label" x="${x + 68}" y="${y + 128}">dimension</text>
+<circle class="callout-marker" cx="${x + 190}" cy="${y + 30}" r="12"/>
+<text class="callout-label" x="${x + 176}" y="${y + 34}">${svgEscape(detailId)}</text>
+</g>`;
+}
+
+function buildConstructionDetail(definition, index, context) {
+  const detailId = createStableId(
+    "construction-detail",
+    context.geometryHash,
+    definition.detailType,
+  );
+  const annotations = [
+    `${definition.detailTitle} is preliminary and coordination-only.`,
+    "Verify dimensions, materials, fire, acoustic, waterproofing, and structural requirements before construction.",
+  ];
+  const dimensions = [
+    {
+      id: `${definition.detailType}-dimension-1`,
+      label: `${definition.detailScale} coordination dimension`,
+      layer: "A-DETAIL-DIMS",
+    },
+  ];
+  const hatches = definition.materialLayers.map((material) => ({
+    material,
+    layer: layerForMaterial(material),
+    pattern: `hatch-${material}`,
+  }));
+  const dxfEntities = buildDetailDxfEntities(definition, index).map((entity) =>
+    entity.role === "detail_callout_reference"
+      ? { ...entity, text: `CALLOUT ${detailId}` }
+      : entity,
+  );
+  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="220" viewBox="0 0 320 220" data-technical-drawing="true" data-image-provider-used="none">${materialPatternDefinitions()}${buildDetailSvg(definition, 0, detailId)}<text class="review" x="18" y="204">${svgEscape(DETAIL_REVIEW_DISCLAIMER)}</text></svg>`;
+  const draft = {
+    version: CONSTRUCTION_DETAIL_LIBRARY_VERSION,
+    detailId,
+    detailType: definition.detailType,
+    detailTitle: definition.detailTitle,
+    detailScale: definition.detailScale,
+    group: definition.group,
+    geometryHash: context.geometryHash,
+    sourceProjectGraphHash: context.sourceProjectGraphHash,
+    jurisdiction: context.jurisdiction,
+    sourceElements: definition.sourceElements,
+    materialLayers: definition.materialLayers,
+    annotations,
+    dimensions,
+    hatches,
+    reviewRequired: true,
+    disclaimer: DETAIL_REVIEW_DISCLAIMER,
+    relatedDrawingRefs: [`REF-${String(index + 1).padStart(2, "0")}`],
+    cadLayers: [...REQUIRED_DETAIL_CAD_LAYERS],
+    svgString,
+    dxfEntities,
+    imageProviderUsed: "none",
+    technicalDrawing: true,
+  };
+  return {
+    ...draft,
+    detailHash: createStableHash(JSON.stringify(draft)),
+  };
+}
+
+export function buildConstructionDetailLibraryFromCompiledProject({
+  compiledProject,
+  jurisdiction = null,
+} = {}) {
+  if (!compiledProject?.geometryHash) {
+    throw new Error(
+      "Compiled project with geometryHash is required to build construction details.",
+    );
+  }
+  const context = {
+    geometryHash: compiledProject.geometryHash,
+    sourceProjectGraphHash: sourceProjectGraphHashOf(compiledProject),
+    jurisdiction: jurisdictionOf(compiledProject, jurisdiction),
+    projectContext: projectContext(compiledProject),
+  };
+  const details = DETAIL_DEFINITIONS.map((definition, index) =>
+    buildConstructionDetail(definition, index, context),
+  );
+  const draft = {
+    version: CONSTRUCTION_DETAIL_LIBRARY_VERSION,
+    detailLibraryId: createStableId(
+      "construction-detail-library",
+      context.geometryHash,
+    ),
+    geometryHash: context.geometryHash,
+    sourceProjectGraphHash: context.sourceProjectGraphHash,
+    jurisdiction: context.jurisdiction,
+    reviewRequired: true,
+    disclaimer: DETAIL_REVIEW_DISCLAIMER,
+    disclaimers: [DETAIL_REVIEW_DISCLAIMER],
+    requiredDetailTypes: [...REQUIRED_CONSTRUCTION_DETAIL_TYPES],
+    requiredCadLayers: [...REQUIRED_DETAIL_CAD_LAYERS],
+    details,
+    detailIds: details.map((detail) => detail.detailId),
+    projectContext: context.projectContext,
+    imageProviderUsed: "none",
+    technicalDrawing: true,
+  };
+  return {
+    ...draft,
+    detailLibraryHash: createStableHash(JSON.stringify(draft)),
+  };
+}
+
+function panelTitle(panelType) {
+  return {
+    detail_sheet_architectural: "Architectural Construction Details",
+    detail_sheet_envelope: "Envelope Construction Details",
+    detail_sheet_wetroom_drainage: "Wet Room and Drainage Details",
+    detail_sheet_mep_riser: "MEP Riser Detail",
+    detail_notes: "Construction Detail Notes",
+  }[panelType];
+}
+
+function detailsForPanel(detailLibrary, panelType) {
+  const details = toArray(detailLibrary.details);
+  if (panelType === "detail_sheet_architectural") {
+    return details.filter((detail) => detail.group === "architectural");
+  }
+  if (panelType === "detail_sheet_envelope") {
+    return details.filter((detail) => detail.group === "envelope");
+  }
+  if (panelType === "detail_sheet_wetroom_drainage") {
+    return details.filter((detail) => detail.group === "wetroom_drainage");
+  }
+  if (panelType === "detail_sheet_mep_riser") {
+    return details.filter((detail) => detail.group === "mep_riser");
+  }
+  return details;
+}
+
+function buildPanelSvg(detailLibrary, panelType) {
+  const details = detailsForPanel(detailLibrary, panelType);
+  const detailMarkup =
+    panelType === "detail_notes"
+      ? toArray(detailLibrary.details)
+          .map(
+            (detail, index) =>
+              `<text class="detail-note" x="48" y="${110 + index * 20}">${svgEscape(detail.detailId)} - ${svgEscape(detail.detailTitle)} - ${svgEscape(detail.detailScale)}</text>`,
+          )
+          .join("")
+      : details
+          .map((detail, index) =>
+            buildDetailSvg(detail, index, detail.detailId),
+          )
+          .join("");
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="820" height="620" viewBox="0 0 820 620" role="img" data-panel-type="${panelType}" data-technical-drawing="true" data-image-provider-used="none">
+${materialPatternDefinitions()}
+<style>
+.sheet{fill:#fbfcf8;stroke:#1f3552;stroke-width:2}.title{font:700 23px monospace;fill:#15233a}.subtitle,.detail-note{font:13px monospace;fill:#29415f}.detail-frame{fill:#fff;stroke:#1f2937;stroke-width:1.5}.detail-title{font:700 12px monospace;fill:#111827}.detail-scale,.dimension-label,.callout-label{font:10px monospace;fill:#111827}.detail-line{stroke:#111827;stroke-width:2}.detail-dimension{stroke:#dc2626;stroke-width:1.5;marker-start:url(#dim);marker-end:url(#dim)}.callout-marker{fill:#fff;stroke:#2563eb;stroke-width:2}.review{font:700 12px monospace;fill:#9b2c2c}
+</style>
+<rect class="sheet" x="16" y="16" width="788" height="588"/>
+<text class="title" x="36" y="48">${svgEscape(panelTitle(panelType))}</text>
+<text class="subtitle" x="36" y="72">PRELIMINARY DETAILS - ARCHITECT / ENGINEER REVIEW REQUIRED</text>
+<metadata>{"panelType":"${panelType}","geometryHash":"${detailLibrary.geometryHash}","detailLibraryHash":"${detailLibrary.detailLibraryHash}","technicalDrawing":true,"imageProviderUsed":"none"}</metadata>
+${detailMarkup}
+<text class="review" x="36" y="590">${svgEscape(DETAIL_REVIEW_DISCLAIMER)}</text>
+</svg>`;
+}
+
+function buildPanel(detailLibrary, panelType) {
+  const svgString = buildPanelSvg(detailLibrary, panelType);
+  return {
+    panelType,
+    drawingType: "detail",
+    version: CONSTRUCTION_DETAIL_PANEL_VERSION,
+    title: panelTitle(panelType),
+    svgString,
+    svgHash: createStableHash(svgString),
+    width: 820,
+    height: 620,
+    renderer: "deterministic_svg",
+    providerUsed: "deterministic_svg",
+    imageProviderUsed: "none",
+    technicalDrawing: true,
+    geometryHash: detailLibrary.geometryHash,
+    sourceGeometryHash: detailLibrary.geometryHash,
+    sourceProjectGraphHash: detailLibrary.sourceProjectGraphHash,
+    detailLibraryHash: detailLibrary.detailLibraryHash,
+    detailHashes: detailsForPanel(detailLibrary, panelType).map(
+      (detail) => detail.detailHash,
+    ),
+    reviewRequired: true,
+    status: "ready",
+    metadata: {
+      panelType,
+      drawingType: "detail",
+      detailLibraryHash: detailLibrary.detailLibraryHash,
+      reviewRequired: true,
+      imageProviderUsed: "none",
+      renderer: "deterministic_svg",
+    },
+  };
+}
+
+export function buildConstructionDetailPanelsFromDetailLibrary(
+  detailLibrary = {},
+) {
+  const detailPanels = {
+    detail_sheet_architectural: buildPanel(
+      detailLibrary,
+      "detail_sheet_architectural",
+    ),
+    detail_sheet_envelope: buildPanel(detailLibrary, "detail_sheet_envelope"),
+    detail_sheet_wetroom_drainage: buildPanel(
+      detailLibrary,
+      "detail_sheet_wetroom_drainage",
+    ),
+    detail_sheet_mep_riser: buildPanel(detailLibrary, "detail_sheet_mep_riser"),
+    detail_notes: buildPanel(detailLibrary, "detail_notes"),
+  };
+  return { detailLibrary, detailPanels };
+}
+
+export function buildConstructionDetailPanelsFromCompiledProject({
+  compiledProject,
+  jurisdiction = null,
+} = {}) {
+  const detailLibrary = buildConstructionDetailLibraryFromCompiledProject({
+    compiledProject,
+    jurisdiction,
+  });
+  return buildConstructionDetailPanelsFromDetailLibrary(detailLibrary);
+}
+
+export function validateConstructionDetailLibrary(
+  detailLibrary = {},
+  { compiledProject = null } = {},
+) {
+  const errors = [];
+  const details = toArray(detailLibrary.details);
+  const detailTypes = new Set(details.map((detail) => detail.detailType));
+  if (!detailLibrary.detailLibraryHash) {
+    errors.push({ code: "DETAIL_LIBRARY_HASH_MISSING" });
+  }
+  if (!detailLibrary.geometryHash) {
+    errors.push({ code: "DETAIL_LIBRARY_GEOMETRY_HASH_MISSING" });
+  }
+  if (
+    compiledProject?.geometryHash &&
+    detailLibrary.geometryHash &&
+    detailLibrary.geometryHash !== compiledProject.geometryHash
+  ) {
+    errors.push({ code: "DETAIL_LIBRARY_GEOMETRY_HASH_MISMATCH" });
+  }
+  if (detailLibrary.reviewRequired !== true) {
+    errors.push({ code: "DETAIL_LIBRARY_REVIEW_REQUIRED_MISSING" });
+  }
+  if (
+    !toArray(detailLibrary.disclaimers)
+      .join(" ")
+      .match(/architect and engineer/i)
+  ) {
+    errors.push({ code: "DETAIL_LIBRARY_DISCLAIMER_MISSING" });
+  }
+  REQUIRED_CONSTRUCTION_DETAIL_TYPES.forEach((detailType) => {
+    if (!detailTypes.has(detailType)) {
+      errors.push({
+        code: "DETAIL_LIBRARY_REQUIRED_DETAIL_MISSING",
+        detailType,
+      });
+    }
+  });
+  details.forEach((detail) => {
+    if (!detail.detailHash) {
+      errors.push({ code: "DETAIL_HASH_MISSING", detailId: detail.detailId });
+    }
+    if (detail.reviewRequired !== true) {
+      errors.push({
+        code: "DETAIL_REVIEW_REQUIRED_MISSING",
+        detailId: detail.detailId,
+      });
+    }
+    if (detail.imageProviderUsed && detail.imageProviderUsed !== "none") {
+      errors.push({
+        code: "DETAIL_IMAGE_PROVIDER_FORBIDDEN",
+        detailId: detail.detailId,
+      });
+    }
+    if (!toArray(detail.hatches).length) {
+      errors.push({
+        code: "DETAIL_HATCHES_MISSING",
+        detailId: detail.detailId,
+      });
+    }
+    if (!toArray(detail.dimensions).length) {
+      errors.push({
+        code: "DETAIL_DIMENSIONS_MISSING",
+        detailId: detail.detailId,
+      });
+    }
+    if (
+      !toArray(detail.dxfEntities).some((entity) =>
+        entity.role?.includes("callout"),
+      )
+    ) {
+      errors.push({
+        code: "DETAIL_CALLOUTS_MISSING",
+        detailId: detail.detailId,
+      });
+    }
+    if (
+      `${detail.disclaimer || ""} ${toArray(detail.annotations).join(" ")}`.match(
+        /approved for construction|code compliant|certified/i,
+      )
+    ) {
+      errors.push({
+        code: "DETAIL_FALSE_APPROVAL_CLAIM",
+        detailId: detail.detailId,
+      });
+    }
+  });
+  if (
+    detailLibrary.imageProviderUsed &&
+    detailLibrary.imageProviderUsed !== "none"
+  ) {
+    errors.push({ code: "DETAIL_LIBRARY_IMAGE_PROVIDER_FORBIDDEN" });
+  }
+  return {
+    valid: errors.length === 0,
+    errors,
+    checks: {
+      detailCount: details.length,
+      requiredDetailTypesPresent: REQUIRED_CONSTRUCTION_DETAIL_TYPES.every(
+        (detailType) => detailTypes.has(detailType),
+      ),
+      hasDetailLibraryHash: Boolean(detailLibrary.detailLibraryHash),
+      geometryHashMatches:
+        !compiledProject?.geometryHash ||
+        detailLibrary.geometryHash === compiledProject.geometryHash,
+      reviewRequired: detailLibrary.reviewRequired === true,
+      imageProviderUsed: detailLibrary.imageProviderUsed || null,
+    },
+  };
+}
+
+export default {
+  CONSTRUCTION_DETAIL_LIBRARY_VERSION,
+  CONSTRUCTION_DETAIL_PANEL_VERSION,
+  DETAIL_REVIEW_DISCLAIMER,
+  REQUIRED_CONSTRUCTION_DETAIL_TYPES,
+  REQUIRED_DETAIL_CAD_LAYERS,
+  buildConstructionDetailLibraryFromCompiledProject,
+  buildConstructionDetailPanelsFromDetailLibrary,
+  buildConstructionDetailPanelsFromCompiledProject,
+  validateConstructionDetailLibrary,
+};

--- a/src/services/project/compiledProjectExportService.js
+++ b/src/services/project/compiledProjectExportService.js
@@ -210,6 +210,8 @@ export function exportCompiledProjectToDXF({
   projectName = "ArchiAI_Project",
   sourceModelHash = null,
   pipelineVersion = null,
+  includeDetailDrawings = false,
+  detailDrawingsEnabled = false,
 } = {}) {
   if (!compiledProject?.geometryHash) {
     throw new Error(
@@ -219,6 +221,11 @@ export function exportCompiledProjectToDXF({
   const canonicalDrawingModel = buildCanonicalDrawingModelFromCompiledProject({
     compiledProject,
     projectName,
+    includeDetailDrawings:
+      includeDetailDrawings === true ||
+      detailDrawingsEnabled === true ||
+      String(process.env.DETAIL_DRAWINGS_ENABLED || "").toLowerCase() ===
+        "true",
   });
   return exportCanonicalDrawingModelToDXF({
     canonicalDrawingModel,

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -14,6 +14,7 @@ import {
 import { buildCompiledProjectTechnicalPanels } from "../canonical/compiledProjectTechnicalPackBuilder.js";
 import { buildStructuralDrawingPanelsFromCompiledProject } from "../structure/structuralModelService.js";
 import { buildMepDrawingPanelsFromCompiledProject } from "../mep/mepModelService.js";
+import { buildConstructionDetailPanelsFromCompiledProject } from "../details/constructionDetailLibrary.js";
 import { compileProject } from "../compiler/index.js";
 import { ensureCompiledProjectRenderInputs } from "../compiler/compiledProjectRenderInputs.js";
 import { resolveArchitectureModelRegistry } from "../modelStepResolver.js";
@@ -5290,6 +5291,7 @@ function drawingTypeForPanel(panelType) {
     return "structural";
   }
   if (panelType.startsWith("mep_")) return "mep";
+  if (panelType.startsWith("detail_")) return "detail";
   if (panelType.startsWith("floor_plan_")) return "floor_plan";
   if (panelType.startsWith("section_")) return "section";
   if (panelType.startsWith("elevation_")) return "elevation";
@@ -5313,6 +5315,14 @@ function mepDrawingsEnabled(options = {}) {
   );
 }
 
+function detailDrawingsEnabled(options = {}) {
+  return (
+    options.detailDrawingsEnabled === true ||
+    options.includeDetailDrawings === true ||
+    String(process.env.DETAIL_DRAWINGS_ENABLED || "").toLowerCase() === "true"
+  );
+}
+
 function buildDrawingSet(compiledProject, options = {}) {
   // Pass layoutTemplate through so the technical pack renders at the slot
   // aspect of the active sheet template (presentation-v3 for residential,
@@ -5331,10 +5341,14 @@ function buildDrawingSet(compiledProject, options = {}) {
   const mepBuild = mepDrawingsEnabled(options)
     ? buildMepDrawingPanelsFromCompiledProject({ compiledProject })
     : { mepModel: null, mepPanels: {} };
+  const detailBuild = detailDrawingsEnabled(options)
+    ? buildConstructionDetailPanelsFromCompiledProject({ compiledProject })
+    : { detailLibrary: null, detailPanels: {} };
   const technicalPanels = {
     ...(technicalBuild.technicalPanels || {}),
     ...(structuralBuild.structuralPanels || {}),
     ...(mepBuild.mepPanels || {}),
+    ...(detailBuild.detailPanels || {}),
   };
   const drawingViews = Object.entries(technicalPanels).map(
     ([panelType, panel]) => {
@@ -5375,7 +5389,9 @@ function buildDrawingSet(compiledProject, options = {}) {
                 ? "structural_model"
                 : drawingType === "mep"
                   ? "mep_model"
-                  : "compiled_project",
+                  : drawingType === "detail"
+                    ? "construction_detail_library"
+                    : "compiled_project",
             entity_ids: [
               ...(compiledProject.rooms || []).map(
                 (room) => room.sourceId || room.id,
@@ -5387,6 +5403,9 @@ function buildDrawingSet(compiledProject, options = {}) {
                 : []),
               ...(drawingType === "mep"
                 ? mepBuild.mepModel?.memberIds || []
+                : []),
+              ...(drawingType === "detail"
+                ? detailBuild.detailLibrary?.detailIds || []
                 : []),
             ],
           },
@@ -5457,6 +5476,11 @@ function buildDrawingSet(compiledProject, options = {}) {
                 null,
               mepModelHash:
                 panel.mepModelHash || panel.metadata?.mepModelHash || null,
+              detailLibraryHash:
+                panel.detailLibraryHash ||
+                panel.metadata?.detailLibraryHash ||
+                null,
+              detailHashes: panel.detailHashes || [],
               reviewRequired: panel.reviewRequired || false,
             },
           },
@@ -5469,6 +5493,8 @@ function buildDrawingSet(compiledProject, options = {}) {
       structuralPanels: structuralBuild.structuralPanels || {},
       mepModel: mepBuild.mepModel || null,
       mepPanels: mepBuild.mepPanels || {},
+      detailLibrary: detailBuild.detailLibrary || null,
+      detailPanels: detailBuild.detailPanels || {},
     },
   };
 }


### PR DESCRIPTION
## Summary

Adds an opt-in construction detail library and CAD detail sheet pipeline.

Detail outputs are disabled by default and only included when `DETAIL_DRAWINGS_ENABLED=true` or `includeDetailDrawings=true`.

All construction details are preliminary and require architect/engineer review before use for construction.

## Changes

- Adds deterministic construction detail library.
- Adds required residential detail types:
  - wall/foundation junction
  - floor/wall junction
  - roof eaves detail
  - roof ridge detail
  - window head/sill/jamb
  - door threshold detail
  - stair detail
  - wet-room floor/wall detail
  - drainage inspection chamber
  - MEP riser detail
- Adds deterministic SVG detail panels.
- Adds optional ProjectGraph drawing-set integration behind `DETAIL_DRAWINGS_ENABLED=true` or explicit option.
- Adds detail CAD/DXF layers and entities when detail drawings are enabled.
- Adds detail callout markers linked to detail IDs.
- Adds detail QA for required details, hashes, review requirement, disclaimers, hatches, dimensions, callouts, and no image provider.
- Updates roadmap to describe construction details as preliminary and opt-in.

## Validation

- Focused audit tests: 5 suites passed
- 45 tests passed
- `npm run lint`
- `git diff --check`
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Safety and scope

- No image-generation path added for construction details.
- Fake DWG remains disabled.
- Existing ProjectGraph/A1/CAD/structural/MEP authority gates were not weakened.
- Default CAD/DXF export remains unchanged unless detail drawings are enabled.
- Detail CAD/DXF is included only when detail drawings are enabled.

## Current limitations

- Preliminary detail coordination only.
- Not code-certified construction details.
- Not approved for construction.
- No jurisdiction-specific detail compliance yet.
- Requires architect/engineer review before construction use.
