### PR TITLE
Add UK France Algeria jurisdiction packs

### DIFF
--- a/docs/roadmaps/professional-cad-bim-output-roadmap.md
+++ b/docs/roadmaps/professional-cad-bim-output-roadmap.md
@@ -29,11 +29,19 @@ contracts and should fail closed when geometry provenance is missing.
   plot-style metadata reference `archiai-monochrome.ctb`.
 - DWG remains conversion-only and unavailable unless a real converter is
   configured. DXF is the guaranteed CAD output.
-- Structural CAD/BIM output is being introduced as an opt-in package behind
-  `STRUCTURAL_DRAWINGS_ENABLED` or an explicit `includeStructuralDrawings`
-  option. Default architectural DXF exports remain non-structural.
-- There is no MEP model, no detail library, and no versioned UK/France/Algeria
-  jurisdiction-pack system.
+- Structural CAD/BIM output is opt-in behind `STRUCTURAL_DRAWINGS_ENABLED` or
+  an explicit `includeStructuralDrawings` option. Default architectural DXF
+  exports remain non-structural.
+- MEP CAD/BIM output is opt-in behind `MEP_DRAWINGS_ENABLED` or an explicit
+  `includeMepDrawings` option. All MEP output remains preliminary and requires
+  qualified MEP engineer review.
+- Construction detail sheets are opt-in behind `DETAIL_DRAWINGS_ENABLED` or an
+  explicit `includeDetailDrawings` option. Details are preliminary and require
+  responsible architect/engineer review.
+- Versioned UK, France, Algeria, and declared generic advisory jurisdiction
+  packs are implemented as data-driven metadata for labels, CAD preferences,
+  local style defaults, climate assumptions, advisory checklists, and review
+  disclaimers.
 
 ## Non-negotiable authority rules
 
@@ -271,18 +279,47 @@ Add versioned jurisdiction packs for UK, France, and Algeria.
 Deliverables:
 
 - `src/services/jurisdiction/`.
-- `data/jurisdictions/uk/`, `data/jurisdictions/france/`, and
-  `data/jurisdictions/algeria/`.
+- `data/uk.json`, `data/france.json`, `data/algeria.json`, and a declared
+  `data/generic.json` advisory fallback.
 - Labels, title-block formats, CAD layer preferences, units/scales, climate
-  defaults, regulatory checklist metadata, planning/site providers,
-  structural/seismic/wind assumptions, typical materials/hatches, MEP defaults,
-  and disclaimers.
+  defaults, planning/regulatory checklist metadata, preliminary structural/MEP
+  assumptions, typical materials/hatches, and disclaimers.
+- Jurisdiction resolver precedence: explicit brief jurisdiction, supplied
+  country/country code, address/postcode inference, then declared generic
+  fallback with source-gap warning.
+- Jurisdiction pack metadata threaded into ProjectGraph drawing-set metadata,
+  A1 title-block labels, CanonicalDrawingModel, DXF metadata, local style
+  evidence, and structural/MEP/detail advisory disclaimers.
 
 Acceptance criteria:
 
 - UK, France, and Algeria briefs select the correct pack.
 - France and Algeria can use French title-block labels where configured.
 - Missing pack fails clearly or falls back only to a declared generic pack.
+- CAD layer names remain DXF-safe ASCII by default; localized labels are
+  metadata/title-block labels rather than renderer-hardcoded layer names.
+- Outputs remain preliminary/advisory and do not claim legal/code compliance or
+  construction approval.
+
+Current limitations after this slice:
+
+- Jurisdiction packs are preliminary advisory data, not official regulation
+  databases.
+- Planning/regulatory checklist metadata must be verified with the relevant
+  local authority and licensed professionals.
+- France and Algeria language support is first-pass deterministic metadata;
+  full typography/language QA for every sheet and viewer remains future work.
+- Algeria Arabic labels are exposed as Arabic-ready alternate metadata while
+  French remains the default title-block label set for CAD safety.
+- No authority-specific planning checks, official regulation ingestion, seismic
+  design verification, fire strategy approval, or permit/construction approval
+  is claimed.
+
+Next jurisdiction fidelity PR:
+
+- Add region-level packs, official regulation/source integration, language QA,
+  authority-specific planning checks, and localized construction-detail
+  variants for UK, France, and Algeria.
 
 ## PR 7: A1 and professional drawing sets
 

--- a/src/__tests__/services/cad/canonicalDrawingModel.test.js
+++ b/src/__tests__/services/cad/canonicalDrawingModel.test.js
@@ -262,6 +262,14 @@ describe("CanonicalDrawingModel", () => {
         ctbFile: "archiai-monochrome.ctb",
       }),
     );
+    expect(model.jurisdictionPack).toEqual(
+      expect.objectContaining({
+        jurisdictionId: "uk",
+        countryCode: "GB",
+        version: "jurisdiction-pack-uk-v1",
+      }),
+    );
+    expect(model.sheetMetadata.titleBlockLabels.project).toBe("Project");
     expect(model.structuralModel).toBeUndefined();
     expect(model.mepModel).toBeUndefined();
     expect(model.detailLibrary).toBeUndefined();
@@ -303,6 +311,10 @@ describe("CanonicalDrawingModel", () => {
         geometryHash: model.geometryHash,
         sourceProjectGraphHash: model.sourceProjectGraphHash,
         jurisdiction: "uk",
+        titleBlockLabels: expect.objectContaining({
+          drawingNumber: "DRAWING_NUMBER",
+          title: "TITLE",
+        }),
         revision: "P01",
         status: "Preliminary",
         date: "undated",
@@ -366,6 +378,72 @@ describe("CanonicalDrawingModel", () => {
     );
     expect(model.drawingScales.map((scale) => scale.ratio)).toEqual(
       expect.arrayContaining(["1:500", "1:100", "1:20", "1:5"]),
+    );
+  });
+
+  test("applies France and Algeria jurisdiction labels while keeping CAD layer names DXF-safe", () => {
+    const franceModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: {
+        ...fixtureCompiledProject(),
+        jurisdiction: "france",
+        locationData: { address: "Paris, France", countryCode: "FR" },
+      },
+    });
+    const algeriaModel = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: {
+        ...fixtureCompiledProject(),
+        jurisdiction: "algeria",
+        locationData: { address: "Algiers, Algeria", countryCode: "DZ" },
+      },
+    });
+
+    expect(franceModel.jurisdictionPack).toEqual(
+      expect.objectContaining({
+        jurisdictionId: "france",
+        countryCode: "FR",
+      }),
+    );
+    expect(franceModel.paperSpace.sheets[0].titleBlockLabels).toEqual(
+      expect.objectContaining({
+        project: "Projet",
+        title: "TITRE",
+        scale: "ECHELLE",
+      }),
+    );
+    expect(algeriaModel.jurisdictionPack).toEqual(
+      expect.objectContaining({
+        jurisdictionId: "algeria",
+        countryCode: "DZ",
+        alternateTitleBlockLabels: expect.objectContaining({
+          ar: expect.objectContaining({ project: "المشروع" }),
+        }),
+      }),
+    );
+    franceModel.layers.concat(algeriaModel.layers).forEach((layer) => {
+      expect(layer.name).toMatch(/^[A-Z0-9-]+$/);
+    });
+  });
+
+  test("opt-in structural, MEP, and detail models include jurisdiction advisory disclaimers", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: {
+        ...fixtureCompiledProject(),
+        jurisdiction: "france",
+        locationData: { address: "Paris, France", countryCode: "FR" },
+      },
+      includeStructuralDrawings: true,
+      includeMepDrawings: true,
+      includeDetailDrawings: true,
+    });
+
+    expect(model.structuralModel.disclaimers.join(" ")).toMatch(
+      /ingenieur structure qualifie|verify with local authority/i,
+    );
+    expect(model.mepModel.disclaimers.join(" ")).toMatch(
+      /ingenieur MEP qualifie|verify with local authority/i,
+    );
+    expect(model.detailLibrary.disclaimers.join(" ")).toMatch(
+      /architecte et les ingenieurs|verify with local authority/i,
     );
   });
 
