### PR TITLE
Add deterministic PDF stitching to artifact packages

### DIFF
--- a/api/project/export/artifact-package.js
+++ b/api/project/export/artifact-package.js
@@ -1,5 +1,5 @@
 import { setCorsHeaders, handlePreflight } from "../../_shared/cors.js";
-import { buildArtifactPackage } from "../../../src/services/export/artifactPackageService.js";
+import { buildArtifactPackageWithPdfStitching } from "../../../src/services/export/artifactPackageService.js";
 import { exportCompiledProjectToDXF } from "../../../src/services/project/compiledProjectExportService.js";
 
 function safeProjectName(value, fallback = "ArchiAI_Project") {
@@ -253,7 +253,8 @@ export default async function handler(req, res) {
       });
     }
 
-    const packageResult = buildArtifactPackage(packageInput);
+    const packageResult =
+      await buildArtifactPackageWithPdfStitching(packageInput);
     const safeName = safeProjectName(packageInput.projectName);
     const zipBuffer = Buffer.from(packageResult.zipBytes);
 

--- a/src/__tests__/api/artifactPackageExport.test.js
+++ b/src/__tests__/api/artifactPackageExport.test.js
@@ -1,8 +1,32 @@
 import artifactPackageHandler from "../../../api/project/export/artifact-package.js";
 import { listZipEntryNames } from "../../services/export/artifactPackageService.js";
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 
 function dataUri(mimeType, value) {
   return `data:${mimeType};base64,${Buffer.from(value).toString("base64")}`;
+}
+
+async function pdfDataUri(label) {
+  const pdf = await PDFDocument.create();
+  pdf.setTitle(label);
+  pdf.setCreator("artifact-package-api-test");
+  pdf.setProducer("artifact-package-api-test");
+  pdf.setCreationDate(new Date("1980-01-01T00:00:00.000Z"));
+  pdf.setModificationDate(new Date("1980-01-01T00:00:00.000Z"));
+  const page = pdf.addPage([200, 200]);
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  page.drawText(label, {
+    x: 24,
+    y: 144,
+    font,
+    size: 12,
+    color: rgb(0, 0, 0),
+  });
+  const bytes = await pdf.save({
+    useObjectStreams: false,
+    addDefaultPage: false,
+  });
+  return dataUri("application/pdf", bytes);
 }
 
 function createMockResponse() {
@@ -144,6 +168,9 @@ describe("/api/project/export/artifact-package", () => {
     );
     expect(qaReport).toEqual(expect.objectContaining({ status: "pass" }));
     expect(manifestText).not.toContain("secret-value-that-must-not-appear");
+    expect(Buffer.from(res.body).toString("latin1")).not.toContain(
+      "secret-value-that-must-not-appear",
+    );
   });
 
   test("DWG and IFC unavailable are source gaps with no fake files", async () => {
@@ -163,6 +190,49 @@ describe("/api/project/export/artifact-package", () => {
     );
     expect(names.some((name) => name.endsWith(".dwg"))).toBe(false);
     expect(names.some((name) => name.endsWith(".ifc"))).toBe(false);
+  });
+
+  test("includes stitched deliverables PDF in ZIP when generated PDFs exist", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: baseBody({
+        a1Pdf: {
+          dataUrl: await pdfDataUri("A1 PDF"),
+          sheetNumber: "A1-001",
+        },
+        technicalDrawings: [
+          {
+            panelType: "section",
+            mimeType: "application/pdf",
+            pdfDataUrl: await pdfDataUri("Section PDF"),
+            sheetNumber: "A-201",
+          },
+        ],
+      }),
+    };
+    const res = createMockResponse();
+
+    await artifactPackageHandler(req, res);
+
+    const names = listZipEntryNames(res.body);
+    const stitchedFileName = "presentation/my-project-2026-deliverables.pdf";
+    const manifest = readZipJson(res.body, "manifest.json");
+    const stitchedBytes = readZipEntry(res.body, stitchedFileName);
+    expect(stitchedBytes).toBeTruthy();
+    const stitchedPdf = await PDFDocument.load(new Uint8Array(stitchedBytes));
+
+    expect(names).toContain(stitchedFileName);
+    expect(manifest.artifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fileName: stitchedFileName,
+          type: "stitched_pdf_package",
+          mimeType: "application/pdf",
+        }),
+      ]),
+    );
+    expect(stitchedPdf.getPageCount()).toBe(3);
   });
 
   test("rejects package requests with no generated artifact source", async () => {

--- a/src/__tests__/services/export/artifactPackageService.test.js
+++ b/src/__tests__/services/export/artifactPackageService.test.js
@@ -1,12 +1,65 @@
 import {
   buildArtifactPackage,
+  buildArtifactPackageWithPdfStitching,
   IFC_EXPORT_UNAVAILABLE,
   listZipEntryNames,
+  PDF_STITCHING_FAILED,
+  PDF_STITCHING_NO_INPUT_PDFS,
 } from "../../../services/export/artifactPackageService.js";
 import { DWG_CONVERSION_UNAVAILABLE } from "../../../services/cad/dwgConversionAdapter.js";
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 
 function dataUri(mimeType, value) {
   return `data:${mimeType};base64,${Buffer.from(value).toString("base64")}`;
+}
+
+async function pdfDataUri(label) {
+  const pdf = await PDFDocument.create();
+  pdf.setTitle(label);
+  pdf.setCreator("artifact-package-test");
+  pdf.setProducer("artifact-package-test");
+  pdf.setCreationDate(new Date("1980-01-01T00:00:00.000Z"));
+  pdf.setModificationDate(new Date("1980-01-01T00:00:00.000Z"));
+  const page = pdf.addPage([200, 200]);
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  page.drawText(label, {
+    x: 24,
+    y: 144,
+    font,
+    size: 12,
+    color: rgb(0, 0, 0),
+  });
+  const bytes = await pdf.save({
+    useObjectStreams: false,
+    addDefaultPage: false,
+  });
+  return dataUri("application/pdf", bytes);
+}
+
+function readZipEntry(zipBytes, entryName) {
+  const bytes = Buffer.from(zipBytes);
+  let offset = 0;
+
+  while (offset + 30 <= bytes.length) {
+    const signature = bytes.readUInt32LE(offset);
+    if (signature !== 0x04034b50) break;
+
+    const compressedSize = bytes.readUInt32LE(offset + 18);
+    const nameLength = bytes.readUInt16LE(offset + 26);
+    const extraLength = bytes.readUInt16LE(offset + 28);
+    const nameStart = offset + 30;
+    const nameEnd = nameStart + nameLength;
+    const name = bytes.slice(nameStart, nameEnd).toString("utf8");
+    const dataStart = nameEnd + extraLength;
+    const dataEnd = dataStart + compressedSize;
+
+    if (name === entryName) {
+      return bytes.slice(dataStart, dataEnd);
+    }
+    offset = dataEnd;
+  }
+
+  return null;
 }
 
 function baseInput(overrides = {}) {
@@ -326,5 +379,101 @@ describe("artifactPackageService", () => {
       expect(artifact.styleBlendManifestHash).toBe("styleblendhash001");
       expect(artifact.jurisdictionId).toBe("uk-england");
     }
+  });
+
+  test("stitches existing generated PDFs into deterministic deliverables PDF", async () => {
+    const a1Pdf = await pdfDataUri("A1 sheet");
+    const sectionPdf = await pdfDataUri("Section sheet");
+    const input = baseInput({
+      a1Pdf: {
+        dataUrl: a1Pdf,
+        sheetNumber: "A1-001",
+      },
+      technicalDrawings: [
+        {
+          panelType: "section",
+          mimeType: "application/pdf",
+          pdfDataUrl: sectionPdf,
+          sheetNumber: "A-201",
+        },
+      ],
+    });
+
+    const first = await buildArtifactPackageWithPdfStitching(input);
+    const second = await buildArtifactPackageWithPdfStitching(input);
+    const stitchedFileName =
+      "presentation/deterministic-package-deliverables.pdf";
+    const stitchedArtifact = first.manifest.artifacts.find(
+      (artifact) => artifact.fileName === stitchedFileName,
+    );
+
+    expect(stitchedArtifact).toEqual(
+      expect.objectContaining({
+        type: "stitched_pdf_package",
+        mimeType: "application/pdf",
+        role: "stitched_deliverables_pdf",
+        source: "PDF stitching from existing generated PDF artifacts",
+      }),
+    );
+    expect(listZipEntryNames(first.zipBytes)).toContain(stitchedFileName);
+    expect(second.packageHash).toBe(first.packageHash);
+    expect(
+      second.manifest.artifacts.find(
+        (artifact) => artifact.fileName === stitchedFileName,
+      )?.hash,
+    ).toBe(stitchedArtifact.hash);
+
+    const stitchedBytes = readZipEntry(first.zipBytes, stitchedFileName);
+    expect(stitchedBytes).toBeTruthy();
+    const stitchedPdf = await PDFDocument.load(new Uint8Array(stitchedBytes));
+    expect(stitchedPdf.getPageCount()).toBe(3);
+  });
+
+  test("stitching source gap is reported when no existing PDFs are supplied", async () => {
+    const result = await buildArtifactPackageWithPdfStitching(
+      baseInput({
+        a1Pdf: null,
+        technicalDrawings: [],
+        existingArtifacts: [],
+      }),
+    );
+
+    expect(result.manifest.sourceGaps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: PDF_STITCHING_NO_INPUT_PDFS }),
+      ]),
+    );
+    expect(
+      result.manifest.artifacts.some(
+        (artifact) => artifact.type === "stitched_pdf_package",
+      ),
+    ).toBe(false);
+  });
+
+  test("stitching failure reports a source gap without creating a fake stitched PDF", async () => {
+    const result = await buildArtifactPackageWithPdfStitching(
+      baseInput({
+        a1Pdf: {
+          dataUrl: dataUri("application/pdf", "not a real pdf"),
+          sheetNumber: "A1-001",
+        },
+      }),
+    );
+
+    expect(result.manifest.sourceGaps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: PDF_STITCHING_FAILED }),
+      ]),
+    );
+    expect(
+      result.manifest.artifacts.some(
+        (artifact) => artifact.type === "stitched_pdf_package",
+      ),
+    ).toBe(false);
+    expect(
+      listZipEntryNames(result.zipBytes).some((name) =>
+        name.endsWith("-deliverables.pdf"),
+      ),
+    ).toBe(false);
   });
 });

