### PR TITLE
Add deterministic local style portfolio blending

### DIFF
--- a/docs/roadmaps/local-style-portfolio-blending-roadmap.md
+++ b/docs/roadmaps/local-style-portfolio-blending-roadmap.md
@@ -1,0 +1,58 @@
+# Local Style + Portfolio Blending Roadmap
+
+## Status
+
+`StyleBlendManifest` is the ProjectGraph production authority for style blend
+evidence, weights, resolved material palette, rejected influences, and QA.
+
+The manifest is deterministic: identical inputs produce the same
+`manifestHash`. It is auditable: local, climate, user, jurisdiction, and
+portfolio evidence remain visible with source gaps and rejected influences.
+
+## Authority Rules
+
+Style blending must never override the ProjectGraph production authority chain:
+
+1. safety and statutory constraints
+2. programme and accessibility
+3. climate and passive-performance suitability
+4. local planning, jurisdiction, and context
+5. user style preference
+6. portfolio and graphic presentation identity
+
+Technical drawings remain deterministic SVG/CAD outputs from ProjectGraph /
+compiled geometry. Image2 panels are presentation renders only and must carry
+the same geometry, visual, and style blend hashes.
+
+## Runtime Integration
+
+- `src/services/style/localStylePack.js` remains the local/material evidence
+  base and provides the 40/25/20/15 default blend.
+- `src/services/style/styleBlendManifestService.js` wraps local, climate, user,
+  jurisdiction, and portfolio evidence into the single audited production
+  manifest.
+- `src/services/render/visualManifestService.js` consumes the style blend hash
+  and rejected-influence summary for image2 prompt locks.
+- `src/services/dnaPromptContext.js` consumes the resolved palette so A1 data
+  panels and key notes use the same source as visual prompts.
+- `src/services/ai/adaptiveStyleTransfer.js` is legacy for the older
+  panel-generation path and is not the ProjectGraph production authority.
+
+## Data Gaps
+
+- UK evidence is strongest when a UK vernacular pack resolves.
+- France and Algeria use deterministic jurisdiction/local-style defaults until
+  richer local datasets are connected.
+- Missing portfolio inputs produce explicit empty portfolio evidence and
+  redistribute portfolio weight; no portfolio identity is invented.
+- Missing jurisdiction/local evidence is recorded as a source gap instead of
+  being hallucinated.
+
+## QA Expectations
+
+- `styleBlendManifestHash` must match across `StyleBlendManifest`,
+  `visualManifest`, SheetDesignContext, A1 metadata, and image2 panel metadata.
+- Rejected influences must not appear as allowed prompt direction.
+- Portfolio influence must be zero when no portfolio evidence exists.
+- Heritage/local context, overheating risk, programme typology, and statutory
+  blockers must reject incompatible lower-priority style influences.

--- a/src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js
+++ b/src/__tests__/services/a1KeyNotesAndMaterialPalettePackDriven.test.js
@@ -85,6 +85,113 @@ describe("buildKeyNoteItems — style provenance group", () => {
   });
 });
 