@@ -499,6 +577,10 @@ describe("CanonicalDrawingModel", () => {
     expect(result.checks.hasNativeViewports).toBe(true);
     expect(result.checks.hasPlotSettings).toBe(true);
     expect(result.checks.hasPlotStyleMetadata).toBe(true);
+    expect(result.checks.hasJurisdictionPack).toBe(true);
+    expect(result.checks.jurisdictionPackId).toBe("uk");
+    expect(result.checks.jurisdictionCountryCode).toBe("GB");
+    expect(result.checks.hasJurisdictionDisclaimer).toBe(true);
     expect(result.checks.hasStructuralModelHash).toBe(false);
     expect(result.checks.hasStructuralDisclaimer).toBe(false);
     expect(result.checks.structuralReviewRequired).toBe(false);

--- a/src/__tests__/services/cad/canonicalDxfExporter.test.js
+++ b/src/__tests__/services/cad/canonicalDxfExporter.test.js
@@ -139,6 +139,11 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).toContain("PLOT_STYLE_TABLE: archiai-monochrome.ctb");
     expect(dxf).toContain("PLOT_STYLE_METADATA: mode=ctb");
     expect(dxf).toContain("CTB_STB_MAPPING: layer-weight-to-ctb");
+    expect(dxf).toContain("JURISDICTION_ID: generic");
+    expect(dxf).toContain("JURISDICTION_COUNTRY_CODE: INT");
+    expect(dxf).toContain(
+      "JURISDICTION_PACK_VERSION: jurisdiction-pack-generic-v1",
+    );
     expect(dxf).toContain("GEOMETRY_HASH: geometry-hash-dxf-model-001");
     expect(dxf).toContain(
       "SOURCE_PROJECT_GRAPH_HASH: project-graph-hash-dxf-model-001",
@@ -177,6 +182,28 @@ describe("exportCanonicalDrawingModelToDXF", () => {
     expect(dxf).toContain("TITLE_BLOCK_A1");
     expect(dxf).toContain("DRAWING_NUMBER: A-100");
     expect(dxf).toContain("SCALE: 1:500");
+  });
+
+  test("emits jurisdiction metadata and localized title-block labels", () => {
+    const model = buildCanonicalDrawingModelFromCompiledProject({
+      compiledProject: {
+        ...fixtureCompiledProject(),
+        jurisdiction: "france",
+        locationData: { address: "Paris, France", countryCode: "FR" },
+      },
+    });
+    const dxf = exportCanonicalDrawingModelToDXF({
+      canonicalDrawingModel: model,
+    });
+
+    expect(dxf).toContain("JURISDICTION_ID: france");
+    expect(dxf).toContain("JURISDICTION_COUNTRY_CODE: FR");
+    expect(dxf).toContain(
+      "JURISDICTION_PACK_VERSION: jurisdiction-pack-france-v1",
+    );
+    expect(dxf).toContain("TITRE: Ground Plan");
+    expect(dxf).toContain("ECHELLE: 1:100");
+    expect(dxf).toContain("Preliminary advisory checklist");
   });
 
   test("keeps default DXF export architectural-only without structural opt-in", () => {

--- a/src/__tests__/services/jurisdiction/jurisdictionPackService.test.js
+++ b/src/__tests__/services/jurisdiction/jurisdictionPackService.test.js
@@ -1,0 +1,79 @@
+import {
+  GENERIC_JURISDICTION_WARNING,
+  loadJurisdictionPack,
+  resolveJurisdictionPack,
+  validateJurisdictionPack,
+} from "../../../services/jurisdiction/jurisdictionPackService.js";
+
+describe("jurisdictionPackService", () => {
+  test("loads UK, France, and Algeria packs with required contract fields", () => {
+    ["uk", "france", "algeria"].forEach((jurisdictionId) => {
+      const pack = loadJurisdictionPack(jurisdictionId);
+      const validation = validateJurisdictionPack(pack);
+
+      expect(validation.valid).toBe(true);
+      expect(pack.version).toEqual(expect.any(String));
+      expect(pack.countryCode).toEqual(expect.any(String));
+      expect(pack.titleBlockLabels).toEqual(expect.any(Object));
+      expect(pack.defaultCadLayers.length).toBeGreaterThan(0);
+      expect(pack.disclaimers.preliminaryAdvisory).toMatch(
+        /verify with local authority and licensed professionals/i,
+      );
+    });
+  });
+
+  test("missing pack fails clearly unless generic fallback is explicit", () => {
+    expect(() => loadJurisdictionPack("mars")).toThrow(
+      /JURISDICTION_PACK_NOT_FOUND/,
+    );
+
+    const generic = loadJurisdictionPack("mars", {
+      allowGenericFallback: true,
+    });
+
+    expect(generic.jurisdictionId).toBe("generic");
+  });
+
+  test("resolver selects UK, France, Algeria, explicit override, and generic warning", () => {
+    expect(
+      resolveJurisdictionPack({
+        address: "12 High Street, Scunthorpe, DN15 6XX, United Kingdom",
+      }).pack.jurisdictionId,
+    ).toBe("uk");
+    expect(
+      resolveJurisdictionPack({
+        address: "Rue de Rivoli, 75001 Paris, France",
+      }).pack.jurisdictionId,
+    ).toBe("france");
+    expect(
+      resolveJurisdictionPack({
+        address: "Hydra, Algiers, Algeria",
+      }).pack.jurisdictionId,
+    ).toBe("algeria");
+    expect(
+      resolveJurisdictionPack({
+        address: "Paris, France",
+        brief: { jurisdiction: "uk" },
+      }).pack.jurisdictionId,
+    ).toBe("uk");
+
+    const unknown = resolveJurisdictionPack({
+      address: "Unknown site",
+    });
+    expect(unknown.pack.jurisdictionId).toBe("generic");
+    expect(unknown.sourceGaps[0].code).toBe(GENERIC_JURISDICTION_WARNING);
+  });
+
+  test("packs do not claim legal compliance or construction approval", () => {
+    ["uk", "france", "algeria", "generic"].forEach((jurisdictionId) => {
+      const pack = loadJurisdictionPack(jurisdictionId, {
+        allowGenericFallback: true,
+      });
+      const text = JSON.stringify(pack);
+
+      expect(text).not.toMatch(/code compliant/i);
+      expect(text).not.toMatch(/approved for construction/i);
+      expect(text).toMatch(/Preliminary advisory checklist/i);
+    });
+  });
+});

--- a/src/__tests__/services/jurisdiction/jurisdictionProjectGraphIntegration.test.js
+++ b/src/__tests__/services/jurisdiction/jurisdictionProjectGraphIntegration.test.js
@@ -1,0 +1,120 @@
+import {
+  __projectGraphVerticalSliceInternals,
+  buildTitleBlockPanelArtifact,
+} from "../../../services/project/projectGraphVerticalSliceService.js";
+import { loadJurisdictionPack } from "../../../services/jurisdiction/jurisdictionPackService.js";
+
+function fixtureCompiledProject() {
+  return {
+    geometryHash: "geometry-hash-jurisdiction-project-001",
+    projectGraphHash: "project-graph-hash-jurisdiction-project-001",
+    projectName: "Jurisdiction Integration Fixture",
+    jurisdiction: "france",
+    metadata: { countryCode: "FR" },
+    locationData: {
+      address: "Rue de Rivoli, 75001 Paris, France",
+      countryCode: "FR",
+    },
+    site: {
+      boundary_polygon: [
+        { x: 0, y: 0 },
+        { x: 12, y: 0 },
+        { x: 12, y: 8 },
+        { x: 0, y: 8 },
+      ],
+    },
+    levels: [{ id: "level-0", level_number: 0, name: "Ground", height_m: 3 }],
+    slabs: [
+      {
+        id: "slab-0",
+        levelId: "level-0",
+        polygon: [
+          { x: 1, y: 1 },
+          { x: 10, y: 1 },
+          { x: 10, y: 7 },
+          { x: 1, y: 7 },
+        ],
+      },
+    ],
+    rooms: [
+      {
+        id: "room-1",
+        levelId: "level-0",
+        name: "Living",
+        type: "living",
+        polygon: [
+          { x: 1, y: 1 },
+          { x: 7, y: 1 },
+          { x: 7, y: 7 },
+          { x: 1, y: 7 },
+        ],
+      },
+    ],
+    walls: [
+      {
+        id: "wall-1",
+        levelId: "level-0",
+        exterior: true,
+        start: { x: 1, y: 1 },
+        end: { x: 10, y: 1 },
+      },
+    ],
+    openings: [
+      {
+        id: "door-1",
+        levelId: "level-0",
+        type: "door",
+        width_m: 1,
+        position_m: { x: 4, y: 1 },
+      },
+    ],
+  };
+}
+
+describe("jurisdiction ProjectGraph integration", () => {
+  test("A1 title block uses France title labels when France pack is supplied", () => {
+    const francePack = loadJurisdictionPack("france");
+    const artifact = buildTitleBlockPanelArtifact({
+      projectGraphId: "project-graph-france-001",
+      brief: {
+        project_name: "Maison Test",
+        target_gia_m2: 120,
+        target_storeys: 2,
+        building_type: "dwelling",
+        site_input: { address: "Paris, France" },
+      },
+      geometryHash: "geometry-hash-france-title-001",
+      sheetPlan: { sheet_number: "A1-01", scale: "1:100" },
+      jurisdictionPack: francePack,
+    });
+
+    expect(artifact.svgString).toContain(">Projet<");
+    expect(artifact.svgString).toContain(">ECHELLE<");
+    expect(artifact.metadata.jurisdictionPack.countryCode).toBe("FR");
+    expect(artifact.metadata.jurisdictionPack.titleBlockLabels.title).toBe(
+      "TITRE",
+    );
+    expect(artifact.metadata.titleBlockLabels.scale).toBe("ECHELLE");
+  });
+
+  test("drawing-set metadata carries selected jurisdiction pack and title labels", () => {
+    const result = __projectGraphVerticalSliceInternals.buildDrawingSet(
+      fixtureCompiledProject(),
+      { layoutTemplate: "presentation-v3" },
+    );
+
+    expect(result.drawingSet.jurisdictionPack).toEqual(
+      expect.objectContaining({
+        jurisdictionId: "france",
+        countryCode: "FR",
+        version: "jurisdiction-pack-france-v1",
+      }),
+    );
+    expect(result.drawingSet.titleBlockLabels.project).toBe("Projet");
+    expect(result.technicalBuild).toEqual(
+      expect.objectContaining({
+        jurisdictionPack: expect.objectContaining({ countryCode: "FR" }),
+      }),
+    );
+  });
+});

--- a/src/__tests__/services/style/localStylePack.test.js
+++ b/src/__tests__/services/style/localStylePack.test.js
@@ -3,6 +3,7 @@ import {
   computeMaterialPalette,
   buildLocalStylePackV2,
 } from "../../../services/style/localStylePack.js";
+import { loadJurisdictionPack } from "../../../services/jurisdiction/jurisdictionPackService.js";
 
 describe("computeBlendWeights", () => {
   test("default sliders sum to 1.0 and are close to plan §6.5 defaults", () => {
@@ -160,10 +161,66 @@ describe("buildLocalStylePackV2 — full pack output", () => {
     expect(pack.blend_weights.local).toBeGreaterThan(
       pack.blend_weights.portfolio,
     );
-    expect(pack.blend_rationale.length).toBe(4);
+    expect(pack.blend_rationale.length).toBeGreaterThanOrEqual(4);
     expect(pack.avoid_keywords).toContain("highly reflective glazing");
     expect(
       pack.material_palette_with_provenance[0].sources.length,
     ).toBeGreaterThan(0);
+  });
+
+  test("France jurisdiction defaults use French material evidence, not UK vernacular pack names", () => {
+    const jurisdictionPack = loadJurisdictionPack("france");
+    const pack = buildLocalStylePackV2({
+      brief: {
+        project_name: "Maison Locale",
+        building_type: "dwelling",
+        user_intent: { style_keywords: [], material_preferences: [] },
+      },
+      site: {},
+      climate: { overheating: { risk_level: "medium" } },
+      jurisdictionPack,
+    });
+
+    expect(pack.jurisdictionEvidence).toEqual(
+      expect.objectContaining({
+        jurisdictionId: "france",
+        countryCode: "FR",
+        packVersion: "jurisdiction-pack-france-v1",
+      }),
+    );
+    expect(pack.source_palettes.local).toEqual(
+      expect.arrayContaining(["lime render", "local stone"]),
+    );
+    expect(JSON.stringify(pack.jurisdictionEvidence)).not.toMatch(
+      /ukVernacularPacks|London stucco|Manchester/i,
+    );
+  });
+
+  test("Algeria jurisdiction defaults use hot-climate cues, not UK vernacular pack names", () => {
+    const jurisdictionPack = loadJurisdictionPack("algeria");
+    const pack = buildLocalStylePackV2({
+      brief: {
+        project_name: "Maison Alger",
+        building_type: "dwelling",
+        user_intent: { style_keywords: [], material_preferences: [] },
+      },
+      site: {},
+      climate: { overheating: { risk_level: "high" } },
+      jurisdictionPack,
+    });
+
+    expect(pack.jurisdictionEvidence).toEqual(
+      expect.objectContaining({
+        jurisdictionId: "algeria",
+        countryCode: "DZ",
+        packVersion: "jurisdiction-pack-algeria-v1",
+      }),
+    );
+    expect(pack.source_palettes.local.join(",")).toMatch(
+      /light coloured render|shading screen|thermal mass/i,
+    );
+    expect(JSON.stringify(pack.jurisdictionEvidence)).not.toMatch(
+      /ukVernacularPacks|London stucco|Manchester/i,
+    );
   });
 });

--- a/src/__tests__/services/style/localStylePack.ukVernacular.test.js
+++ b/src/__tests__/services/style/localStylePack.ukVernacular.test.js
@@ -2,6 +2,7 @@ import {
   buildLocalStylePackV2,
   computeMaterialPalette,
 } from "../../../services/style/localStylePack.js";
+import { loadJurisdictionPack } from "../../../services/jurisdiction/jurisdictionPackService.js";
 import { resolveUKVernacular } from "../../../services/style/ukVernacularPacks.js";
 
 const baseBrief = {
@@ -72,6 +73,7 @@ describe("localStylePack — UK vernacular pack integration", () => {
       brief: baseBrief,
       site,
       climate: baseClimate,
+      jurisdictionPack: loadJurisdictionPack("uk"),
     });
     expect(stylePack.style_provenance).toEqual(
       expect.objectContaining({

--- a/src/services/cad/canonicalDrawingModel.js
+++ b/src/services/cad/canonicalDrawingModel.js
@@ -11,6 +11,12 @@ import {
   buildConstructionDetailLibraryFromCompiledProject,
   REQUIRED_CONSTRUCTION_DETAIL_TYPES,
 } from "../details/constructionDetailLibrary.js";
+import {
+  packHasFalseComplianceClaim,
+  resolveJurisdictionPack,
+  summarizeJurisdictionPack,
+  validateJurisdictionPack,
+} from "../jurisdiction/jurisdictionPackService.js";
 
 export const CANONICAL_DRAWING_MODEL_VERSION = "canonical-drawing-model-v1";
 
@@ -632,6 +638,70 @@ function jurisdictionOf(compiledProject = {}, fallback = "generic") {
     compiledProject.metadata?.jurisdiction ||
     fallback
   );
+}
+
+function projectAddressOf(compiledProject = {}) {
+  return (
+    compiledProject.locationData?.address ||
+    compiledProject.location_data?.address ||
+    compiledProject.site?.address ||
+    compiledProject.metadata?.address ||
+    compiledProject.metadata?.location ||
+    ""
+  );
+}
+
+function countryOf(compiledProject = {}) {
+  return (
+    compiledProject.countryCode ||
+    compiledProject.country_code ||
+    compiledProject.country ||
+    compiledProject.locationData?.countryCode ||
+    compiledProject.locationData?.country ||
+    compiledProject.metadata?.countryCode ||
+    compiledProject.metadata?.country_code ||
+    compiledProject.metadata?.country ||
+    null
+  );
+}
+
+function resolveCadJurisdictionPack({
+  compiledProject = {},
+  jurisdiction = null,
+  jurisdictionPack = null,
+} = {}) {
+  if (jurisdictionPack?.titleBlockLabels && jurisdictionPack?.version) {
+    return {
+      pack: jurisdictionPack,
+      summary: summarizeJurisdictionPack(jurisdictionPack),
+      source: "explicit_option",
+      warnings: [],
+      sourceGaps: [],
+    };
+  }
+  const explicitJurisdiction =
+    jurisdiction ||
+    compiledProject.jurisdiction ||
+    compiledProject.regulations?.jurisdiction ||
+    compiledProject.metadata?.jurisdiction ||
+    null;
+  const resolution = resolveJurisdictionPack({
+    address: projectAddressOf(compiledProject),
+    country: countryOf(compiledProject),
+    coordinates:
+      compiledProject.locationData?.coordinates ||
+      compiledProject.site?.coordinates ||
+      null,
+    locale: compiledProject.locale || compiledProject.metadata?.locale || null,
+    brief: {
+      ...(compiledProject.brief || compiledProject.metadata?.brief || {}),
+      ...(explicitJurisdiction ? { jurisdiction: explicitJurisdiction } : {}),
+    },
+  });
+  return {
+    ...resolution,
+    summary: summarizeJurisdictionPack(resolution.pack),
+  };
 }
 
 function entityHash(parts = []) {
@@ -1737,12 +1807,14 @@ function buildStructuralPrimitiveEntities(
   compiledProject = {},
   geometryHash,
   includeStructuralDrawings = false,
+  jurisdictionPack = null,
 ) {
   if (!includeStructuralDrawings) {
     return [];
   }
   const structuralModel = buildStructuralModelFromCompiledProject({
     compiledProject,
+    jurisdictionPack,
   });
   const entities = buildStructuralModelEntities(structuralModel, geometryHash);
   return entities;
@@ -2128,12 +2200,14 @@ function buildMepPrimitiveEntities(
   compiledProject = {},
   geometryHash,
   includeMepDrawings = false,
+  jurisdictionPack = null,
 ) {
   if (!includeMepDrawings) {
     return [];
   }
   const mepModel = buildMepModelFromCompiledProject({
     compiledProject,
+    jurisdictionPack,
   });
   return buildMepModelEntities(mepModel, geometryHash);
 }
@@ -2292,12 +2366,14 @@ function buildConstructionDetailPrimitiveEntities(
   compiledProject = {},
   geometryHash,
   includeDetailDrawings = false,
+  jurisdictionPack = null,
 ) {
   if (!includeDetailDrawings) {
     return [];
   }
   const detailLibrary = buildConstructionDetailLibraryFromCompiledProject({
     compiledProject,
+    jurisdictionPack,
   });
   return buildConstructionDetailEntities(detailLibrary, geometryHash);
 }
@@ -2433,6 +2509,7 @@ function buildSheetMetadata({
   geometryHash,
   sourceProjectGraphHash,
   jurisdiction,
+  jurisdictionPack = null,
   units,
   sheetNumber,
   title,
@@ -2449,6 +2526,10 @@ function buildSheetMetadata({
     geometryHash,
     sourceProjectGraphHash,
     jurisdiction,
+    jurisdictionPack: summarizeJurisdictionPack(jurisdictionPack),
+    titleBlockLabels: clone(jurisdictionPack?.titleBlockLabels || {}),
+    drawingStatusLabels: clone(jurisdictionPack?.drawingStatusLabels || {}),
+    disclaimer: jurisdictionPack?.disclaimers?.preliminaryAdvisory || null,
     units,
     revision: compiledProject.metadata?.revision || "P01",
     status: compiledProject.metadata?.status || "Preliminary",
@@ -2602,6 +2683,7 @@ function createSheet({
   geometryHash,
   sourceProjectGraphHash,
   jurisdiction,
+  jurisdictionPack = null,
   units,
 } = {}) {
   const revision = compiledProject.metadata?.revision || "P01";
@@ -2642,6 +2724,10 @@ function createSheet({
     geometryHash,
     sourceProjectGraphHash,
     jurisdiction,
+    jurisdictionPack: summarizeJurisdictionPack(jurisdictionPack),
+    titleBlockLabels: clone(jurisdictionPack?.titleBlockLabels || {}),
+    drawingStatusLabels: clone(jurisdictionPack?.drawingStatusLabels || {}),
+    disclaimer: jurisdictionPack?.disclaimers?.preliminaryAdvisory || null,
     revision,
     status,
     date: sheetDateOf(compiledProject),
@@ -2653,6 +2739,7 @@ function createSheet({
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction,
+      jurisdictionPack,
       units,
       sheetNumber,
       title,
@@ -2669,6 +2756,7 @@ function buildPaperSpaceSheets({
   geometryHash,
   sourceProjectGraphHash,
   jurisdiction,
+  jurisdictionPack = null,
   units,
   projectName,
 }) {
@@ -2689,6 +2777,7 @@ function buildPaperSpaceSheets({
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction,
+      jurisdictionPack,
       units,
     }),
     createSheet({
@@ -2715,6 +2804,7 @@ function buildPaperSpaceSheets({
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction,
+      jurisdictionPack,
       units,
     }),
   ];
@@ -2747,6 +2837,7 @@ function buildPaperSpaceSheets({
         geometryHash,
         sourceProjectGraphHash,
         jurisdiction,
+        jurisdictionPack,
         units,
       }),
     );
@@ -2782,6 +2873,7 @@ function buildPaperSpaceSheets({
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction,
+      jurisdictionPack,
       units,
     }),
     createSheet({
@@ -2808,6 +2900,7 @@ function buildPaperSpaceSheets({
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction,
+      jurisdictionPack,
       units,
     }),
   );
@@ -2835,6 +2928,7 @@ function buildDetailPaperSpaceSheets({
   geometryHash,
   sourceProjectGraphHash,
   jurisdiction,
+  jurisdictionPack = null,
   units,
 } = {}) {
   if (!baseSheet || !detailLibrary) {
@@ -2897,6 +2991,10 @@ function buildDetailPaperSpaceSheets({
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction,
+      jurisdictionPack: summarizeJurisdictionPack(jurisdictionPack),
+      titleBlockLabels: clone(jurisdictionPack?.titleBlockLabels || {}),
+      drawingStatusLabels: clone(jurisdictionPack?.drawingStatusLabels || {}),
+      disclaimer: jurisdictionPack?.disclaimers?.preliminaryAdvisory || null,
       units,
       modelViews: [sheet.panelType],
       detailLibraryHash: detailLibrary.detailLibraryHash,
@@ -2965,6 +3063,7 @@ export function buildCanonicalDrawingModelFromCompiledProject({
   compiledProject,
   projectName = null,
   jurisdiction = null,
+  jurisdictionPack = null,
   units = "meters",
   includeStructuralDrawings = false,
   structuralDrawingsEnabled = false,
@@ -2981,7 +3080,17 @@ export function buildCanonicalDrawingModelFromCompiledProject({
 
   const geometryHash = compiledProject.geometryHash;
   const resolvedProjectName = projectName || projectNameOf(compiledProject);
-  const resolvedJurisdiction = jurisdiction || jurisdictionOf(compiledProject);
+  const jurisdictionResolution = resolveCadJurisdictionPack({
+    compiledProject,
+    jurisdiction,
+    jurisdictionPack,
+  });
+  const resolvedJurisdictionPack = jurisdictionResolution.pack;
+  const jurisdictionPackSummary = jurisdictionResolution.summary;
+  const resolvedJurisdiction =
+    resolvedJurisdictionPack?.jurisdictionId ||
+    jurisdiction ||
+    jurisdictionOf(compiledProject);
   const sourceProjectGraphHash = sourceProjectGraphHashOf(compiledProject);
   const shouldIncludeStructuralDrawings =
     includeStructuralDrawings === true || structuralDrawingsEnabled === true;
@@ -2993,18 +3102,21 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     ? buildStructuralModelFromCompiledProject({
         compiledProject,
         jurisdiction: resolvedJurisdiction,
+        jurisdictionPack: resolvedJurisdictionPack,
       })
     : null;
   const mepModel = shouldIncludeMepDrawings
     ? buildMepModelFromCompiledProject({
         compiledProject,
         jurisdiction: resolvedJurisdiction,
+        jurisdictionPack: resolvedJurisdictionPack,
       })
     : null;
   const detailLibrary = shouldIncludeDetailDrawings
     ? buildConstructionDetailLibraryFromCompiledProject({
         compiledProject,
         jurisdiction: resolvedJurisdiction,
+        jurisdictionPack: resolvedJurisdictionPack,
       })
     : null;
   const modelSpaceEntities = [
@@ -3016,16 +3128,19 @@ export function buildCanonicalDrawingModelFromCompiledProject({
       compiledProject,
       geometryHash,
       shouldIncludeStructuralDrawings,
+      resolvedJurisdictionPack,
     ),
     ...buildMepPrimitiveEntities(
       compiledProject,
       geometryHash,
       shouldIncludeMepDrawings,
+      resolvedJurisdictionPack,
     ),
     ...buildConstructionDetailPrimitiveEntities(
       compiledProject,
       geometryHash,
       shouldIncludeDetailDrawings,
+      resolvedJurisdictionPack,
     ),
   ];
   const architecturalSheets = buildPaperSpaceSheets({
@@ -3033,6 +3148,7 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     geometryHash,
     sourceProjectGraphHash,
     jurisdiction: resolvedJurisdiction,
+    jurisdictionPack: resolvedJurisdictionPack,
     units,
     projectName: resolvedProjectName,
   });
@@ -3044,6 +3160,7 @@ export function buildCanonicalDrawingModelFromCompiledProject({
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction: resolvedJurisdiction,
+      jurisdictionPack: resolvedJurisdictionPack,
       units,
     }),
   ];
@@ -3055,6 +3172,12 @@ export function buildCanonicalDrawingModelFromCompiledProject({
     geometryHash,
     sourceProjectGraphHash,
     jurisdiction: resolvedJurisdiction,
+    jurisdictionPack: jurisdictionPackSummary,
+    jurisdictionPackResolution: {
+      source: jurisdictionResolution.source,
+      warnings: jurisdictionResolution.warnings || [],
+      sourceGaps: jurisdictionResolution.sourceGaps || [],
+    },
     units,
     modelSpace: {
       units,
@@ -3067,6 +3190,12 @@ export function buildCanonicalDrawingModelFromCompiledProject({
       nativeLayouts: sheets.map((sheet) => sheet.nativeLayout),
     },
     plotStyleMetadata: clone(DEFAULT_PLOT_STYLE_METADATA),
+    materialHatchPreferences: clone(
+      resolvedJurisdictionPack?.materialHatchPreferences || {},
+    ),
+    cadLayerPreferences: clone(
+      resolvedJurisdictionPack?.cadLayerPreferences || {},
+    ),
     ...(structuralModel ? { structuralModel } : {}),
     ...(mepModel ? { mepModel } : {}),
     ...(detailLibrary ? { detailLibrary } : {}),
@@ -3105,6 +3234,8 @@ export function buildCanonicalDrawingModelFromCompiledProject({
         ],
         geometryHash,
         sourceProjectGraphHash,
+        labels: clone(resolvedJurisdictionPack?.titleBlockLabels || {}),
+        jurisdictionPack: jurisdictionPackSummary,
       },
     ],
     viewports: sheets.flatMap((sheet) =>
@@ -3113,12 +3244,23 @@ export function buildCanonicalDrawingModelFromCompiledProject({
         sheetId: sheet.sheetId,
       })),
     ),
-    drawingScales: buildDrawingScales(),
+    drawingScales:
+      resolvedJurisdictionPack?.drawingScales?.map((ratio) => ({
+        name: `jurisdiction_${String(ratio).replace(/[^0-9]+/g, "_")}`,
+        ratio,
+        paperUnits: "mm",
+        modelUnits: "m",
+      })) || buildDrawingScales(),
     sheetMetadata: {
       projectName: resolvedProjectName,
       geometryHash,
       sourceProjectGraphHash,
       jurisdiction: resolvedJurisdiction,
+      jurisdictionPack: jurisdictionPackSummary,
+      titleBlockLabels: clone(resolvedJurisdictionPack?.titleBlockLabels || {}),
+      drawingStatusLabels: clone(
+        resolvedJurisdictionPack?.drawingStatusLabels || {},
+      ),
       units,
       revision: "P01",
       status: "Preliminary",
@@ -3132,6 +3274,12 @@ export function buildCanonicalDrawingModelFromCompiledProject({
       technicalDrawing: true,
       imageProviderUsed: "none",
       source: "compiled_project",
+      jurisdictionPack: jurisdictionPackSummary,
+      jurisdictionPackResolution: {
+        source: jurisdictionResolution.source,
+        warnings: jurisdictionResolution.warnings || [],
+        sourceGaps: jurisdictionResolution.sourceGaps || [],
+      },
     },
   };
 }
@@ -3192,6 +3340,39 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
       validationError(
         "CAD_MODEL_UNITS_MISSING",
         "CanonicalDrawingModel requires units.",
+      ),
+    );
+  }
+  const jurisdictionPackValidation = model.jurisdictionPack
+    ? validateJurisdictionPack(model.jurisdictionPack)
+    : null;
+  if (!model.jurisdictionPack) {
+    warnings.push(
+      validationError(
+        "CAD_MODEL_JURISDICTION_PACK_MISSING",
+        "CanonicalDrawingModel has no jurisdiction pack metadata.",
+      ),
+    );
+  } else if (!jurisdictionPackValidation.valid) {
+    jurisdictionPackValidation.errors.forEach((issue) => {
+      errors.push(
+        validationError(
+          issue.code || "CAD_MODEL_JURISDICTION_PACK_INVALID",
+          issue.message ||
+            "CanonicalDrawingModel jurisdiction pack is invalid.",
+          issue.details || {},
+        ),
+      );
+    });
+  }
+  if (
+    model.jurisdictionPack &&
+    packHasFalseComplianceClaim(model.jurisdictionPack)
+  ) {
+    errors.push(
+      validationError(
+        "CAD_MODEL_JURISDICTION_FALSE_COMPLIANCE_CLAIM",
+        "Jurisdiction metadata must not claim legal/code compliance or construction approval.",
       ),
     );
   }
@@ -3744,6 +3925,15 @@ export function validateCanonicalDrawingModel(model = {}, options = {}) {
       hasNativeViewports,
       hasPlotSettings,
       hasPlotStyleMetadata,
+      hasJurisdictionPack: Boolean(model.jurisdictionPack?.version),
+      jurisdictionPackId: model.jurisdictionPack?.jurisdictionId || null,
+      jurisdictionCountryCode: model.jurisdictionPack?.countryCode || null,
+      jurisdictionPackVersion: model.jurisdictionPack?.version || null,
+      hasJurisdictionDisclaimer: Boolean(
+        model.jurisdictionPack?.disclaimers?.preliminaryAdvisory,
+      ),
+      jurisdictionSourceGaps:
+        model.metadata?.jurisdictionPackResolution?.sourceGaps || [],
       hasStructuralModelHash,
       hasStructuralDisclaimer: Boolean(hasStructuralDisclaimer),
       structuralReviewRequired: model.structuralModel?.reviewRequired === true,
@@ -3775,6 +3965,13 @@ export function summarizeCanonicalDrawingModel(model = {}) {
     sourceProjectGraphHash: model.sourceProjectGraphHash || null,
     units: model.units || null,
     jurisdiction: model.jurisdiction || null,
+    jurisdictionPack: model.jurisdictionPack
+      ? {
+          jurisdictionId: model.jurisdictionPack.jurisdictionId || null,
+          countryCode: model.jurisdictionPack.countryCode || null,
+          version: model.jurisdictionPack.version || null,
+        }
+      : null,
     entityCount: entities.length,
     sheetCount: toArray(model.paperSpace?.sheets).length,
     layerCount: toArray(model.layers).length,

--- a/src/services/cad/canonicalDxfExporter.js
+++ b/src/services/cad/canonicalDxfExporter.js
@@ -504,6 +504,10 @@ function paperSpaceTextEntity(sheet, text, x, y, height = 3.2) {
   );
 }
 
+function titleBlockLabel(sheet = {}, key, fallback) {
+  return sheet.titleBlockLabels?.[key] || fallback;
+}
+
 function paperSpacePolylineEntity(sheet, points, layer = "A-TITLE") {
   return paperSpaceEntity(
     {
@@ -605,35 +609,35 @@ function buildPaperSpaceEntities(model = {}) {
       ),
       paperSpaceTextEntity(
         sheet,
-        `DRAWING_NUMBER: ${sheet.sheetNumber || sheet.drawingNumber}`,
+        `${titleBlockLabel(sheet, "drawingNumber", "DRAWING_NUMBER")}: ${sheet.sheetNumber || sheet.drawingNumber}`,
         width - 190,
         60,
         3.2,
       ),
       paperSpaceTextEntity(
         sheet,
-        `TITLE: ${sheet.title}`,
+        `${titleBlockLabel(sheet, "title", "TITLE")}: ${sheet.title}`,
         width - 190,
         52,
         3.2,
       ),
       paperSpaceTextEntity(
         sheet,
-        `SCALE: ${sheet.scale}`,
+        `${titleBlockLabel(sheet, "scale", "SCALE")}: ${sheet.scale}`,
         width - 190,
         44,
         2.8,
       ),
       paperSpaceTextEntity(
         sheet,
-        `REVISION: ${sheet.revision}`,
+        `${titleBlockLabel(sheet, "revision", "REVISION")}: ${sheet.revision}`,
         width - 190,
         36,
         2.8,
       ),
       paperSpaceTextEntity(
         sheet,
-        `STATUS: ${sheet.status}`,
+        `${titleBlockLabel(sheet, "status", "STATUS")}: ${sheet.status}`,
         width - 190,
         28,
         2.8,
@@ -703,6 +707,18 @@ function writeEntitiesSection({
     `SOURCE_PROJECT_GRAPH_HASH: ${model.sourceProjectGraphHash}`,
     sourceModelHash ? `SOURCE_MODEL_HASH: ${sourceModelHash}` : null,
     pipelineVersion ? `PIPELINE: ${pipelineVersion}` : null,
+    model.jurisdictionPack?.jurisdictionId
+      ? `JURISDICTION_ID: ${model.jurisdictionPack.jurisdictionId}`
+      : null,
+    model.jurisdictionPack?.countryCode
+      ? `JURISDICTION_COUNTRY_CODE: ${model.jurisdictionPack.countryCode}`
+      : null,
+    model.jurisdictionPack?.version
+      ? `JURISDICTION_PACK_VERSION: ${model.jurisdictionPack.version}`
+      : null,
+    model.jurisdictionPack?.disclaimers?.preliminaryAdvisory
+      ? `JURISDICTION_DISCLAIMER: ${model.jurisdictionPack.disclaimers.preliminaryAdvisory}`
+      : null,
     `EXPORT_VERSION: ${DXF_EXPORT_VERSION}`,
     `DRAWING_MODEL_VERSION: ${model.schema_version}`,
   ].filter(Boolean);

--- a/src/services/details/constructionDetailLibrary.js
+++ b/src/services/details/constructionDetailLibrary.js
@@ -3,6 +3,7 @@ import {
   createStableId,
   roundMetric,
 } from "../cad/projectGeometrySchema.js";
+import { summarizeJurisdictionPack } from "../jurisdiction/jurisdictionPackService.js";
 
 export const CONSTRUCTION_DETAIL_LIBRARY_VERSION =
   "construction-detail-library-v1";
@@ -388,6 +389,7 @@ function buildConstructionDetail(definition, index, context) {
 export function buildConstructionDetailLibraryFromCompiledProject({
   compiledProject,
   jurisdiction = null,
+  jurisdictionPack = null,
 } = {}) {
   if (!compiledProject?.geometryHash) {
     throw new Error(
@@ -397,9 +399,19 @@ export function buildConstructionDetailLibraryFromCompiledProject({
   const context = {
     geometryHash: compiledProject.geometryHash,
     sourceProjectGraphHash: sourceProjectGraphHashOf(compiledProject),
-    jurisdiction: jurisdictionOf(compiledProject, jurisdiction),
+    jurisdiction:
+      jurisdictionPack?.jurisdictionId ||
+      jurisdictionOf(compiledProject, jurisdiction),
     projectContext: projectContext(compiledProject),
   };
+  const jurisdictionPackSummary = jurisdictionPack
+    ? summarizeJurisdictionPack(jurisdictionPack)
+    : null;
+  const disclaimers = [
+    DETAIL_REVIEW_DISCLAIMER,
+    jurisdictionPackSummary?.disclaimers?.details,
+    jurisdictionPackSummary?.disclaimers?.preliminaryAdvisory,
+  ].filter(Boolean);
   const details = DETAIL_DEFINITIONS.map((definition, index) =>
     buildConstructionDetail(definition, index, context),
   );
@@ -412,9 +424,11 @@ export function buildConstructionDetailLibraryFromCompiledProject({
     geometryHash: context.geometryHash,
     sourceProjectGraphHash: context.sourceProjectGraphHash,
     jurisdiction: context.jurisdiction,
+    jurisdictionPack: jurisdictionPackSummary,
+    jurisdictionPackVersion: jurisdictionPackSummary?.version || null,
     reviewRequired: true,
     disclaimer: DETAIL_REVIEW_DISCLAIMER,
-    disclaimers: [DETAIL_REVIEW_DISCLAIMER],
+    disclaimers,
     requiredDetailTypes: [...REQUIRED_CONSTRUCTION_DETAIL_TYPES],
     requiredCadLayers: [...REQUIRED_DETAIL_CAD_LAYERS],
     details,
@@ -542,10 +556,12 @@ export function buildConstructionDetailPanelsFromDetailLibrary(
 export function buildConstructionDetailPanelsFromCompiledProject({
   compiledProject,
   jurisdiction = null,
+  jurisdictionPack = null,
 } = {}) {
   const detailLibrary = buildConstructionDetailLibraryFromCompiledProject({
     compiledProject,
     jurisdiction,
+    jurisdictionPack,
   });
   return buildConstructionDetailPanelsFromDetailLibrary(detailLibrary);
 }

--- a/src/services/jurisdiction/data/algeria.json
+++ b/src/services/jurisdiction/data/algeria.json
@@ -1,0 +1,170 @@
+{
+  "jurisdictionId": "algeria",
+  "countryCode": "DZ",
+  "countryName": "Algeria",
+  "version": "jurisdiction-pack-algeria-v1",
+  "languages": ["fr", "ar", "en"],
+  "defaultLanguage": "fr",
+  "units": {
+    "length": "m",
+    "area": "m2",
+    "paper": "mm"
+  },
+  "drawingScales": ["1:500", "1:200", "1:100", "1:50", "1:20", "1:10", "1:5"],
+  "titleBlockLabels": {
+    "project": "Projet",
+    "drawingNumber": "DESSIN",
+    "title": "TITRE",
+    "scale": "ECHELLE",
+    "revision": "REVISION",
+    "status": "STATUT",
+    "date": "Date",
+    "author": "Auteur",
+    "company": "Societe",
+    "location": "Site / Wilaya",
+    "programme": "Programme",
+    "ribaStage": "Phase",
+    "bilingualNote": "French default with Arabic-ready alternate labels"
+  },
+  "a1TitleBlockLabels": {
+    "project": "Projet",
+    "scale": "ECHELLE",
+    "status": "STATUT",
+    "date": "Date",
+    "drawingNumber": "DESSIN",
+    "revision": "REVISION",
+    "location": "Site / Wilaya",
+    "programme": "Programme",
+    "ribaStage": "Phase"
+  },
+  "alternateTitleBlockLabels": {
+    "ar": {
+      "project": "المشروع",
+      "drawingNumber": "رقم الرسم",
+      "title": "العنوان",
+      "scale": "المقياس",
+      "revision": "المراجعة",
+      "status": "الحالة",
+      "date": "التاريخ",
+      "location": "الموقع"
+    }
+  },
+  "drawingStatusLabels": {
+    "preliminary": "Preliminaire",
+    "draft": "Projet pour revue",
+    "information": "Pour information",
+    "review": "Pour revue professionnelle"
+  },
+  "cadLayerPreferences": {
+    "naming": "ascii_safe_archiai_layers_with_french_bilingual_labels",
+    "keepCurrentArchitecturalLayers": true,
+    "aliases": {
+      "A-WALL": "A-MUR",
+      "A-DOOR": "A-PORTE",
+      "A-WINDOW": "A-FENETRE",
+      "A-DIMS": "A-COTES",
+      "A-TEXT": "A-TEXTE"
+    }
+  },
+  "defaultCadLayers": [
+    "A-WALL",
+    "A-WALL-EXT",
+    "A-DOOR",
+    "A-WINDOW",
+    "A-STAIR",
+    "A-ROOM",
+    "A-DIMS",
+    "A-TEXT",
+    "A-HATCH",
+    "A-SITE",
+    "A-TITLE",
+    "S-FOUNDATION",
+    "S-COLUMN",
+    "S-BEAM",
+    "S-SLAB",
+    "S-ROOF",
+    "S-GRID",
+    "S-NOTES",
+    "S-DIMS",
+    "E-LIGHT",
+    "E-POWER",
+    "P-WATER",
+    "P-DRAIN",
+    "M-VENT",
+    "MEP-NOTES",
+    "A-DETAIL",
+    "A-CALLOUT"
+  ],
+  "materialHatchPreferences": {
+    "masonry": "STONE",
+    "concrete": "CONCRETE",
+    "timber": "TIMBER",
+    "insulation": "INSULATION",
+    "earth": "EARTH",
+    "membrane": "MEMBRANE"
+  },
+  "climateAssumptions": {
+    "climateZone": "hot_dry_to_mediterranean_advisory",
+    "rainfall": "regional rainfall and flood risk must be verified",
+    "overheating": "solar control, thermal mass, courtyard/patio cooling, and night ventilation should be reviewed locally"
+  },
+  "localStyleDefaults": {
+    "source": "algeria_jurisdiction_pack",
+    "materials": [
+      "light coloured render",
+      "local stone",
+      "high-albedo facade",
+      "timber or metal shading screen",
+      "thermal mass wall"
+    ],
+    "facadeCues": [
+      "deep reveals",
+      "shading screens",
+      "courtyard or patio cues",
+      "light-coloured wall planes"
+    ],
+    "climateResponses": [
+      "solar control",
+      "thermal mass",
+      "courtyard ventilation",
+      "reduced west glazing"
+    ],
+    "vernacularPackHints": []
+  },
+  "planningRegulatoryChecklist": {
+    "status": "preliminary_advisory",
+    "items": [
+      "wilaya/local authority planning context",
+      "site access",
+      "fire safety review",
+      "seismic/structural review",
+      "water and drainage review"
+    ],
+    "sourceNote": "Preliminary advisory checklist - verify with local authority and licensed professionals."
+  },
+  "structuralAssumptions": {
+    "basis": "preliminary Algeria residential coordination assumptions",
+    "review": "licensed structural engineer review required"
+  },
+  "mepAssumptions": {
+    "basis": "preliminary Algeria MEP coordination assumptions",
+    "review": "qualified MEP engineer review required"
+  },
+  "disclaimers": {
+    "preliminaryAdvisory": "Preliminary advisory checklist - verify with local authority and licensed professionals.",
+    "structural": "Informations structurelles preliminaires uniquement - revue par un ingenieur structure qualifie requise.",
+    "mep": "Informations MEP preliminaires uniquement - revue par un ingenieur MEP qualifie requise.",
+    "details": "Details de construction preliminaires uniquement - revue par l'architecte et les ingenieurs responsables requise."
+  },
+  "reviewRequirements": {
+    "architect": true,
+    "structuralEngineer": true,
+    "mepEngineer": true,
+    "localAuthority": true
+  },
+  "exportNamingConventions": {
+    "drawingPrefix": "A",
+    "technicalSetPrefix": "DZ",
+    "fileSlug": "algeria"
+  }
+}

--- a/src/services/jurisdiction/data/france.json
+++ b/src/services/jurisdiction/data/france.json
@@ -1,0 +1,155 @@
+{
+  "jurisdictionId": "france",
+  "countryCode": "FR",
+  "countryName": "France",
+  "version": "jurisdiction-pack-france-v1",
+  "languages": ["fr", "en"],
+  "defaultLanguage": "fr",
+  "units": {
+    "length": "m",
+    "area": "m2",
+    "paper": "mm"
+  },
+  "drawingScales": ["1:500", "1:200", "1:100", "1:50", "1:20", "1:10", "1:5"],
+  "titleBlockLabels": {
+    "project": "Projet",
+    "drawingNumber": "DESSIN",
+    "title": "TITRE",
+    "scale": "ECHELLE",
+    "revision": "REVISION",
+    "status": "STATUT",
+    "date": "Date",
+    "author": "Auteur",
+    "company": "Societe",
+    "location": "Adresse",
+    "programme": "Programme",
+    "ribaStage": "Phase"
+  },
+  "a1TitleBlockLabels": {
+    "project": "Projet",
+    "scale": "ECHELLE",
+    "status": "STATUT",
+    "date": "Date",
+    "drawingNumber": "DESSIN",
+    "revision": "REVISION",
+    "location": "Adresse",
+    "programme": "Programme",
+    "ribaStage": "Phase"
+  },
+  "drawingStatusLabels": {
+    "preliminary": "Preliminaire",
+    "draft": "Projet pour revue",
+    "information": "Pour information",
+    "review": "Pour revue professionnelle"
+  },
+  "cadLayerPreferences": {
+    "naming": "ascii_safe_archiai_layers_with_french_labels",
+    "keepCurrentArchitecturalLayers": true,
+    "aliases": {
+      "A-WALL": "A-MUR",
+      "A-DOOR": "A-PORTE",
+      "A-WINDOW": "A-FENETRE",
+      "A-DIMS": "A-COTES",
+      "A-TEXT": "A-TEXTE"
+    }
+  },
+  "defaultCadLayers": [
+    "A-WALL",
+    "A-WALL-EXT",
+    "A-DOOR",
+    "A-WINDOW",
+    "A-STAIR",
+    "A-ROOM",
+    "A-DIMS",
+    "A-TEXT",
+    "A-HATCH",
+    "A-SITE",
+    "A-TITLE",
+    "S-FOUNDATION",
+    "S-COLUMN",
+    "S-BEAM",
+    "S-SLAB",
+    "S-ROOF",
+    "S-GRID",
+    "S-NOTES",
+    "S-DIMS",
+    "E-LIGHT",
+    "E-POWER",
+    "P-WATER",
+    "P-DRAIN",
+    "M-VENT",
+    "MEP-NOTES",
+    "A-DETAIL",
+    "A-CALLOUT"
+  ],
+  "materialHatchPreferences": {
+    "masonry": "STONE",
+    "concrete": "CONCRETE",
+    "timber": "TIMBER",
+    "insulation": "INSULATION",
+    "roofTile": "TERRACOTTA_TILE",
+    "slate": "SLATE"
+  },
+  "climateAssumptions": {
+    "climateZone": "mixed_temperate_mediterranean_advisory",
+    "rainfall": "regional exposure must be verified",
+    "overheating": "shading, thermal mass, and ventilation should be reviewed locally"
+  },
+  "localStyleDefaults": {
+    "source": "france_jurisdiction_pack",
+    "materials": [
+      "lime render",
+      "local stone",
+      "terracotta roof tile",
+      "natural slate",
+      "timber shutters"
+    ],
+    "facadeCues": [
+      "rendered wall planes",
+      "stone base or reveals",
+      "terracotta or slate roof response"
+    ],
+    "climateResponses": [
+      "solar shading",
+      "thermal mass",
+      "natural ventilation"
+    ],
+    "vernacularPackHints": []
+  },
+  "planningRegulatoryChecklist": {
+    "status": "preliminary_advisory",
+    "items": [
+      "planning/zoning context",
+      "site access",
+      "fire safety review",
+      "accessibility review",
+      "thermal/environmental review"
+    ],
+    "sourceNote": "Preliminary advisory checklist - verify with local authority and licensed professionals."
+  },
+  "structuralAssumptions": {
+    "basis": "preliminary France residential coordination assumptions",
+    "review": "licensed structural engineer review required"
+  },
+  "mepAssumptions": {
+    "basis": "preliminary France MEP coordination assumptions",
+    "review": "qualified MEP engineer review required"
+  },
+  "disclaimers": {
+    "preliminaryAdvisory": "Preliminary advisory checklist - verify with local authority and licensed professionals.",
+    "structural": "Informations structurelles preliminaires uniquement - revue par un ingenieur structure qualifie requise.",
+    "mep": "Informations MEP preliminaires uniquement - revue par un ingenieur MEP qualifie requise.",
+    "details": "Details de construction preliminaires uniquement - revue par l'architecte et les ingenieurs responsables requise."
+  },
+  "reviewRequirements": {
+    "architect": true,
+    "structuralEngineer": true,
+    "mepEngineer": true,
+    "localAuthority": true
+  },
+  "exportNamingConventions": {
+    "drawingPrefix": "A",
+    "technicalSetPrefix": "FR",
+    "fileSlug": "france"
+  }
+}

--- a/src/services/jurisdiction/data/generic.json
+++ b/src/services/jurisdiction/data/generic.json
@@ -1,0 +1,120 @@
+{
+  "jurisdictionId": "generic",
+  "countryCode": "INT",
+  "countryName": "International / Unresolved",
+  "version": "jurisdiction-pack-generic-v1",
+  "languages": ["en"],
+  "defaultLanguage": "en",
+  "units": {
+    "length": "m",
+    "area": "m2",
+    "paper": "mm"
+  },
+  "drawingScales": ["1:500", "1:200", "1:100", "1:50", "1:20", "1:10", "1:5"],
+  "titleBlockLabels": {
+    "project": "Project",
+    "drawingNumber": "DRAWING_NUMBER",
+    "title": "TITLE",
+    "scale": "SCALE",
+    "revision": "REVISION",
+    "status": "STATUS",
+    "date": "Date",
+    "author": "Author",
+    "company": "Company",
+    "location": "Location",
+    "programme": "Programme",
+    "ribaStage": "Design Stage"
+  },
+  "a1TitleBlockLabels": {
+    "project": "Project",
+    "scale": "Scale",
+    "status": "Status",
+    "date": "Date",
+    "drawingNumber": "Drawing No.",
+    "revision": "Rev",
+    "location": "Location",
+    "programme": "Programme",
+    "ribaStage": "Design Stage"
+  },
+  "drawingStatusLabels": {
+    "preliminary": "Preliminary",
+    "draft": "Draft for review",
+    "information": "For information",
+    "review": "For professional review"
+  },
+  "cadLayerPreferences": {
+    "naming": "current_archiai_ascii_layers",
+    "keepCurrentArchitecturalLayers": true,
+    "aliases": {}
+  },
+  "defaultCadLayers": [
+    "A-WALL",
+    "A-WALL-EXT",
+    "A-DOOR",
+    "A-WINDOW",
+    "A-STAIR",
+    "A-ROOM",
+    "A-DIMS",
+    "A-TEXT",
+    "A-HATCH",
+    "A-SITE",
+    "A-TITLE"
+  ],
+  "materialHatchPreferences": {
+    "masonry": "BRICK",
+    "concrete": "CONCRETE",
+    "timber": "TIMBER",
+    "insulation": "INSULATION"
+  },
+  "climateAssumptions": {
+    "climateZone": "unknown",
+    "rainfall": "verify local climate assumptions",
+    "overheating": "verify local solar and ventilation assumptions"
+  },
+  "localStyleDefaults": {
+    "source": "generic_jurisdiction_pack",
+    "materials": [
+      "neutral render",
+      "local masonry",
+      "timber accent",
+      "durable roof finish"
+    ],
+    "facadeCues": ["locally verified material palette"],
+    "climateResponses": ["verify climate response locally"],
+    "vernacularPackHints": []
+  },
+  "planningRegulatoryChecklist": {
+    "status": "source_gap",
+    "items": [
+      "local planning context",
+      "professional review",
+      "local authority verification"
+    ],
+    "sourceNote": "Preliminary advisory checklist - verify with local authority and licensed professionals."
+  },
+  "structuralAssumptions": {
+    "basis": "generic preliminary structural coordination assumptions",
+    "review": "licensed structural engineer review required"
+  },
+  "mepAssumptions": {
+    "basis": "generic preliminary MEP coordination assumptions",
+    "review": "qualified MEP engineer review required"
+  },
+  "disclaimers": {
+    "preliminaryAdvisory": "Preliminary advisory checklist - verify with local authority and licensed professionals.",
+    "structural": "Preliminary structural information only - licensed structural engineer review is required.",
+    "mep": "Preliminary MEP information only - qualified MEP engineer review is required.",
+    "details": "Preliminary construction details only - responsible architect and engineer review is required."
+  },
+  "reviewRequirements": {
+    "architect": true,
+    "structuralEngineer": true,
+    "mepEngineer": true,
+    "localAuthority": true
+  },
+  "exportNamingConventions": {
+    "drawingPrefix": "A",
+    "technicalSetPrefix": "INT",
+    "fileSlug": "generic"
+  }
+}

--- a/src/services/jurisdiction/data/uk.json
+++ b/src/services/jurisdiction/data/uk.json
@@ -1,0 +1,148 @@
+{
+  "jurisdictionId": "uk",
+  "countryCode": "GB",
+  "countryName": "United Kingdom",
+  "version": "jurisdiction-pack-uk-v1",
+  "languages": ["en"],
+  "defaultLanguage": "en",
+  "units": {
+    "length": "m",
+    "area": "m2",
+    "paper": "mm"
+  },
+  "drawingScales": ["1:500", "1:200", "1:100", "1:50", "1:20", "1:10", "1:5"],
+  "titleBlockLabels": {
+    "project": "Project",
+    "drawingNumber": "DRAWING_NUMBER",
+    "title": "TITLE",
+    "scale": "SCALE",
+    "revision": "REVISION",
+    "status": "STATUS",
+    "date": "Date",
+    "author": "Author",
+    "company": "Company",
+    "location": "Location",
+    "programme": "Programme",
+    "ribaStage": "RIBA Stage"
+  },
+  "a1TitleBlockLabels": {
+    "project": "Project",
+    "scale": "Scale",
+    "status": "Status",
+    "date": "Date",
+    "drawingNumber": "Drawing No.",
+    "revision": "Rev",
+    "location": "Location",
+    "programme": "Programme",
+    "ribaStage": "RIBA Stage"
+  },
+  "drawingStatusLabels": {
+    "preliminary": "Preliminary",
+    "draft": "Draft for review",
+    "information": "For information",
+    "review": "For professional review"
+  },
+  "cadLayerPreferences": {
+    "naming": "current_archiai_ascii_layers",
+    "keepCurrentArchitecturalLayers": true,
+    "aliases": {}
+  },
+  "defaultCadLayers": [
+    "A-WALL",
+    "A-WALL-EXT",
+    "A-DOOR",
+    "A-WINDOW",
+    "A-STAIR",
+    "A-ROOM",
+    "A-DIMS",
+    "A-TEXT",
+    "A-HATCH",
+    "A-SITE",
+    "A-TITLE",
+    "S-FOUNDATION",
+    "S-COLUMN",
+    "S-BEAM",
+    "S-SLAB",
+    "S-ROOF",
+    "S-GRID",
+    "S-NOTES",
+    "S-DIMS",
+    "E-LIGHT",
+    "E-POWER",
+    "P-WATER",
+    "P-DRAIN",
+    "M-VENT",
+    "MEP-NOTES",
+    "A-DETAIL",
+    "A-CALLOUT"
+  ],
+  "materialHatchPreferences": {
+    "masonry": "BRICK",
+    "concrete": "CONCRETE",
+    "timber": "TIMBER",
+    "insulation": "INSULATION",
+    "earth": "EARTH"
+  },
+  "climateAssumptions": {
+    "climateZone": "temperate_maritime",
+    "rainfall": "wind-driven rain should be reviewed locally",
+    "overheating": "cross ventilation and shading should be reviewed for dwellings"
+  },
+  "localStyleDefaults": {
+    "source": "uk_jurisdiction_pack",
+    "materials": [
+      "warm stock brick",
+      "render with detailed reveals",
+      "timber boarding",
+      "concrete tile",
+      "slate"
+    ],
+    "facadeCues": [
+      "masonry rhythm",
+      "robust rain detailing",
+      "recessed openings"
+    ],
+    "climateResponses": [
+      "rain protection",
+      "moderate solar control",
+      "thermal continuity"
+    ],
+    "vernacularPackHints": ["ukVernacularPacks"]
+  },
+  "planningRegulatoryChecklist": {
+    "status": "preliminary_advisory",
+    "items": [
+      "planning context",
+      "neighbour amenity",
+      "access",
+      "fire strategy review",
+      "building control review"
+    ],
+    "sourceNote": "Preliminary advisory checklist - verify with local authority and licensed professionals."
+  },
+  "structuralAssumptions": {
+    "basis": "preliminary UK residential coordination assumptions",
+    "review": "licensed structural engineer review required"
+  },
+  "mepAssumptions": {
+    "basis": "preliminary UK MEP coordination assumptions",
+    "review": "qualified MEP engineer review required"
+  },
+  "disclaimers": {
+    "preliminaryAdvisory": "Preliminary advisory checklist - verify with local authority and licensed professionals.",
+    "structural": "Preliminary structural information only - licensed structural engineer review is required.",
+    "mep": "Preliminary MEP information only - qualified MEP engineer review is required.",
+    "details": "Preliminary construction details only - responsible architect and engineer review is required."
+  },
+  "reviewRequirements": {
+    "architect": true,
+    "structuralEngineer": true,
+    "mepEngineer": true,
+    "localAuthority": true
+  },
+  "exportNamingConventions": {
+    "drawingPrefix": "A",
+    "technicalSetPrefix": "UK",
+    "fileSlug": "uk"
+  }
+}

--- a/src/services/jurisdiction/jurisdictionPackService.js
+++ b/src/services/jurisdiction/jurisdictionPackService.js
@@ -1,0 +1,360 @@
+import ukPack from "./data/uk.json";
+import francePack from "./data/france.json";
+import algeriaPack from "./data/algeria.json";
+import genericPack from "./data/generic.json";
+
+export const JURISDICTION_PACK_SERVICE_VERSION = "jurisdiction-pack-service-v1";
+
+export const GENERIC_JURISDICTION_WARNING =
+  "JURISDICTION_PACK_GENERIC_FALLBACK";
+
+const PACKS = Object.freeze({
+  uk: ukPack,
+  france: francePack,
+  algeria: algeriaPack,
+  generic: genericPack,
+});
+
+const COUNTRY_ALIASES = Object.freeze({
+  uk: "uk",
+  gb: "uk",
+  gbr: "uk",
+  britain: "uk",
+  "great britain": "uk",
+  "united kingdom": "uk",
+  england: "uk",
+  scotland: "uk",
+  wales: "uk",
+  "northern ireland": "uk",
+  fr: "france",
+  fra: "france",
+  france: "france",
+  "republique francaise": "france",
+  "république française": "france",
+  dz: "algeria",
+  dza: "algeria",
+  algeria: "algeria",
+  algerie: "algeria",
+  algérie: "algeria",
+  الجزائر: "algeria",
+  generic: "generic",
+  international: "generic",
+});
+
+const REQUIRED_PACK_FIELDS = Object.freeze([
+  "jurisdictionId",
+  "countryCode",
+  "countryName",
+  "version",
+  "languages",
+  "defaultLanguage",
+  "units",
+  "drawingScales",
+  "titleBlockLabels",
+  "drawingStatusLabels",
+  "cadLayerPreferences",
+  "defaultCadLayers",
+  "materialHatchPreferences",
+  "climateAssumptions",
+  "localStyleDefaults",
+  "planningRegulatoryChecklist",
+  "structuralAssumptions",
+  "mepAssumptions",
+  "disclaimers",
+  "reviewRequirements",
+  "exportNamingConventions",
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function compactText(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function sourceGap(message, details = {}) {
+  return {
+    code: GENERIC_JURISDICTION_WARNING,
+    severity: "warning",
+    message,
+    details,
+  };
+}
+
+function resolveAlias(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  if (COUNTRY_ALIASES[raw]) return COUNTRY_ALIASES[raw];
+  const compact = compactText(raw);
+  return COUNTRY_ALIASES[compact] || null;
+}
+
+function inferFromAddress(address = "") {
+  const raw = String(address || "");
+  const compact = compactText(raw);
+  if (!compact) return null;
+  if (
+    /\b(united kingdom|great britain|england|scotland|wales|northern ireland|scunthorpe)\b/i.test(
+      raw,
+    ) ||
+    /\b[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}\b/i.test(raw)
+  ) {
+    return "uk";
+  }
+  if (
+    /\b(france|paris|lyon|marseille|republique francaise|république française)\b/i.test(
+      raw,
+    ) ||
+    (/\b\d{5}\b/.test(raw) && /\bfrance\b/i.test(raw))
+  ) {
+    return "france";
+  }
+  if (
+    /\b(algeria|algerie|algérie|algiers|alger|oran|constantine|wilaya)\b/i.test(
+      raw,
+    ) ||
+    /الجزائر/.test(raw) ||
+    (/\b\d{5}\b/.test(raw) && /\b(dz|dza|algeria|algerie|algérie)\b/i.test(raw))
+  ) {
+    return "algeria";
+  }
+  if (compact.includes("alger")) return "algeria";
+  return null;
+}
+
+function assertPackKnown(id, input) {
+  if (id && PACKS[id]) return id;
+  const error = new Error(
+    `JURISDICTION_PACK_NOT_FOUND: ${input || "unknown jurisdiction"}`,
+  );
+  error.code = "JURISDICTION_PACK_NOT_FOUND";
+  error.jurisdiction = input || null;
+  throw error;
+}
+
+function packWithValidation(pack) {
+  const cloned = clone(pack);
+  const validation = validateJurisdictionPack(cloned);
+  if (!validation.valid) {
+    const error = new Error(
+      `JURISDICTION_PACK_INVALID: ${validation.errors.map((entry) => entry.code).join(", ")}`,
+    );
+    error.code = "JURISDICTION_PACK_INVALID";
+    error.errors = validation.errors;
+    throw error;
+  }
+  return cloned;
+}
+
+export function loadJurisdictionPack(jurisdiction, options = {}) {
+  const id = resolveAlias(jurisdiction) || compactText(jurisdiction);
+  if (id && PACKS[id]) return packWithValidation(PACKS[id]);
+  if (options.allowGenericFallback === true) {
+    return packWithValidation(PACKS.generic);
+  }
+  assertPackKnown(id, jurisdiction);
+  return null;
+}
+
+export function resolveJurisdictionPack({
+  address = null,
+  country = null,
+  countryCode = null,
+  coordinates = null,
+  locale = null,
+  brief = null,
+} = {}) {
+  const explicitJurisdiction =
+    brief?.jurisdiction ||
+    brief?.jurisdictionId ||
+    brief?.jurisdiction_id ||
+    brief?.regulatory_jurisdiction ||
+    null;
+  const explicitId = resolveAlias(explicitJurisdiction);
+  if (explicitId && explicitId !== "generic") {
+    return {
+      pack: loadJurisdictionPack(explicitId),
+      jurisdictionId: explicitId,
+      source: "brief.jurisdiction",
+      warnings: [],
+      sourceGaps: [],
+    };
+  }
+
+  const countryInput =
+    countryCode ||
+    country ||
+    brief?.countryCode ||
+    brief?.country_code ||
+    brief?.country ||
+    null;
+  const countryId = resolveAlias(countryInput);
+  if (countryId && countryId !== "generic") {
+    return {
+      pack: loadJurisdictionPack(countryId),
+      jurisdictionId: countryId,
+      source: countryCode || brief?.countryCode ? "countryCode" : "country",
+      warnings: [],
+      sourceGaps: [],
+    };
+  }
+
+  const addressText = [
+    address,
+    brief?.address,
+    brief?.site_input?.address,
+    brief?.site_input?.postcode,
+    brief?.siteInput?.address,
+    brief?.siteInput?.postcode,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const addressId = inferFromAddress(addressText);
+  if (addressId) {
+    return {
+      pack: loadJurisdictionPack(addressId),
+      jurisdictionId: addressId,
+      source: "address",
+      warnings: [],
+      sourceGaps: [],
+    };
+  }
+
+  const localeId = resolveAlias(locale);
+  if (localeId && localeId !== "generic") {
+    return {
+      pack: loadJurisdictionPack(localeId),
+      jurisdictionId: localeId,
+      source: "locale",
+      warnings: [],
+      sourceGaps: [],
+    };
+  }
+
+  const warning = sourceGap(
+    "Jurisdiction could not be resolved from explicit jurisdiction, country, address, locale, or coordinates; using declared generic advisory pack.",
+    { address: addressText || null, country: countryInput, coordinates },
+  );
+  return {
+    pack: loadJurisdictionPack("generic", { allowGenericFallback: true }),
+    jurisdictionId: "generic",
+    source: "generic_fallback",
+    warnings: [warning],
+    sourceGaps: [warning],
+  };
+}
+
+export function summarizeJurisdictionPack(pack = null) {
+  if (!pack) return null;
+  return {
+    jurisdictionId: pack.jurisdictionId || null,
+    countryCode: pack.countryCode || null,
+    countryName: pack.countryName || null,
+    version: pack.version || null,
+    languages: asArray(pack.languages),
+    defaultLanguage: pack.defaultLanguage || null,
+    units: clone(pack.units || {}),
+    drawingScales: asArray(pack.drawingScales),
+    titleBlockLabels: clone(pack.titleBlockLabels || {}),
+    a1TitleBlockLabels: clone(pack.a1TitleBlockLabels || {}),
+    alternateTitleBlockLabels: clone(pack.alternateTitleBlockLabels || {}),
+    drawingStatusLabels: clone(pack.drawingStatusLabels || {}),
+    cadLayerPreferences: clone(pack.cadLayerPreferences || {}),
+    defaultCadLayers: asArray(pack.defaultCadLayers),
+    materialHatchPreferences: clone(pack.materialHatchPreferences || {}),
+    localStyleDefaults: clone(pack.localStyleDefaults || {}),
+    climateAssumptions: clone(pack.climateAssumptions || {}),
+    planningRegulatoryChecklist: clone(pack.planningRegulatoryChecklist || {}),
+    structuralAssumptions: clone(pack.structuralAssumptions || {}),
+    mepAssumptions: clone(pack.mepAssumptions || {}),
+    disclaimers: clone(pack.disclaimers || {}),
+    reviewRequirements: clone(pack.reviewRequirements || {}),
+    exportNamingConventions: clone(pack.exportNamingConventions || {}),
+  };
+}
+
+export function packHasFalseComplianceClaim(pack = {}) {
+  const haystack = JSON.stringify(pack || {});
+  return /\b(code compliant|approved for construction|certified for construction|legally approved|permit approved)\b/i.test(
+    haystack,
+  );
+}
+
+export function validateJurisdictionPack(pack = {}) {
+  const errors = [];
+  const warnings = [];
+  REQUIRED_PACK_FIELDS.forEach((field) => {
+    if (pack?.[field] === undefined || pack?.[field] === null) {
+      errors.push({
+        code: "JURISDICTION_PACK_FIELD_MISSING",
+        message: `Jurisdiction pack is missing ${field}.`,
+        details: { field },
+      });
+    }
+  });
+  if (!asArray(pack.languages).includes(pack.defaultLanguage)) {
+    errors.push({
+      code: "JURISDICTION_PACK_DEFAULT_LANGUAGE_INVALID",
+      message: "defaultLanguage must be listed in languages.",
+      details: { defaultLanguage: pack.defaultLanguage },
+    });
+  }
+  if (!asArray(pack.defaultCadLayers).length) {
+    errors.push({
+      code: "JURISDICTION_PACK_CAD_LAYERS_MISSING",
+      message: "Jurisdiction pack must declare default CAD layers.",
+    });
+  }
+  if (!pack.disclaimers?.preliminaryAdvisory) {
+    errors.push({
+      code: "JURISDICTION_PACK_DISCLAIMER_MISSING",
+      message:
+        "Jurisdiction pack must include preliminary advisory disclaimer text.",
+    });
+  }
+  if (packHasFalseComplianceClaim(pack)) {
+    errors.push({
+      code: "JURISDICTION_PACK_FALSE_COMPLIANCE_CLAIM",
+      message:
+        "Jurisdiction packs must not claim legal/code compliance or construction approval.",
+    });
+  }
+  if (pack.jurisdictionId === "generic") {
+    warnings.push(
+      sourceGap("Generic jurisdiction pack is advisory fallback only."),
+    );
+  }
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    checks: {
+      hasVersion: Boolean(pack.version),
+      hasCountryCode: Boolean(pack.countryCode),
+      hasTitleBlockLabels: Boolean(pack.titleBlockLabels),
+      hasCadLayers: asArray(pack.defaultCadLayers).length > 0,
+      hasDisclaimer: Boolean(pack.disclaimers?.preliminaryAdvisory),
+      falseComplianceClaim: packHasFalseComplianceClaim(pack),
+    },
+  };
+}
+
+export default {
+  JURISDICTION_PACK_SERVICE_VERSION,
+  GENERIC_JURISDICTION_WARNING,
+  loadJurisdictionPack,
+  resolveJurisdictionPack,
+  summarizeJurisdictionPack,
+  validateJurisdictionPack,
+  packHasFalseComplianceClaim,
+};

--- a/src/services/mep/mepModelService.js
+++ b/src/services/mep/mepModelService.js
@@ -5,6 +5,7 @@ import {
   createStableId,
   roundMetric,
 } from "../cad/projectGeometrySchema.js";
+import { summarizeJurisdictionPack } from "../jurisdiction/jurisdictionPackService.js";
 
 export const MEP_MODEL_VERSION = "mep-model-v1";
 export const MEP_DRAWING_PANEL_VERSION = "mep-drawing-panel-v1";
@@ -462,6 +463,7 @@ function buildSchedules(mepModelDraft) {
 export function buildMepModelFromCompiledProject({
   compiledProject,
   jurisdiction = null,
+  jurisdictionPack = null,
 } = {}) {
   if (!compiledProject?.geometryHash) {
     throw new Error(
@@ -474,11 +476,23 @@ export function buildMepModelFromCompiledProject({
   const electrical = buildElectricalLayouts(rooms);
   const hydraulic = buildPlumbingAndDrainage(rooms, risers);
   const ventilation = buildVentilation(rooms, risers);
+  const jurisdictionPackSummary = jurisdictionPack
+    ? summarizeJurisdictionPack(jurisdictionPack)
+    : null;
+  const disclaimers = [
+    MEP_REVIEW_DISCLAIMER,
+    jurisdictionPackSummary?.disclaimers?.mep,
+    jurisdictionPackSummary?.disclaimers?.preliminaryAdvisory,
+  ].filter(Boolean);
   const draft = {
     version: MEP_MODEL_VERSION,
     geometryHash: compiledProject.geometryHash,
     sourceProjectGraphHash: sourceProjectGraphHashOf(compiledProject),
-    jurisdiction: jurisdictionOf(compiledProject, jurisdiction),
+    jurisdiction:
+      jurisdictionPackSummary?.jurisdictionId ||
+      jurisdictionOf(compiledProject, jurisdiction),
+    jurisdictionPack: jurisdictionPackSummary,
+    jurisdictionPackVersion: jurisdictionPackSummary?.version || null,
     designBasis: {
       status: "preliminary",
       outputType: "coordination_model",
@@ -491,7 +505,7 @@ export function buildMepModelFromCompiledProject({
       "No pipe sizing, pressure drop, ventilation duty, circuit loading, discrimination, or code compliance calculations are performed.",
       "Fixture counts and routes are preliminary placeholders for qualified MEP engineer review.",
     ],
-    disclaimers: [MEP_REVIEW_DISCLAIMER],
+    disclaimers,
     reviewRequired: true,
     imageProviderUsed: "none",
     technicalDrawing: true,
@@ -799,10 +813,12 @@ export function buildMepDrawingPanelsFromMepModel(mepModel = {}) {
 export function buildMepDrawingPanelsFromCompiledProject({
   compiledProject,
   jurisdiction = null,
+  jurisdictionPack = null,
 } = {}) {
   const mepModel = buildMepModelFromCompiledProject({
     compiledProject,
     jurisdiction,
+    jurisdictionPack,
   });
   return buildMepDrawingPanelsFromMepModel(mepModel);
 }

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -15,6 +15,10 @@ import { buildCompiledProjectTechnicalPanels } from "../canonical/compiledProjec
 import { buildStructuralDrawingPanelsFromCompiledProject } from "../structure/structuralModelService.js";
 import { buildMepDrawingPanelsFromCompiledProject } from "../mep/mepModelService.js";
 import { buildConstructionDetailPanelsFromCompiledProject } from "../details/constructionDetailLibrary.js";
+import {
+  resolveJurisdictionPack,
+  summarizeJurisdictionPack,
+} from "../jurisdiction/jurisdictionPackService.js";
 import { compileProject } from "../compiler/index.js";
 import { ensureCompiledProjectRenderInputs } from "../compiler/compiledProjectRenderInputs.js";
 import { resolveArchitectureModelRegistry } from "../modelStepResolver.js";
@@ -4618,13 +4622,14 @@ function applyRegulationRules(regulations, ctx) {
   };
 }
 
-function buildLocalStylePack(brief, site, climate) {
+function buildLocalStylePack(brief, site, climate, jurisdictionPack = null) {
   // Plan §6.5 weighted blend: local 40 / user 25 / climate 20 / portfolio 15
   // modulated by user_intent.local_blend_strength and innovation_strength.
   return buildLocalStylePackV2({
     brief,
     site,
     climate,
+    jurisdictionPack,
     createStableId,
     paletteSize: 6,
   });
@@ -5323,6 +5328,62 @@ function detailDrawingsEnabled(options = {}) {
   );
 }
 
+function resolveProjectGraphJurisdictionPack({
+  brief = null,
+  compiledProject = null,
+  site = null,
+  input = null,
+  explicitPack = null,
+  explicitResolution = null,
+} = {}) {
+  if (explicitPack?.version) {
+    return {
+      pack: explicitPack,
+      jurisdictionId: explicitPack.jurisdictionId || null,
+      source: "explicit_option",
+      warnings: explicitResolution?.warnings || [],
+      sourceGaps: explicitResolution?.sourceGaps || [],
+    };
+  }
+  if (explicitResolution?.pack?.version) return explicitResolution;
+  return resolveJurisdictionPack({
+    address:
+      compiledProject?.locationData?.address ||
+      compiledProject?.metadata?.address ||
+      brief?.site_input?.address ||
+      input?.siteAddress ||
+      input?.locationData?.address ||
+      null,
+    country:
+      compiledProject?.metadata?.country ||
+      compiledProject?.locationData?.country ||
+      site?.country ||
+      input?.country ||
+      input?.locationData?.country ||
+      null,
+    countryCode:
+      compiledProject?.metadata?.countryCode ||
+      compiledProject?.locationData?.countryCode ||
+      input?.countryCode ||
+      input?.locationData?.countryCode ||
+      null,
+    coordinates:
+      compiledProject?.locationData?.coordinates ||
+      site?.coordinates ||
+      (site?.lat && site?.lon ? { lat: site.lat, lng: site.lon } : null),
+    locale: brief?.locale || input?.locale || null,
+    brief: {
+      ...(brief || {}),
+      ...(compiledProject?.jurisdiction
+        ? { jurisdiction: compiledProject.jurisdiction }
+        : {}),
+      ...(compiledProject?.metadata?.jurisdiction
+        ? { jurisdiction: compiledProject.metadata.jurisdiction }
+        : {}),
+    },
+  });
+}
+
 function buildDrawingSet(compiledProject, options = {}) {
   // Pass layoutTemplate through so the technical pack renders at the slot
   // aspect of the active sheet template (presentation-v3 for residential,
@@ -5331,18 +5392,38 @@ function buildDrawingSet(compiledProject, options = {}) {
     typeof options.layoutTemplate === "string" && options.layoutTemplate
       ? options.layoutTemplate
       : "board-v2";
+  const jurisdictionResolution = resolveProjectGraphJurisdictionPack({
+    brief: options.brief || compiledProject?.brief || null,
+    compiledProject,
+    site: options.site || null,
+    input: options.input || null,
+    explicitPack: options.jurisdictionPack || null,
+    explicitResolution: options.jurisdictionPackResolution || null,
+  });
+  const jurisdictionPack = jurisdictionResolution.pack;
+  const jurisdictionPackSummary = summarizeJurisdictionPack(jurisdictionPack);
   const technicalBuild = buildCompiledProjectTechnicalPanels(compiledProject, {
     layoutTemplate,
     vernacularPack: options.vernacularPack || null,
+    jurisdictionPack: jurisdictionPackSummary,
   });
   const structuralBuild = structuralDrawingsEnabled(options)
-    ? buildStructuralDrawingPanelsFromCompiledProject({ compiledProject })
+    ? buildStructuralDrawingPanelsFromCompiledProject({
+        compiledProject,
+        jurisdictionPack,
+      })
     : { structuralModel: null, structuralPanels: {} };
   const mepBuild = mepDrawingsEnabled(options)
-    ? buildMepDrawingPanelsFromCompiledProject({ compiledProject })
+    ? buildMepDrawingPanelsFromCompiledProject({
+        compiledProject,
+        jurisdictionPack,
+      })
     : { mepModel: null, mepPanels: {} };
   const detailBuild = detailDrawingsEnabled(options)
-    ? buildConstructionDetailPanelsFromCompiledProject({ compiledProject })
+    ? buildConstructionDetailPanelsFromCompiledProject({
+        compiledProject,
+        jurisdictionPack,
+      })
     : { detailLibrary: null, detailPanels: {} };
   const technicalPanels = {
     ...(technicalBuild.technicalPanels || {}),
@@ -5416,6 +5497,7 @@ function buildDrawingSet(compiledProject, options = {}) {
         contentBounds: panel.contentBounds || null,
         normalizedViewBox: panel.normalizedViewBox || null,
         status: panel.status || "ready",
+        jurisdictionPack: jurisdictionPackSummary,
       };
     },
   );
@@ -5424,6 +5506,13 @@ function buildDrawingSet(compiledProject, options = {}) {
     drawingSet: {
       model_version_id: `model-${compiledProject.geometryHash.slice(0, 12)}`,
       drawings: drawingViews,
+      jurisdictionPack: jurisdictionPackSummary,
+      jurisdictionPackResolution: {
+        source: jurisdictionResolution.source,
+        warnings: jurisdictionResolution.warnings || [],
+        sourceGaps: jurisdictionResolution.sourceGaps || [],
+      },
+      titleBlockLabels: jurisdictionPackSummary?.titleBlockLabels || {},
     },
     drawingArtifacts: Object.fromEntries(
       Object.entries(technicalPanels).map(([panelType, panel]) => {
@@ -5482,6 +5571,13 @@ function buildDrawingSet(compiledProject, options = {}) {
                 null,
               detailHashes: panel.detailHashes || [],
               reviewRequired: panel.reviewRequired || false,
+              jurisdictionPack: jurisdictionPackSummary,
+              jurisdictionPackResolution: {
+                source: jurisdictionResolution.source,
+                warnings: jurisdictionResolution.warnings || [],
+                sourceGaps: jurisdictionResolution.sourceGaps || [],
+              },
+              titleBlockLabels: jurisdictionPackSummary?.titleBlockLabels || {},
             },
           },
         ];
@@ -5495,6 +5591,12 @@ function buildDrawingSet(compiledProject, options = {}) {
       mepPanels: mepBuild.mepPanels || {},
       detailLibrary: detailBuild.detailLibrary || null,
       detailPanels: detailBuild.detailPanels || {},
+      jurisdictionPack: jurisdictionPackSummary,
+      jurisdictionPackResolution: {
+        source: jurisdictionResolution.source,
+        warnings: jurisdictionResolution.warnings || [],
+        sourceGaps: jurisdictionResolution.sourceGaps || [],
+      },
     },
   };
 }
@@ -7315,6 +7417,7 @@ export function buildTitleBlockPanelArtifact({
   sheetPlan,
   sheetDesignContext = null,
   visualManifest = null,
+  jurisdictionPack = null,
 }) {
   const width = 620;
   const height = 900;
@@ -7358,23 +7461,31 @@ export function buildTitleBlockPanelArtifact({
     visualManifest?.manifestHash ||
     sheetDesignContext?.visualManifestHash ||
     null;
+  const titleBlockLabels =
+    jurisdictionPack?.a1TitleBlockLabels ||
+    jurisdictionPack?.titleBlockLabels ||
+    {};
+  const labelFor = (key, fallback) => titleBlockLabels[key] || fallback;
   const disclaimerLines = splitNoteLines(PROFESSIONAL_REVIEW_DISCLAIMER, 64, 3);
   // Phase 2 — broader RIBA-style metadata. The first 5 rows preserve the
   // existing data source (so existing tests and downstream readers continue
   // working). The new rows surface RIBA Stage / Status / Revision / Date /
   // Drawing No. so reviewers get the full set on the sheet.
   const rows = [
-    ["Project", resolveProjectTitle(brief, sheetDesignContext)],
-    ["Scale", sheetPlan?.scale || "As noted"],
-    ["Status", status],
-    ["Date", dateLabel],
-    ["Drawing No.", drawingNumber],
-    ["Rev", revision],
-    ["Location", location],
-    ["Programme", programmeLabel],
+    [
+      labelFor("project", "Project"),
+      resolveProjectTitle(brief, sheetDesignContext),
+    ],
+    [labelFor("scale", "Scale"), sheetPlan?.scale || "As noted"],
+    [labelFor("status", "Status"), status],
+    [labelFor("date", "Date"), dateLabel],
+    [labelFor("drawingNumber", "Drawing No."), drawingNumber],
+    [labelFor("revision", "Rev"), revision],
+    [labelFor("location", "Location"), location],
+    [labelFor("programme", "Programme"), programmeLabel],
     ["Target GIA", `${round(brief?.target_gia_m2 || 0, 1)} m²`],
     ["Storeys", `${brief?.target_storeys || 1}`],
-    ["RIBA Stage", ribaStageLabel],
+    [labelFor("ribaStage", "RIBA Stage"), ribaStageLabel],
   ];
   const rowStartY = 232;
   const rowGap = 50;
@@ -7477,6 +7588,8 @@ export function buildTitleBlockPanelArtifact({
       studioFooter,
       visualManifestHash,
       rowKeys: rows.map((r) => r[0]),
+      jurisdictionPack: summarizeJurisdictionPack(jurisdictionPack),
+      titleBlockLabels,
       sheetDesignContextHash: sheetDesignContext?.contextHash || null,
       sourceContext: sheetDesignContext
         ? "sheet_design_context"
@@ -8416,6 +8529,7 @@ async function buildSheetPanelArtifacts({
   siteSnapshot = null,
   sheetPlan = null,
   visualManifest = null,
+  jurisdictionPack = null,
   // Phase 1: optional SheetDesignContext. Reserved for downstream
   // consumers; not consumed by the existing data-panel builders yet.
   // eslint-disable-next-line no-unused-vars
@@ -8465,6 +8579,7 @@ async function buildSheetPanelArtifacts({
     sheetPlan,
     sheetDesignContext,
     visualManifest,
+    jurisdictionPack,
   });
   const sheetNeedsVisual3d = sheetPlanRequiresVisual3d(sheetPlan);
   const visual3d = sheetNeedsVisual3d
@@ -9870,6 +9985,7 @@ async function buildA1Sheet({
   siteSnapshot = null,
   sheetPlan = null,
   visualManifest = null,
+  jurisdictionPack = null,
   // Phase 1: optional SheetDesignContext. Existing callers may omit it; the
   // function does not yet hard-depend on it.
   sheetDesignContext = null,
@@ -9962,6 +10078,7 @@ async function buildA1Sheet({
     compiledProject,
     geometryHash,
     siteSnapshot,
+    jurisdictionPack,
     sheetPlan: {
       ...(sheetPlan || {}),
       sheet_number: drawingNumber,
@@ -12839,9 +12956,21 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
   __vsMark = __vsLog("site_context", __vsMark);
   const siteMapSnapshot = await resolveSiteMapSnapshot({ input, brief, site });
   __vsMark = __vsLog("site_map_snapshot", __vsMark);
+  const jurisdictionPackResolution = resolveProjectGraphJurisdictionPack({
+    brief,
+    site,
+    input,
+  });
+  const jurisdictionPack = jurisdictionPackResolution.pack;
+  const jurisdictionPackSummary = summarizeJurisdictionPack(jurisdictionPack);
   const climate = buildClimatePack(brief, site, { weather });
   const regulationsMetadata = buildRegulationPack(brief);
-  const localStyle = buildLocalStylePack(brief, site, climate);
+  const localStyle = buildLocalStylePack(
+    brief,
+    site,
+    climate,
+    jurisdictionPack,
+  );
   const draftProgramme = buildProgramme({
     brief,
     programSpaces: input.programSpaces || input.programmeSpaces || [],
@@ -12911,6 +13040,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     },
   });
   compiledProject.generationSeed = brief.generation_seed;
+  compiledProject.jurisdiction = jurisdictionPack?.jurisdictionId || null;
   compiledProject.seedSource = brief.seedSource || null;
   compiledProject.variationMode = brief.variationMode || null;
   compiledProject.metadata = {
@@ -12919,6 +13049,12 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     seedSource: brief.seedSource || null,
     variationMode: brief.variationMode || null,
     generationLifecycle: brief.generation_lifecycle || null,
+    jurisdictionPack: jurisdictionPackSummary,
+    jurisdictionPackResolution: {
+      source: jurisdictionPackResolution.source,
+      warnings: jurisdictionPackResolution.warnings || [],
+      sourceGaps: jurisdictionPackResolution.sourceGaps || [],
+    },
   };
   __vsMark = __vsLog("compile_project", __vsMark);
   // Compiled-project QA. Catches geometry layers losing a level (e.g. the
@@ -12955,6 +13091,11 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     {
       layoutTemplate: drawingSetLayoutTemplate,
       vernacularPack: localStyle?.style_provenance || null,
+      jurisdictionPack,
+      jurisdictionPackResolution,
+      brief,
+      site,
+      input,
     },
   );
   __vsMark = __vsLog(
@@ -13142,6 +13283,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       siteSnapshot: siteMapSnapshot,
       sheetPlan,
       visualManifest,
+      jurisdictionPack,
       sheetDesignContext,
       architectReasoningManifest,
       visual3dArtifacts,
@@ -13941,6 +14083,12 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       generationLifecycle,
       geometryHash: compiledProject.geometryHash,
       visualManifestHash: visualManifest.manifestHash,
+      jurisdictionPack: jurisdictionPackSummary,
+      jurisdictionPackResolution: {
+        source: jurisdictionPackResolution.source,
+        warnings: jurisdictionPackResolution.warnings || [],
+        sourceGaps: jurisdictionPackResolution.sourceGaps || [],
+      },
     },
     projectTypeSupport: brief.project_type_support || null,
     projectGraph: finalGraph,

--- a/src/services/structure/structuralModelService.js
+++ b/src/services/structure/structuralModelService.js
@@ -6,6 +6,7 @@ import {
   rectangleToPolygon,
   roundMetric,
 } from "../cad/projectGeometrySchema.js";
+import { summarizeJurisdictionPack } from "../jurisdiction/jurisdictionPackService.js";
 import { buildStructuralGrid } from "./structuralGridService.js";
 
 export const STRUCTURAL_MODEL_VERSION = "structural-model-v1";
@@ -389,6 +390,7 @@ function buildSchedules({
 export function buildStructuralModelFromCompiledProject({
   compiledProject,
   jurisdiction = null,
+  jurisdictionPack = null,
 } = {}) {
   if (!compiledProject?.geometryHash) {
     throw new Error(
@@ -411,14 +413,27 @@ export function buildStructuralModelFromCompiledProject({
     "Column/grid coordination is indicative and must be rationalized by structural engineer calculations.",
     "Lateral stability, uplift, disproportionate collapse, and movement joints are not calculated.",
   ];
+  const jurisdictionPackSummary = jurisdictionPack
+    ? summarizeJurisdictionPack(jurisdictionPack)
+    : null;
+  const disclaimers = [
+    STRUCTURAL_REVIEW_DISCLAIMER,
+    jurisdictionPackSummary?.disclaimers?.structural,
+    jurisdictionPackSummary?.disclaimers?.preliminaryAdvisory,
+  ].filter(Boolean);
   const partial = {
     version: STRUCTURAL_MODEL_VERSION,
     geometryHash: compiledProject.geometryHash,
     sourceProjectGraphHash: sourceProjectGraphHashOf(compiledProject),
-    jurisdiction: jurisdiction || jurisdictionOf(compiledProject),
+    jurisdiction:
+      jurisdictionPackSummary?.jurisdictionId ||
+      jurisdiction ||
+      jurisdictionOf(compiledProject),
+    jurisdictionPack: jurisdictionPackSummary,
+    jurisdictionPackVersion: jurisdictionPackSummary?.version || null,
     designBasis,
     assumptions,
-    disclaimers: [STRUCTURAL_REVIEW_DISCLAIMER],
+    disclaimers,
     reviewRequired: true,
     foundationSystem,
     foundations,
@@ -767,10 +782,12 @@ export function buildStructuralDrawingPanelsFromStructuralModel(
 export function buildStructuralDrawingPanelsFromCompiledProject({
   compiledProject,
   jurisdiction = null,
+  jurisdictionPack = null,
 } = {}) {
   const structuralModel = buildStructuralModelFromCompiledProject({
     compiledProject,
     jurisdiction,
+    jurisdictionPack,
   });
   return {
     structuralModel,

--- a/src/services/style/localStylePack.js
+++ b/src/services/style/localStylePack.js
@@ -42,8 +42,12 @@ export function computeBlendWeights({
   portfolioStyleStrength = null,
 } = {}) {
   const local = clamp01(localBlendStrength, 0.5);
+  const hasExplicitPortfolioStyle =
+    portfolioStyleStrength !== null &&
+    portfolioStyleStrength !== undefined &&
+    portfolioStyleStrength !== "";
   const explicitPortfolioStyle = Number(portfolioStyleStrength);
-  if (Number.isFinite(explicitPortfolioStyle)) {
+  if (hasExplicitPortfolioStyle && Number.isFinite(explicitPortfolioStyle)) {
     const portfolioWeight = clamp01(explicitPortfolioStyle, 0.15);
     const remaining = Math.max(0, 1 - portfolioWeight);
     const localShareOfRemaining = 0.25 + 0.5 * local;
@@ -185,18 +189,36 @@ const CLIMATE_PALETTES_BY_RISK = Object.freeze({
   unknown: ["warm brick", "timber boarding", "standing seam roof"],
 });
 
-function localContextPalette(brief, site) {
+function jurisdictionLocalMaterials(jurisdictionPack = null) {
+  return Array.isArray(jurisdictionPack?.localStyleDefaults?.materials)
+    ? jurisdictionPack.localStyleDefaults.materials
+    : [];
+}
+
+function localContextPalette(brief, site, jurisdictionPack = null) {
   // UK regional vernacular pack (paper §4.3 transfer-by-curation): when a
   // resolved pack is present on the site, its materials lead the palette so
   // London-stucco, Edinburgh-tenement, etc. don't collapse to one nationwide
   // dwelling default.
-  const vernacularPack = site?.uk_vernacular_pack || null;
+  const vernacularHints =
+    jurisdictionPack &&
+    Array.isArray(jurisdictionPack?.localStyleDefaults?.vernacularPackHints)
+      ? jurisdictionPack.localStyleDefaults.vernacularPackHints
+      : null;
+  const useUkVernacular = vernacularHints
+    ? vernacularHints.includes("ukVernacularPacks")
+    : true;
+  const vernacularPack = useUkVernacular
+    ? site?.uk_vernacular_pack || null
+    : null;
   const vernacularMaterials = Array.isArray(vernacularPack?.materials)
     ? vernacularPack.materials
     : [];
-  const list =
-    LOCAL_PALETTES_BY_TYPE[brief.building_type] ||
-    LOCAL_PALETTES_BY_TYPE.community;
+  const jurisdictionMaterials = jurisdictionLocalMaterials(jurisdictionPack);
+  const list = jurisdictionMaterials.length
+    ? jurisdictionMaterials
+    : LOCAL_PALETTES_BY_TYPE[brief.building_type] ||
+      LOCAL_PALETTES_BY_TYPE.community;
   const explicitLocal =
     clamp01(brief?.user_intent?.local_material_strength, 0) > 0.9 &&
     Array.isArray(brief?.user_intent?.material_preferences)
@@ -291,10 +313,11 @@ export function computeMaterialPalette({
   brief,
   site,
   climate,
+  jurisdictionPack = null,
   paletteSize = 6,
 }) {
   const sourcePalettes = {
-    local: localContextPalette(brief, site),
+    local: localContextPalette(brief, site, jurisdictionPack),
     user: userPalette(brief),
     climate: climatePalette(climate),
     portfolio: portfolioPalette(brief),
@@ -343,10 +366,17 @@ export function buildLocalStylePackV2({
   brief,
   site,
   climate,
+  jurisdictionPack = null,
   createStableId,
   paletteSize = 6,
 } = {}) {
-  const blend = computeMaterialPalette({ brief, site, climate, paletteSize });
+  const blend = computeMaterialPalette({
+    brief,
+    site,
+    climate,
+    jurisdictionPack,
+    paletteSize,
+  });
   const styleKeywords = Array.isArray(brief?.user_intent?.style_keywords)
     ? brief.user_intent.style_keywords
     : [];
@@ -412,6 +442,22 @@ export function buildLocalStylePackV2({
         layout_archetype: null,
         conservation_typical: false,
       };
+  const jurisdictionEvidence = jurisdictionPack
+    ? {
+        source: "jurisdictionPack",
+        jurisdictionId: jurisdictionPack.jurisdictionId || null,
+        countryCode: jurisdictionPack.countryCode || null,
+        countryName: jurisdictionPack.countryName || null,
+        packVersion: jurisdictionPack.version || null,
+        defaultLanguage: jurisdictionPack.defaultLanguage || null,
+        materials: jurisdictionLocalMaterials(jurisdictionPack),
+        climateResponses: Array.isArray(
+          jurisdictionPack?.localStyleDefaults?.climateResponses,
+        )
+          ? [...jurisdictionPack.localStyleDefaults.climateResponses]
+          : [],
+      }
+    : null;
   return {
     style_pack_id: createStableId
       ? createStableId(
@@ -444,6 +490,8 @@ export function buildLocalStylePackV2({
     innovation_strength: brief?.user_intent?.innovation_strength ?? 0.5,
     data_quality: Array.isArray(site?.data_quality) ? site.data_quality : [],
     style_provenance: styleProvenance,
+    jurisdictionEvidence,
+    jurisdiction_style_defaults: jurisdictionPack?.localStyleDefaults || null,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds data-driven UK, France, Algeria, and declared generic jurisdiction packs for the professional CAD/BIM output pipeline.

Jurisdiction packs are data-driven, preliminary/advisory, and do not claim legal, planning, regulatory, or construction approval.

## Changes

- Adds `jurisdictionPackService` with versioned jurisdiction pack loading, validation, summarization, and resolver logic.
- Adds jurisdiction data packs for:
  - United Kingdom
  - France
  - Algeria
  - declared generic advisory fallback
- Resolver precedence:
  - explicit `brief.jurisdiction`
  - supplied `country` / `countryCode`
  - address/postcode inference
  - locale inference
  - generic fallback with source-gap warning
- Threads jurisdiction metadata into:
  - ProjectGraph drawing-set metadata
  - A1 title-block labels
  - CanonicalDrawingModel
  - DXF metadata
  - structural/MEP/detail advisory disclaimers
  - local style evidence
- Keeps CAD layer names DXF-safe ASCII while allowing localized title-block labels.
- Adds France local material/style defaults without UK vernacular names.
- Adds Algeria French/default labels plus Arabic alternate metadata without breaking CAD safety.
- Updates roadmap to describe jurisdiction packs as preliminary advisory data.

## Audit fixes

- A1 title-block labels are now pack-driven through `a1TitleBlockLabels`.
- UK vernacular selection now uses pack-provided `localStyleDefaults.vernacularPackHints` instead of hardcoded `jurisdictionId` checks.
- `computeBlendWeights` now handles null `portfolioStyleStrength` without accidentally treating it as an explicit zero.

## Validation

- Focused jurisdiction/CAD/DXF/style/structural/MEP/detail tests passed: 10 suites, 77 tests.
- `npm run lint`
- `git diff --check` passed with CRLF warnings only.
- `npm run check:env` passed with existing advisory warnings.
- `npm run check:contracts`
- `npm run build:active` passed with existing CRA bundle-size warning.

## Safety and scope

- No image-generation path added for technical drawings.
- Fake DWG remains disabled.
- Existing ProjectGraph/A1/CAD/structural/MEP/detail authority gates were not weakened.
- Unknown jurisdiction does not silently default to UK; it uses the declared generic advisory pack with a warning.

## Current limitations

- Packs are preliminary advisory metadata, not official regulation databases.
- Planning/regulatory checklist metadata must be verified with local authorities and licensed professionals.
- Algeria Arabic labels are exposed as alternate metadata; French remains the default CAD-safe title-block label set.
- No region-level packs, authority-specific planning checks, official regulation ingestion, or certified code compliance yet.
