### PR TITLE
Add artifact package API and ZIP download

### DIFF
--- a/api/project/export/artifact-package.js
+++ b/api/project/export/artifact-package.js
@@ -1,0 +1,283 @@
+import { setCorsHeaders, handlePreflight } from "../../_shared/cors.js";
+import { buildArtifactPackage } from "../../../src/services/export/artifactPackageService.js";
+import { exportCompiledProjectToDXF } from "../../../src/services/project/compiledProjectExportService.js";
+
+function safeProjectName(value, fallback = "ArchiAI_Project") {
+  const cleaned = String(value || fallback)
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80);
+  return cleaned || fallback;
+}
+
+function asArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : Object.values(value);
+}
+
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null);
+}
+
+function resolvePayload(body = {}) {
+  return body.packageInput || body.result || body;
+}
+
+function resolveArtifacts(payload = {}) {
+  return payload.artifacts || payload.result?.artifacts || {};
+}
+
+function resolveCompiledProject(payload = {}, artifacts = {}) {
+  return (
+    payload.compiledProject ||
+    artifacts.compiledProject ||
+    payload.result?.compiledProject ||
+    payload.result?.artifacts?.compiledProject ||
+    null
+  );
+}
+
+function hasContent(value) {
+  if (!value) return false;
+  if (typeof value === "string") return value.length > 0;
+  if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+    return value.byteLength > 0;
+  }
+  if (ArrayBuffer.isView(value)) return value.byteLength > 0;
+  if (typeof value !== "object") return false;
+  return Boolean(
+    value.svgString ||
+    value.svg ||
+    value.dataUrl ||
+    value.dataUri ||
+    value.pdfDataUrl ||
+    value.pngDataUrl ||
+    value.content ||
+    value.bytes ||
+    value.dxf ||
+    value.ifc ||
+    value.workbookArray ||
+    value.json ||
+    value.geometryHash,
+  );
+}
+
+function buildDxfArtifact({
+  compiledProject,
+  projectName,
+  includeDetailDrawings,
+  detailDrawingsEnabled,
+}) {
+  if (!compiledProject?.geometryHash) return null;
+  const dxf = exportCompiledProjectToDXF({
+    compiledProject,
+    projectName,
+    includeDetailDrawings,
+    detailDrawingsEnabled,
+  });
+  return {
+    type: "dxf",
+    fileName: `cad/${safeProjectName(projectName)}.dxf`,
+    mimeType: "application/dxf",
+    role: "cad_exchange",
+    discipline: "cad",
+    source: "CanonicalDrawingModel DXF export",
+    content: dxf,
+    geometryHash: compiledProject.geometryHash,
+    sourceGeometryHash: compiledProject.geometryHash,
+  };
+}
+
+function buildPackageInput(body = {}) {
+  const payload = resolvePayload(body);
+  const artifacts = resolveArtifacts(payload);
+  const compiledProject = resolveCompiledProject(payload, artifacts);
+  const projectName = firstValue(
+    payload.projectName,
+    payload.metadata?.projectName,
+    payload.result?.projectName,
+    "ArchiAI_Project",
+  );
+  const dxfArtifact =
+    payload.dxfArtifact ||
+    artifacts.dxf ||
+    buildDxfArtifact({
+      compiledProject,
+      projectName,
+      includeDetailDrawings: payload.includeDetailDrawings === true,
+      detailDrawingsEnabled: payload.detailDrawingsEnabled === true,
+    });
+  const structuralArtifacts = firstValue(
+    payload.structuralArtifacts,
+    artifacts.structuralArtifacts,
+  );
+  const mepArtifacts = firstValue(payload.mepArtifacts, artifacts.mepArtifacts);
+  const detailArtifacts = firstValue(
+    payload.detailArtifacts,
+    artifacts.detailArtifacts,
+  );
+
+  return {
+    projectName,
+    projectId: firstValue(
+      payload.projectId,
+      payload.project_id,
+      payload.designId,
+      payload.metadata?.projectId,
+      payload.result?.projectId,
+    ),
+    projectGraphId: firstValue(
+      payload.projectGraphId,
+      payload.project_graph_id,
+      artifacts.projectGraphId,
+      payload.projectGraph?.projectGraphId,
+      payload.projectGraph?.project_id,
+      payload.result?.projectGraphId,
+    ),
+    projectGraph: payload.projectGraph || payload.result?.projectGraph || null,
+    compiledProject,
+    geometryHash: firstValue(
+      payload.geometryHash,
+      artifacts.geometryHash,
+      compiledProject?.geometryHash,
+      payload.result?.geometryHash,
+    ),
+    visualManifestHash: firstValue(
+      payload.visualManifestHash,
+      artifacts.visualManifestHash,
+      payload.visualManifest?.manifestHash,
+      payload.result?.visualManifestHash,
+    ),
+    styleBlendManifestHash: firstValue(
+      payload.styleBlendManifestHash,
+      artifacts.styleBlendManifestHash,
+      payload.styleBlendManifest?.manifestHash,
+      payload.result?.styleBlendManifestHash,
+    ),
+    jurisdictionId: firstValue(
+      payload.jurisdictionId,
+      payload.jurisdictionPack?.jurisdictionId,
+      payload.result?.jurisdictionPack?.jurisdictionId,
+      compiledProject?.jurisdictionId,
+    ),
+    countryCode: firstValue(
+      payload.countryCode,
+      payload.jurisdictionPack?.countryCode,
+      payload.result?.jurisdictionPack?.countryCode,
+      compiledProject?.countryCode,
+    ),
+    flags: {
+      ...(payload.flags || {}),
+      structuralEnabled:
+        payload.flags?.structuralEnabled === true ||
+        asArray(structuralArtifacts).length > 0,
+      mepEnabled:
+        payload.flags?.mepEnabled === true || asArray(mepArtifacts).length > 0,
+      detailsEnabled:
+        payload.flags?.detailsEnabled === true ||
+        asArray(detailArtifacts).length > 0,
+      dwgEnabled: payload.flags?.dwgEnabled === true,
+      ifcEnabled: payload.flags?.ifcEnabled === true,
+    },
+    a1Sheet: firstValue(payload.a1Sheet, artifacts.a1Sheet),
+    a1Pdf: firstValue(payload.a1Pdf, artifacts.a1Pdf),
+    a1Png: firstValue(payload.a1Png, artifacts.a1Png, artifacts.renderedProof),
+    dxfArtifact,
+    dwgArtifact: firstValue(payload.dwgArtifact, artifacts.dwg),
+    ifcArtifact: firstValue(payload.ifcArtifact, artifacts.ifc),
+    technicalDrawings: firstValue(
+      payload.technicalDrawings,
+      artifacts.drawings,
+    ),
+    existingArtifacts: payload.existingArtifacts || [],
+    structuralArtifacts,
+    mepArtifacts,
+    detailArtifacts,
+    schedulesWorkbook: firstValue(
+      payload.schedulesWorkbook,
+      artifacts.schedulesWorkbook,
+    ),
+    qaReport: firstValue(payload.qaReport, artifacts.qaReport, payload.qa),
+    visualManifest: firstValue(
+      payload.visualManifest,
+      artifacts.visualManifest,
+    ),
+    styleBlendManifest: firstValue(
+      payload.styleBlendManifest,
+      artifacts.styleBlendManifest,
+    ),
+    jurisdictionPack: firstValue(
+      payload.jurisdictionPack,
+      payload.jurisdiction,
+      artifacts.jurisdictionPack,
+    ),
+    sourceGaps: payload.sourceGaps || [],
+    producerVersions: payload.producerVersions || {},
+  };
+}
+
+function hasPackageSource(input = {}) {
+  return Boolean(
+    input.compiledProject?.geometryHash ||
+    hasContent(input.a1Sheet) ||
+    hasContent(input.a1Pdf) ||
+    hasContent(input.a1Png) ||
+    hasContent(input.dxfArtifact) ||
+    hasContent(input.dwgArtifact) ||
+    hasContent(input.ifcArtifact) ||
+    asArray(input.technicalDrawings).some(hasContent) ||
+    asArray(input.existingArtifacts).some(hasContent) ||
+    asArray(input.structuralArtifacts).some(hasContent) ||
+    asArray(input.mepArtifacts).some(hasContent) ||
+    asArray(input.detailArtifacts).some(hasContent) ||
+    hasContent(input.schedulesWorkbook),
+  );
+}
+
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const packageInput = buildPackageInput(req.body || {});
+    if (!hasPackageSource(packageInput)) {
+      return res.status(400).json({
+        error: "At least one generated artifact or compiledProject is required",
+        code: "PACKAGE_ARTIFACTS_REQUIRED",
+      });
+    }
+
+    const packageResult = buildArtifactPackage(packageInput);
+    const safeName = safeProjectName(packageInput.projectName);
+    const zipBuffer = Buffer.from(packageResult.zipBytes);
+
+    res.setHeader("Content-Type", "application/zip");
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${safeName}-deliverables.zip"`,
+    );
+    res.setHeader("X-Artifact-Package-Id", packageResult.packageId);
+    res.setHeader("X-Artifact-Package-Hash", packageResult.packageHash);
+    res.setHeader(
+      "X-Artifact-Source-Gap-Count",
+      String(packageResult.sourceGaps.length),
+    );
+    return res.status(200).send(zipBuffer);
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "Artifact package export failed",
+    });
+  }
+}
+
+export const __artifactPackageExportInternals = Object.freeze({
+  buildPackageInput,
+  safeProjectName,
+  hasPackageSource,
+});