--- a/src/services/export/artifactPackageService.js
+++ b/src/services/export/artifactPackageService.js
@@ -7,6 +7,20 @@ import {
   DWG_CONVERSION_UNAVAILABLE,
   resolveDwgConversionCapabilities,
 } from "../cad/dwgConversionAdapter.js";
+import {
+  buildStitchedPdfArtifact,
+  PDF_STITCHING_SERVICE_VERSION,
+  PDF_STITCHING_STRATEGY,
+  PDF_STITCHING_FAILED,
+  PDF_STITCHING_NO_INPUT_PDFS,
+  PDF_STITCHING_UNAVAILABLE,
+} from "./pdfStitchingService.js";
+
+export {
+  PDF_STITCHING_FAILED,
+  PDF_STITCHING_NO_INPUT_PDFS,
+  PDF_STITCHING_UNAVAILABLE,
+} from "./pdfStitchingService.js";
 
 export const ARTIFACT_PACKAGE_SCHEMA_VERSION = "artifact-package-manifest-v1";
 export const ARTIFACT_PACKAGE_SERVICE_VERSION = "artifact-package-service-v1";
@@ -310,7 +324,7 @@ function normalizeZipPath(value) {
 function safeName(value, fallback = "artifact") {
   const cleaned = String(value || fallback)
     .trim()
-    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
     .toLowerCase();
@@ -1050,13 +1064,41 @@ export function buildArtifactPackage(input = {}) {
   };
 }
 
+export async function buildArtifactPackageWithPdfStitching(input = {}) {
+  const context = resolveContext(input);
+  const stitchedPdf = await buildStitchedPdfArtifact(input, context);
+  const existingArtifacts = [
+    ...asArray(input.existingArtifacts),
+    ...(stitchedPdf.artifact ? [stitchedPdf.artifact] : []),
+  ];
+  const sourceGaps = [
+    ...asArray(input.sourceGaps),
+    ...asArray(stitchedPdf.sourceGaps),
+  ];
+
+  return buildArtifactPackage({
+    ...input,
+    existingArtifacts,
+    sourceGaps,
+    producerVersions: {
+      ...(input.producerVersions || {}),
+      pdfStitchingService: PDF_STITCHING_SERVICE_VERSION,
+      pdfStitchingStrategy: PDF_STITCHING_STRATEGY,
+    },
+  });
+}
+
 export default {
   ARTIFACT_PACKAGE_SCHEMA_VERSION,
   ARTIFACT_PACKAGE_SERVICE_VERSION,
   ARTIFACT_PACKAGE_FOLDERS,
   DWG_CONVERSION_UNAVAILABLE,
   IFC_EXPORT_UNAVAILABLE,
+  PDF_STITCHING_FAILED,
+  PDF_STITCHING_NO_INPUT_PDFS,
+  PDF_STITCHING_UNAVAILABLE,
   buildArtifactPackage,
+  buildArtifactPackageWithPdfStitching,
   buildDeterministicZip,
   hashBytes,
   listZipEntryNames,

--- a/src/services/export/pdfStitchingService.js
+++ b/src/services/export/pdfStitchingService.js
@@ -1,0 +1,452 @@
+/* global globalThis */
+
+export const PDF_STITCHING_SERVICE_VERSION = "pdf-stitching-service-v1";
+export const PDF_STITCHING_STRATEGY = "existing-pdfs-cover-index-sorted-v1";
+export const PDF_STITCHING_UNAVAILABLE = "PDF_STITCHING_UNAVAILABLE";
+export const PDF_STITCHING_FAILED = "PDF_STITCHING_FAILED";
+export const PDF_STITCHING_NO_INPUT_PDFS = "PDF_STITCHING_NO_INPUT_PDFS";
+
+const FIXED_PDF_DATE = new Date("1980-01-01T00:00:00.000Z");
+const COVER_PAGE_SIZE = [595.28, 841.89];
+
+function utf8Bytes(value) {
+  const text = String(value ?? "");
+  const Encoder = globalThis.TextEncoder;
+  if (typeof Encoder === "function") return new Encoder().encode(text);
+  const BufferCtor = globalThis.Buffer;
+  if (BufferCtor?.from) return new Uint8Array(BufferCtor.from(text, "utf8"));
+  const encoded = unescape(encodeURIComponent(text));
+  const out = new Uint8Array(encoded.length);
+  for (let i = 0; i < encoded.length; i += 1) out[i] = encoded.charCodeAt(i);
+  return out;
+}
+
+function dataUriToBytes(value) {
+  const comma = value.indexOf(",");
+  if (comma === -1) return utf8Bytes(value);
+  const meta = value.slice(0, comma).toLowerCase();
+  const payload = value.slice(comma + 1);
+  if (!meta.includes(";base64")) return utf8Bytes(decodeURIComponent(payload));
+  const BufferCtor = globalThis.Buffer;
+  if (BufferCtor?.from)
+    return new Uint8Array(BufferCtor.from(payload, "base64"));
+  const binary = globalThis.atob(payload);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function normalizeBytes(value) {
+  if (value == null) return null;
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (typeof value === "object" && Array.isArray(value.data)) {
+    return new Uint8Array(value.data);
+  }
+  if (typeof value === "string") {
+    return value.startsWith("data:") ? dataUriToBytes(value) : utf8Bytes(value);
+  }
+  return utf8Bytes(JSON.stringify(value));
+}
+
+function normalizeZipPath(value) {
+  return String(value || "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/{2,}/g, "/")
+    .trim();
+}
+
+function safeName(value, fallback = "project") {
+  const cleaned = String(value || fallback)
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+  return cleaned || fallback;
+}
+
+function asArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : Object.values(value);
+}
+
+function firstValue(...values) {
+  return values.find((value) => value !== undefined && value !== null);
+}
+
+function pdfContent(candidate = {}) {
+  return firstValue(
+    candidate.bytes,
+    candidate.contentBytes,
+    candidate.content,
+    candidate.dataUrl,
+    candidate.dataUri,
+    candidate.pdfDataUrl,
+    candidate.pdfDataUri,
+  );
+}
+
+function isPdfCandidate(candidate = {}) {
+  const fileName = normalizeZipPath(candidate.fileName).toLowerCase();
+  const mimeType = String(candidate.mimeType || "").toLowerCase();
+  return (
+    mimeType === "application/pdf" ||
+    fileName.endsWith(".pdf") ||
+    typeof candidate.pdfDataUrl === "string" ||
+    typeof candidate.pdfDataUri === "string" ||
+    String(candidate.dataUrl || candidate.dataUri || "").startsWith(
+      "data:application/pdf",
+    )
+  );
+}
+
+function createPdfInput(candidate, defaults = {}) {
+  if (!candidate || !isPdfCandidate({ ...defaults, ...candidate })) {
+    return null;
+  }
+  const content = pdfContent(candidate);
+  const bytes = normalizeBytes(content);
+  if (!bytes?.byteLength) return null;
+  const merged = { ...defaults, ...candidate };
+  const fileName = normalizeZipPath(merged.fileName || defaults.fileName);
+  if (!fileName) return null;
+  return {
+    fileName,
+    bytes,
+    sheetNumber: merged.sheetNumber || merged.sheet_number || null,
+    role: merged.role || defaults.role || "pdf_artifact",
+    discipline: merged.discipline || defaults.discipline || "architecture",
+    source: merged.source || defaults.source || "existing_pdf_artifact",
+    stitchOrder: Number.isFinite(Number(merged.stitchOrder))
+      ? Number(merged.stitchOrder)
+      : Number(defaults.stitchOrder || 1000),
+  };
+}
+
+function comparePdfInputs(a, b) {
+  return (
+    a.stitchOrder - b.stitchOrder ||
+    String(a.sheetNumber || "").localeCompare(String(b.sheetNumber || "")) ||
+    a.fileName.localeCompare(b.fileName)
+  );
+}
+
+export function collectPackagePdfInputs(input = {}) {
+  const artifacts = input.artifacts || {};
+  const projectSlug = safeName(
+    input.projectName || input.projectId || input.projectGraphId || "project",
+  );
+  const pdfs = [];
+  const seen = new Set();
+  const add = (candidate, defaults) => {
+    const pdf = createPdfInput(candidate, defaults);
+    if (!pdf || seen.has(pdf.fileName)) return;
+    seen.add(pdf.fileName);
+    pdfs.push(pdf);
+  };
+
+  const a1Pdf = input.a1Pdf || artifacts.a1Pdf;
+  add(a1Pdf, {
+    fileName: `presentation/${projectSlug}-a1-sheet.pdf`,
+    role: "a1_sheet",
+    discipline: "architecture",
+    source: "ProjectGraph A1 PDF artifact",
+    stitchOrder: 10,
+    sheetNumber: a1Pdf?.sheetNumber || "A1-001",
+  });
+
+  for (const drawing of asArray(
+    input.technicalDrawings || artifacts.drawings,
+  )) {
+    const id = safeName(
+      drawing.panelType || drawing.type || drawing.artifactId || "technical",
+    );
+    add(drawing, {
+      fileName: `technical/${id}.pdf`,
+      role: drawing.role || "technical_drawing",
+      discipline: drawing.discipline || "architecture",
+      source: drawing.source || "ProjectGraph technical drawing PDF artifact",
+      stitchOrder: 20,
+    });
+  }
+
+  for (const artifact of asArray(
+    input.structuralArtifacts || artifacts.structuralArtifacts,
+  )) {
+    const id = safeName(
+      artifact.fileStem || artifact.type || artifact.role || "structural",
+    );
+    add(artifact, {
+      fileName: `technical/${id}.pdf`,
+      role: artifact.role || "structural_sheet",
+      discipline: "structure",
+      source: artifact.source || "Existing structural PDF artifact",
+      stitchOrder: 30,
+    });
+  }
+
+  for (const artifact of asArray(
+    input.mepArtifacts || artifacts.mepArtifacts,
+  )) {
+    const id = safeName(
+      artifact.fileStem || artifact.type || artifact.role || "mep",
+    );
+    add(artifact, {
+      fileName: `technical/${id}.pdf`,
+      role: artifact.role || "mep_sheet",
+      discipline: "mep",
+      source: artifact.source || "Existing MEP PDF artifact",
+      stitchOrder: 40,
+    });
+  }
+
+  for (const artifact of asArray(
+    input.detailArtifacts || artifacts.detailArtifacts,
+  )) {
+    const id = safeName(
+      artifact.fileStem || artifact.type || artifact.role || "detail",
+    );
+    add(artifact, {
+      fileName: `technical/${id}.pdf`,
+      role: artifact.role || "construction_detail",
+      discipline: "details",
+      source: artifact.source || "Existing detail PDF artifact",
+      stitchOrder: 50,
+    });
+  }
+
+  asArray(input.existingArtifacts).forEach((artifact, index) => {
+    add(artifact, {
+      fileName:
+        artifact.fileName || `presentation/existing-pdf-${index + 1}.pdf`,
+      role: artifact.role || "existing_pdf",
+      discipline: artifact.discipline || "architecture",
+      source: artifact.source || "Existing PDF artifact",
+      stitchOrder: Number.isFinite(Number(artifact.stitchOrder))
+        ? Number(artifact.stitchOrder)
+        : 60,
+    });
+  });
+
+  return pdfs.sort(comparePdfInputs);
+}
+
+async function loadPdfLib() {
+  return import("pdf-lib");
+}
+
+function applyDeterministicMetadata(pdfDoc, title) {
+  pdfDoc.setTitle(title);
+  pdfDoc.setSubject(
+    "Deterministic deliverables PDF assembled from existing PDFs",
+  );
+  pdfDoc.setCreator("architect-ai-platform");
+  pdfDoc.setProducer(PDF_STITCHING_SERVICE_VERSION);
+  pdfDoc.setCreationDate(FIXED_PDF_DATE);
+  pdfDoc.setModificationDate(FIXED_PDF_DATE);
+  pdfDoc.setKeywords([PDF_STITCHING_STRATEGY]);
+}
+
+function drawTextLine(page, text, x, y, options) {
+  page.drawText(String(text || ""), {
+    x,
+    y,
+    font: options.font,
+    size: options.size,
+    color: options.color,
+  });
+}
+
+async function addCoverPage(pdfDoc, pdfLib, pdfInputs, input, context) {
+  const { StandardFonts, rgb } = pdfLib;
+  const page = pdfDoc.addPage(COVER_PAGE_SIZE);
+  const regular = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const bold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+  const ink = rgb(0.08, 0.1, 0.12);
+  const muted = rgb(0.32, 0.36, 0.42);
+  const accent = rgb(0.12, 0.28, 0.55);
+  const projectName = input.projectName || input.projectId || "Project";
+
+  drawTextLine(page, "Deliverables PDF Index", 48, 778, {
+    font: bold,
+    size: 22,
+    color: ink,
+  });
+  drawTextLine(page, String(projectName), 48, 748, {
+    font: regular,
+    size: 14,
+    color: accent,
+  });
+
+  const metadataRows = [
+    ["Project", context.projectId],
+    ["ProjectGraph", context.projectGraphId],
+    ["Geometry", context.geometryHash],
+    ["Visual", context.visualManifestHash],
+    ["Style", context.styleBlendManifestHash],
+    ["Jurisdiction", context.jurisdictionId || context.countryCode],
+    ["Created at policy", "deterministic-fixed"],
+  ].filter(([, value]) => value);
+
+  let y = 704;
+  for (const [label, value] of metadataRows) {
+    drawTextLine(page, `${label}:`, 48, y, {
+      font: bold,
+      size: 9,
+      color: muted,
+    });
+    drawTextLine(page, String(value).slice(0, 92), 132, y, {
+      font: regular,
+      size: 9,
+      color: ink,
+    });
+    y -= 16;
+  }
+
+  y -= 16;
+  drawTextLine(page, "Included PDF sources", 48, y, {
+    font: bold,
+    size: 13,
+    color: ink,
+  });
+  y -= 22;
+
+  pdfInputs.forEach((pdf, index) => {
+    if (y < 70) return;
+    const label = `${index + 1}. ${pdf.sheetNumber ? `${pdf.sheetNumber} - ` : ""}${pdf.fileName}`;
+    drawTextLine(page, label.slice(0, 98), 58, y, {
+      font: regular,
+      size: 9,
+      color: ink,
+    });
+    y -= 14;
+  });
+}
+
+export async function buildStitchedPdfArtifact(input = {}, context = {}) {
+  const projectSlug = safeName(
+    input.projectName || input.projectId || context.projectGraphId || "project",
+  );
+  const fileName = `presentation/${projectSlug}-deliverables.pdf`;
+  const pdfInputs = collectPackagePdfInputs(input);
+
+  if (pdfInputs.length === 0) {
+    return {
+      artifact: null,
+      pdfInputs,
+      sourceGaps: [
+        {
+          code: PDF_STITCHING_NO_INPUT_PDFS,
+          severity: "info",
+          discipline: "architecture",
+          fileName,
+          omittedByFlag: false,
+          message:
+            "No existing generated PDF artifacts were supplied; no stitched PDF was created.",
+          details: { strategy: PDF_STITCHING_STRATEGY },
+        },
+      ],
+    };
+  }
+
+  let pdfLib;
+  try {
+    pdfLib = await loadPdfLib();
+  } catch (error) {
+    return {
+      artifact: null,
+      pdfInputs,
+      sourceGaps: [
+        {
+          code: PDF_STITCHING_UNAVAILABLE,
+          severity: "warning",
+          discipline: "architecture",
+          fileName,
+          omittedByFlag: false,
+          message:
+            "PDF stitching library is unavailable; no stitched PDF was created.",
+          details: { error: error.message, strategy: PDF_STITCHING_STRATEGY },
+        },
+      ],
+    };
+  }
+
+  try {
+    const { PDFDocument } = pdfLib;
+    const merged = await PDFDocument.create();
+    applyDeterministicMetadata(
+      merged,
+      `${input.projectName || "Project"} deliverables`,
+    );
+
+    if (input.includePdfCoverPage !== false) {
+      await addCoverPage(merged, pdfLib, pdfInputs, input, context);
+    }
+
+    for (const pdf of pdfInputs) {
+      const sourceDoc = await PDFDocument.load(pdf.bytes, {
+        ignoreEncryption: false,
+      });
+      const copiedPages = await merged.copyPages(
+        sourceDoc,
+        sourceDoc.getPageIndices(),
+      );
+      copiedPages.forEach((page) => merged.addPage(page));
+    }
+
+    const bytes = await merged.save({
+      useObjectStreams: false,
+      addDefaultPage: false,
+    });
+
+    return {
+      artifact: {
+        type: "stitched_pdf_package",
+        fileName,
+        mimeType: "application/pdf",
+        role: "stitched_deliverables_pdf",
+        discipline: "architecture",
+        source: "PDF stitching from existing generated PDF artifacts",
+        content: bytes,
+      },
+      pdfInputs,
+      sourceGaps: [],
+    };
+  } catch (error) {
+    return {
+      artifact: null,
+      pdfInputs,
+      sourceGaps: [
+        {
+          code: PDF_STITCHING_FAILED,
+          severity: "warning",
+          discipline: "architecture",
+          fileName,
+          omittedByFlag: false,
+          message:
+            "Existing generated PDFs could not be stitched; original PDFs remain packaged separately.",
+          details: {
+            error: error.message,
+            strategy: PDF_STITCHING_STRATEGY,
+            sourceFiles: pdfInputs.map((pdf) => pdf.fileName),
+          },
+        },
+      ],
+    };
+  }
+}
+
+export default {
+  PDF_STITCHING_SERVICE_VERSION,
+  PDF_STITCHING_STRATEGY,
+  PDF_STITCHING_UNAVAILABLE,
+  PDF_STITCHING_FAILED,
+  PDF_STITCHING_NO_INPUT_PDFS,
+  buildStitchedPdfArtifact,
+  collectPackagePdfInputs,
+};


### PR DESCRIPTION
## Summary

Adds Phase 3 of the professional deliverable package system: deterministic PDF stitching for artifact packages.

This combines existing generated PDFs only. It does not create fake PDFs, add drawing engines, add storage/signed URL handling, or integrate new IFC/DWG generation.

## Changes

- Adds `pdfStitchingService`.
- Adds deterministic cover/index page.
- Combines existing generated PDFs in deterministic order.
- Adds stitched PDF to ZIP manifest as `stitched_pdf_package` when successful.
- Keeps original PDFs packaged separately if stitching fails.
- Adds source gaps for:
  - no PDF inputs
  - stitching failure
- Updates artifact package API to use `buildArtifactPackageWithPdfStitching`.
- Adds focused tests for package/API/PDF stitching.

## Validation

- Focused package/API/UI tests: 3 suites, 19 tests passed
- `npm run lint`
- `git diff --check` passed with CRLF warnings only
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Safety and scope

- Existing generated PDFs only.
- No fake PDF output.
- No new drawing engines.
- No image-generation paths.
- No storage/signed URL work.
- No IFC/DWG integration work.
- Existing authority gates were not weakened.
- Existing unavailable DWG/IFC source gaps remain.