+describe("buildKeyNoteItems — StyleBlend portfolio provenance", () => {
+  test("does not leak rejected glass-heavy portfolio materials into key notes", () => {
+    const styleBlendManifest = {
+      manifestHash: "styleblend-glass-risk",
+      blendWeights: { local: 0.55, user: 0.2, climate: 0.2, portfolio: 0.05 },
+      localStyleEvidence: { label: "high overheating local context" },
+      portfolioStyleEvidence: {
+        hasPortfolioEvidence: true,
+        materials: [
+          "all-glass curtain wall",
+          "mirrored facade",
+          "fully glazed",
+          "timber solar screen",
+        ],
+      },
+      rejectedInfluences: [
+        {
+          influence: "unshaded/high-glass portfolio facade language",
+          rejectedBy: "climate",
+          reason:
+            "Climate suitability outranks portfolio identity where overheating risk is material.",
+        },
+      ],
+      conflicts: [
+        {
+          lower_priority_dropped:
+            "unshaded/high-glass portfolio facade language",
+          summary:
+            "Climate suitability reduced portfolio glazing influence because overheating risk is material.",
+        },
+      ],
+    };
+    const groups = buildKeyNoteItems({
+      brief: baseBrief,
+      site: baseSite,
+      climate: { overheating: { risk_level: "high" } },
+      regulations: baseRegulations,
+      localStyle: makeLocalStyleWithPack(null),
+      sheetDesignContext: {
+        styleBlendManifest,
+        styleBlendManifestHash: styleBlendManifest.manifestHash,
+        visualManifest: {
+          styleBlendPortfolioRationale: {
+            materials: ["timber solar screen"],
+          },
+        },
+      },
+    });
+    const provenanceGroup = groups.find((g) => g.id === "style_provenance");
+    const allText = provenanceGroup.lines.join(" ");
+
+    expect(allText).not.toMatch(/all-glass curtain wall/i);
+    expect(allText).not.toMatch(/mirrored facade/i);
+    expect(allText).not.toMatch(/fully glazed/i);
+    expect(allText).toMatch(/Compatible portfolio: timber solar screen/i);
+    expect(allText).toMatch(/Rejected style influences were excluded/i);
+    expect(styleBlendManifest.rejectedInfluences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          influence: "unshaded/high-glass portfolio facade language",
+        }),
+      ]),
+    );
+  });
+
+  test("filters raw portfolio materials when no visual rationale is supplied", () => {
+    const styleBlendManifest = {
+      manifestHash: "styleblend-raw-filter",
+      blendWeights: { local: 0.55, user: 0.2, climate: 0.2, portfolio: 0.05 },
+      localStyleEvidence: { label: "high overheating local context" },
+      portfolioStyleEvidence: {
+        hasPortfolioEvidence: true,
+        materials: [
+          "all-glass curtain wall",
+          "mirrored facade",
+          "fully glazed",
+          "terracotta baguette screen",
+        ],
+      },
+      rejectedInfluences: [
+        {
+          influence: "unshaded/high-glass portfolio facade language",
+          rejectedBy: "climate",
+        },
+      ],
+    };
+    const groups = buildKeyNoteItems({
+      brief: baseBrief,
+      site: baseSite,
+      climate: { overheating: { risk_level: "high" } },
+      regulations: baseRegulations,
+      localStyle: makeLocalStyleWithPack(null),
+      sheetDesignContext: {
+        styleBlendManifest,
+        styleBlendManifestHash: styleBlendManifest.manifestHash,
+      },
+    });
+    const provenanceGroup = groups.find((g) => g.id === "style_provenance");
+    const allText = provenanceGroup.lines.join(" ");
+
+    expect(allText).not.toMatch(/all-glass curtain wall/i);
+    expect(allText).not.toMatch(/mirrored facade/i);
+    expect(allText).not.toMatch(/fully glazed/i);
+    expect(allText).toMatch(/terracotta baguette screen/i);
+  });
+});
+
 describe("buildKeyNoteItems — QA summary group", () => {
   test("emits a 'QA summary' group when qaSummary carries adjacency + quantitative scores", () => {
     const groups = buildKeyNoteItems({

--- a/src/__tests__/services/style/styleBlendManifestService.test.js
+++ b/src/__tests__/services/style/styleBlendManifestService.test.js
@@ -1,0 +1,436 @@
+import {
+  buildStyleBlendManifest,
+  evaluateStyleBlendQA,
+  STYLE_BLEND_MANIFEST_VERSION,
+} from "../../../services/style/styleBlendManifestService.js";
+import { buildLocalStylePackV2 } from "../../../services/style/localStylePack.js";
+import { loadJurisdictionPack } from "../../../services/jurisdiction/jurisdictionPackService.js";
+
+function baseBrief(overrides = {}) {
+  return {
+    project_name: "Style Blend Test",
+    building_type: "dwelling",
+    target_storeys: 2,
+    site_input: { address: "Scunthorpe, United Kingdom", postcode: "DN15" },
+    user_intent: {
+      style_keywords: ["contextual contemporary"],
+      material_preferences: ["warm stock brick"],
+      local_blend_strength: 0.65,
+      innovation_strength: 0.35,
+      portfolio_mood: "riba_stage2",
+      ...(overrides.user_intent || {}),
+    },
+    ...overrides,
+  };
+}
+
+function buildFixture({
+  brief = baseBrief(),
+  site = {},
+  climate = { overheating: { risk_level: "low" } },
+  jurisdictionPack = loadJurisdictionPack("uk"),
+  portfolioItems = [],
+  portfolioProfile = null,
+  compiledProject = { geometryHash: "geom-style-001", levels: [{}, {}] },
+  programme = { template_provenance: { source: "matched_template" } },
+  regulations = { rule_summary: { hard_blocker_count: 0 } },
+} = {}) {
+  const localStyle = buildLocalStylePackV2({
+    brief,
+    site,
+    climate,
+    jurisdictionPack,
+  });
+  return buildStyleBlendManifest({
+    brief,
+    site,
+    climate,
+    localStyle,
+    portfolioItems,
+    portfolioProfile,
+    jurisdictionPack,
+    jurisdictionPackResolution: {
+      source: "test",
+      warnings: [],
+      sourceGaps: [],
+    },
+    compiledProject,
+    projectGraphId: "pg-style-001",
+    programme,
+    regulations,
+  });
+}
+
+describe("StyleBlendManifest contract", () => {
+  test("is deterministic for identical inputs", () => {
+    const first = buildFixture();
+    const second = buildFixture();
+    expect(first.version).toBe(STYLE_BLEND_MANIFEST_VERSION);
+    expect(first.manifestId).toBe(second.manifestId);
+    expect(first.manifestHash).toBe(second.manifestHash);
+    expect(first.authorityPriority).toEqual([
+      "safety",
+      "programme",
+      "climate",
+      "local",
+      "user",
+      "portfolio",
+    ]);
+  });
+
+  test("does not invent portfolio identity when no portfolio evidence exists", () => {
+    const manifest = buildFixture();
+    expect(manifest.portfolioStyleEvidence.hasPortfolioEvidence).toBe(false);
+    expect(manifest.blendWeights.portfolio).toBe(0);
+    expect(manifest.qaWarnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "STYLE_BLEND_PORTFOLIO_EVIDENCE_EMPTY",
+        }),
+      ]),
+    );
+    expect(JSON.stringify(manifest.portfolioStyleEvidence)).not.toMatch(
+      /restrained brick|riba_stage2/i,
+    );
+  });
+
+  test("extracts explicit portfolio material/style evidence", () => {
+    const manifest = buildFixture({
+      portfolioItems: [
+        {
+          id: "p1",
+          materials: ["brick", "timber"],
+          tags: ["deep reveals"],
+          style: "warm contemporary",
+          buildingType: "terraced house",
+        },
+      ],
+    });
+    expect(manifest.portfolioStyleEvidence.hasPortfolioEvidence).toBe(true);
+    expect(manifest.portfolioStyleEvidence.materials).toEqual(
+      expect.arrayContaining(["brick", "timber"]),
+    );
+    expect(manifest.resolvedPalette.map((entry) => entry.name)).toEqual(
+      expect.arrayContaining(["brick", "timber"]),
+    );
+  });
+
+  test("climate rejects high-glass portfolio language under overheating risk", () => {
+    const manifest = buildFixture({
+      climate: { overheating: { risk_level: "high" } },
+      portfolioItems: [
+        {
+          materials: ["all-glass curtain wall", "mirrored facade"],
+          tags: ["fully glazed"],
+          style: "glass box",
+        },
+      ],
+    });
+    expect(manifest.rejectedInfluences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rejectedBy: "climate",
+        }),
+      ]),
+    );
+    expect(manifest.blendWeights.portfolio).toBeLessThanOrEqual(0.05);
+  });
+
+  test("terraced context rejects detached portfolio typology", () => {
+    const brief = baseBrief({
+      original_subtype: "terraced-house",
+      project_type_support: { subtypeId: "terraced-house" },
+    });
+    const manifest = buildFixture({
+      brief,
+      portfolioItems: [
+        {
+          buildingType: "detached villa",
+          tags: ["freestanding open sides"],
+          materials: ["timber"],
+        },
+      ],
+      compiledProject: {
+        geometryHash: "geom-terrace",
+        partyWalls: [{ side: "left" }, { side: "right" }],
+      },
+    });
+    expect(manifest.rejectedInfluences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          influence: "detached/freestanding portfolio typology",
+        }),
+      ]),
+    );
+  });
+
+  test("France and Algeria use jurisdiction-local evidence without UK vernacular bleed", () => {
+    const france = buildFixture({
+      brief: baseBrief({
+        site_input: { address: "Lyon, France" },
+        jurisdiction: "france",
+      }),
+      jurisdictionPack: loadJurisdictionPack("france"),
+    });
+    const algeria = buildFixture({
+      brief: baseBrief({
+        site_input: { address: "Alger, Algeria" },
+        jurisdiction: "algeria",
+      }),
+      climate: { overheating: { risk_level: "high" } },
+      jurisdictionPack: loadJurisdictionPack("algeria"),
+    });
+
+    expect(france.localStyleEvidence.jurisdictionId).toBe("france");
+    expect(france.localStyleEvidence.materials.join(",")).toMatch(
+      /lime render|local stone/i,
+    );
+    expect(algeria.localStyleEvidence.jurisdictionId).toBe("algeria");
+    expect(algeria.localStyleEvidence.materials.join(",")).toMatch(
+      /light coloured render|thermal mass|shading screen/i,
+    );
+    expect(
+      JSON.stringify([france.localStyleEvidence, algeria.localStyleEvidence]),
+    ).not.toMatch(/ukVernacularPacks|London stucco|Manchester/i);
+  });
+});
+
+describe("StyleBlendQA", () => {
+  test("fails on visual manifest hash mismatch", () => {
+    const styleBlendManifest = buildFixture();
+    const report = evaluateStyleBlendQA({
+      styleBlendManifest,
+      visualManifest: {
+        styleBlendManifestHash: "different",
+      },
+      sheetDesignContext: {
+        styleBlendManifestHash: styleBlendManifest.manifestHash,
+      },
+    });
+    expect(report.status).toBe("fail");
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "STYLE_BLEND_VISUAL_MANIFEST_HASH_MISMATCH",
+        }),
+      ]),
+    );
+  });
+
+  test("catches A1 material palette drift", () => {
+    const styleBlendManifest = buildFixture({
+      portfolioItems: [{ materials: ["warm brick"], style: "contextual" }],
+    });
+    const report = evaluateStyleBlendQA({
+      styleBlendManifest,
+      visualManifest: {
+        styleBlendManifestHash: styleBlendManifest.manifestHash,
+      },
+      a1MaterialPalette: [{ name: "mirror-polished chrome panel" }],
+      strict: true,
+    });
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "STYLE_BLEND_A1_PALETTE_DRIFT" }),
+      ]),
+    );
+  });
+
+  test("catches missing styleBlendManifestHash in prompt evidence", () => {
+    const styleBlendManifest = buildFixture({
+      portfolioItems: [{ materials: ["brick"], style: "contextual" }],
+    });
+    const report = evaluateStyleBlendQA({
+      styleBlendManifest,
+      promptEvidence: [
+        {
+          panelType: "hero_3d",
+          finalPrompt: "GEOMETRY AND VISUAL AUTHORITY\ngeometryHash: geom",
+        },
+      ],
+      strict: true,
+    });
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "STYLE_BLEND_PROMPT_HASH_MISSING" }),
+      ]),
+    );
+  });
+
+  test("catches portfolio overweight in heritage/high-local context", () => {
+    const styleBlendManifest = buildFixture({
+      portfolioItems: [{ materials: ["brick"], style: "contextual" }],
+    });
+    const report = evaluateStyleBlendQA({
+      styleBlendManifest: {
+        ...styleBlendManifest,
+        localStyleEvidence: {
+          ...styleBlendManifest.localStyleEvidence,
+          heritageFlags: ["conservation-area"],
+        },
+        blendWeights: {
+          ...styleBlendManifest.blendWeights,
+          local: 0.65,
+          portfolio: 0.12,
+        },
+      },
+      strict: true,
+    });
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "STYLE_BLEND_PORTFOLIO_OVERWEIGHT" }),
+      ]),
+    );
+  });
+
+  test("catches rejected influence leakage into prompt evidence", () => {
+    const styleBlendManifest = {
+      ...buildFixture({
+        portfolioItems: [{ materials: ["brick"], style: "contextual" }],
+      }),
+      rejectedInfluences: [
+        {
+          influence: "sci-fi glass facade",
+          rejectedBy: "local",
+          reason: "Heritage context.",
+        },
+      ],
+    };
+    const report = evaluateStyleBlendQA({
+      styleBlendManifest,
+      promptEvidence: [
+        {
+          panelType: "exterior_render",
+          finalPrompt: `styleBlendManifestHash: ${styleBlendManifest.manifestHash}\nRender a sci-fi glass facade.`,
+        },
+      ],
+      strict: true,
+    });
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "STYLE_BLEND_REJECTED_INFLUENCE_LEAK",
+        }),
+      ]),
+    );
+  });
+
+  test("catches France and Algeria UK vernacular bleed", () => {
+    const france = buildFixture({
+      brief: baseBrief({
+        site_input: { address: "Lyon, France" },
+        jurisdiction: "france",
+      }),
+      jurisdictionPack: loadJurisdictionPack("france"),
+      portfolioItems: [{ materials: ["lime render"], style: "contextual" }],
+    });
+    const report = evaluateStyleBlendQA({
+      styleBlendManifest: {
+        ...france,
+        localStyleEvidence: {
+          ...france.localStyleEvidence,
+          materials: ["london-stucco-terrace"],
+        },
+      },
+      strict: true,
+    });
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "STYLE_BLEND_JURISDICTION_VERNACULAR_BLEED",
+        }),
+      ]),
+    );
+  });
+
+  test("valid UK terraced style blend passes strict QA", () => {
+    const brief = baseBrief({
+      original_subtype: "terraced-house",
+      project_type_support: { subtypeId: "terraced-house" },
+    });
+    const styleBlendManifest = buildFixture({
+      brief,
+      portfolioItems: [
+        {
+          buildingType: "terraced house",
+          materials: ["brick", "timber"],
+          style: "warm contextual",
+        },
+      ],
+      compiledProject: {
+        geometryHash: "geom-terrace-valid",
+        partyWalls: [{ side: "left" }, { side: "right" }],
+      },
+    });
+    const report = evaluateStyleBlendQA({
+      styleBlendManifest,
+      visualManifest: {
+        styleBlendManifestHash: styleBlendManifest.manifestHash,
+      },
+      sheetDesignContext: {
+        styleBlendManifestHash: styleBlendManifest.manifestHash,
+      },
+      a1MaterialPalette: styleBlendManifest.resolvedPalette,
+      promptEvidence: [
+        {
+          panelType: "hero_3d",
+          finalPrompt: `styleBlendManifestHash: ${styleBlendManifest.manifestHash}\nContextual terraced project.`,
+        },
+      ],
+      panelArtifacts: {
+        hero_3d: {
+          panelType: "hero_3d",
+          promptHash: "prompt-hash",
+          metadata: {
+            styleBlendManifestHash: styleBlendManifest.manifestHash,
+          },
+        },
+      },
+      strict: true,
+    });
+    expect(report.status).toBe("pass");
+  });
+
+  test("valid France and Algeria style blends do not use UK vernacular names", () => {
+    const france = buildFixture({
+      brief: baseBrief({
+        site_input: { address: "Lyon, France" },
+        jurisdiction: "france",
+      }),
+      jurisdictionPack: loadJurisdictionPack("france"),
+      portfolioItems: [{ materials: ["lime render"], style: "contextual" }],
+    });
+    const algeria = buildFixture({
+      brief: baseBrief({
+        site_input: { address: "Alger, Algeria" },
+        jurisdiction: "algeria",
+      }),
+      climate: { overheating: { risk_level: "high" } },
+      jurisdictionPack: loadJurisdictionPack("algeria"),
+      portfolioItems: [
+        { materials: ["shading screen"], style: "climate responsive" },
+      ],
+    });
+    for (const styleBlendManifest of [france, algeria]) {
+      const report = evaluateStyleBlendQA({
+        styleBlendManifest,
+        visualManifest: {
+          styleBlendManifestHash: styleBlendManifest.manifestHash,
+        },
+        a1MaterialPalette: styleBlendManifest.resolvedPalette,
+        promptEvidence: [
+          {
+            panelType: "hero_3d",
+            finalPrompt: `styleBlendManifestHash: ${styleBlendManifest.manifestHash}\nLocal jurisdiction style.`,
+          },
+        ],
+        strict: true,
+      });
+      expect(
+        report.issues.some(
+          (issue) => issue.code === "STYLE_BLEND_JURISDICTION_VERNACULAR_BLEED",
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/src/__tests__/services/visualManifestService.test.js
+++ b/src/__tests__/services/visualManifestService.test.js
@@ -247,6 +247,82 @@ describe("buildVisualManifest", () => {
     ]);
   });
 
+  test("carries StyleBlendManifest hash and rejected influence evidence", () => {
+    const styleBlendManifest = {
+      manifestId: "style-blend-001",
+      manifestHash: "styleblendhash001",
+      blendWeights: { local: 0.55, user: 0.2, climate: 0.2, portfolio: 0.05 },
+      materialWeights: {
+        local: 0.55,
+        user: 0.2,
+        climate: 0.2,
+        portfolio: 0.05,
+      },
+      resolvedPalette: [
+        { name: "Multi-stock red brick", application: "primary facade" },
+        { name: "Dark grey roof tile", application: "roof" },
+        { name: "Painted timber sash", application: "openings" },
+      ],
+      facadeLanguage: "red-brick terrace facade",
+      roofLanguage: "pitched tile roof",
+      windowLanguage: "regular sash window rhythm",
+      massingLanguage: "attached terrace massing",
+      detailLanguage: "painted timber sash",
+      graphicPresentationStyle: "restrained architectural presentation",
+      localStyleEvidence: { label: "Birmingham red-brick vernacular" },
+      portfolioStyleEvidence: {
+        hasPortfolioEvidence: true,
+        materials: ["timber"],
+        styles: ["warm contemporary"],
+        referenceCount: 1,
+      },
+      rejectedInfluences: [
+        {
+          influence: "detached/freestanding portfolio typology",
+          rejectedBy: "programme/local",
+          reason: "Terraced context.",
+        },
+      ],
+    };
+    const m = buildVisualManifest({
+      ...canonicalFixture(),
+      styleBlendManifest,
+    });
+    expect(m.styleBlendManifestHash).toBe("styleblendhash001");
+    expect(m.styleBlend.manifestHash).toBe("styleblendhash001");
+    expect(m.styleBlend.resolvedPalette).toEqual(
+      styleBlendManifest.resolvedPalette,
+    );
+    expect(m.styleBlend.facadeLanguage).toBe("red-brick terrace facade");
+    expect(m.styleBlend.roofLanguage).toBe("pitched tile roof");
+    expect(m.styleBlend.windowLanguage).toBe("regular sash window rhythm");
+    expect(m.styleBlend.detailLanguage).toBe("painted timber sash");
+    expect(m.resolvedPalette).toEqual(styleBlendManifest.resolvedPalette);
+    expect(m.facadeLanguage).toBe("red-brick terrace facade");
+    expect(m.roofLanguage).toBe("pitched tile roof");
+    expect(m.windowLanguage).toBe("regular sash window rhythm");
+    expect(m.detailLanguage).toBe("painted timber sash");
+    expect(m.styleBlendWeights.portfolio).toBe(0.05);
+    expect(m.styleBlendRejectedInfluences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          influence: "detached/freestanding portfolio typology",
+        }),
+      ]),
+    );
+    const lockBlock = buildVisualIdentityLockBlock(m);
+    expect(lockBlock).toContain("StyleBlendManifest: styleblendhash001");
+    expect(lockBlock).toContain("Compatible portfolio influence: timber");
+    expect(lockBlock).toContain(
+      "Rejected style influences were excluded by the style blend QA.",
+    );
+    expect(lockBlock).not.toContain("Rejected influence:");
+    expect(lockBlock).not.toContain("detached/freestanding portfolio typology");
+    expect(lockBlock).toContain(
+      "Do not violate safety, programme, climate, local/jurisdiction, or technical authority constraints",
+    );
+  });
+
   test("carries terraced attachment type and party wall sides from the residential subtype", () => {
     const m = buildVisualManifest(terracedFixture());
     expect(m.buildingType).toBe("dwelling");
@@ -462,6 +538,70 @@ describe("buildProjectGraphRenderPrompt — Phase D injection", () => {
     expect(interior).toContain("Render an indoor interior view only");
     expect(interior).toContain("Do not show an exterior facade");
     expect(interior).toContain("room programme, room adjacency");
+  });
+
+  test("prompt includes style blend hash and excludes rejected influence as allowed direction", () => {
+    const fixture = terracedFixture();
+    const styleBlendManifest = {
+      manifestId: "style-blend-terrace",
+      manifestHash: "styleblendterrace",
+      blendWeights: { local: 0.62, user: 0.18, climate: 0.15, portfolio: 0.05 },
+      materialWeights: {
+        local: 0.62,
+        user: 0.18,
+        climate: 0.15,
+        portfolio: 0.05,
+      },
+      resolvedPalette: [
+        { name: "Red brick", application: "primary facade" },
+        { name: "Clay tile", application: "roof" },
+        { name: "Painted timber", application: "openings" },
+      ],
+      facadeLanguage: "terraced brick frontage",
+      roofLanguage: "pitched clay tile roof",
+      windowLanguage: "regular punched windows",
+      massingLanguage: "attached terrace",
+      detailLanguage: "painted timber openings",
+      localStyleEvidence: { label: "terraced local context" },
+      portfolioStyleEvidence: {
+        hasPortfolioEvidence: true,
+        materials: ["timber"],
+        styles: ["warm contemporary"],
+      },
+      rejectedInfluences: [
+        {
+          influence: "detached/freestanding portfolio typology",
+          rejectedBy: "programme/local",
+          reason: "Terraced context.",
+        },
+      ],
+    };
+    const manifest = buildVisualManifest({
+      ...fixture,
+      styleBlendManifest,
+    });
+    const prompt = buildProjectGraphRenderPrompt({
+      panelType: "exterior_render",
+      brief: fixture.brief,
+      compiledProject: fixture.compiledProject,
+      climate: fixture.climate,
+      localStyle: fixture.localStyle,
+      styleDNA: fixture.styleDNA,
+      programmeSummary: { targetStoreys: 3 },
+      region: "Birmingham",
+      visualManifest: manifest,
+    });
+
+    expect(prompt).toContain("styleBlendManifestHash: styleblendterrace");
+    expect(prompt).toContain(
+      "Rejected style influences were excluded by the style blend QA.",
+    );
+    expect(prompt).not.toContain("Rejected influence:");
+    expect(prompt).not.toContain("detached/freestanding portfolio typology");
+    expect(prompt).toContain(
+      "Do not include rejected portfolio/local-style influences",
+    );
+    expect(prompt).toContain("No freestanding detached house");
   });
 
   test("when no manifest is supplied, no lock block is emitted", () => {

--- a/src/services/ai/adaptiveStyleTransfer.js
+++ b/src/services/ai/adaptiveStyleTransfer.js
@@ -1,9 +1,19 @@
 /**
- * Adaptive Style Transfer Service
+ * Adaptive Style Transfer Service (legacy)
  *
  * Blends portfolio styles with local architectural context to create
  * a unified style profile for design generation.
+ *
+ * This service is not the ProjectGraph production authority. The
+ * ProjectGraph path must use StyleBlendManifest from
+ * services/style/styleBlendManifestService.js so safety, programme, climate,
+ * local/jurisdiction, and technical authority constraints stay above
+ * portfolio influence.
  */
+
+export const ADAPTIVE_STYLE_TRANSFER_LEGACY = true;
+export const ADAPTIVE_STYLE_TRANSFER_LEGACY_NOTICE =
+  "Legacy panel-generation style helper only; ProjectGraph production uses StyleBlendManifest.";
 
 /**
  * Calculate dynamic weights based on portfolio, location, and creativity settings
@@ -189,6 +199,8 @@ export function applyStyleToPrompt(prompt, style = {}) {
 }
 
 export default {
+  ADAPTIVE_STYLE_TRANSFER_LEGACY,
+  ADAPTIVE_STYLE_TRANSFER_LEGACY_NOTICE,
   calculateDynamicWeights,
   transferStyle,
   applyStyleToPrompt,

--- a/src/services/design/panelGenerationService.js
+++ b/src/services/design/panelGenerationService.js
@@ -1573,7 +1573,8 @@ export async function planA1Panels({
   console.log(`   Panels: ${panelSequence.join(", ")}`);
   console.log(`   Seed source: ${seedSource}`);
 
-  // NEW: Generate style profile using adaptive style transfer (0.6/0.3/0.1 blend)
+  // Legacy multi-panel path only: ProjectGraph production style authority is
+  // StyleBlendManifest, not this adaptive style helper.
   // When conditionedPipeline is enabled, use its styleDescriptors instead
   // CRITICAL FIX: Use designFingerprint-scoped cache to prevent cross-generation contamination
   let styleProfile = styleProfileCache.get(designFingerprint);
@@ -1599,7 +1600,7 @@ export async function planA1Panels({
   } else if (!styleProfile) {
     try {
       console.log(
-        "🎨 Generating style profile (0.6 Portfolio / 0.3 Local / 0.1 Variation)...",
+        "🎨 Generating legacy adaptive style profile for non-ProjectGraph panels...",
       );
       const dynamicWeights = calculateDynamicWeights({
         portfolioItems,

--- a/src/services/dnaPromptContext.js
+++ b/src/services/dnaPromptContext.js
@@ -27,6 +27,8 @@ export const SHEET_DESIGN_CONTEXT_KEYS = Object.freeze([
   "region",
   "sustainability",
   "designFingerprint",
+  "styleBlendManifest",
+  "styleBlendManifestHash",
   "visualManifest",
   "contextHash",
 ]);
@@ -92,6 +94,14 @@ function normaliseMaterialEntry(entry, fallbackApplication = null) {
     application: application || null,
     role: nullIfBlank(entry.role) || null,
     hatch: nullIfBlank(entry.hatch) || null,
+    sourceTags: Array.isArray(entry.sourceTags)
+      ? entry.sourceTags.filter(Boolean)
+      : Array.isArray(entry.sources)
+        ? entry.sources.filter(Boolean)
+        : [],
+    provenanceLabel:
+      nullIfBlank(entry.provenanceLabel) ||
+      (Array.isArray(entry.sourceTags) ? entry.sourceTags.join("+") : null),
   };
 }
 
@@ -102,7 +112,18 @@ function normaliseMaterialList(rawList, fallbackApplication = null) {
     .filter(Boolean);
 }
 
-function resolveCanonicalMaterials({ masterDNA, compiledProject, localStyle }) {
+function resolveCanonicalMaterials({
+  masterDNA,
+  compiledProject,
+  localStyle,
+  styleBlendManifest = null,
+}) {
+  const fromStyleBlend = normaliseMaterialList(
+    styleBlendManifest?.resolvedPalette,
+    null,
+  );
+  if (fromStyleBlend.length > 0) return fromStyleBlend;
+
   // Prefer the canonical palette (Phase 8 SSOT) when it can be derived.
   try {
     const canonical = getCanonicalMaterialPalette({
@@ -147,28 +168,38 @@ function resolveCanonicalMaterials({ masterDNA, compiledProject, localStyle }) {
   return fromDNA;
 }
 
-function deriveStyleDescriptor({ masterDNA, localStyle, styleDNA }) {
+function deriveStyleDescriptor({
+  masterDNA,
+  localStyle,
+  styleDNA,
+  styleBlendManifest = null,
+}) {
   const structured = masterDNA?._structured || null;
   const architecture =
+    nullIfBlank(styleBlendManifest?.facadeLanguage) ||
     nullIfBlank(structured?.style?.architecture) ||
     nullIfBlank(masterDNA?.style?.architecture) ||
     nullIfBlank(localStyle?.primary_style) ||
     nullIfBlank(styleDNA?.style_name) ||
     "contemporary";
   const facadeLanguage =
+    nullIfBlank(styleBlendManifest?.facadeLanguage) ||
     nullIfBlank(styleDNA?.facade_language) ||
     nullIfBlank(localStyle?.facade_language) ||
     nullIfBlank(structured?.style?.facade_language) ||
     null;
   const roofLanguage =
+    nullIfBlank(styleBlendManifest?.roofLanguage) ||
     nullIfBlank(styleDNA?.roof_language) ||
     nullIfBlank(localStyle?.roof_language) ||
     null;
   const massingLanguage =
+    nullIfBlank(styleBlendManifest?.massingLanguage) ||
     nullIfBlank(styleDNA?.massing_language) ||
     nullIfBlank(localStyle?.massing_language) ||
     null;
   const windowLanguage =
+    nullIfBlank(styleBlendManifest?.windowLanguage) ||
     nullIfBlank(styleDNA?.window_language) ||
     nullIfBlank(localStyle?.window_language) ||
     null;
@@ -178,6 +209,7 @@ function deriveStyleDescriptor({ masterDNA, localStyle, styleDNA }) {
     styleDNA?.keywords,
     localStyle?.style_keywords,
     localStyle?.keywords,
+    styleBlendManifest?.userIntentEvidence?.styleKeywords,
   ]) {
     if (Array.isArray(list)) {
       for (const kw of list) {
@@ -231,7 +263,21 @@ function deriveClimateSummary(climate) {
   };
 }
 
-function derivePortfolioBlend({ localStyle }) {
+function derivePortfolioBlend({ localStyle, styleBlendManifest = null }) {
+  if (styleBlendManifest?.blendWeights) {
+    return {
+      localWeight: asNumberOrNull(styleBlendManifest.blendWeights.local),
+      portfolioWeight: asNumberOrNull(
+        styleBlendManifest.blendWeights.portfolio,
+      ),
+      climateWeight: asNumberOrNull(styleBlendManifest.blendWeights.climate),
+      userWeight: asNumberOrNull(styleBlendManifest.blendWeights.user),
+      styleBlendManifestHash: styleBlendManifest.manifestHash || null,
+      portfolioEvidence:
+        styleBlendManifest.portfolioStyleEvidence?.hasPortfolioEvidence ===
+        true,
+    };
+  }
   const weights = localStyle?.style_weights || localStyle?.weights || null;
   if (!weights || typeof weights !== "object") return null;
   const out = {
@@ -323,6 +369,7 @@ function deriveSustainability({ regulations, climate }) {
  * @param {object} [options.compiledProject]   - compiled geometry (authority)
  * @param {object} [options.climate]           - climate pack
  * @param {object} [options.localStyle]        - regional vernacular pack
+ * @param {object} [options.styleBlendManifest] - style blend authority
  * @param {object} [options.styleDNA]          - generated style DNA
  * @param {object} [options.regulations]      - regulation pack
  * @param {object} [options.programmeSummary]  - per-level programme summary
@@ -338,6 +385,7 @@ export function buildSheetDesignContext({
   compiledProject = null,
   climate = null,
   localStyle = null,
+  styleBlendManifest = null,
   styleDNA = null,
   regulations = null,
   programmeSummary = null,
@@ -360,10 +408,19 @@ export function buildSheetDesignContext({
     masterDNA,
     compiledProject,
     localStyle,
+    styleBlendManifest,
   });
-  const style = deriveStyleDescriptor({ masterDNA, localStyle, styleDNA });
+  const style = deriveStyleDescriptor({
+    masterDNA,
+    localStyle,
+    styleDNA,
+    styleBlendManifest,
+  });
   const climateSummary = deriveClimateSummary(climate);
-  const portfolioBlend = derivePortfolioBlend({ localStyle });
+  const portfolioBlend = derivePortfolioBlend({
+    localStyle,
+    styleBlendManifest,
+  });
   const programSpaces = deriveProgramSpaces({ programmeSummary, masterDNA });
   const sustainability = deriveSustainability({ regulations, climate });
   const resolvedRegion = nullIfBlank(region) || null;
@@ -391,6 +448,7 @@ export function buildSheetDesignContext({
     region: resolvedRegion,
     sustainability,
     visualManifestHash: visualManifest?.manifestHash || null,
+    styleBlendManifestHash: styleBlendManifest?.manifestHash || null,
   };
   const contextHash = computeCDSHashSync(hashable);
 
@@ -406,6 +464,8 @@ export function buildSheetDesignContext({
     region: resolvedRegion,
     sustainability,
     designFingerprint: designFingerprint || null,
+    styleBlendManifest: styleBlendManifest || null,
+    styleBlendManifestHash: styleBlendManifest?.manifestHash || null,
     visualManifest: visualManifest || null,
     contextHash,
   };

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -6628,6 +6628,96 @@ function compactManifestText(value, fallback = "", maxLength = 180) {
   return `${raw.slice(0, Math.max(0, maxLength - 1)).trimEnd()}.`;
 }
 
+function comparableStyleText(value) {
+  return String(value || "")
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function collectStyleBlendRejectedText(styleBlend = null) {
+  const rejectedInfluences = Array.isArray(styleBlend?.rejectedInfluences)
+    ? styleBlend.rejectedInfluences
+    : [];
+  const conflicts = Array.isArray(styleBlend?.conflicts)
+    ? styleBlend.conflicts
+    : [];
+  return [
+    ...rejectedInfluences.flatMap((entry) => [
+      entry?.influence,
+      entry?.reason,
+      entry?.rejectedBy,
+    ]),
+    ...conflicts.flatMap((entry) => [
+      entry?.lower_priority_dropped,
+      entry?.summary,
+    ]),
+  ]
+    .map(comparableStyleText)
+    .filter(Boolean)
+    .join(" ");
+}
+
+function filterCompatiblePortfolioKeyNoteMaterials(
+  materials = [],
+  styleBlend = null,
+) {
+  if (!Array.isArray(materials)) return [];
+  const rejectedText = collectStyleBlendRejectedText(styleBlend);
+  const seen = new Set();
+  return materials
+    .map((entry) =>
+      typeof entry === "string"
+        ? compactManifestText(entry, "", 120)
+        : compactManifestText(
+            entry?.name || entry?.material || entry?.label,
+            "",
+            120,
+          ),
+    )
+    .filter((name) => {
+      const normalized = comparableStyleText(name);
+      if (!normalized || seen.has(normalized)) return false;
+      seen.add(normalized);
+      if (!rejectedText) return true;
+      if (rejectedText.includes(normalized)) return false;
+      if (
+        /glass|glaz|curtain wall|mirrored/.test(normalized) &&
+        /glass|glaz|curtain wall|mirrored/.test(rejectedText)
+      ) {
+        return false;
+      }
+      if (
+        /sci fi|futur|parametric|blob/.test(normalized) &&
+        /sci fi|futur|parametric|blob/.test(rejectedText)
+      ) {
+        return false;
+      }
+      if (
+        /detached|freestanding/.test(normalized) &&
+        /detached|freestanding/.test(rejectedText)
+      ) {
+        return false;
+      }
+      return true;
+    });
+}
+
+function getCompatiblePortfolioKeyNoteMaterials({
+  styleBlend = null,
+  sheetDesignContext = null,
+} = {}) {
+  const visualRationaleMaterials =
+    sheetDesignContext?.visualManifest?.styleBlendPortfolioRationale?.materials;
+  const sourceMaterials =
+    Array.isArray(visualRationaleMaterials) && visualRationaleMaterials.length
+      ? visualRationaleMaterials
+      : styleBlend?.portfolioStyleEvidence?.materials;
+  return filterCompatiblePortfolioKeyNoteMaterials(sourceMaterials, styleBlend);
+}
+
 function summarizeProgrammeZones(
   programmeSummary = null,
   compiledProject = {},
@@ -7039,11 +7129,19 @@ export function buildKeyNoteItems({
     styleBlend?.portfolioStyleEvidence?.hasPortfolioEvidence === true &&
     Array.isArray(styleBlend.portfolioStyleEvidence.materials)
   ) {
-    styleProvenanceLines.push(
-      `Compatible portfolio: ${styleBlend.portfolioStyleEvidence.materials
-        .slice(0, 3)
-        .join(", ")}.`,
+    const compatiblePortfolioMaterials = getCompatiblePortfolioKeyNoteMaterials(
+      {
+        styleBlend,
+        sheetDesignContext,
+      },
     );
+    if (compatiblePortfolioMaterials.length > 0) {
+      styleProvenanceLines.push(
+        `Compatible portfolio: ${compatiblePortfolioMaterials
+          .slice(0, 3)
+          .join(", ")}.`,
+      );
+    }
   }
   if (
     Array.isArray(styleBlend?.rejectedInfluences) &&

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -77,6 +77,10 @@ import {
   summarizeRuleResults,
 } from "../regulation/runRules.js";
 import { buildLocalStylePackV2 } from "../style/localStylePack.js";
+import {
+  buildStyleBlendManifest,
+  evaluateStyleBlendQA,
+} from "../style/styleBlendManifestService.js";
 import { resolveUKVernacular } from "../style/ukVernacularPacks.js";
 import { generateRectangularOptions } from "../design/optionGenerator.js";
 import { scoreOption, selectBestOption } from "../design/optionScorer.js";
@@ -6503,10 +6507,16 @@ export function buildMaterialPalettePanelArtifact({
       categoryOffset: 10,
     },
   });
-  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="material_palette" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}">
+  const styleBlendManifestHash =
+    sheetDesignContext?.styleBlendManifestHash ||
+    sheetDesignContext?.styleBlendManifest?.manifestHash ||
+    localStyle?.styleBlendManifestHash ||
+    null;
+  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="material_palette" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-style-blend-manifest-hash="${escapeXml(styleBlendManifestHash || "")}">
   <defs>${defs}</defs>
   <rect width="${width}" height="${height}" fill="#ffffff"/>
   <text x="34" y="48" font-family="Arial, sans-serif" font-size="32" font-weight="700" fill="#111111">MATERIAL PALETTE</text>
+  <text x="34" y="78" font-family="Arial, sans-serif" font-size="13" fill="#444444">StyleBlendManifest ${escapeXml(String(styleBlendManifestHash || "n/a").slice(0, 18))}</text>
   <line x1="34" y1="66" x2="666" y2="66" stroke="#111111" stroke-width="2"/>
   ${cards}
 </svg>`;
@@ -6549,6 +6559,7 @@ export function buildMaterialPalettePanelArtifact({
       ).size,
       categories: cardMetadata.map((card) => card.category || null),
       sheetDesignContextHash: sheetDesignContext?.contextHash || null,
+      styleBlendManifestHash,
       sourceContext: sheetDesignContext ? "sheet_design_context" : "legacy_dna",
     },
   };
@@ -6999,6 +7010,49 @@ export function buildKeyNoteItems({
       ? localStyle.style_provenance
       : null;
   const styleProvenanceLines = [];
+  const styleBlend =
+    sheetDesignContext?.styleBlendManifest ||
+    (localStyle?.styleBlendManifestHash
+      ? {
+          manifestHash: localStyle.styleBlendManifestHash,
+          blendWeights: localStyle.style_blend_weights || null,
+          resolvedPalette: localStyle.style_blend_resolved_palette || [],
+          rejectedInfluences: [],
+        }
+      : null);
+  if (styleBlend?.manifestHash) {
+    styleProvenanceLines.push(
+      `StyleBlendManifest: ${String(styleBlend.manifestHash).slice(0, 18)}.`,
+    );
+  }
+  if (styleBlend?.blendWeights) {
+    styleProvenanceLines.push(
+      `Blend weights: local ${Math.round((styleBlend.blendWeights.local || 0) * 100)}%, user ${Math.round((styleBlend.blendWeights.user || 0) * 100)}%, climate ${Math.round((styleBlend.blendWeights.climate || 0) * 100)}%, portfolio ${Math.round((styleBlend.blendWeights.portfolio || 0) * 100)}%.`,
+    );
+  }
+  if (styleBlend?.localStyleEvidence?.label) {
+    styleProvenanceLines.push(
+      `Local style: ${String(styleBlend.localStyleEvidence.label).slice(0, 120)}.`,
+    );
+  }
+  if (
+    styleBlend?.portfolioStyleEvidence?.hasPortfolioEvidence === true &&
+    Array.isArray(styleBlend.portfolioStyleEvidence.materials)
+  ) {
+    styleProvenanceLines.push(
+      `Compatible portfolio: ${styleBlend.portfolioStyleEvidence.materials
+        .slice(0, 3)
+        .join(", ")}.`,
+    );
+  }
+  if (
+    Array.isArray(styleBlend?.rejectedInfluences) &&
+    styleBlend.rejectedInfluences.length > 0
+  ) {
+    styleProvenanceLines.push(
+      "Rejected style influences were excluded by StyleBlendManifest QA.",
+    );
+  }
   if (styleProvenance && styleProvenance.packLabel) {
     const period = styleProvenance.historical_period
       ? ` (${String(styleProvenance.historical_period).slice(0, 80)})`
@@ -7894,10 +7948,15 @@ export function buildProjectGraphRenderPrompt({
     visualManifest?.geometryHash ||
     "n/a";
   const visualManifestHash = visualManifest?.manifestHash || "n/a";
+  const styleBlendManifestHash =
+    visualManifest?.styleBlendManifestHash ||
+    sheetDesignContext?.styleBlendManifestHash ||
+    "n/a";
   const authorityLine = [
     "GEOMETRY AND VISUAL AUTHORITY:",
     `geometryHash: ${geometryHash}`,
     `visualManifestHash: ${visualManifestHash}`,
+    `styleBlendManifestHash: ${styleBlendManifestHash}`,
     "Use the supplied control image as the geometry reference; do not use text-only generation and do not invent project geometry.",
   ].join("\n");
   const visualContinuity =
@@ -8352,6 +8411,10 @@ export async function buildVisual3DPanelArtifacts({
       const requestId =
         renderProvenance?.requestId || renderResult?.requestId || null;
       const usage = renderProvenance?.usage || renderResult?.usage || null;
+      const styleBlendManifestHash =
+        visualManifest?.styleBlendManifestHash ||
+        sheetDesignContext?.styleBlendManifestHash ||
+        null;
       const generationSeed = normalizeGenerationSeed(brief?.generation_seed);
       const seedSource = brief?.seedSource || null;
       const variationMode = brief?.variationMode || null;
@@ -8392,6 +8455,7 @@ export async function buildVisual3DPanelArtifacts({
           variationMode,
           visualManifestId: visualManifest?.manifestId || null,
           visualManifestHash: visualManifest?.manifestHash || null,
+          styleBlendManifestHash,
           visualIdentityLocked: Boolean(visualManifest?.manifestHash),
           visualControlConsistency: controlConsistency,
           referenceSource: "compiled_3d_control_svg",
@@ -8474,6 +8538,7 @@ export async function buildVisual3DPanelArtifacts({
             // applies (the deterministic source is geometry-bound).
             visualManifestId: visualManifest?.manifestId || null,
             visualManifestHash: visualManifest?.manifestHash || null,
+            styleBlendManifestHash,
             visualIdentityLocked: Boolean(visualManifest?.manifestHash),
             buildingTypology: visualManifest?.buildingTypology || null,
             attachmentType: visualManifest?.attachmentType || null,
@@ -12782,6 +12847,7 @@ function buildProjectGraph({
   compiledProject,
   modelRegistry,
   projectGraphId,
+  styleBlendManifest = null,
 }) {
   const projectId =
     projectGraphId || createStableId("project-graph", brief.project_name);
@@ -12814,6 +12880,9 @@ function buildProjectGraph({
     climate,
     regulations,
     local_style: localStyle,
+    style_blend_manifest: styleBlendManifest,
+    styleBlendManifest,
+    styleBlendManifestHash: styleBlendManifest?.manifestHash || null,
     programme,
     design_options: scoredOptions,
     selected_design: {
@@ -13056,6 +13125,63 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       sourceGaps: jurisdictionPackResolution.sourceGaps || [],
     },
   };
+  const projectGraphId = createStableId(
+    "project-graph",
+    brief.project_name,
+    compiledProject.geometryHash,
+  );
+  const styleBlendManifest = buildStyleBlendManifest({
+    brief,
+    site,
+    climate,
+    localStyle,
+    portfolioItems: [
+      ...(Array.isArray(input.portfolioItems) ? input.portfolioItems : []),
+      ...(Array.isArray(input.portfolioReferences)
+        ? input.portfolioReferences
+        : []),
+      ...(Array.isArray(input.portfolioImages) ? input.portfolioImages : []),
+      ...(Array.isArray(input.portfolioFiles) ? input.portfolioFiles : []),
+      ...(Array.isArray(input.brief?.portfolioItems)
+        ? input.brief.portfolioItems
+        : []),
+    ],
+    portfolioProfile:
+      input.portfolioProfile ||
+      input.portfolioAnalysis ||
+      input.projectDetails?.portfolioProfile ||
+      input.brief?.portfolioProfile ||
+      null,
+    jurisdictionPack,
+    jurisdictionPackResolution,
+    compiledProject,
+    projectGraphId,
+    programme,
+    regulations,
+  });
+  Object.assign(localStyle, {
+    styleBlendManifestId: styleBlendManifest.manifestId,
+    styleBlendManifestHash: styleBlendManifest.manifestHash,
+    style_blend_manifest_id: styleBlendManifest.manifestId,
+    style_blend_manifest_hash: styleBlendManifest.manifestHash,
+    style_blend_weights: styleBlendManifest.blendWeights,
+    style_blend_resolved_palette: styleBlendManifest.resolvedPalette,
+    material_palette: styleBlendManifest.resolvedPalette,
+    material_palette_with_provenance: styleBlendManifest.resolvedPalette.map(
+      (entry) => ({
+        material: entry.name || entry.material,
+        score: entry.score,
+        sources: entry.sources || entry.sourceTags || [],
+      }),
+    ),
+  });
+  compiledProject.styleBlendManifestHash = styleBlendManifest.manifestHash;
+  compiledProject.metadata = {
+    ...(compiledProject.metadata || {}),
+    styleBlendManifestId: styleBlendManifest.manifestId,
+    styleBlendManifestHash: styleBlendManifest.manifestHash,
+    styleBlendManifest,
+  };
   __vsMark = __vsLog("compile_project", __vsMark);
   // Compiled-project QA. Catches geometry layers losing a level (e.g. the
   // 3-level brief silently producing a 2-level model). The level-count
@@ -13140,11 +13266,6 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     fineTunedModelUsed: entry.fineTunedModelUsed || null,
     deterministicGeometry: entry.deterministicGeometry === true,
   }));
-  const projectGraphId = createStableId(
-    "project-graph",
-    brief.project_name,
-    compiledProject.geometryHash,
-  );
   const drawingSetWithGraph = {
     ...drawingSet,
     drawings: drawingSet.drawings.map((drawing) => ({
@@ -13185,8 +13306,12 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     siteSnapshot: siteMapSnapshot,
     climate,
     localStyle,
+    styleBlendManifest,
     styleDNA: styleDNAForManifest,
-    materialPalette: localStyle?.material_palette || null,
+    materialPalette:
+      styleBlendManifest?.resolvedPalette ||
+      localStyle?.material_palette ||
+      null,
   });
   __vsMark = __vsLog("visual_manifest", __vsMark);
   // Phase 1 — SheetDesignContext foundation. One frozen contract object
@@ -13201,6 +13326,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     compiledProject,
     climate,
     localStyle,
+    styleBlendManifest,
     styleDNA: styleDNAForManifest,
     regulations,
     programmeSummary,
@@ -13310,6 +13436,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       renderProof: pdf.renderedProof,
       textRenderStatus: pdf.renderedProof?.textRenderStatus,
       sheetDesignContextHash: sheetDesignContext.contextHash,
+      styleBlendManifestHash: styleBlendManifest.manifestHash,
       sheetDesignContextVersion: SHEET_DESIGN_CONTEXT_VERSION,
     };
     renderedSheets.push({
@@ -13354,6 +13481,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     seedSource: generationLifecycle.seedSource,
     variationMode: generationLifecycle.variationMode,
     generationLifecycle,
+    styleBlendManifestHash: styleBlendManifest.manifestHash,
   };
   const siteMapArtifact =
     Object.values(primaryPanelArtifacts).find(
@@ -13828,6 +13956,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     compiledProject,
     modelRegistry,
     projectGraphId,
+    styleBlendManifest,
   });
   const graphWithStableId = {
     ...initialGraph,
@@ -13882,6 +14011,8 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     // metadata.visualManifestId / Hash / visualIdentityLocked.
     visualManifest,
     visualManifestHash: visualManifest.manifestHash,
+    styleBlendManifest,
+    styleBlendManifestHash: styleBlendManifest.manifestHash,
     // Phase 1 — SheetDesignContext foundation. Frozen contract object that
     // wraps visualManifest with material/style/climate/portfolio/programme.
     // Surfaced here so downstream tests/consumers can prove every panel
@@ -13934,6 +14065,36 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     qa,
     artifacts?.a1Sheet?.quality?.exportGate || null,
   );
+  const styleBlendQa = evaluateStyleBlendQA({
+    styleBlendManifest,
+    visualManifest,
+    sheetDesignContext,
+    panelArtifacts: primaryPanelArtifacts,
+    a1MaterialPalette:
+      sheetDesignContext?.materials || localStyle?.material_palette || [],
+    strict: true,
+  });
+  artifacts.styleBlendQa = styleBlendQa;
+  sheetArtifact.metadata = {
+    ...(sheetArtifact.metadata || {}),
+    styleBlendQa,
+  };
+  qa.styleBlend = styleBlendQa;
+  for (const issue of styleBlendQa.issues || []) {
+    qa.issues.push({
+      code: issue.code,
+      severity: issue.severity,
+      message: issue.message,
+      details: issue.details || {},
+    });
+  }
+  if (styleBlendQa.errorCount > 0) {
+    qa.status = "fail";
+    qa.score = Math.max(
+      0,
+      Number(qa.score || 0) - styleBlendQa.errorCount * 18,
+    );
+  }
   qa.openai = openaiQaMetadata;
   __vsMark = __vsLog("validate_qa", __vsMark, `qa_status=${qa.status}`);
 
@@ -13994,6 +14155,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
         }
       : null,
     style: {
+      styleBlendManifestHash: styleBlendManifest.manifestHash,
       regional_vernacular:
         localStyle?.region || localStyle?.region_label || null,
       facade_language:
@@ -14083,6 +14245,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       generationLifecycle,
       geometryHash: compiledProject.geometryHash,
       visualManifestHash: visualManifest.manifestHash,
+      styleBlendManifestHash: styleBlendManifest.manifestHash,
       jurisdictionPack: jurisdictionPackSummary,
       jurisdictionPackResolution: {
         source: jurisdictionPackResolution.source,
@@ -14094,8 +14257,10 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     projectGraph: finalGraph,
     provenanceManifest,
     architectReasoningManifest,
+    styleBlendManifest,
     artifacts: {
       ...artifacts,
+      styleBlendManifest,
       ...(architectReasoningManifest ? { architectReasoningManifest } : {}),
       qaReport: {
         asset_id: createStableId(

--- a/src/services/render/visualManifestService.js
+++ b/src/services/render/visualManifestService.js
@@ -43,6 +43,16 @@ function nullable(value) {
   return value;
 }
 
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function compactText(value) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function numericOrNull(value) {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
@@ -109,6 +119,108 @@ function normaliseMaterial(entry, fallbackApplication = null) {
     hex,
     application: nullable(entry.application) || fallbackApplication,
   };
+}
+
+function summarizeConflicts(conflicts = []) {
+  if (!Array.isArray(conflicts)) return [];
+  return conflicts
+    .map((entry) => ({
+      conflictId: entry?.conflict_id || entry?.id || null,
+      higherPriority: entry?.higher_priority || null,
+      lowerPriority: entry?.lower_priority || null,
+      summary: entry?.summary || null,
+    }))
+    .filter((entry) => entry.conflictId || entry.summary)
+    .slice(0, 8);
+}
+
+function buildStyleBlendRationaleSummary(styleBlendManifest = null) {
+  if (!styleBlendManifest) return null;
+  const local =
+    styleBlendManifest.localStyleEvidence?.label ||
+    styleBlendManifest.localStyleEvidence?.source ||
+    null;
+  const weights = styleBlendManifest.blendWeights || null;
+  const rejectedCount = Array.isArray(styleBlendManifest.rejectedInfluences)
+    ? styleBlendManifest.rejectedInfluences.length
+    : 0;
+  return {
+    local,
+    portfolioEvidence:
+      styleBlendManifest.portfolioStyleEvidence?.hasPortfolioEvidence === true,
+    climateEvidence:
+      Array.isArray(styleBlendManifest.climateEvidence?.climateResponses) &&
+      styleBlendManifest.climateEvidence.climateResponses.length > 0,
+    weights: weights ? clone(weights) : null,
+    rejectedInfluenceCount: rejectedCount,
+    constraintsOverridePortfolio: rejectedCount > 0,
+  };
+}
+
+function buildStyleBlendSnapshot(styleBlendManifest = null) {
+  if (!styleBlendManifest) return null;
+  return {
+    manifestHash: styleBlendManifest.manifestHash || null,
+    blendWeights: clone(styleBlendManifest.blendWeights || null),
+    materialWeights: clone(styleBlendManifest.materialWeights || null),
+    resolvedPalette: clone(styleBlendManifest.resolvedPalette || []),
+    facadeLanguage: nullable(styleBlendManifest.facadeLanguage),
+    roofLanguage: nullable(styleBlendManifest.roofLanguage),
+    windowLanguage: nullable(styleBlendManifest.windowLanguage),
+    massingLanguage: nullable(styleBlendManifest.massingLanguage),
+    detailLanguage: nullable(styleBlendManifest.detailLanguage),
+    graphicPresentationStyle: nullable(
+      styleBlendManifest.graphicPresentationStyle,
+    ),
+    conflictsSummary: summarizeConflicts(styleBlendManifest.conflicts),
+    rejectedInfluenceCount: Array.isArray(styleBlendManifest.rejectedInfluences)
+      ? styleBlendManifest.rejectedInfluences.length
+      : 0,
+    rationaleSummary: buildStyleBlendRationaleSummary(styleBlendManifest),
+  };
+}
+
+function filterCompatiblePortfolioValues(
+  values = [],
+  styleBlendManifest = null,
+) {
+  if (!Array.isArray(values)) return [];
+  const rejectedText = [
+    ...(styleBlendManifest?.rejectedInfluences || []).map(
+      (entry) => entry?.influence,
+    ),
+    ...(styleBlendManifest?.conflicts || []).map(
+      (entry) => entry?.lower_priority_dropped,
+    ),
+  ]
+    .map(compactText)
+    .join(" ")
+    .toLowerCase();
+  return values.filter((value) => {
+    const text = compactText(value);
+    if (!text) return false;
+    const lower = text.toLowerCase();
+    if (rejectedText.includes(lower)) return false;
+    if (
+      /glass|glaz|curtain wall/.test(lower) &&
+      /glass|glaz/.test(rejectedText)
+    ) {
+      return false;
+    }
+    if (
+      /sci-fi|futur|parametric|blob/.test(lower) &&
+      /sci-fi|futur|parametric|blob/.test(rejectedText)
+    ) {
+      return false;
+    }
+    if (
+      /detached|freestanding/.test(lower) &&
+      /detached|freestanding/.test(rejectedText)
+    ) {
+      return false;
+    }
+    return true;
+  });
 }
 
 function deriveRoof({ compiledProject, masterDNA, styleDNA, palette }) {
@@ -485,6 +597,9 @@ function deriveWindowRhythmFingerprint({ compiledProject }) {
  *                                             future use).
  * @param {object} [options.climate]         — climate pack.
  * @param {object} [options.localStyle]      — regional vernacular pack.
+ * @param {object} [options.styleBlendManifest]
+ *                                             — deterministic style blend
+ *                                             authority snapshot.
  * @param {object} [options.styleDNA]        — generated style DNA.
  * @param {Array}  [options.materialPalette] — explicit palette (overrides
  *                                             localStyle.material_palette).
@@ -501,6 +616,7 @@ export function buildVisualManifest({
   // documenting that it is a recognised input.
   climate = null,
   localStyle = null,
+  styleBlendManifest = null,
   styleDNA = null,
   materialPalette = null,
 } = {}) {
@@ -566,6 +682,21 @@ export function buildVisualManifest({
   if (palette.length === 0) manifestSourceGaps.push("materialPalette");
   if (!primaryFacadeMaterial) manifestSourceGaps.push("primaryFacadeMaterial");
 
+  const styleBlend = buildStyleBlendSnapshot(styleBlendManifest);
+  const resolvedPalette = styleBlend?.resolvedPalette || null;
+  const facadeLanguage = styleBlend?.facadeLanguage || null;
+  const roofLanguage = styleBlend?.roofLanguage || null;
+  const windowLanguage = styleBlend?.windowLanguage || null;
+  const detailLanguage = styleBlend?.detailLanguage || null;
+  const compatiblePortfolioMaterials = filterCompatiblePortfolioValues(
+    styleBlendManifest?.portfolioStyleEvidence?.materials || [],
+    styleBlendManifest,
+  );
+  const compatiblePortfolioStyles = filterCompatiblePortfolioValues(
+    styleBlendManifest?.portfolioStyleEvidence?.styles || [],
+    styleBlendManifest,
+  );
+
   const draft = {
     version: VISUAL_MANIFEST_VERSION,
     geometryHash,
@@ -606,6 +737,37 @@ export function buildVisualManifest({
     climateResponse: deriveClimateResponse({ climate }),
     localStyle: deriveLocalStyleLabel({ localStyle, styleDNA }),
     styleKeywords: deriveStyleKeywords({ styleDNA, localStyle }),
+    styleBlendManifestId: styleBlendManifest?.manifestId || null,
+    styleBlendManifestHash: styleBlendManifest?.manifestHash || null,
+    styleBlend,
+    resolvedPalette,
+    facadeLanguage,
+    roofLanguage,
+    windowLanguage,
+    detailLanguage,
+    styleBlendWeights: styleBlendManifest?.blendWeights || null,
+    styleBlendRejectedInfluences: Array.isArray(
+      styleBlendManifest?.rejectedInfluences,
+    )
+      ? styleBlendManifest.rejectedInfluences.map((entry) => ({
+          influence: entry.influence || null,
+          rejectedBy: entry.rejectedBy || null,
+          reason: entry.reason || null,
+        }))
+      : [],
+    styleBlendLocalRationale:
+      styleBlendManifest?.localStyleEvidence?.label ||
+      styleBlendManifest?.localStyleEvidence?.source ||
+      null,
+    styleBlendPortfolioRationale:
+      styleBlendManifest?.portfolioStyleEvidence?.hasPortfolioEvidence === true
+        ? {
+            styles: compatiblePortfolioStyles,
+            materials: compatiblePortfolioMaterials,
+            referenceCount:
+              styleBlendManifest.portfolioStyleEvidence.referenceCount || 0,
+          }
+        : null,
     manifestSourceGaps,
   };
 
@@ -684,6 +846,30 @@ export function buildVisualIdentityLockBlock(manifest) {
           : ""
       }`
     : null;
+  const styleBlendLine = m.styleBlendManifestHash
+    ? `StyleBlendManifest: ${m.styleBlendManifestHash}`
+    : null;
+  const blendWeightsLine = m.styleBlendWeights
+    ? `Style blend weights: local ${Math.round((m.styleBlendWeights.local || 0) * 100)}%, user ${Math.round((m.styleBlendWeights.user || 0) * 100)}%, climate ${Math.round((m.styleBlendWeights.climate || 0) * 100)}%, portfolio ${Math.round((m.styleBlendWeights.portfolio || 0) * 100)}%.`
+    : null;
+  const localRationaleLine = m.styleBlendLocalRationale
+    ? `Local style rationale: ${m.styleBlendLocalRationale}.`
+    : null;
+  const compatiblePortfolioValues = m.styleBlendPortfolioRationale
+    ? [
+        ...(m.styleBlendPortfolioRationale.materials || []),
+        ...(m.styleBlendPortfolioRationale.styles || []),
+      ].slice(0, 4)
+    : [];
+  const portfolioLine = compatiblePortfolioValues.length
+    ? `Compatible portfolio influence: ${compatiblePortfolioValues.join(", ")}.`
+    : null;
+  const hasRejectedInfluences =
+    Array.isArray(m.styleBlendRejectedInfluences) &&
+    m.styleBlendRejectedInfluences.length > 0;
+  const rejectedSummaryLine = hasRejectedInfluences
+    ? "Rejected style influences were excluded by the style blend QA."
+    : null;
 
   const constraints = Array.isArray(m.negativeConstraints)
     ? m.negativeConstraints
@@ -708,10 +894,21 @@ export function buildVisualIdentityLockBlock(manifest) {
     entranceLine,
     climateLine,
     styleLine,
+    styleBlendLine,
+    blendWeightsLine,
+    localRationaleLine,
+    portfolioLine,
+    rejectedSummaryLine,
     typologyConstraints.length ? `Typology constraints:` : null,
     ...typologyConstraints.map((c) => `- ${c}`),
     `Constraints (do NOT violate):`,
     ...constraints.map((c) => `- ${c}`),
+    `Do not violate safety, programme, climate, local/jurisdiction, or technical authority constraints for style or portfolio reasons.`,
+    ...(hasRejectedInfluences
+      ? [
+          `Do not include rejected portfolio/local-style influences in this panel.`,
+        ]
+      : []),
     `This panel MUST depict the SAME building identity as all other visual panels.`,
     `geometryHash: ${m.geometryHash || "n/a"}`,
     `=== END IDENTITY LOCK ===`,

--- a/src/services/style/styleBlendManifestService.js
+++ b/src/services/style/styleBlendManifestService.js
@@ -1,0 +1,1444 @@
+import { createStableId } from "../cad/projectGeometrySchema.js";
+import { computeCDSHashSync } from "../validation/cdsHash.js";
+import {
+  computeBlendWeights,
+  computeMaterialPalette,
+} from "./localStylePack.js";
+import { summarizePortfolioReferences } from "./portfolioEmbeddingService.js";
+import { detectConflicts } from "../design/constraintPriority.js";
+
+export const STYLE_BLEND_MANIFEST_VERSION = "style-blend-manifest-v1";
+
+const PRIORITY = Object.freeze([
+  "safety",
+  "programme",
+  "climate",
+  "local",
+  "user",
+  "portfolio",
+]);
+
+const GLASS_RISK_TERMS = Object.freeze([
+  "all-glass",
+  "fully glazed",
+  "frameless glass",
+  "mirrored facade",
+  "highly reflective glazing",
+  "curtain wall",
+]);
+
+const CONTEXT_RISK_TERMS = Object.freeze([
+  "sci-fi",
+  "futurism",
+  "alien geometry",
+  "blob form",
+  "parametric ribbon",
+]);
+
+const DETACHED_TERMS = Object.freeze([
+  "detached",
+  "standalone villa",
+  "freestanding",
+  "open sides",
+]);
+
+export const STYLE_BLEND_PORTFOLIO_LIMITS = Object.freeze({
+  strongLocal: 0.05,
+  default: 0.25,
+});
+
+const UK_VERNACULAR_BLEED_TERMS = Object.freeze([
+  "ukVernacularPacks",
+  "REGIONAL VERNACULAR (UK pack)",
+  "UK pack",
+  "london-stucco-terrace",
+  "london-victorian-terrace",
+  "edinburgh-tenement",
+  "manchester-back-to-back",
+  "cotswolds-cottage",
+  "London stucco terrace",
+  "London Victorian terrace",
+  "Edinburgh tenement",
+  "Manchester back-to-back",
+  "Cotswolds cottage",
+  "UK vernacular",
+]);
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function round(value, precision = 4) {
+  const factor = 10 ** precision;
+  return Math.round((Number(value) || 0) * factor) / factor;
+}
+
+function compactText(value) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function lc(value) {
+  return compactText(value).toLowerCase();
+}
+
+function comparableText(value) {
+  return lc(value)
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) return value.filter((entry) => entry != null);
+  if (value === undefined || value === null || value === "") return [];
+  return [value];
+}
+
+function uniqueStrings(values = []) {
+  return [
+    ...new Set(
+      values
+        .flat()
+        .map((entry) =>
+          typeof entry === "string"
+            ? compactText(entry)
+            : compactText(entry?.name || entry?.material || entry?.label),
+        )
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function asNumberOrNull(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function materialName(entry) {
+  if (typeof entry === "string") return compactText(entry);
+  return compactText(entry?.name || entry?.material || entry?.label || "");
+}
+
+function inferApplication(name = "", explicit = "") {
+  const text = lc(`${name} ${explicit}`);
+  if (/roof|tile|slate|zinc|standing seam|terracotta/.test(text)) {
+    return "roof";
+  }
+  if (/window|glaz|glass|frame|aluminium|aluminum|door/.test(text)) {
+    return "openings";
+  }
+  if (/brick|render|stone|stucco|masonry|cladding|facade|wall/.test(text)) {
+    return "primary facade";
+  }
+  if (/timber|screen|brise|soffit|trim|coping|metal/.test(text)) {
+    return "detail";
+  }
+  return explicit || "finish";
+}
+
+function normalizeWeights(weights = {}) {
+  const base = {
+    local: Math.max(0, Number(weights.local) || 0),
+    user: Math.max(0, Number(weights.user) || 0),
+    climate: Math.max(0, Number(weights.climate) || 0),
+    portfolio: Math.max(0, Number(weights.portfolio) || 0),
+  };
+  const total = Object.values(base).reduce((sum, value) => sum + value, 0);
+  if (total <= 0) {
+    return { local: 0.4, user: 0.25, climate: 0.2, portfolio: 0.15 };
+  }
+  const rounded = {
+    local: round(base.local / total),
+    user: round(base.user / total),
+    climate: round(base.climate / total),
+    portfolio: round(base.portfolio / total),
+  };
+  const delta = round(
+    1 - (rounded.local + rounded.user + rounded.climate + rounded.portfolio),
+  );
+  rounded.local = round(rounded.local + delta);
+  return rounded;
+}
+
+function redistributePortfolioWeight(weights, reason) {
+  const normalized = normalizeWeights(weights);
+  const portfolio = normalized.portfolio;
+  if (portfolio <= 0) return { weights: normalized, redistribution: null };
+  const recipients = ["local", "user", "climate"];
+  const recipientTotal = recipients.reduce(
+    (sum, key) => sum + normalized[key],
+    0,
+  );
+  const next = { ...normalized, portfolio: 0 };
+  recipients.forEach((key) => {
+    const share = recipientTotal > 0 ? normalized[key] / recipientTotal : 1 / 3;
+    next[key] = next[key] + portfolio * share;
+  });
+  return {
+    weights: normalizeWeights(next),
+    redistribution: {
+      from: "portfolio",
+      amount: round(portfolio),
+      to: recipients,
+      reason,
+    },
+  };
+}
+
+function capPortfolioWeight(weights, cap, reason) {
+  const normalized = normalizeWeights(weights);
+  if (normalized.portfolio <= cap) {
+    return { weights: normalized, redistribution: null };
+  }
+  const excess = normalized.portfolio - cap;
+  const next = { ...normalized, portfolio: cap };
+  const recipients = ["local", "climate", "user"];
+  const recipientTotal = recipients.reduce(
+    (sum, key) => sum + normalized[key],
+    0,
+  );
+  recipients.forEach((key) => {
+    const share = recipientTotal > 0 ? normalized[key] / recipientTotal : 1 / 3;
+    next[key] = next[key] + excess * share;
+  });
+  return {
+    weights: normalizeWeights(next),
+    redistribution: {
+      from: "portfolio",
+      amount: round(excess),
+      cap: round(cap),
+      to: recipients,
+      reason,
+    },
+  };
+}
+
+function buildPortfolioEvidence({
+  portfolioItems = [],
+  portfolioProfile = null,
+  selectedPortfolioMood = null,
+} = {}) {
+  const references = [
+    ...toArray(portfolioItems),
+    ...toArray(portfolioProfile?.references),
+    ...toArray(portfolioProfile?.items),
+  ];
+  const summary = summarizePortfolioReferences(references);
+  const profileMaterials = uniqueStrings([
+    portfolioProfile?.materials,
+    portfolioProfile?.dominant_materials,
+    portfolioProfile?.facadeMaterials,
+  ]);
+  const profileStyles = uniqueStrings([
+    portfolioProfile?.styles,
+    portfolioProfile?.dominant_styles,
+    portfolioProfile?.style,
+  ]);
+  const profileTags = uniqueStrings([
+    portfolioProfile?.tags,
+    portfolioProfile?.dominant_tags,
+    portfolioProfile?.keywords,
+  ]);
+  const profileBuildingTypes = uniqueStrings([
+    portfolioProfile?.buildingTypes,
+    portfolioProfile?.dominant_building_types,
+    portfolioProfile?.buildingType,
+  ]);
+  const materials = uniqueStrings([
+    summary.dominant_materials,
+    profileMaterials,
+  ]);
+  const styles = uniqueStrings([summary.dominant_styles, profileStyles]);
+  const tags = uniqueStrings([summary.dominant_tags, profileTags]);
+  const buildingTypes = uniqueStrings([
+    summary.dominant_building_types,
+    profileBuildingTypes,
+  ]);
+  const hasPortfolioEvidence =
+    summary.reference_count > 0 ||
+    materials.length > 0 ||
+    styles.length > 0 ||
+    tags.length > 0 ||
+    buildingTypes.length > 0;
+
+  return {
+    source: hasPortfolioEvidence ? "portfolio_inputs" : "none",
+    hasPortfolioEvidence,
+    referenceCount: summary.reference_count,
+    selectedPortfolioMood: hasPortfolioEvidence
+      ? selectedPortfolioMood || null
+      : null,
+    materials,
+    styles,
+    tags,
+    buildingTypes,
+    graphicPresentationStyle:
+      portfolioProfile?.graphicPresentationStyle ||
+      portfolioProfile?.boardStyle ||
+      (hasPortfolioEvidence ? selectedPortfolioMood || null : null),
+    titleBlockStyle:
+      portfolioProfile?.titleBlockStyle ||
+      portfolioProfile?.graphicBoardStyle ||
+      null,
+  };
+}
+
+function buildLocalEvidence({ localStyle, site, jurisdictionPack }) {
+  const provenance =
+    localStyle?.style_provenance &&
+    typeof localStyle.style_provenance === "object"
+      ? localStyle.style_provenance
+      : {};
+  const jurisdictionEvidence = localStyle?.jurisdictionEvidence || null;
+  const jurisdictionDefaults = jurisdictionPack?.localStyleDefaults || {};
+  const materials = uniqueStrings([
+    provenance.materials,
+    localStyle?.material_palette,
+    localStyle?.materials_local,
+    localStyle?.local_materials,
+    jurisdictionEvidence?.materials,
+    jurisdictionDefaults.materials,
+  ]);
+  const heritageFlags = Array.isArray(site?.heritage_flags)
+    ? site.heritage_flags
+    : [];
+  return {
+    source:
+      provenance.source ||
+      jurisdictionEvidence?.source ||
+      (materials.length ? "localStylePack" : "none"),
+    packId:
+      provenance.packId ||
+      provenance.ukVernacularPackId ||
+      jurisdictionEvidence?.packVersion ||
+      jurisdictionPack?.version ||
+      null,
+    label:
+      provenance.packLabel ||
+      provenance.label ||
+      localStyle?.primary_style ||
+      jurisdictionPack?.countryName ||
+      null,
+    jurisdictionId:
+      jurisdictionEvidence?.jurisdictionId ||
+      jurisdictionPack?.jurisdictionId ||
+      null,
+    materials,
+    facadeLanguage:
+      provenance.facade_language ||
+      localStyle?.facade_language ||
+      localStyle?.styleDNA?.facade_language ||
+      jurisdictionDefaults.facadeLanguage ||
+      jurisdictionDefaults.facade_language ||
+      null,
+    roofLanguage:
+      provenance.roof_language ||
+      localStyle?.roof_language ||
+      localStyle?.styleDNA?.roof_language ||
+      jurisdictionDefaults.roofLanguage ||
+      jurisdictionDefaults.roof_language ||
+      null,
+    windowLanguage:
+      provenance.window_language ||
+      localStyle?.window_language ||
+      localStyle?.styleDNA?.window_language ||
+      jurisdictionDefaults.windowLanguage ||
+      jurisdictionDefaults.window_language ||
+      null,
+    massingLanguage:
+      provenance.layout_archetype ||
+      localStyle?.massing_language ||
+      localStyle?.styleDNA?.massing_language ||
+      jurisdictionDefaults.massingLanguage ||
+      jurisdictionDefaults.massing_language ||
+      null,
+    heritageFlags: clone(heritageFlags),
+    conservationTypical: provenance.conservation_typical === true,
+  };
+}
+
+function buildClimateEvidence(climate = {}) {
+  const overheatingRisk =
+    climate?.overheating?.risk_level ||
+    climate?.overheatingRisk ||
+    climate?.overheating_risk ||
+    "unknown";
+  return {
+    source: climate?.weather_source || climate?.source || "deterministic",
+    zone: climate?.zone || climate?.koppen || climate?.climateZone || null,
+    overheatingRisk,
+    rainfallMm:
+      asNumberOrNull(climate?.rainfall_mm) ??
+      asNumberOrNull(climate?.annual_rainfall_mm) ??
+      asNumberOrNull(climate?.precipitation_mm),
+    climateResponses: uniqueStrings([
+      climate?.design_recommendations,
+      climate?.recommendations,
+      climate?.material_weathering_notes,
+    ]),
+  };
+}
+
+function buildUserIntentEvidence(brief = {}, userSettings = {}) {
+  const userIntent = {
+    ...(brief?.user_intent || {}),
+    ...(userSettings || {}),
+  };
+  return {
+    styleKeywords: uniqueStrings(userIntent.style_keywords),
+    avoidKeywords: uniqueStrings(userIntent.avoid_keywords),
+    materialPreferences: uniqueStrings(userIntent.material_preferences),
+    portfolioMood: userIntent.portfolio_mood || null,
+    localBlendStrength: asNumberOrNull(userIntent.local_blend_strength),
+    innovationStrength: asNumberOrNull(userIntent.innovation_strength),
+    portfolioStyleStrength: asNumberOrNull(userIntent.portfolio_style_strength),
+    portfolioMaterialWeight: asNumberOrNull(
+      userIntent.portfolio_material_weight,
+    ),
+    localMaterialStrength: asNumberOrNull(userIntent.local_material_strength),
+  };
+}
+
+function hasAnyTerm(values, terms) {
+  const haystack = uniqueStrings(values).join(" ").toLowerCase();
+  return terms.some((term) => haystack.includes(term));
+}
+
+function isTerracedContext({ brief, localEvidence, compiledProject }) {
+  const text = [
+    brief?.building_type,
+    brief?.original_subtype,
+    brief?.project_type_support?.subtypeId,
+    localEvidence?.massingLanguage,
+    compiledProject?.attachmentType,
+    compiledProject?.metadata?.attachmentType,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const partyWalls =
+    Array.isArray(compiledProject?.partyWalls) &&
+    compiledProject.partyWalls.length > 0;
+  return /terrace|terraced|row-house|townhouse/.test(text) || partyWalls;
+}
+
+function makeRejectedInfluence({
+  source = "portfolio",
+  influence,
+  rejectedBy,
+  reason,
+  severity = "warning",
+}) {
+  return {
+    source,
+    influence,
+    rejectedBy,
+    reason,
+    severity,
+  };
+}
+
+export function resolveStyleConflicts({
+  brief,
+  site,
+  climate,
+  localEvidence,
+  portfolioEvidence,
+  userIntentEvidence,
+  regulations,
+  programme,
+  localStyle,
+  compiledProject,
+  initialWeights,
+} = {}) {
+  const conflicts = detectConflicts({
+    brief,
+    site,
+    climate,
+    programme,
+    regulations,
+    localStyle,
+  }).map((conflict) => ({
+    ...conflict,
+    source: "constraintPriority",
+  }));
+  const rejectedInfluences = [];
+  const qaWarnings = [];
+  const qaErrors = [];
+  let resolvedWeights = normalizeWeights(initialWeights);
+  const redistributions = [];
+
+  if (!portfolioEvidence?.hasPortfolioEvidence) {
+    const redistributed = redistributePortfolioWeight(
+      resolvedWeights,
+      "No portfolio evidence was supplied; portfolio weight was redistributed to local, user, and climate sources.",
+    );
+    resolvedWeights = redistributed.weights;
+    if (redistributed.redistribution) {
+      redistributions.push(redistributed.redistribution);
+      qaWarnings.push({
+        code: "STYLE_BLEND_PORTFOLIO_EVIDENCE_EMPTY",
+        severity: "warning",
+        message:
+          "Portfolio evidence is empty; portfolio influence is zero and redistributed transparently.",
+      });
+    }
+  }
+
+  const overheatingRisk = climate?.overheating?.risk_level || "unknown";
+  const portfolioTokens = [
+    portfolioEvidence?.materials,
+    portfolioEvidence?.styles,
+    portfolioEvidence?.tags,
+  ];
+  if (
+    ["high", "medium", "moderate"].includes(lc(overheatingRisk)) &&
+    hasAnyTerm(portfolioTokens, GLASS_RISK_TERMS)
+  ) {
+    rejectedInfluences.push(
+      makeRejectedInfluence({
+        influence: "unshaded/high-glass portfolio facade language",
+        rejectedBy: "climate",
+        reason:
+          "Climate suitability outranks portfolio identity where overheating risk is material.",
+      }),
+    );
+    conflicts.push({
+      conflict_id: "climate-overrides-portfolio-glazing",
+      higher_priority: "climate",
+      lower_priority: "portfolio",
+      higher_priority_kept: `overheating risk = ${overheatingRisk}`,
+      lower_priority_dropped: "unshaded/high-glass portfolio facade language",
+      severity: "warning",
+      summary:
+        "Climate suitability reduced portfolio glazing influence because overheating risk is material.",
+      source: "styleBlendManifest",
+    });
+    const capped = capPortfolioWeight(
+      resolvedWeights,
+      0.05,
+      "Climate conflict reduced portfolio influence.",
+    );
+    resolvedWeights = capped.weights;
+    if (capped.redistribution) redistributions.push(capped.redistribution);
+  }
+
+  const heritageFlagged =
+    Array.isArray(localEvidence?.heritageFlags) &&
+    localEvidence.heritageFlags.length > 0;
+  if (
+    (heritageFlagged || localEvidence?.conservationTypical === true) &&
+    hasAnyTerm(portfolioTokens, CONTEXT_RISK_TERMS)
+  ) {
+    rejectedInfluences.push(
+      makeRejectedInfluence({
+        influence: "context-incompatible futuristic portfolio language",
+        rejectedBy: "local",
+        reason:
+          "Local heritage/context constraints outrank portfolio identity.",
+      }),
+    );
+    conflicts.push({
+      conflict_id: "local-overrides-portfolio-context",
+      higher_priority: "local",
+      lower_priority: "portfolio",
+      higher_priority_kept: "heritage/conservation local context",
+      lower_priority_dropped:
+        "context-incompatible futuristic portfolio language",
+      severity: "warning",
+      summary:
+        "Local heritage/context reduced portfolio influence because the portfolio language conflicts with the site context.",
+      source: "styleBlendManifest",
+    });
+    const capped = capPortfolioWeight(
+      resolvedWeights,
+      0.05,
+      "Local heritage/context conflict reduced portfolio influence.",
+    );
+    resolvedWeights = capped.weights;
+    if (capped.redistribution) redistributions.push(capped.redistribution);
+  }
+
+  if (
+    isTerracedContext({ brief, localEvidence, compiledProject }) &&
+    hasAnyTerm(portfolioEvidence?.buildingTypes, DETACHED_TERMS)
+  ) {
+    rejectedInfluences.push(
+      makeRejectedInfluence({
+        influence: "detached/freestanding portfolio typology",
+        rejectedBy: "programme/local",
+        reason:
+          "Terraced programme/local typology outranks incompatible portfolio building type.",
+      }),
+    );
+    conflicts.push({
+      conflict_id: "programme-local-overrides-detached-portfolio",
+      higher_priority: "programme/local",
+      lower_priority: "portfolio",
+      higher_priority_kept: "terraced/row-house typology",
+      lower_priority_dropped: "detached/freestanding portfolio typology",
+      severity: "warning",
+      summary:
+        "Terraced local/programme context rejected detached portfolio typology.",
+      source: "styleBlendManifest",
+    });
+    const capped = capPortfolioWeight(
+      resolvedWeights,
+      0.05,
+      "Terraced typology conflict reduced portfolio influence.",
+    );
+    resolvedWeights = capped.weights;
+    if (capped.redistribution) redistributions.push(capped.redistribution);
+  }
+
+  const hardBlockerCount = Number(
+    regulations?.rule_summary?.hard_blocker_count,
+  );
+  if (Number.isFinite(hardBlockerCount) && hardBlockerCount > 0) {
+    qaErrors.push({
+      code: "STYLE_BLEND_SAFETY_BLOCKER_PRESENT",
+      severity: "error",
+      message:
+        "Safety/statutory blockers are present; style blending cannot override them.",
+    });
+  }
+
+  return {
+    conflicts,
+    rejectedInfluences,
+    resolvedWeights,
+    redistributions,
+    qaWarnings,
+    qaErrors,
+  };
+}
+
+function addMaterial(scored, entry, source, weight) {
+  const name = materialName(entry);
+  if (!name || weight <= 0) return;
+  const key = lc(name);
+  const existing = scored.get(key) || {
+    name,
+    material: name,
+    score: 0,
+    sources: new Set(),
+    sourceTags: new Set(),
+    application: inferApplication(name, entry?.application || entry?.role),
+  };
+  existing.score += Number(weight) || 0;
+  existing.sources.add(source);
+  existing.sourceTags.add(source);
+  scored.set(key, existing);
+}
+
+function buildResolvedPalette({
+  localStyle,
+  localEvidence,
+  climateEvidence,
+  userIntentEvidence,
+  portfolioEvidence,
+  weights,
+  materialWeights,
+  rejectedInfluences,
+}) {
+  const scored = new Map();
+  const rejectedText = rejectedInfluences
+    .map((entry) => lc(entry.influence))
+    .join(" ");
+
+  const provenanceEntries = Array.isArray(
+    localStyle?.material_palette_with_provenance,
+  )
+    ? localStyle.material_palette_with_provenance
+    : [];
+  provenanceEntries.forEach((entry) => {
+    const sources = Array.isArray(entry.sources) ? entry.sources : ["local"];
+    sources.forEach((source) => {
+      if (source === "portfolio" && !portfolioEvidence.hasPortfolioEvidence) {
+        return;
+      }
+      addMaterial(
+        scored,
+        entry.material || entry.name || entry,
+        source,
+        materialWeights[source] || weights[source] || 0,
+      );
+    });
+  });
+
+  localEvidence.materials.forEach((entry) =>
+    addMaterial(scored, entry, "local", materialWeights.local || weights.local),
+  );
+  climateEvidence.climateResponses.forEach((entry) =>
+    addMaterial(
+      scored,
+      entry,
+      "climate",
+      materialWeights.climate || weights.climate,
+    ),
+  );
+  userIntentEvidence.materialPreferences.forEach((entry) =>
+    addMaterial(scored, entry, "user", materialWeights.user || weights.user),
+  );
+  if (portfolioEvidence.hasPortfolioEvidence && weights.portfolio > 0) {
+    portfolioEvidence.materials.forEach((entry) => {
+      if (rejectedText && rejectedText.includes(lc(entry))) return;
+      addMaterial(
+        scored,
+        entry,
+        "portfolio",
+        materialWeights.portfolio || weights.portfolio,
+      );
+    });
+  }
+
+  return [...scored.values()]
+    .map((entry) => {
+      const sourceTags = [...entry.sourceTags].sort();
+      return {
+        name: entry.name,
+        material: entry.material,
+        score: round(entry.score),
+        sources: [...entry.sources].sort(),
+        sourceTags,
+        provenanceLabel: sourceTags.join("+"),
+        application: `${entry.application} | ${sourceTags.join("+")}`,
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+    .slice(0, 8);
+}
+
+function deriveLanguage({ localValue, userValues, portfolioValues, rejected }) {
+  if (localValue) return { value: localValue, source: "local" };
+  const user = uniqueStrings(userValues)[0] || null;
+  if (user) return { value: user, source: "user" };
+  const rejectedText = rejected.map((entry) => lc(entry.influence)).join(" ");
+  const portfolio = uniqueStrings(portfolioValues).find(
+    (entry) => !rejectedText.includes(lc(entry)),
+  );
+  if (portfolio) return { value: portfolio, source: "portfolio" };
+  return { value: null, source: null };
+}
+
+export function buildStyleBlendManifest({
+  brief = {},
+  site = {},
+  climate = {},
+  localStyle = {},
+  portfolioItems = [],
+  portfolioProfile = null,
+  jurisdictionPack = null,
+  jurisdictionPackResolution = null,
+  compiledProject = null,
+  projectGraphId = null,
+  programme = null,
+  regulations = null,
+  userSettings = {},
+} = {}) {
+  const userIntentEvidence = buildUserIntentEvidence(brief, userSettings);
+  const localEvidence = buildLocalEvidence({
+    localStyle,
+    site,
+    jurisdictionPack,
+  });
+  const climateEvidence = buildClimateEvidence(climate);
+  const portfolioEvidence = buildPortfolioEvidence({
+    portfolioItems,
+    portfolioProfile,
+    selectedPortfolioMood: userIntentEvidence.portfolioMood,
+  });
+  const styleWeights = localStyle?.blend_weights
+    ? normalizeWeights(localStyle.blend_weights)
+    : computeBlendWeights({
+        localBlendStrength: userIntentEvidence.localBlendStrength,
+        innovationStrength: userIntentEvidence.innovationStrength,
+        portfolioStyleStrength: userIntentEvidence.portfolioStyleStrength,
+      });
+  let materialPalette;
+  try {
+    materialPalette = computeMaterialPalette({
+      brief,
+      site,
+      climate,
+      jurisdictionPack,
+      paletteSize: 8,
+    });
+  } catch {
+    materialPalette = null;
+  }
+  const materialWeights = normalizeWeights(
+    localStyle?.material_blend_weights ||
+      materialPalette?.material_weights ||
+      styleWeights,
+  );
+  const conflictResolution = resolveStyleConflicts({
+    brief,
+    site,
+    climate,
+    localEvidence,
+    portfolioEvidence,
+    userIntentEvidence,
+    regulations,
+    programme,
+    localStyle,
+    compiledProject,
+    initialWeights: styleWeights,
+  });
+  const resolvedWeights = conflictResolution.resolvedWeights;
+  const resolvedMaterialWeights = portfolioEvidence.hasPortfolioEvidence
+    ? materialWeights
+    : redistributePortfolioWeight(
+        materialWeights,
+        "No portfolio evidence was supplied; portfolio material weight was redistributed.",
+      ).weights;
+  const resolvedPalette = buildResolvedPalette({
+    localStyle,
+    localEvidence,
+    climateEvidence,
+    userIntentEvidence,
+    portfolioEvidence,
+    weights: resolvedWeights,
+    materialWeights: resolvedMaterialWeights,
+    rejectedInfluences: conflictResolution.rejectedInfluences,
+  });
+
+  const facade = deriveLanguage({
+    localValue: localEvidence.facadeLanguage,
+    userValues: userIntentEvidence.styleKeywords,
+    portfolioValues: [portfolioEvidence.styles, portfolioEvidence.tags],
+    rejected: conflictResolution.rejectedInfluences,
+  });
+  const roof = deriveLanguage({
+    localValue: localEvidence.roofLanguage,
+    userValues: userIntentEvidence.styleKeywords.filter((entry) =>
+      /roof|tile|slate|parapet|gable|flat/i.test(entry),
+    ),
+    portfolioValues: [portfolioEvidence.styles, portfolioEvidence.tags],
+    rejected: conflictResolution.rejectedInfluences,
+  });
+  const windows = deriveLanguage({
+    localValue: localEvidence.windowLanguage,
+    userValues: userIntentEvidence.styleKeywords.filter((entry) =>
+      /window|opening|glaz|fenestration|rhythm/i.test(entry),
+    ),
+    portfolioValues: [portfolioEvidence.tags],
+    rejected: conflictResolution.rejectedInfluences,
+  });
+  const massing = deriveLanguage({
+    localValue: localEvidence.massingLanguage,
+    userValues: userIntentEvidence.styleKeywords.filter((entry) =>
+      /massing|terrace|courtyard|compact|villa|detached/i.test(entry),
+    ),
+    portfolioValues: [portfolioEvidence.buildingTypes, portfolioEvidence.tags],
+    rejected: conflictResolution.rejectedInfluences,
+  });
+
+  const sourceGaps = [];
+  const qaWarnings = [...conflictResolution.qaWarnings];
+  if (!localEvidence.materials.length) {
+    sourceGaps.push({
+      code: "STYLE_BLEND_LOCAL_EVIDENCE_MISSING",
+      severity: "warning",
+      message:
+        "No local material evidence was available; downstream renderers must use explicit source gaps rather than invented local evidence.",
+    });
+  }
+  if (
+    !jurisdictionPack ||
+    jurisdictionPack?.jurisdictionId === "generic" ||
+    jurisdictionPackResolution?.source === "generic_fallback"
+  ) {
+    sourceGaps.push({
+      code: "STYLE_BLEND_JURISDICTION_PACK_MISSING",
+      severity: "warning",
+      message:
+        "Specific jurisdiction/local style pack was not resolved; using advisory generic evidence only.",
+    });
+  }
+  sourceGaps.push(...(jurisdictionPackResolution?.sourceGaps || []));
+  qaWarnings.push(...sourceGaps);
+
+  const jurisdiction = {
+    jurisdictionId:
+      jurisdictionPack?.jurisdictionId || localEvidence.jurisdictionId || null,
+    countryCode: jurisdictionPack?.countryCode || null,
+    countryName: jurisdictionPack?.countryName || null,
+    packVersion: jurisdictionPack?.version || null,
+    resolutionSource: jurisdictionPackResolution?.source || null,
+  };
+  const location = {
+    address: brief?.site_input?.address || site?.address || null,
+    postcode: brief?.site_input?.postcode || site?.postcode || null,
+    lat: brief?.site_input?.lat ?? site?.lat ?? null,
+    lon: brief?.site_input?.lon ?? site?.lon ?? null,
+    region: site?.region || site?.country || brief?.site_input?.region || null,
+  };
+  const manifestBody = {
+    version: STYLE_BLEND_MANIFEST_VERSION,
+    jurisdiction,
+    location,
+    geometryHash:
+      compiledProject?.geometryHash || compiledProject?.geometry_hash || null,
+    projectGraphId: projectGraphId || null,
+    localStyleEvidence: localEvidence,
+    portfolioStyleEvidence: portfolioEvidence,
+    userIntentEvidence,
+    climateEvidence,
+    blendWeights: resolvedWeights,
+    requestedBlendWeights: normalizeWeights(styleWeights),
+    materialWeights: resolvedMaterialWeights,
+    requestedMaterialWeights: normalizeWeights(materialWeights),
+    resolvedPalette,
+    facadeLanguage:
+      facade.value || localEvidence.facadeLanguage || "contextual facade",
+    facadeLanguageSource: facade.source,
+    roofLanguage: roof.value || localEvidence.roofLanguage || "contextual roof",
+    roofLanguageSource: roof.source,
+    windowLanguage:
+      windows.value || localEvidence.windowLanguage || "contextual openings",
+    windowLanguageSource: windows.source,
+    massingLanguage: massing.value,
+    massingLanguageSource: massing.source,
+    detailLanguage:
+      resolvedPalette
+        .filter((entry) => /detail|openings/.test(entry.application))
+        .map((entry) => entry.name)
+        .slice(0, 3)
+        .join(", ") ||
+      localEvidence.windowLanguage ||
+      resolvedPalette
+        .map((entry) => entry.name)
+        .filter(Boolean)
+        .slice(0, 2)
+        .join(", ") ||
+      "contextual detailing",
+    graphicPresentationStyle:
+      portfolioEvidence.hasPortfolioEvidence &&
+      !conflictResolution.rejectedInfluences.some((entry) =>
+        /graphic/i.test(entry.influence),
+      )
+        ? portfolioEvidence.graphicPresentationStyle
+        : null,
+    conflicts: conflictResolution.conflicts,
+    rejectedInfluences: conflictResolution.rejectedInfluences,
+    redistributions: conflictResolution.redistributions,
+    qaWarnings,
+    qaErrors: conflictResolution.qaErrors,
+    sourceGaps,
+    authorityPriority: [...PRIORITY],
+  };
+  const manifestHash = computeCDSHashSync(manifestBody);
+  const manifestId = createStableId(
+    "style-blend",
+    manifestHash,
+    manifestBody.geometryHash || "no-geometry",
+  );
+  return {
+    ...manifestBody,
+    manifestId,
+    manifestHash,
+  };
+}
+
+function asIssue(code, severity, message, details = {}) {
+  return { code, severity, message, details };
+}
+
+function issueSeverity(strict, fallback = "warning") {
+  return strict ? "error" : fallback;
+}
+
+function collectTextFragments(value, depth = 0) {
+  if (value == null || depth > 5) return [];
+  if (typeof value === "string") return [value];
+  if (typeof value === "number" || typeof value === "boolean") {
+    return [String(value)];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectTextFragments(entry, depth + 1));
+  }
+  if (typeof value === "object") {
+    return Object.keys(value)
+      .sort()
+      .flatMap((key) => collectTextFragments(value[key], depth + 1));
+  }
+  return [];
+}
+
+function materialNamesFromEvidence(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return uniqueStrings(
+      value.flatMap((entry) => {
+        if (entry == null) return [];
+        if (typeof entry === "string") return [entry];
+        return [
+          materialName(entry),
+          entry.material,
+          entry.name,
+          entry.label,
+          entry.displayName,
+        ];
+      }),
+    );
+  }
+  if (typeof value === "object") {
+    return uniqueStrings([
+      materialNamesFromEvidence(value.materials),
+      materialNamesFromEvidence(value.palette),
+      materialNamesFromEvidence(value.resolvedPalette),
+      materialNamesFromEvidence(value.cardMetadata),
+      materialNamesFromEvidence(value.metadata?.materials),
+    ]);
+  }
+  return [];
+}
+
+function namesOverlap(left = [], right = []) {
+  const normalizedLeft = left.map(comparableText).filter(Boolean);
+  const normalizedRight = right.map(comparableText).filter(Boolean);
+  return normalizedLeft.some((a) =>
+    normalizedRight.some((b) => a.includes(b) || b.includes(a)),
+  );
+}
+
+function normalizeEvidenceArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter(Boolean);
+  if (typeof value === "object") return Object.values(value).filter(Boolean);
+  return [];
+}
+
+function promptTextFromEvidence(record) {
+  if (!record || typeof record !== "object") return "";
+  return [
+    record.promptText,
+    record.finalPrompt,
+    record.lockBlock,
+    record.prompt,
+    record.metadata?.promptText,
+    record.metadata?.finalPrompt,
+    record.metadata?.lockBlock,
+    record.metadata?.prompt,
+  ]
+    .map(compactText)
+    .filter(Boolean)
+    .join("\n");
+}
+
+function promptHashFromEvidence(record) {
+  return (
+    record?.styleBlendManifestHash ||
+    record?.metadata?.styleBlendManifestHash ||
+    null
+  );
+}
+
+function collectPromptEvidence({ promptEvidence, panelArtifacts }) {
+  const supplied = normalizeEvidenceArray(promptEvidence);
+  const panels = normalizeEvidenceArray(panelArtifacts).filter((artifact) =>
+    ["hero_3d", "exterior_render", "interior_3d", "axonometric"].includes(
+      artifact?.panel_type || artifact?.panelType,
+    ),
+  );
+  return [...supplied, ...panels];
+}
+
+function promptContainsExpectedHash(text, expected) {
+  if (!text || !expected) return false;
+  return (
+    text.includes(`styleBlendManifestHash: ${expected}`) ||
+    text.includes(`StyleBlendManifest: ${expected}`) ||
+    text.includes(expected)
+  );
+}
+
+function rejectedPromptTerms(rejectedInfluences = []) {
+  const terms = new Set();
+  rejectedInfluences.forEach((entry) => {
+    const influence = compactText(entry?.influence || entry?.message || "");
+    if (!influence) return;
+    terms.add(influence);
+    const text = lc(influence);
+    if (/glass|glaz|curtain wall/.test(text)) {
+      [...GLASS_RISK_TERMS, "all glass", "high glass"].forEach((term) =>
+        terms.add(term),
+      );
+    }
+    if (/sci-fi|futur|alien|blob|parametric/.test(text)) {
+      [...CONTEXT_RISK_TERMS, "futuristic"].forEach((term) => terms.add(term));
+    }
+    if (/detached house/.test(text)) {
+      terms.add("detached house");
+    }
+    if (/uk vernacular|uk pack/.test(text)) {
+      UK_VERNACULAR_BLEED_TERMS.forEach((term) => terms.add(term));
+    }
+  });
+  return [...terms].map(comparableText).filter((term) => term.length > 3);
+}
+
+function textContainsComparableTerm(text, term) {
+  const normalized = comparableText(text);
+  const needle = comparableText(term);
+  return Boolean(normalized && needle && normalized.includes(needle));
+}
+
+function isStrongLocalContext(styleBlendManifest) {
+  const localEvidence = styleBlendManifest?.localStyleEvidence || {};
+  const conflicts = Array.isArray(styleBlendManifest?.conflicts)
+    ? styleBlendManifest.conflicts
+    : [];
+  const rejected = Array.isArray(styleBlendManifest?.rejectedInfluences)
+    ? styleBlendManifest.rejectedInfluences
+    : [];
+  const localWeight = Number(styleBlendManifest?.blendWeights?.local || 0);
+  const explicitLocalConstraint =
+    localEvidence.conservationTypical === true ||
+    (Array.isArray(localEvidence.heritageFlags) &&
+      localEvidence.heritageFlags.length > 0);
+  const conflictBackedConstraint =
+    conflicts.some(
+      (conflict) =>
+        lc(conflict?.lower_priority).includes("portfolio") &&
+        /local|jurisdiction|heritage|conservation|climate|programme/.test(
+          lc(conflict?.higher_priority || conflict?.higher_priority_kept),
+        ),
+    ) ||
+    rejected.some((entry) =>
+      /local|jurisdiction|heritage|conservation|climate|programme/.test(
+        lc(entry?.rejectedBy),
+      ),
+    );
+  return (
+    explicitLocalConstraint ||
+    conflictBackedConstraint ||
+    (localWeight >= 0.55 &&
+      (explicitLocalConstraint || conflictBackedConstraint))
+  );
+}
+
+function isFranceOrAlgeria(jurisdiction = {}) {
+  const id = lc(jurisdiction.jurisdictionId);
+  const code = lc(jurisdiction.countryCode);
+  const name = lc(jurisdiction.countryName);
+  return (
+    ["fr", "fra", "dz", "dza"].includes(code) ||
+    id === "france" ||
+    id === "algeria" ||
+    name.includes("france") ||
+    name.includes("algeria")
+  );
+}
+
+function buildJurisdictionBleedText({
+  styleBlendManifest,
+  visualManifest,
+  sheetDesignContext,
+  a1MaterialPalette,
+  promptRecords,
+}) {
+  const visualEvidence = visualManifest
+    ? {
+        localStyle: visualManifest.localStyle,
+        styleKeywords: visualManifest.styleKeywords,
+        materials: visualManifest.materials,
+        resolvedPalette: visualManifest.resolvedPalette,
+        styleBlend: visualManifest.styleBlend,
+        facadeLanguage: visualManifest.facadeLanguage,
+        roofLanguage: visualManifest.roofLanguage,
+        windowLanguage: visualManifest.windowLanguage,
+        detailLanguage: visualManifest.detailLanguage,
+      }
+    : null;
+  const sheetEvidence = sheetDesignContext
+    ? {
+        style: sheetDesignContext.style,
+        materials: sheetDesignContext.materials,
+        portfolioBlend: sheetDesignContext.portfolioBlend,
+      }
+    : null;
+  return [
+    collectTextFragments(styleBlendManifest?.localStyleEvidence),
+    collectTextFragments(styleBlendManifest?.resolvedPalette),
+    collectTextFragments({
+      facadeLanguage: styleBlendManifest?.facadeLanguage,
+      roofLanguage: styleBlendManifest?.roofLanguage,
+      windowLanguage: styleBlendManifest?.windowLanguage,
+      detailLanguage: styleBlendManifest?.detailLanguage,
+    }),
+    collectTextFragments(visualEvidence),
+    collectTextFragments(sheetEvidence),
+    collectTextFragments(a1MaterialPalette),
+    promptRecords.map(promptTextFromEvidence),
+  ]
+    .flat()
+    .join("\n");
+}
+
+export function evaluateStyleBlendQA({
+  styleBlendManifest = null,
+  visualManifest = null,
+  sheetDesignContext = null,
+  panelArtifacts = null,
+  a1MaterialPalette = null,
+  promptEvidence = null,
+  strict = true,
+} = {}) {
+  const issues = [];
+  if (!styleBlendManifest?.manifestHash) {
+    issues.push(
+      asIssue(
+        "STYLE_BLEND_MANIFEST_MISSING",
+        "error",
+        "StyleBlendManifest is missing from the ProjectGraph output.",
+      ),
+    );
+  }
+  const expected = styleBlendManifest?.manifestHash || null;
+  if (
+    expected &&
+    visualManifest?.styleBlendManifestHash &&
+    visualManifest.styleBlendManifestHash !== expected
+  ) {
+    issues.push(
+      asIssue(
+        "STYLE_BLEND_VISUAL_MANIFEST_HASH_MISMATCH",
+        "error",
+        "visualManifest.styleBlendManifestHash does not match StyleBlendManifest.manifestHash.",
+        {
+          expected,
+          actual: visualManifest.styleBlendManifestHash,
+        },
+      ),
+    );
+  }
+  if (
+    expected &&
+    sheetDesignContext?.styleBlendManifestHash &&
+    sheetDesignContext.styleBlendManifestHash !== expected
+  ) {
+    issues.push(
+      asIssue(
+        "STYLE_BLEND_SHEET_CONTEXT_HASH_MISMATCH",
+        "error",
+        "SheetDesignContext styleBlendManifestHash does not match StyleBlendManifest.manifestHash.",
+        {
+          expected,
+          actual: sheetDesignContext.styleBlendManifestHash,
+        },
+      ),
+    );
+  }
+  const panels = panelArtifacts ? Object.values(panelArtifacts) : [];
+  const visualPanels = panels.filter((artifact) =>
+    ["hero_3d", "exterior_render", "interior_3d", "axonometric"].includes(
+      artifact?.panel_type || artifact?.panelType,
+    ),
+  );
+  visualPanels.forEach((artifact) => {
+    const panelType = artifact.panel_type || artifact.panelType;
+    const actual =
+      artifact.styleBlendManifestHash ||
+      artifact.metadata?.styleBlendManifestHash ||
+      null;
+    if (expected && actual !== expected) {
+      issues.push(
+        asIssue(
+          "STYLE_BLEND_VISUAL_PANEL_HASH_MISSING_OR_MISMATCHED",
+          "warning",
+          `Visual panel ${panelType} does not carry the matching styleBlendManifestHash.`,
+          { panelType, expected, actual },
+        ),
+      );
+    }
+  });
+  if (
+    styleBlendManifest?.portfolioStyleEvidence?.hasPortfolioEvidence ===
+      false &&
+    Number(styleBlendManifest?.blendWeights?.portfolio || 0) > 0
+  ) {
+    issues.push(
+      asIssue(
+        "STYLE_BLEND_EMPTY_PORTFOLIO_HAS_WEIGHT",
+        "error",
+        "Portfolio weight must be zero when no portfolio evidence exists.",
+        { blendWeights: styleBlendManifest.blendWeights },
+      ),
+    );
+  }
+  const missingLanguageFields = [
+    "facadeLanguage",
+    "roofLanguage",
+    "windowLanguage",
+    "detailLanguage",
+  ].filter((field) => !compactText(styleBlendManifest?.[field]));
+  if (
+    !Array.isArray(styleBlendManifest?.resolvedPalette) ||
+    styleBlendManifest.resolvedPalette.length === 0
+  ) {
+    missingLanguageFields.push("resolvedPalette");
+  }
+  if (styleBlendManifest?.manifestHash && missingLanguageFields.length > 0) {
+    issues.push(
+      asIssue(
+        "STYLE_BLEND_MANIFEST_LANGUAGE_MISSING",
+        issueSeverity(strict),
+        "StyleBlendManifest is missing required language or palette fields.",
+        { missingFields: missingLanguageFields },
+      ),
+    );
+  }
+
+  const resolvedMaterialNames = materialNamesFromEvidence(
+    styleBlendManifest?.resolvedPalette,
+  );
+  const a1MaterialNames = materialNamesFromEvidence(a1MaterialPalette);
+  if (
+    styleBlendManifest?.manifestHash &&
+    a1MaterialPalette != null &&
+    resolvedMaterialNames.length > 0 &&
+    (a1MaterialNames.length === 0 ||
+      !namesOverlap(resolvedMaterialNames, a1MaterialNames))
+  ) {
+    issues.push(
+      asIssue(
+        "STYLE_BLEND_A1_PALETTE_DRIFT",
+        issueSeverity(strict),
+        "A1 material palette evidence does not match the resolved StyleBlendManifest palette.",
+        {
+          resolvedMaterialNames,
+          a1MaterialNames,
+        },
+      ),
+    );
+  }
+
+  if (
+    styleBlendManifest?.manifestHash &&
+    isStrongLocalContext(styleBlendManifest) &&
+    Number(styleBlendManifest?.blendWeights?.portfolio || 0) >
+      STYLE_BLEND_PORTFOLIO_LIMITS.strongLocal
+  ) {
+    issues.push(
+      asIssue(
+        "STYLE_BLEND_PORTFOLIO_OVERWEIGHT",
+        issueSeverity(strict),
+        "Portfolio weight exceeds the allowed cap for heritage/high-local constraint contexts.",
+        {
+          portfolioWeight: Number(styleBlendManifest.blendWeights.portfolio),
+          allowedPortfolioWeight: STYLE_BLEND_PORTFOLIO_LIMITS.strongLocal,
+          blendWeights: styleBlendManifest.blendWeights,
+        },
+      ),
+    );
+  }
+
+  const promptRecords = collectPromptEvidence({
+    promptEvidence,
+    panelArtifacts,
+  });
+  promptRecords.forEach((record, index) => {
+    const panelType =
+      record?.panel_type || record?.panelType || `prompt_${index}`;
+    const text = promptTextFromEvidence(record);
+    const actualHash = promptHashFromEvidence(record);
+    if (
+      expected &&
+      ((text && !promptContainsExpectedHash(text, expected)) ||
+        (record?.promptHash && actualHash !== expected))
+    ) {
+      issues.push(
+        asIssue(
+          "STYLE_BLEND_PROMPT_HASH_MISSING",
+          issueSeverity(strict),
+          `Prompt evidence for ${panelType} does not carry the matching styleBlendManifestHash.`,
+          { panelType, expected, actual: actualHash },
+        ),
+      );
+    }
+  });
+
+  const rejectedTerms = rejectedPromptTerms(
+    styleBlendManifest?.rejectedInfluences || [],
+  );
+  promptRecords.forEach((record, index) => {
+    const text = promptTextFromEvidence(record);
+    if (!text || rejectedTerms.length === 0) return;
+    const leakedTerm = rejectedTerms.find((term) =>
+      textContainsComparableTerm(text, term),
+    );
+    if (leakedTerm) {
+      issues.push(
+        asIssue(
+          "STYLE_BLEND_REJECTED_INFLUENCE_LEAK",
+          issueSeverity(strict),
+          "Final prompt evidence contains a rejected style influence.",
+          {
+            panelType:
+              record?.panel_type || record?.panelType || `prompt_${index}`,
+            leakedTerm,
+          },
+        ),
+      );
+    }
+  });
+
+  if (isFranceOrAlgeria(styleBlendManifest?.jurisdiction || {})) {
+    const bleedText = buildJurisdictionBleedText({
+      styleBlendManifest,
+      visualManifest,
+      sheetDesignContext,
+      a1MaterialPalette,
+      promptRecords,
+    });
+    const matchedTerm = UK_VERNACULAR_BLEED_TERMS.find((term) =>
+      textContainsComparableTerm(bleedText, term),
+    );
+    if (matchedTerm) {
+      issues.push(
+        asIssue(
+          "STYLE_BLEND_JURISDICTION_VERNACULAR_BLEED",
+          issueSeverity(strict),
+          "France/Algeria style evidence contains UK vernacular pack language.",
+          {
+            jurisdiction: styleBlendManifest.jurisdiction,
+            matchedTerm,
+          },
+        ),
+      );
+    }
+  }
+
+  (styleBlendManifest?.qaErrors || []).forEach((issue) =>
+    issues.push(asIssue(issue.code, "error", issue.message, issue)),
+  );
+  (styleBlendManifest?.qaWarnings || []).forEach((issue) =>
+    issues.push(asIssue(issue.code, "warning", issue.message, issue)),
+  );
+
+  const errorCount = issues.filter(
+    (issue) => issue.severity === "error",
+  ).length;
+  const warningCount = issues.filter(
+    (issue) => issue.severity === "warning",
+  ).length;
+  return {
+    version: "style-blend-qa-v1",
+    status: errorCount > 0 ? "fail" : warningCount > 0 ? "warning" : "pass",
+    expectedStyleBlendManifestHash: expected,
+    errorCount,
+    warningCount,
+    issues,
+  };
+}
+
+export default {
+  STYLE_BLEND_MANIFEST_VERSION,
+  buildStyleBlendManifest,
+  resolveStyleConflicts,
+  evaluateStyleBlendQA,
+};


### PR DESCRIPTION
## Summary

Adds a deterministic `StyleBlendManifest` authority path for accurate local style and portfolio blending.

The new path blends local context, user intent, climate suitability, jurisdiction evidence, and portfolio identity while respecting constraint priority:

`safety > programme > climate > local > user > portfolio`

## Changes

- Adds `styleBlendManifestService`.
- Adds deterministic `StyleBlendManifest` with manifest hash.
- Extracts local, portfolio, user, climate, and jurisdiction style evidence.
- Adds conflict resolution and rejected influence reporting.
- Prevents portfolio style from overriding climate, local/heritage, programme, safety, or jurisdiction constraints.
- Threads `StyleBlendManifest` through:
  - ProjectGraph metadata
  - visual manifest
  - SheetDesignContext / prompt context
  - A1 material palette
  - A1 key notes
  - image2 prompt identity locks
  - QA metadata
- Adds `StyleBlendQA` gates for:
  - A1 material palette drift
  - prompt hash presence
  - portfolio overweight in high-local/heritage contexts
  - rejected influence leakage into prompts
  - France/Algeria UK-vernacular bleed
  - missing language/palette fields
- Removes literal rejected influence values from final image2 prompts and A1 key-note text.
- Keeps rejected influence values in metadata/QA for auditability.
- Marks `adaptiveStyleTransfer` as legacy-only.
- Adds roadmap: `docs/roadmaps/local-style-portfolio-blending-roadmap.md`.

## Validation

- Focused tests: 7 suites, 88 tests passed
- ProjectGraph narrowed full-slice deterministic tests: 2 passed, 61 skipped
- `npm run lint`
- `git diff --check` passed with CRLF warnings only
- `npm run check:env` passed with existing optional provider warnings only
- `npm run check:contracts`
- `npm run build:active`

## Safety and scope

- No technical drawing is routed through image generation.
- Image2 visual panels remain geometry-locked.
- Existing ProjectGraph/A1/CAD/structural/MEP/detail authority gates are not weakened.
- Fake DWG remains disabled.
- Portfolio influence is allowed only when compatible with higher-priority constraints.

## Current limitations

- Portfolio extraction is only as strong as the supplied portfolio metadata/items.
- France and Algeria local style evidence uses first-pass jurisdiction defaults until region-level packs are added.
- Official planning/regulatory integration is not included.
- This does not certify style or regulatory compliance.