--- a/server.cjs
+++ b/server.cjs
@@ -381,6 +381,7 @@ mountDynamicApiRoute('post', '/api/project/export/json',    'api/project/export/
 mountDynamicApiRoute('post', '/api/project/export/dxf',     'api/project/export/dxf.js');
 mountDynamicApiRoute('post', '/api/project/export/ifc',     'api/project/export/ifc.js');
 mountDynamicApiRoute('post', '/api/project/export/xlsx',    'api/project/export/xlsx.js');
+mountDynamicApiRoute('post', '/api/project/export/artifact-package', 'api/project/export/artifact-package.js');
 
 // Phase 1/2 architecture backend routes (shared with api/models/* serverless handlers)
 mountDynamicApiRoute('post', '/api/models/generate-style', 'api/models/generate-style.js', [aiApiLimiter]);

--- a/src/__tests__/api/artifactPackageExport.test.js
+++ b/src/__tests__/api/artifactPackageExport.test.js
@@ -1,0 +1,183 @@
+import artifactPackageHandler from "../../../api/project/export/artifact-package.js";
+import { listZipEntryNames } from "../../services/export/artifactPackageService.js";
+
+function dataUri(mimeType, value) {
+  return `data:${mimeType};base64,${Buffer.from(value).toString("base64")}`;
+}
+
+function createMockResponse() {
+  return {
+    headers: {},
+    statusCode: 200,
+    body: null,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function readZipEntry(zipBytes, entryName) {
+  const bytes = Buffer.from(zipBytes);
+  let offset = 0;
+
+  while (offset + 30 <= bytes.length) {
+    const signature = bytes.readUInt32LE(offset);
+    if (signature !== 0x04034b50) break;
+
+    const compressedSize = bytes.readUInt32LE(offset + 18);
+    const nameLength = bytes.readUInt16LE(offset + 26);
+    const extraLength = bytes.readUInt16LE(offset + 28);
+    const nameStart = offset + 30;
+    const nameEnd = nameStart + nameLength;
+    const name = bytes.slice(nameStart, nameEnd).toString("utf8");
+    const dataStart = nameEnd + extraLength;
+    const dataEnd = dataStart + compressedSize;
+
+    if (name === entryName) {
+      return bytes.slice(dataStart, dataEnd);
+    }
+    offset = dataEnd;
+  }
+
+  return null;
+}
+
+function readZipJson(zipBytes, entryName) {
+  const entry = readZipEntry(zipBytes, entryName);
+  expect(entry).toBeTruthy();
+  return JSON.parse(entry.toString("utf8"));
+}
+
+function baseBody(overrides = {}) {
+  return {
+    projectName: "My Project ../ 2026",
+    projectId: "project-zip-001",
+    projectGraphId: "graph-zip-001",
+    geometryHash: "geometryhash-zip-001",
+    visualManifestHash: "visualhash-zip-001",
+    styleBlendManifestHash: "stylehash-zip-001",
+    jurisdictionId: "uk-england",
+    countryCode: "GB",
+    flags: {
+      structuralEnabled: false,
+      mepEnabled: false,
+      detailsEnabled: false,
+      dwgEnabled: false,
+      ifcEnabled: false,
+    },
+    a1Sheet: {
+      svgString:
+        '<svg xmlns="http://www.w3.org/2000/svg"><text>A1</text></svg>',
+      sheetNumber: "A1-001",
+    },
+    a1Pdf: {
+      dataUrl: dataUri("application/pdf", "%PDF package"),
+      sheetNumber: "A1-001",
+    },
+    dxfArtifact: {
+      fileName: "cad/my-project.dxf",
+      content: "0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n",
+    },
+    qaReport: {
+      status: "pass",
+      issues: [],
+    },
+    env: {
+      OPENAI_API_KEY: "secret-value-that-must-not-appear",
+    },
+    ...overrides,
+  };
+}
+
+describe("/api/project/export/artifact-package", () => {
+  test("returns application/zip with a safe attachment filename", async () => {
+    const req = { method: "POST", headers: {}, body: baseBody() };
+    const res = createMockResponse();
+
+    await artifactPackageHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["Content-Type"]).toBe("application/zip");
+    expect(res.headers["Content-Disposition"]).toBe(
+      'attachment; filename="My_Project_2026-deliverables.zip"',
+    );
+    expect(Buffer.isBuffer(res.body)).toBe(true);
+  });
+
+  test("includes manifest.json and supplied QA report without secret values", async () => {
+    const req = { method: "POST", headers: {}, body: baseBody() };
+    const res = createMockResponse();
+
+    await artifactPackageHandler(req, res);
+
+    const names = listZipEntryNames(res.body);
+    expect(names).toEqual(
+      expect.arrayContaining(["manifest.json", "qa/qa-report.json"]),
+    );
+
+    const manifest = readZipJson(res.body, "manifest.json");
+    const qaReport = readZipJson(res.body, "qa/qa-report.json");
+    const manifestText = JSON.stringify(manifest);
+
+    expect(manifest).toEqual(
+      expect.objectContaining({
+        projectId: "project-zip-001",
+        projectGraphId: "graph-zip-001",
+        geometryHash: "geometryhash-zip-001",
+        visualManifestHash: "visualhash-zip-001",
+        styleBlendManifestHash: "stylehash-zip-001",
+        jurisdictionId: "uk-england",
+        countryCode: "GB",
+      }),
+    );
+    expect(qaReport).toEqual(expect.objectContaining({ status: "pass" }));
+    expect(manifestText).not.toContain("secret-value-that-must-not-appear");
+  });
+
+  test("DWG and IFC unavailable are source gaps with no fake files", async () => {
+    const req = { method: "POST", headers: {}, body: baseBody() };
+    const res = createMockResponse();
+
+    await artifactPackageHandler(req, res);
+
+    const manifest = readZipJson(res.body, "manifest.json");
+    const names = listZipEntryNames(res.body);
+
+    expect(manifest.sourceGaps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "DWG_CONVERSION_UNAVAILABLE" }),
+        expect.objectContaining({ code: "IFC_EXPORT_UNAVAILABLE" }),
+      ]),
+    );
+    expect(names.some((name) => name.endsWith(".dwg"))).toBe(false);
+    expect(names.some((name) => name.endsWith(".ifc"))).toBe(false);
+  });
+
+  test("rejects package requests with no generated artifact source", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: { projectName: "Empty Project" },
+    };
+    const res = createMockResponse();
+
+    await artifactPackageHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual(
+      expect.objectContaining({ code: "PACKAGE_ARTIFACTS_REQUIRED" }),
+    );
+  });
+});

--- a/src/__tests__/components/exportPanelDeliverables.test.jsx
+++ b/src/__tests__/components/exportPanelDeliverables.test.jsx
@@ -1,0 +1,179 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import ExportPanel from "../../components/ExportPanel.jsx";
+import exportService from "../../services/exportService.js";
+
+jest.mock("../../components/ui/feedback/Tooltip.jsx", () => ({
+  Tooltip: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("../../components/ui/feedback/Tooltip", () => ({
+  Tooltip: ({ children }) => <>{children}</>,
+}));
+
+const mockToast = {
+  success: jest.fn(),
+  error: jest.fn(),
+  warning: jest.fn(),
+};
+
+jest.mock("../../components/ui/ToastProvider.jsx", () => ({
+  useToastContext: () => ({ toast: mockToast }),
+}));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function renderComponent(ui) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function buttonByText(container, text) {
+  return [...container.querySelectorAll("button")].find((button) =>
+    button.textContent.includes(text),
+  );
+}
+
+function createHeaders(headers = {}) {
+  return {
+    get(name) {
+      const key = Object.keys(headers).find(
+        (headerName) => headerName.toLowerCase() === name.toLowerCase(),
+      );
+      return key ? headers[key] : null;
+    },
+  };
+}
+
+describe("ExportPanel deliverables ZIP entry point", () => {
+  const originalFetch = global.fetch;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalAnchorClick = HTMLAnchorElement.prototype.click;
+
+  beforeEach(() => {
+    mockToast.success.mockClear();
+    mockToast.error.mockClear();
+    mockToast.warning.mockClear();
+    URL.createObjectURL = jest.fn(() => "blob:deliverables-zip");
+    URL.revokeObjectURL = jest.fn();
+    HTMLAnchorElement.prototype.click = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    HTMLAnchorElement.prototype.click = originalAnchorClick;
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  test("disables deliverables ZIP download when no completed artifacts exist", () => {
+    const { container, unmount } = renderComponent(
+      <ExportPanel designData={{}} onExport={jest.fn()} />,
+    );
+
+    const zipButton = buttonByText(container, "Download Deliverables ZIP");
+
+    expect(zipButton).toBeTruthy();
+    expect(zipButton.disabled).toBe(true);
+    expect(zipButton.textContent).toContain("Generate first");
+
+    unmount();
+  });
+
+  test("triggers artifact package download when generated artifacts exist", async () => {
+    const responseBlob = new Blob(["zip-bytes"], { type: "application/zip" });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: createHeaders({
+        "Content-Disposition": 'attachment; filename="test-deliverables.zip"',
+      }),
+      blob: jest.fn().mockResolvedValue(responseBlob),
+    });
+
+    const designData = {
+      projectName: "Test Project",
+      projectId: "project-ui-001",
+      projectGraphId: "graph-ui-001",
+      geometryHash: "geometry-ui-001",
+      visualManifestHash: "visual-ui-001",
+      styleBlendManifestHash: "style-ui-001",
+      jurisdictionId: "uk-england",
+      countryCode: "GB",
+      artifacts: {
+        a1Sheet: {
+          svgString:
+            '<svg xmlns="http://www.w3.org/2000/svg"><text>A1</text></svg>',
+        },
+        a1Pdf: {
+          dataUrl: "data:application/pdf;base64,JVBERi0xLjcgYTFwZGY=",
+        },
+        qaReport: {
+          status: "pass",
+        },
+      },
+      compiledProject: {
+        geometryHash: "geometry-ui-001",
+      },
+    };
+
+    const { container, unmount } = renderComponent(
+      <ExportPanel
+        designData={designData}
+        onExport={(format, sheet) =>
+          exportService.exportSheet({ sheet, format })
+        }
+      />,
+    );
+
+    await act(async () => {
+      buttonByText(container, "Download Deliverables ZIP").click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/project/export/artifact-package",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const [, requestOptions] = global.fetch.mock.calls[0];
+    const payload = JSON.parse(requestOptions.body);
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        projectName: "Test Project",
+        projectId: "project-ui-001",
+        geometryHash: "geometry-ui-001",
+        visualManifestHash: "visual-ui-001",
+        styleBlendManifestHash: "style-ui-001",
+        jurisdictionId: "uk-england",
+      }),
+    );
+    expect(payload).not.toHaveProperty("env");
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+    expect(mockToast.success).toHaveBeenCalledWith(
+      "Export complete",
+      "Deliverables ZIP downloaded.",
+    );
+
+    unmount();
+  });
+});

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -13,6 +13,7 @@
 import React from "react";
 import {
   Download,
+  Archive,
   Box,
   FileSpreadsheet,
   FileText,
@@ -56,6 +57,39 @@ function downloadBlenderRenders(panels) {
   return count;
 }
 
+function hasDeliverablePackageArtifacts(designData = {}) {
+  const artifacts = designData?.artifacts || {};
+  const compiledProject =
+    designData?.compiledProject ||
+    designData?.a1Sheet?.compiledProject ||
+    designData?.metadata?.compiledProject ||
+    null;
+  const designUrlIsData =
+    typeof designData?.url === "string" && designData.url.startsWith("data:");
+  const designPdfUrlIsData =
+    typeof designData?.pdfUrl === "string" &&
+    designData.pdfUrl.startsWith("data:");
+
+  return Boolean(
+    compiledProject?.geometryHash ||
+    artifacts?.a1Sheet?.svgString ||
+    artifacts?.a1Sheet?.svg ||
+    artifacts?.a1Pdf?.dataUrl ||
+    artifacts?.a1Pdf?.pdfDataUrl ||
+    artifacts?.a1Png?.dataUrl ||
+    artifacts?.renderedProof?.dataUrl ||
+    artifacts?.dxf ||
+    artifacts?.drawings ||
+    artifacts?.qaReport ||
+    designData?.a1Sheet?.svgString ||
+    designData?.a1Sheet?.svg ||
+    designData?.a1Pdf?.dataUrl ||
+    designData?.a1Pdf?.pdfDataUrl ||
+    designUrlIsData ||
+    designPdfUrlIsData,
+  );
+}
+
 /**
  * Single export row — consistent layout regardless of format.
  */
@@ -65,6 +99,7 @@ const ExportRow = ({
   formatChip,
   available,
   blockedReason,
+  statusLabel,
   tooltip,
   onClick,
 }) => {
@@ -100,7 +135,12 @@ const ExportRow = ({
         </span>
       )}
 
-      <StatusChip status={status} size="sm" tooltip={statusTooltip} />
+      <StatusChip
+        status={status}
+        size="sm"
+        label={statusLabel}
+        tooltip={statusTooltip}
+      />
     </button>
   );
 
@@ -182,6 +222,7 @@ const ExportPanel = ({
     (entry) => entry?.available,
   ).length;
   const totalExportCount = Object.keys(exportsMap).length;
+  const deliverablesReady = hasDeliverablePackageArtifacts(designData);
 
   // Per-format availability + blocked-reason logic.
   const isAvailable = (key, fallback = true) =>
@@ -221,6 +262,16 @@ const ExportPanel = ({
 
       {/* Documents */}
       <ExportSection title="Documents">
+        <ExportRow
+          icon={Archive}
+          label="Download Deliverables ZIP"
+          formatChip="ZIP"
+          available={deliverablesReady}
+          blockedReason="Generate first"
+          statusLabel={deliverablesReady ? undefined : "Generate first"}
+          tooltip="Deterministic package with manifest, QA report, drawings, CAD, and source gaps."
+          onClick={() => void handleExport("zip", "Deliverables ZIP")}
+        />
         <ExportRow
           icon={FileText}
           label="Export as PDF"

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -50,10 +50,36 @@ class ExportService {
   resolveProjectName(sheet = {}) {
     return (
       sheet?.projectName ||
+      sheet?.brief?.project_name ||
+      sheet?.projectGraph?.brief?.project_name ||
       sheet?.metadata?.projectName ||
       sheet?.dna?.projectType ||
       "ArchiAI_Project"
     );
+  }
+
+  safeProjectName(value, fallback = "ArchiAI_Project") {
+    const cleaned = String(value || fallback)
+      .trim()
+      .replace(/[^a-zA-Z0-9_-]+/g, "_")
+      .replace(/_+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .slice(0, 80);
+    return cleaned || fallback;
+  }
+
+  filenameFromContentDisposition(headerValue, fallback) {
+    const header = String(headerValue || "");
+    const utf8Match = header.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utf8Match) {
+      try {
+        return decodeURIComponent(utf8Match[1].replace(/^"|"$/g, ""));
+      } catch (_error) {
+        return utf8Match[1].replace(/^"|"$/g, "") || fallback;
+      }
+    }
+    const filenameMatch = header.match(/filename="?([^";]+)"?/i);
+    return filenameMatch?.[1] || fallback;
   }
 
   async downloadResponseBlob(response, filename) {
@@ -65,6 +91,183 @@ class ExportService {
     link.click();
     URL.revokeObjectURL(url);
     return url;
+  }
+
+  async readJsonError(response, fallbackMessage) {
+    const errorData = await response.json().catch(() => ({}));
+    return (
+      errorData?.error?.message ||
+      errorData?.error ||
+      errorData?.message ||
+      fallbackMessage
+    );
+  }
+
+  hasDeliverableArtifacts(sheet = {}) {
+    const artifacts = sheet?.artifacts || {};
+    const compiledProject = this.resolveCompiledProject(sheet);
+    const sheetUrlIsData =
+      typeof sheet?.url === "string" && sheet.url.startsWith("data:");
+    const sheetPdfUrlIsData =
+      typeof sheet?.pdfUrl === "string" && sheet.pdfUrl.startsWith("data:");
+    return Boolean(
+      compiledProject?.geometryHash ||
+      artifacts?.a1Sheet?.svgString ||
+      artifacts?.a1Sheet?.svg ||
+      artifacts?.a1Pdf?.dataUrl ||
+      artifacts?.a1Pdf?.pdfDataUrl ||
+      artifacts?.a1Png?.dataUrl ||
+      artifacts?.renderedProof?.dataUrl ||
+      artifacts?.dxf ||
+      artifacts?.drawings ||
+      artifacts?.qaReport ||
+      sheet?.a1Sheet?.svgString ||
+      sheet?.a1Sheet?.svg ||
+      sheet?.a1Pdf?.dataUrl ||
+      sheet?.a1Pdf?.pdfDataUrl ||
+      sheetUrlIsData ||
+      sheetPdfUrlIsData,
+    );
+  }
+
+  buildArtifactPackagePayload(sheet = {}) {
+    const artifacts = sheet?.artifacts || {};
+    const compiledProject = this.resolveCompiledProject(sheet);
+    const sheetUrlPng =
+      typeof sheet?.url === "string" && sheet.url.startsWith("data:")
+        ? { dataUrl: sheet.url }
+        : null;
+    const sheetPdfUrl =
+      typeof sheet?.pdfUrl === "string" && sheet.pdfUrl.startsWith("data:")
+        ? { dataUrl: sheet.pdfUrl }
+        : null;
+    const flags = {
+      structuralEnabled: Boolean(
+        sheet?.flags?.structuralEnabled ||
+        artifacts?.structuralArtifacts?.length ||
+        compiledProject?.structuralModel,
+      ),
+      mepEnabled: Boolean(
+        sheet?.flags?.mepEnabled ||
+        artifacts?.mepArtifacts?.length ||
+        compiledProject?.mepModel,
+      ),
+      detailsEnabled: Boolean(
+        sheet?.flags?.detailsEnabled ||
+        artifacts?.detailArtifacts?.length ||
+        compiledProject?.constructionDetailLibrary ||
+        compiledProject?.detailLibrary,
+      ),
+      dwgEnabled: Boolean(sheet?.flags?.dwgEnabled),
+      ifcEnabled: Boolean(sheet?.flags?.ifcEnabled),
+    };
+
+    return {
+      projectName: this.resolveProjectName(sheet),
+      projectId:
+        sheet?.projectId ||
+        sheet?.project_id ||
+        sheet?.designId ||
+        sheet?.metadata?.projectId ||
+        null,
+      projectGraphId:
+        sheet?.projectGraphId ||
+        sheet?.projectGraph?.projectGraphId ||
+        sheet?.projectGraph?.project_id ||
+        artifacts?.projectGraphId ||
+        null,
+      projectGraph: sheet?.projectGraph || null,
+      compiledProject,
+      geometryHash:
+        sheet?.geometryHash ||
+        artifacts?.geometryHash ||
+        compiledProject?.geometryHash ||
+        null,
+      visualManifestHash:
+        sheet?.visualManifestHash ||
+        artifacts?.visualManifestHash ||
+        sheet?.visualManifest?.manifestHash ||
+        null,
+      styleBlendManifestHash:
+        sheet?.styleBlendManifestHash ||
+        artifacts?.styleBlendManifestHash ||
+        sheet?.styleBlendManifest?.manifestHash ||
+        null,
+      jurisdictionId:
+        sheet?.jurisdictionId ||
+        sheet?.jurisdictionPack?.jurisdictionId ||
+        sheet?.metadata?.jurisdictionId ||
+        compiledProject?.jurisdictionId ||
+        null,
+      countryCode:
+        sheet?.countryCode ||
+        sheet?.jurisdictionPack?.countryCode ||
+        sheet?.metadata?.countryCode ||
+        compiledProject?.countryCode ||
+        null,
+      flags,
+      a1Sheet: artifacts?.a1Sheet || sheet?.a1Sheet || null,
+      a1Pdf: artifacts?.a1Pdf || sheet?.a1Pdf || sheetPdfUrl,
+      a1Png:
+        artifacts?.a1Png ||
+        artifacts?.renderedProof ||
+        sheet?.a1Png ||
+        sheetUrlPng,
+      dxfArtifact: artifacts?.dxf || sheet?.dxfArtifact || null,
+      dwgArtifact: artifacts?.dwg || sheet?.dwgArtifact || null,
+      ifcArtifact: artifacts?.ifc || sheet?.ifcArtifact || null,
+      technicalDrawings:
+        artifacts?.drawings || sheet?.technicalDrawings || null,
+      existingArtifacts:
+        artifacts?.existingArtifacts || sheet?.existingArtifacts || [],
+      structuralArtifacts:
+        artifacts?.structuralArtifacts || sheet?.structuralArtifacts || null,
+      mepArtifacts: artifacts?.mepArtifacts || sheet?.mepArtifacts || null,
+      detailArtifacts:
+        artifacts?.detailArtifacts || sheet?.detailArtifacts || null,
+      schedulesWorkbook:
+        artifacts?.schedulesWorkbook || sheet?.schedulesWorkbook || null,
+      qaReport: artifacts?.qaReport || sheet?.qaReport || sheet?.qa || null,
+      visualManifest:
+        artifacts?.visualManifest || sheet?.visualManifest || null,
+      styleBlendManifest:
+        artifacts?.styleBlendManifest || sheet?.styleBlendManifest || null,
+      jurisdictionPack:
+        artifacts?.jurisdictionPack || sheet?.jurisdictionPack || null,
+      sourceGaps: sheet?.sourceGaps || [],
+      producerVersions: sheet?.producerVersions || {},
+    };
+  }
+
+  async exportDeliverablesPackage({ sheet }) {
+    if (!this.hasDeliverableArtifacts(sheet)) {
+      throw new Error("Generate a design before downloading deliverables.");
+    }
+
+    const payload = this.buildArtifactPackagePayload(sheet);
+    const safeName = this.safeProjectName(payload.projectName);
+    const fallbackFilename = `${safeName}-deliverables.zip`;
+    const response = await fetch("/api/project/export/artifact-package", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const message = await this.readJsonError(
+        response,
+        `Deliverables ZIP export failed: ${response.status}`,
+      );
+      throw new Error(message);
+    }
+
+    const filename = this.filenameFromContentDisposition(
+      response.headers?.get?.("content-disposition"),
+      fallbackFilename,
+    );
+    const url = await this.downloadResponseBlob(response, filename);
+    logger.success("Deliverables ZIP export complete", { filename });
+    return { success: true, url, filename, format: "ZIP" };
   }
 
   /**
@@ -104,6 +307,10 @@ class ExportService {
 
     if (fmt === "GLB") {
       return this.exportGLB({ sheet });
+    }
+
+    if (fmt === "ZIP" || fmt === "DELIVERABLES" || fmt === "ARTIFACT_PACKAGE") {
+      return this.exportDeliverablesPackage({ sheet, env: effectiveEnv });
     }
 
     // Determine export method based on environment


### PR DESCRIPTION
## Summary

Adds Phase 2 of the professional deliverable package system: API/export wiring and a UI download entry point for deterministic deliverable ZIP packages.

## Changes

- Adds artifact package API endpoint.
- Returns real ZIP output from `buildArtifactPackage`.
- Adds correct ZIP download headers.
- Adds UI entry point: `Download Deliverables ZIP`.
- Disables the UI button when no completed artifacts exist.
- Includes `manifest.json` in the ZIP.
- Includes `qa/qa-report.json` when QA report is supplied.
- Preserves explicit source gaps for unavailable DWG/IFC.
- Ensures no fake `.dwg` or `.ifc` files are generated.
- Adds tests for endpoint, ZIP contents, secret safety, unavailable DWG/IFC handling, and UI button behaviour.

## Validation

- Focused tests: 4 suites, 25 tests passed
- `npm run lint`
- `git diff --check` passed with CRLF warnings only
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Safety and scope

- No PDF stitching added in this PR.
- No new drawing engine added.
- No image-generation path added.
- No fake DWG/IFC output.
- Existing ProjectGraph/A1/CAD/structural/MEP/detail authority gates were not weakened.

## Remaining phases

- PDF stitching.
- Storage/signed URL integration if needed.
- Full artifact manager UI.
- Real DWG/IFC inclusion only when configured and available.
