### PR TITLE
Add artifact package storage and history

### DIFF
--- a/api/project/export/artifact-package/[packageId].js
+++ b/api/project/export/artifact-package/[packageId].js
@@ -1,0 +1,73 @@
+import { setCorsHeaders, handlePreflight } from "../../../_shared/cors.js";
+import { getDefaultArtifactStorageAdapter } from "../../../../src/services/export/artifactStorageService.js";
+import { getArtifactPackageHistoryRecord } from "../../../../src/services/export/artifactHistoryService.js";
+
+function resolvePackageId(req) {
+  return req.query?.packageId || req.query?.id || req.body?.packageId || null;
+}
+
+function packageSummary(record = {}) {
+  const manifest = record.manifest || {};
+  return {
+    packageId: record.packageId,
+    packageHash: record.packageHash || manifest.packageHash,
+    projectId: manifest.projectId || null,
+    projectGraphId: manifest.projectGraphId || null,
+    geometryHash: manifest.geometryHash || null,
+    visualManifestHash: manifest.visualManifestHash || null,
+    styleBlendManifestHash: manifest.styleBlendManifestHash || null,
+    jurisdictionId: manifest.jurisdictionId || null,
+    countryCode: manifest.countryCode || null,
+    artifactCount: Array.isArray(manifest.artifacts)
+      ? manifest.artifacts.length
+      : 0,
+    sourceGapCount: Array.isArray(manifest.sourceGaps)
+      ? manifest.sourceGaps.length
+      : 0,
+    byteLength: record.byteLength || 0,
+    storageKey: record.storageKey || null,
+    status: record.status || "stored",
+    qaSummary: manifest.qaSummary || null,
+    flags: manifest.flags || {},
+    producerVersions: manifest.producerVersions || {},
+  };
+}
+
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "GET, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, OPTIONS" });
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const packageId = resolvePackageId(req);
+  if (!packageId) {
+    return res.status(400).json({
+      error: "packageId is required",
+      code: "PACKAGE_ID_REQUIRED",
+    });
+  }
+
+  const adapter = getDefaultArtifactStorageAdapter();
+  const result = await adapter.getArtifactPackage({ packageId });
+  if (!result.found) {
+    return res
+      .status(result.code === "ARTIFACT_STORAGE_DELETED" ? 410 : 404)
+      .json({
+        error: "Artifact package not found",
+        code: result.code,
+      });
+  }
+
+  const history = getArtifactPackageHistoryRecord({ packageId });
+
+  return res.status(200).json({
+    package: packageSummary(result.record),
+    manifest: result.record.manifest,
+    history: history.found ? history.record : null,
+    storage: {
+      adapterCapabilities: adapter.adapterCapabilities,
+    },
+  });
+}

--- a/api/project/export/artifact-package/[packageId]/download.js
+++ b/api/project/export/artifact-package/[packageId]/download.js
@@ -1,0 +1,98 @@
+/* global globalThis */
+import { setCorsHeaders, handlePreflight } from "../../../../_shared/cors.js";
+import {
+  getDefaultArtifactStorageAdapter,
+  verifySignedDownloadToken,
+} from "../../../../../src/services/export/artifactStorageService.js";
+import { __artifactPackageExportInternals } from "../../artifact-package.js";
+
+const { safeProjectName } = __artifactPackageExportInternals;
+
+function resolvePackageId(req) {
+  return req.query?.packageId || req.query?.id || req.body?.packageId || null;
+}
+
+function packageFileName(record = {}) {
+  const manifest = record.manifest || {};
+  const projectName =
+    record.metadata?.projectName ||
+    manifest.projectId ||
+    manifest.projectGraphId ||
+    record.packageId ||
+    "ArchiAI_Project";
+  return `${safeProjectName(projectName)}-deliverables.zip`;
+}
+
+async function validateSignedQuery(req, packageId) {
+  const signature = req.query?.signature || req.query?.sig || null;
+  const expires = req.query?.expires || null;
+  if (!signature && !expires) return { ok: true, signed: false };
+
+  const secret =
+    globalThis.process?.env?.ARTIFACT_PACKAGE_SIGNING_SECRET ||
+    globalThis.process?.env?.ARTIFACT_SIGNING_SECRET ||
+    null;
+  const verification = await verifySignedDownloadToken({
+    packageId,
+    expires,
+    signature,
+    secret,
+  });
+  if (!verification.valid) {
+    return {
+      ok: false,
+      status: verification.reason === "ARTIFACT_STORAGE_EXPIRED" ? 410 : 403,
+      body: {
+        error: "Signed artifact download URL is invalid or expired",
+        code: verification.reason,
+      },
+    };
+  }
+  return { ok: true, signed: true, verification };
+}
+
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "GET, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, OPTIONS" });
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const packageId = resolvePackageId(req);
+  if (!packageId) {
+    return res.status(400).json({
+      error: "packageId is required",
+      code: "PACKAGE_ID_REQUIRED",
+    });
+  }
+
+  const signed = await validateSignedQuery(req, packageId);
+  if (!signed.ok) {
+    return res.status(signed.status).json(signed.body);
+  }
+
+  const adapter = getDefaultArtifactStorageAdapter();
+  const result = await adapter.getArtifactPackage({ packageId });
+  if (!result.found) {
+    return res
+      .status(result.code === "ARTIFACT_STORAGE_DELETED" ? 410 : 404)
+      .json({
+        error: "Artifact package not found",
+        code: result.code,
+      });
+  }
+
+  const zipBuffer = Buffer.from(result.record.zipBytes);
+  res.setHeader("Content-Type", "application/zip");
+  res.setHeader(
+    "Content-Disposition",
+    `attachment; filename="${packageFileName(result.record)}"`,
+  );
+  res.setHeader("X-Artifact-Package-Id", result.record.packageId);
+  res.setHeader(
+    "X-Artifact-Package-Hash",
+    result.record.packageHash || result.record.manifest?.packageHash || "",
+  );
+  return res.status(200).send(zipBuffer);
+}

--- a/api/project/export/artifact-package/history.js
+++ b/api/project/export/artifact-package/history.js
@@ -1,0 +1,66 @@
+import { setCorsHeaders, handlePreflight } from "../../../_shared/cors.js";
+import {
+  getDefaultArtifactStorageAdapter,
+  DEFAULT_SIGNED_URL_EXPIRES_SECONDS,
+} from "../../../../src/services/export/artifactStorageService.js";
+import { listArtifactPackageHistory } from "../../../../src/services/export/artifactHistoryService.js";
+
+function resolveQuery(req) {
+  return {
+    projectId: req.query?.projectId || req.query?.project_id || null,
+    userId:
+      req.query?.userId ||
+      req.query?.user_id ||
+      req.headers?.["x-user-id"] ||
+      null,
+    includeDeleted: req.query?.includeDeleted === "true",
+  };
+}
+
+function directDownloadRoute(packageId) {
+  return `/api/project/export/artifact-package/${encodeURIComponent(
+    packageId,
+  )}/download`;
+}
+
+async function withDownloadUrls(records, adapter) {
+  return Promise.all(
+    records.map(async (record) => {
+      const signedUrlInfo = await adapter.createSignedDownloadUrl({
+        packageId: record.packageId,
+        expiresInSeconds: DEFAULT_SIGNED_URL_EXPIRES_SECONDS,
+      });
+      return {
+        ...record,
+        signedUrl: signedUrlInfo.supported ? signedUrlInfo.signedUrl : null,
+        signedUrlAvailable: signedUrlInfo.supported === true,
+        expiresAt: signedUrlInfo.supported ? signedUrlInfo.expiresAt : null,
+        downloadUrl: signedUrlInfo.supported
+          ? signedUrlInfo.signedUrl
+          : directDownloadRoute(record.packageId),
+      };
+    }),
+  );
+}
+
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "GET, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, OPTIONS" });
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const adapter = getDefaultArtifactStorageAdapter();
+  const query = resolveQuery(req);
+  const records = listArtifactPackageHistory(query);
+  const history = await withDownloadUrls(records, adapter);
+
+  return res.status(200).json({
+    history,
+    count: history.length,
+    storage: {
+      adapterCapabilities: adapter.adapterCapabilities,
+    },
+  });
+}

--- a/api/project/export/artifact-package/store.js
+++ b/api/project/export/artifact-package/store.js
@@ -1,0 +1,124 @@
+import { setCorsHeaders, handlePreflight } from "../../../_shared/cors.js";
+import { buildArtifactPackageWithPdfStitching } from "../../../../src/services/export/artifactPackageService.js";
+import {
+  getDefaultArtifactStorageAdapter,
+  DEFAULT_SIGNED_URL_EXPIRES_SECONDS,
+} from "../../../../src/services/export/artifactStorageService.js";
+import {
+  createArtifactHistoryRecord,
+  recordArtifactPackageHistory,
+} from "../../../../src/services/export/artifactHistoryService.js";
+import { __artifactPackageExportInternals } from "../artifact-package.js";
+
+const { buildPackageInput, hasPackageSource, safeProjectName } =
+  __artifactPackageExportInternals;
+
+function resolveUserId(req, body = {}) {
+  return (
+    body.userId ||
+    body.metadata?.userId ||
+    req.headers?.["x-user-id"] ||
+    req.headers?.["X-User-Id"] ||
+    null
+  );
+}
+
+function downloadRouteFor(packageId) {
+  return `/api/project/export/artifact-package/${encodeURIComponent(
+    packageId,
+  )}/download`;
+}
+
+function manifestSummary(manifest = {}) {
+  return {
+    packageId: manifest.packageId,
+    packageHash: manifest.packageHash,
+    projectId: manifest.projectId,
+    projectGraphId: manifest.projectGraphId,
+    geometryHash: manifest.geometryHash,
+    visualManifestHash: manifest.visualManifestHash,
+    styleBlendManifestHash: manifest.styleBlendManifestHash,
+    jurisdictionId: manifest.jurisdictionId,
+    countryCode: manifest.countryCode,
+    artifactCount: Array.isArray(manifest.artifacts)
+      ? manifest.artifacts.length
+      : 0,
+    sourceGapCount: Array.isArray(manifest.sourceGaps)
+      ? manifest.sourceGaps.length
+      : 0,
+    qaSummary: manifest.qaSummary || null,
+    flags: manifest.flags || {},
+    producerVersions: manifest.producerVersions || {},
+  };
+}
+
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "POST, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "POST, OPTIONS" });
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const packageInput = buildPackageInput(req.body || {});
+    if (!hasPackageSource(packageInput)) {
+      return res.status(400).json({
+        error: "At least one generated artifact or compiledProject is required",
+        code: "PACKAGE_ARTIFACTS_REQUIRED",
+      });
+    }
+
+    const packageResult =
+      await buildArtifactPackageWithPdfStitching(packageInput);
+    const adapter = getDefaultArtifactStorageAdapter();
+    const userId = resolveUserId(req, req.body || {});
+    const metadata = {
+      projectName: safeProjectName(packageInput.projectName),
+      userId,
+      packageHash: packageResult.packageHash,
+    };
+    const storageRecord = await adapter.putArtifactPackage({
+      packageId: packageResult.packageId,
+      zipBytes: packageResult.zipBytes,
+      manifest: packageResult.manifest,
+      metadata,
+    });
+    const signedUrlInfo = await adapter.createSignedDownloadUrl({
+      packageId: packageResult.packageId,
+      expiresInSeconds:
+        Number(req.body?.expiresInSeconds) ||
+        DEFAULT_SIGNED_URL_EXPIRES_SECONDS,
+    });
+    const fallbackDownloadRoute = downloadRouteFor(packageResult.packageId);
+    const historyRecord = recordArtifactPackageHistory(
+      createArtifactHistoryRecord({
+        packageResult,
+        storageRecord,
+        userId,
+        signedUrlInfo,
+        downloadRoute: fallbackDownloadRoute,
+      }),
+    );
+
+    return res.status(200).json({
+      packageId: packageResult.packageId,
+      packageHash: packageResult.packageHash,
+      manifest: manifestSummary(packageResult.manifest),
+      storage: {
+        adapterCapabilities: adapter.adapterCapabilities,
+        storageKey: storageRecord.storageKey,
+        byteLength: storageRecord.byteLength,
+        status: storageRecord.status,
+      },
+      signedUrl: signedUrlInfo.supported ? signedUrlInfo.signedUrl : null,
+      expiresAt: signedUrlInfo.supported ? signedUrlInfo.expiresAt : null,
+      downloadRoute: signedUrlInfo.supported ? null : fallbackDownloadRoute,
+      history: historyRecord,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "Artifact package storage failed",
+    });
+  }
+}

--- a/docs/roadmaps/professional-cad-bim-output-roadmap.md
+++ b/docs/roadmaps/professional-cad-bim-output-roadmap.md
@@ -42,6 +42,12 @@ contracts and should fail closed when geometry provenance is missing.
   packs are implemented as data-driven metadata for labels, CAD preferences,
   local style defaults, climate assumptions, advisory checklists, and review
   disclaimers.
+- The professional deliverable package system now includes deterministic
+  manifest/ZIP generation, API/download wiring, deterministic PDF stitching from
+  existing generated PDFs, provider-neutral package storage, capability-based
+  signed download URLs, and package history metadata. `packageHash` remains
+  deterministic package evidence; history timestamps are operational metadata
+  and do not feed back into the package hash.
 
 ## Non-negotiable authority rules
 
@@ -376,6 +382,32 @@ Acceptance criteria:
 - Main generation response returns lightweight artifact metadata and URLs, not
   huge base64 payloads.
 - Each export stage has status, logs, retry metadata, and manifest entries.
+
+Current package-delivery implementation:
+
+- Phase 1 implemented deterministic artifact manifests and ZIP packaging using
+  sorted entries, fixed timestamps, stored ZIP entries, CRC32, and explicit
+  source gaps for unavailable gated artifacts.
+- Phase 2 exposed the package builder through the export API and a minimal
+  `Download Deliverables ZIP` UI entry point.
+- Phase 3 added deterministic PDF stitching from existing generated PDFs only,
+  with source gaps for no PDF inputs or stitching failure.
+- Phase 4 adds provider-neutral artifact package storage and package history.
+  The storage contract supports local/test memory, optional filesystem-backed
+  storage when configured, capability reporting, delete/list/get, and signed
+  download URLs only when a real signing secret is configured.
+
+Current limitations after Phase 4:
+
+- Storage is provider-neutral and local-first; production object storage
+  provider integration remains future work.
+- Signed URLs are capability-based. When signing is unsupported, the API returns
+  the direct package download route rather than fabricating signed URLs.
+- Package history stores operational timestamps, status, package hash,
+  authority hashes, flags, source-gap counts, and producer versions. These
+  timestamps do not affect deterministic package hashes.
+- Retention policies, team/project permissions, audit-log persistence, and a
+  full artifact browser UI remain future work.
 
 ## Final validation stack
 

--- a/src/__tests__/api/artifactPackageExport.test.js
+++ b/src/__tests__/api/artifactPackageExport.test.js
@@ -1,5 +1,15 @@
 import artifactPackageHandler from "../../../api/project/export/artifact-package.js";
+import storeArtifactPackageHandler from "../../../api/project/export/artifact-package/store.js";
+import artifactPackageMetadataHandler from "../../../api/project/export/artifact-package/[packageId].js";
+import downloadArtifactPackageHandler from "../../../api/project/export/artifact-package/[packageId]/download.js";
+import artifactPackageHistoryHandler from "../../../api/project/export/artifact-package/history.js";
 import { listZipEntryNames } from "../../services/export/artifactPackageService.js";
+import {
+  clearInMemoryArtifactStorage,
+  createInMemoryArtifactStorageAdapter,
+  setDefaultArtifactStorageAdapter,
+} from "../../services/export/artifactStorageService.js";
+import { clearArtifactPackageHistory } from "../../services/export/artifactHistoryService.js";
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 
 function dataUri(mimeType, value) {
@@ -126,6 +136,13 @@ function baseBody(overrides = {}) {
 }
 
 describe("/api/project/export/artifact-package", () => {
+  afterEach(() => {
+    clearInMemoryArtifactStorage();
+    clearArtifactPackageHistory();
+    setDefaultArtifactStorageAdapter(createInMemoryArtifactStorageAdapter());
+    delete process.env.ARTIFACT_PACKAGE_SIGNING_SECRET;
+  });
+
   test("returns application/zip with a safe attachment filename", async () => {
     const req = { method: "POST", headers: {}, body: baseBody() };
     const res = createMockResponse();
@@ -248,6 +265,125 @@ describe("/api/project/export/artifact-package", () => {
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual(
       expect.objectContaining({ code: "PACKAGE_ARTIFACTS_REQUIRED" }),
+    );
+  });
+
+  test("stores a real package, records history, and downloads through fallback route", async () => {
+    setDefaultArtifactStorageAdapter(createInMemoryArtifactStorageAdapter());
+    const storeReq = { method: "POST", headers: {}, body: baseBody() };
+    const storeRes = createMockResponse();
+
+    await storeArtifactPackageHandler(storeReq, storeRes);
+
+    expect(storeRes.statusCode).toBe(200);
+    expect(storeRes.body).toEqual(
+      expect.objectContaining({
+        packageId: expect.stringMatching(/^artifact-package-/),
+        packageHash: expect.any(String),
+        signedUrl: null,
+        downloadRoute: expect.stringContaining("/download"),
+        history: expect.objectContaining({
+          projectId: "project-zip-001",
+          geometryHash: "geometryhash-zip-001",
+          visualManifestHash: "visualhash-zip-001",
+          styleBlendManifestHash: "stylehash-zip-001",
+          jurisdictionId: "uk-england",
+          status: "stored",
+        }),
+      }),
+    );
+    expect(JSON.stringify(storeRes.body)).not.toContain(
+      "secret-value-that-must-not-appear",
+    );
+
+    const packageId = storeRes.body.packageId;
+    const metadataRes = createMockResponse();
+    await artifactPackageMetadataHandler(
+      { method: "GET", headers: {}, query: { packageId } },
+      metadataRes,
+    );
+    expect(metadataRes.statusCode).toBe(200);
+    expect(metadataRes.body.manifest.packageHash).toBe(
+      storeRes.body.packageHash,
+    );
+
+    const downloadRes = createMockResponse();
+    await downloadArtifactPackageHandler(
+      { method: "GET", headers: {}, query: { packageId } },
+      downloadRes,
+    );
+    expect(downloadRes.statusCode).toBe(200);
+    expect(downloadRes.headers["Content-Type"]).toBe("application/zip");
+    expect(listZipEntryNames(downloadRes.body)).toContain("manifest.json");
+
+    const historyRes = createMockResponse();
+    await artifactPackageHistoryHandler(
+      {
+        method: "GET",
+        headers: {},
+        query: { projectId: "project-zip-001" },
+      },
+      historyRes,
+    );
+    expect(historyRes.statusCode).toBe(200);
+    expect(historyRes.body.history).toHaveLength(1);
+    expect(JSON.stringify(historyRes.body)).not.toContain("zipBytes");
+    expect(JSON.stringify(historyRes.body)).not.toContain(
+      "secret-value-that-must-not-appear",
+    );
+  });
+
+  test("store endpoint returns a real signed URL when adapter supports it", async () => {
+    process.env.ARTIFACT_PACKAGE_SIGNING_SECRET = "api-test-secret";
+    setDefaultArtifactStorageAdapter(
+      createInMemoryArtifactStorageAdapter({
+        signedUrlSecret: "api-test-secret",
+        signedUrlBaseUrl: "/api/project/export/artifact-package",
+        now: "2026-05-09T12:00:00.000Z",
+      }),
+    );
+    const storeRes = createMockResponse();
+
+    await storeArtifactPackageHandler(
+      {
+        method: "POST",
+        headers: {},
+        body: { ...baseBody(), expiresInSeconds: 60 },
+      },
+      storeRes,
+    );
+
+    expect(storeRes.statusCode).toBe(200);
+    expect(storeRes.body.signedUrl).toContain(
+      `/api/project/export/artifact-package/${storeRes.body.packageId}/download`,
+    );
+    expect(storeRes.body.signedUrl).toContain("signature=");
+    expect(storeRes.body.downloadRoute).toBe(null);
+  });
+
+  test("deleted stored package returns a clear download error", async () => {
+    const adapter = createInMemoryArtifactStorageAdapter();
+    setDefaultArtifactStorageAdapter(adapter);
+    const storeRes = createMockResponse();
+    await storeArtifactPackageHandler(
+      { method: "POST", headers: {}, body: baseBody() },
+      storeRes,
+    );
+
+    await adapter.deleteArtifactPackage({ packageId: storeRes.body.packageId });
+    const downloadRes = createMockResponse();
+    await downloadArtifactPackageHandler(
+      {
+        method: "GET",
+        headers: {},
+        query: { packageId: storeRes.body.packageId },
+      },
+      downloadRes,
+    );
+
+    expect(downloadRes.statusCode).toBe(410);
+    expect(downloadRes.body).toEqual(
+      expect.objectContaining({ code: "ARTIFACT_STORAGE_DELETED" }),
     );
   });
 });

--- a/src/__tests__/components/exportPanelDeliverables.test.jsx
+++ b/src/__tests__/components/exportPanelDeliverables.test.jsx
@@ -176,4 +176,90 @@ describe("ExportPanel deliverables ZIP entry point", () => {
 
     unmount();
   });
+
+  test("saves a package and downloads it from package history", async () => {
+    const responseBlob = new Blob(["stored-zip-bytes"], {
+      type: "application/zip",
+    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          packageId: "artifact-package-ui-001",
+          packageHash: "packagehash-ui-001",
+          signedUrl: null,
+          downloadRoute:
+            "/api/project/export/artifact-package/artifact-package-ui-001/download",
+          history: {
+            packageId: "artifact-package-ui-001",
+            packageHash: "packagehash-ui-001",
+            projectId: "project-ui-001",
+            artifactCount: 4,
+            sourceGapCount: 2,
+            downloadUrl:
+              "/api/project/export/artifact-package/artifact-package-ui-001/download",
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: createHeaders({
+          "Content-Disposition": 'attachment; filename="saved.zip"',
+        }),
+        blob: jest.fn().mockResolvedValue(responseBlob),
+      });
+
+    const designData = {
+      projectName: "Test Project",
+      projectId: "project-ui-001",
+      geometryHash: "geometry-ui-001",
+      artifacts: {
+        a1Sheet: {
+          svgString:
+            '<svg xmlns="http://www.w3.org/2000/svg"><text>A1</text></svg>',
+        },
+      },
+      compiledProject: {
+        geometryHash: "geometry-ui-001",
+      },
+    };
+
+    const { container, unmount } = renderComponent(
+      <ExportPanel designData={designData} onExport={jest.fn()} />,
+    );
+
+    await act(async () => {
+      buttonByText(container, "Save Package").click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/project/export/artifact-package/store",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    expect(container.textContent).toContain("packagehash-ui-001");
+    expect(mockToast.success).toHaveBeenCalledWith(
+      "Package saved",
+      "Deliverables ZIP stored for this project.",
+    );
+
+    await act(async () => {
+      buttonByText(container, "packagehash-ui-001").click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      "/api/project/export/artifact-package/artifact-package-ui-001/download",
+      { method: "GET" },
+    );
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+
+    unmount();
+  });
 });

--- a/src/__tests__/services/export/artifactStorageHistoryService.test.js
+++ b/src/__tests__/services/export/artifactStorageHistoryService.test.js
@@ -1,0 +1,220 @@
+import {
+  buildArtifactPackage,
+  listZipEntryNames,
+} from "../../../services/export/artifactPackageService.js";
+import {
+  ARTIFACT_STORAGE_DELETED,
+  ARTIFACT_STORAGE_EXPIRED,
+  clearInMemoryArtifactStorage,
+  createInMemoryArtifactStorageAdapter,
+  verifySignedDownloadToken,
+} from "../../../services/export/artifactStorageService.js";
+import {
+  clearArtifactPackageHistory,
+  createArtifactHistoryRecord,
+  listArtifactPackageHistory,
+  markArtifactPackageDeleted,
+  recordArtifactPackageHistory,
+} from "../../../services/export/artifactHistoryService.js";
+
+function baseInput(overrides = {}) {
+  return {
+    projectName: "Stored Package",
+    projectId: "project-storage-001",
+    projectGraphId: "graph-storage-001",
+    geometryHash: "geometry-storage-001",
+    visualManifestHash: "visual-storage-001",
+    styleBlendManifestHash: "style-storage-001",
+    jurisdictionId: "uk-england",
+    countryCode: "GB",
+    flags: {
+      structuralEnabled: false,
+      mepEnabled: false,
+      detailsEnabled: false,
+      dwgEnabled: false,
+      ifcEnabled: false,
+    },
+    a1Sheet: {
+      svgString:
+        '<svg xmlns="http://www.w3.org/2000/svg"><text>A1</text></svg>',
+    },
+    a1Pdf: {
+      dataUrl: "data:application/pdf;base64,JVBERi0xLjcgYTFwZGY=",
+    },
+    qaReport: {
+      status: "pass",
+      issues: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("artifact storage and history services", () => {
+  afterEach(() => {
+    clearInMemoryArtifactStorage();
+    clearArtifactPackageHistory();
+  });
+
+  test("storage adapter stores and retrieves package bytes without changing packageHash", async () => {
+    const packageResult = buildArtifactPackage(baseInput());
+    const adapter = createInMemoryArtifactStorageAdapter();
+
+    const stored = await adapter.putArtifactPackage({
+      packageId: packageResult.packageId,
+      zipBytes: packageResult.zipBytes,
+      manifest: packageResult.manifest,
+      metadata: { userId: "user-storage-001" },
+    });
+    const retrieved = await adapter.getArtifactPackage({
+      packageId: packageResult.packageId,
+    });
+
+    expect(stored.packageHash).toBe(packageResult.packageHash);
+    expect(retrieved.found).toBe(true);
+    expect(retrieved.record.packageHash).toBe(packageResult.packageHash);
+    expect([...retrieved.record.zipBytes]).toEqual([...packageResult.zipBytes]);
+    expect(listZipEntryNames(retrieved.record.zipBytes)).toContain(
+      "manifest.json",
+    );
+  });
+
+  test("history record includes package and authority hashes without secret values", async () => {
+    const packageResult = buildArtifactPackage(
+      baseInput({
+        env: { OPENAI_API_KEY: "secret-that-must-not-appear" },
+      }),
+    );
+    const adapter = createInMemoryArtifactStorageAdapter();
+    const storageRecord = await adapter.putArtifactPackage({
+      packageId: packageResult.packageId,
+      zipBytes: packageResult.zipBytes,
+      manifest: packageResult.manifest,
+      metadata: { userId: "user-history-001" },
+    });
+
+    const record = recordArtifactPackageHistory(
+      createArtifactHistoryRecord({
+        packageResult,
+        storageRecord,
+        userId: "user-history-001",
+        downloadRoute: `/api/project/export/artifact-package/${packageResult.packageId}/download`,
+        now: "2026-05-09T12:00:00.000Z",
+      }),
+    );
+
+    expect(record).toEqual(
+      expect.objectContaining({
+        packageHash: packageResult.packageHash,
+        projectId: "project-storage-001",
+        projectGraphId: "graph-storage-001",
+        geometryHash: "geometry-storage-001",
+        visualManifestHash: "visual-storage-001",
+        styleBlendManifestHash: "style-storage-001",
+        jurisdictionId: "uk-england",
+        countryCode: "GB",
+        status: "stored",
+        qaStatus: "pass",
+      }),
+    );
+    expect(JSON.stringify(record)).not.toContain("secret-that-must-not-appear");
+    expect(
+      listArtifactPackageHistory({ projectId: "project-storage-001" }),
+    ).toHaveLength(1);
+  });
+
+  test("signed URL capability is explicit and verifiable when configured", async () => {
+    const adapter = createInMemoryArtifactStorageAdapter({
+      signedUrlSecret: "test-signing-secret",
+      signedUrlBaseUrl: "/api/project/export/artifact-package",
+      now: "2026-05-09T12:00:00.000Z",
+    });
+    const packageResult = buildArtifactPackage(baseInput());
+    await adapter.putArtifactPackage({
+      packageId: packageResult.packageId,
+      zipBytes: packageResult.zipBytes,
+      manifest: packageResult.manifest,
+    });
+
+    const signed = await adapter.createSignedDownloadUrl({
+      packageId: packageResult.packageId,
+      expiresInSeconds: 60,
+    });
+    const url = new URL(`https://example.test${signed.signedUrl}`);
+    const verification = await verifySignedDownloadToken({
+      packageId: packageResult.packageId,
+      expires: url.searchParams.get("expires"),
+      signature: url.searchParams.get("signature"),
+      secret: "test-signing-secret",
+      now: "2026-05-09T12:00:30.000Z",
+    });
+    const expired = await verifySignedDownloadToken({
+      packageId: packageResult.packageId,
+      expires: url.searchParams.get("expires"),
+      signature: url.searchParams.get("signature"),
+      secret: "test-signing-secret",
+      now: "2026-05-09T12:02:00.000Z",
+    });
+
+    expect(adapter.adapterCapabilities.signedUrls).toBe(true);
+    expect(signed.supported).toBe(true);
+    expect(verification.valid).toBe(true);
+    expect(expired).toEqual(
+      expect.objectContaining({
+        valid: false,
+        reason: ARTIFACT_STORAGE_EXPIRED,
+      }),
+    );
+  });
+
+  test("signed URLs are not faked when unsupported", async () => {
+    const adapter = createInMemoryArtifactStorageAdapter();
+    const signed = await adapter.createSignedDownloadUrl({
+      packageId: "package-no-signing",
+      expiresInSeconds: 60,
+    });
+
+    expect(adapter.adapterCapabilities.signedUrls).toBe(false);
+    expect(signed.supported).toBe(false);
+    expect(signed.signedUrl).toBeUndefined();
+  });
+
+  test("deleted package handling returns a clear status", async () => {
+    const adapter = createInMemoryArtifactStorageAdapter();
+    const packageResult = buildArtifactPackage(baseInput());
+    await adapter.putArtifactPackage({
+      packageId: packageResult.packageId,
+      zipBytes: packageResult.zipBytes,
+      manifest: packageResult.manifest,
+    });
+    recordArtifactPackageHistory(
+      createArtifactHistoryRecord({
+        packageResult,
+        storageRecord: await adapter
+          .getArtifactPackage({
+            packageId: packageResult.packageId,
+          })
+          .then((result) => result.record),
+      }),
+    );
+
+    const deleted = await adapter.deleteArtifactPackage({
+      packageId: packageResult.packageId,
+    });
+    const retrieved = await adapter.getArtifactPackage({
+      packageId: packageResult.packageId,
+    });
+    const history = markArtifactPackageDeleted({
+      packageId: packageResult.packageId,
+      now: "2026-05-09T13:00:00.000Z",
+    });
+
+    expect(deleted.deleted).toBe(true);
+    expect(retrieved).toEqual(
+      expect.objectContaining({
+        found: false,
+        code: ARTIFACT_STORAGE_DELETED,
+      }),
+    );
+    expect(history.record.status).toBe("deleted");
+  });
+});

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -10,7 +10,7 @@
  * Emits success/error toasts via ToastProvider.
  */
 
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Download,
   Archive,
@@ -26,6 +26,7 @@ import Button from "./ui/Button.jsx";
 import StatusChip from "./ui/StatusChip.jsx";
 import { Tooltip } from "./ui/feedback/Tooltip.jsx";
 import { useToastContext } from "./ui/ToastProvider.jsx";
+import exportService from "../services/exportService.js";
 
 /**
  * Download a base64 data URL as a file.
@@ -174,6 +175,19 @@ const ExportPanel = ({
   onExportError,
 }) => {
   const { toast } = useToastContext();
+  const initialPackageHistory = useMemo(() => {
+    const history =
+      designData?.artifactPackageHistory ||
+      designData?.metadata?.artifactPackageHistory ||
+      [];
+    return Array.isArray(history) ? history : [];
+  }, [designData]);
+  const [packageHistory, setPackageHistory] = useState(initialPackageHistory);
+  const [packageAction, setPackageAction] = useState(null);
+
+  useEffect(() => {
+    setPackageHistory(initialPackageHistory);
+  }, [initialPackageHistory]);
 
   const handleExport = async (format, label) => {
     if (onExportStart) onExportStart(format);
@@ -201,6 +215,54 @@ const ExportPanel = ({
       toast.success("Renders downloaded", `${count} 3D views saved.`);
     } else {
       toast.warning("Nothing to download", "No Blender renders found.");
+    }
+  };
+
+  const handleSavePackage = async () => {
+    if (!deliverablesReady) return;
+    setPackageAction("storing");
+    try {
+      const result = await exportService.storeDeliverablesPackage({
+        sheet: designData,
+      });
+      const record = result.history || {
+        packageId: result.packageId,
+        packageHash: result.packageHash,
+        artifactCount: result.manifest?.artifactCount,
+        sourceGapCount: result.manifest?.sourceGapCount,
+        createdAt: new Date().toISOString(),
+        downloadUrl: result.signedUrl || result.downloadRoute,
+      };
+      setPackageHistory((current) => [
+        record,
+        ...current.filter((item) => item.packageId !== record.packageId),
+      ]);
+      toast.success(
+        "Package saved",
+        "Deliverables ZIP stored for this project.",
+      );
+    } catch (err) {
+      toast.error(
+        "Save failed",
+        err?.message || "Could not store deliverables ZIP.",
+      );
+    } finally {
+      setPackageAction(null);
+    }
+  };
+
+  const handleDownloadStoredPackage = async (packageRecord) => {
+    setPackageAction(packageRecord.packageId);
+    try {
+      await exportService.downloadStoredDeliverablesPackage({ packageRecord });
+      toast.success("Export complete", "Saved deliverables ZIP downloaded.");
+    } catch (err) {
+      toast.error(
+        "Download failed",
+        err?.message || "Could not download saved deliverables ZIP.",
+      );
+    } finally {
+      setPackageAction(null);
     }
   };
 
@@ -272,6 +334,49 @@ const ExportPanel = ({
           tooltip="Deterministic package with manifest, QA report, drawings, CAD, and source gaps."
           onClick={() => void handleExport("zip", "Deliverables ZIP")}
         />
+        <ExportRow
+          icon={Archive}
+          label="Save Package"
+          formatChip="ZIP"
+          available={deliverablesReady && packageAction !== "storing"}
+          blockedReason="Generate first"
+          statusLabel={packageAction === "storing" ? "Saving" : "Store"}
+          tooltip="Persist the deterministic deliverables package and record package history."
+          onClick={() => void handleSavePackage()}
+        />
+        {packageHistory.length > 0 && (
+          <div className="rounded-lg border border-white/8 bg-white/[0.025] px-3 py-2">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <span className="text-eyebrow">Saved Packages</span>
+              <span className="font-mono text-[10px] text-white/45">
+                {packageHistory.length}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              {packageHistory.slice(0, 3).map((record) => (
+                <button
+                  key={record.packageId}
+                  type="button"
+                  onClick={() => void handleDownloadStoredPackage(record)}
+                  className="flex w-full items-center gap-2 rounded-md border border-white/8 bg-white/[0.025] px-2 py-1.5 text-left text-xs text-white/70 hover:border-white/15 hover:bg-white/[0.05] focus:outline-none focus:ring-2 focus:ring-royal-500/30"
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-mono text-white/80">
+                      {record.packageHash || record.packageId}
+                    </span>
+                    <span className="block text-[10px] text-white/45">
+                      {(record.artifactCount ?? 0).toString()} artifacts /{" "}
+                      {(record.sourceGapCount ?? 0).toString()} gaps
+                    </span>
+                  </span>
+                  <span className="text-[10px] uppercase tracking-wider text-royal-300">
+                    {packageAction === record.packageId ? "..." : "Download"}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
         <ExportRow
           icon={FileText}
           label="Export as PDF"

--- a/src/services/export/artifactHistoryService.js
+++ b/src/services/export/artifactHistoryService.js
@@ -1,0 +1,191 @@
+/* global globalThis */
+import {
+  canonicalStringify,
+  computeCDSHashSync,
+} from "../validation/cdsHash.js";
+
+export const ARTIFACT_HISTORY_SERVICE_VERSION = "artifact-history-service-v1";
+export const ARTIFACT_HISTORY_SCHEMA_VERSION =
+  "artifact-package-history-record-v1";
+export const ARTIFACT_HISTORY_NOT_FOUND = "ARTIFACT_HISTORY_NOT_FOUND";
+
+const HISTORY_STATE_KEY = "__archiaiArtifactPackageHistory";
+
+function getHistoryState() {
+  if (!globalThis[HISTORY_STATE_KEY]) {
+    globalThis[HISTORY_STATE_KEY] = {
+      records: new Map(),
+    };
+  }
+  return globalThis[HISTORY_STATE_KEY];
+}
+
+function cloneJson(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function nowIso(now) {
+  if (now instanceof Date) return now.toISOString();
+  if (typeof now === "function") return nowIso(now());
+  if (typeof now === "string" || typeof now === "number") {
+    return new Date(now).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function asCount(value) {
+  const count = Number(value);
+  return Number.isFinite(count) ? count : 0;
+}
+
+function safeRecord(record = {}) {
+  const clone = cloneJson(record);
+  delete clone?.zipBytes;
+  delete clone?.rawBytes;
+  delete clone?.secret;
+  delete clone?.env;
+  return clone;
+}
+
+export function createArtifactHistoryRecord({
+  packageResult,
+  storageRecord,
+  userId = null,
+  signedUrlInfo = null,
+  downloadRoute = null,
+  status = "stored",
+  now = undefined,
+} = {}) {
+  const manifest = packageResult?.manifest || storageRecord?.manifest || {};
+  const sourceGaps = Array.isArray(manifest.sourceGaps)
+    ? manifest.sourceGaps
+    : [];
+  const artifacts = Array.isArray(manifest.artifacts) ? manifest.artifacts : [];
+  const manifestHash = computeCDSHashSync({
+    manifest: canonicalStringify(manifest),
+  });
+  const createdAt = nowIso(now);
+
+  return safeRecord({
+    schemaVersion: ARTIFACT_HISTORY_SCHEMA_VERSION,
+    packageId:
+      packageResult?.packageId ||
+      storageRecord?.packageId ||
+      manifest.packageId,
+    packageHash:
+      packageResult?.packageHash ||
+      storageRecord?.packageHash ||
+      manifest.packageHash,
+    projectId: manifest.projectId || null,
+    projectGraphId: manifest.projectGraphId || null,
+    userId: userId || null,
+    createdAt,
+    manifestHash,
+    geometryHash: manifest.geometryHash || null,
+    visualManifestHash: manifest.visualManifestHash || null,
+    styleBlendManifestHash: manifest.styleBlendManifestHash || null,
+    jurisdictionId: manifest.jurisdictionId || null,
+    countryCode: manifest.countryCode || null,
+    artifactCount: artifacts.length,
+    sourceGapCount: sourceGaps.length,
+    byteLength: asCount(
+      storageRecord?.byteLength || packageResult?.zipBytes?.byteLength,
+    ),
+    storageKey: storageRecord?.storageKey || null,
+    downloadUrl: signedUrlInfo?.supported
+      ? signedUrlInfo.signedUrl
+      : downloadRoute,
+    signedUrl: signedUrlInfo?.supported ? signedUrlInfo.signedUrl : null,
+    signedUrlAvailable: signedUrlInfo?.supported === true,
+    expiresAt: signedUrlInfo?.supported ? signedUrlInfo.expiresAt : null,
+    status,
+    qaStatus: manifest.qaSummary?.status || null,
+    flags: cloneJson(manifest.flags || {}),
+    producerVersions: cloneJson(manifest.producerVersions || {}),
+  });
+}
+
+export function recordArtifactPackageHistory(
+  record,
+  state = getHistoryState(),
+) {
+  const clean = safeRecord(record);
+  if (!clean.packageId) {
+    throw new Error("packageId is required for artifact package history");
+  }
+  state.records.set(clean.packageId, clean);
+  return cloneJson(clean);
+}
+
+export function getArtifactPackageHistoryRecord(
+  { packageId },
+  state = getHistoryState(),
+) {
+  const record = state.records.get(packageId);
+  if (!record) return { found: false, code: ARTIFACT_HISTORY_NOT_FOUND };
+  return { found: true, record: cloneJson(record) };
+}
+
+export function listArtifactPackageHistory(
+  { projectId = null, userId = null, includeDeleted = false } = {},
+  state = getHistoryState(),
+) {
+  return [...state.records.values()]
+    .filter((record) => (includeDeleted ? true : record.status !== "deleted"))
+    .filter((record) => (projectId ? record.projectId === projectId : true))
+    .filter((record) => (userId ? record.userId === userId : true))
+    .sort((a, b) =>
+      [b.createdAt || "", b.packageId || ""]
+        .join(":")
+        .localeCompare([a.createdAt || "", a.packageId || ""].join(":")),
+    )
+    .map((record) => cloneJson(record));
+}
+
+export function markArtifactPackageDeleted(
+  { packageId, now = undefined },
+  state = getHistoryState(),
+) {
+  const existing = state.records.get(packageId);
+  if (!existing) return { updated: false, code: ARTIFACT_HISTORY_NOT_FOUND };
+  const updated = {
+    ...existing,
+    status: "deleted",
+    deletedAt: nowIso(now),
+  };
+  state.records.set(packageId, updated);
+  return { updated: true, record: cloneJson(updated) };
+}
+
+export function markArtifactPackageFailed(
+  { packageId, reason, now = undefined },
+  state = getHistoryState(),
+) {
+  const existing = state.records.get(packageId) || { packageId };
+  const updated = {
+    ...existing,
+    status: "failed",
+    failedAt: nowIso(now),
+    failureReason: reason || "Artifact package storage failed",
+  };
+  state.records.set(packageId, updated);
+  return { updated: true, record: cloneJson(updated) };
+}
+
+export function clearArtifactPackageHistory(state = getHistoryState()) {
+  state.records.clear();
+}
+
+export default {
+  ARTIFACT_HISTORY_SERVICE_VERSION,
+  ARTIFACT_HISTORY_SCHEMA_VERSION,
+  ARTIFACT_HISTORY_NOT_FOUND,
+  createArtifactHistoryRecord,
+  recordArtifactPackageHistory,
+  getArtifactPackageHistoryRecord,
+  listArtifactPackageHistory,
+  markArtifactPackageDeleted,
+  markArtifactPackageFailed,
+  clearArtifactPackageHistory,
+};

--- a/src/services/export/artifactStorageService.js
+++ b/src/services/export/artifactStorageService.js
@@ -1,0 +1,567 @@
+/* global globalThis */
+import { computeCDSHashSync } from "../validation/cdsHash.js";
+
+export const ARTIFACT_STORAGE_SERVICE_VERSION = "artifact-storage-service-v1";
+export const ARTIFACT_STORAGE_NOT_FOUND = "ARTIFACT_STORAGE_NOT_FOUND";
+export const ARTIFACT_STORAGE_DELETED = "ARTIFACT_STORAGE_DELETED";
+export const ARTIFACT_STORAGE_EXPIRED = "ARTIFACT_STORAGE_EXPIRED";
+export const ARTIFACT_STORAGE_SIGNED_URL_UNSUPPORTED =
+  "ARTIFACT_STORAGE_SIGNED_URL_UNSUPPORTED";
+export const DEFAULT_SIGNED_URL_EXPIRES_SECONDS = 15 * 60;
+
+const MEMORY_STATE_KEY = "__archiaiArtifactPackageStorage";
+
+function getMemoryState() {
+  if (!globalThis[MEMORY_STATE_KEY]) {
+    globalThis[MEMORY_STATE_KEY] = {
+      packages: new Map(),
+    };
+  }
+  return globalThis[MEMORY_STATE_KEY];
+}
+
+function normalizeBytes(value) {
+  if (value == null) return new Uint8Array();
+  if (value instanceof Uint8Array) return new Uint8Array(value);
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (typeof value === "object" && Array.isArray(value.data)) {
+    return new Uint8Array(value.data);
+  }
+  const BufferCtor = globalThis.Buffer;
+  if (BufferCtor?.from) return new Uint8Array(BufferCtor.from(String(value)));
+  return new TextEncoder().encode(String(value));
+}
+
+function cloneBytes(value) {
+  return new Uint8Array(normalizeBytes(value));
+}
+
+function bytesToBuffer(bytes) {
+  const normalized = normalizeBytes(bytes);
+  const BufferCtor = globalThis.Buffer;
+  return BufferCtor?.from ? BufferCtor.from(normalized) : normalized;
+}
+
+function cloneJson(value) {
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function sanitizePackageId(value) {
+  return String(value || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_.-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function nowDate(now) {
+  if (now instanceof Date) return now;
+  if (typeof now === "function") return nowDate(now());
+  if (typeof now === "string" || typeof now === "number") return new Date(now);
+  return new Date();
+}
+
+function publicBaseUrl(value) {
+  return String(value || "/api/project/export/artifact-package").replace(
+    /\/+$/,
+    "",
+  );
+}
+
+function signedUrlPath({ packageId, baseUrl, expiresAtMs, signature }) {
+  const encodedId = encodeURIComponent(packageId);
+  const sep = publicBaseUrl(baseUrl).includes("?") ? "&" : "?";
+  return `${publicBaseUrl(baseUrl)}/${encodedId}/download${sep}expires=${expiresAtMs}&signature=${encodeURIComponent(signature)}`;
+}
+
+async function signPayload(payload, secret) {
+  if (!secret) return null;
+  const { createHmac } = await import("node:crypto");
+  return createHmac("sha256", String(secret))
+    .update(String(payload))
+    .digest("hex");
+}
+
+function timingSafeEqualString(a, b) {
+  const left = String(a || "");
+  const right = String(b || "");
+  if (left.length !== right.length) return false;
+  let mismatch = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    mismatch |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return mismatch === 0;
+}
+
+function storageRecord({
+  packageId,
+  zipBytes,
+  manifest,
+  metadata,
+  storageKey,
+  adapterName,
+  now,
+}) {
+  const bytes = cloneBytes(zipBytes);
+  const storedAt = nowDate(now).toISOString();
+  return {
+    packageId,
+    packageHash: manifest?.packageHash || metadata?.packageHash || null,
+    manifest: cloneJson(manifest),
+    metadata: cloneJson(metadata || {}),
+    zipBytes: bytes,
+    byteLength: bytes.byteLength,
+    storageKey,
+    adapterName,
+    storedAt,
+    status: "stored",
+  };
+}
+
+function deletedRecord(packageId, existing = {}, now) {
+  return {
+    ...existing,
+    packageId,
+    zipBytes: null,
+    byteLength: existing.byteLength || 0,
+    status: "deleted",
+    deletedAt: nowDate(now).toISOString(),
+  };
+}
+
+function visibleStorageRecord(record) {
+  if (!record) return null;
+  if (record.status === "deleted") {
+    return {
+      ...record,
+      zipBytes: null,
+    };
+  }
+  return {
+    ...record,
+    manifest: cloneJson(record.manifest),
+    metadata: cloneJson(record.metadata || {}),
+    zipBytes: cloneBytes(record.zipBytes),
+  };
+}
+
+export function createInMemoryArtifactStorageAdapter(options = {}) {
+  const state = options.state || getMemoryState();
+  const signedUrlSecret = options.signedUrlSecret || null;
+  const signedUrlBaseUrl =
+    options.signedUrlBaseUrl || "/api/project/export/artifact-package";
+  const adapterName = options.adapterName || "memory";
+  const now = options.now;
+
+  const adapterCapabilities = Object.freeze({
+    adapter: adapterName,
+    persistent: false,
+    signedUrls: Boolean(signedUrlSecret),
+    delete: true,
+    list: true,
+  });
+
+  return {
+    adapterCapabilities,
+
+    async putArtifactPackage({ packageId, zipBytes, manifest, metadata = {} }) {
+      const safeId = sanitizePackageId(packageId || manifest?.packageId);
+      if (!safeId) {
+        throw new Error("packageId is required to store artifact package");
+      }
+      const record = storageRecord({
+        packageId: safeId,
+        zipBytes,
+        manifest,
+        metadata,
+        storageKey: `memory://${safeId}.zip`,
+        adapterName,
+        now,
+      });
+      state.packages.set(safeId, record);
+      return visibleStorageRecord(record);
+    },
+
+    async getArtifactPackage({ packageId }) {
+      const safeId = sanitizePackageId(packageId);
+      const record = state.packages.get(safeId);
+      if (!record) {
+        return { found: false, code: ARTIFACT_STORAGE_NOT_FOUND };
+      }
+      if (record.status === "deleted") {
+        return {
+          found: false,
+          code: ARTIFACT_STORAGE_DELETED,
+          record: visibleStorageRecord(record),
+        };
+      }
+      return { found: true, record: visibleStorageRecord(record) };
+    },
+
+    async createSignedDownloadUrl({
+      packageId,
+      expiresInSeconds = DEFAULT_SIGNED_URL_EXPIRES_SECONDS,
+    }) {
+      if (!signedUrlSecret) {
+        return {
+          supported: false,
+          capability: "signedUrls=false",
+          code: ARTIFACT_STORAGE_SIGNED_URL_UNSUPPORTED,
+        };
+      }
+      const safeId = sanitizePackageId(packageId);
+      const expiresAtMs =
+        nowDate(now).getTime() + Number(expiresInSeconds || 0) * 1000;
+      const payload = `${safeId}:${expiresAtMs}`;
+      const signature = await signPayload(payload, signedUrlSecret);
+      const url = signedUrlPath({
+        packageId: safeId,
+        baseUrl: signedUrlBaseUrl,
+        expiresAtMs,
+        signature,
+      });
+      return {
+        supported: true,
+        signedUrl: url,
+        expiresAt: new Date(expiresAtMs).toISOString(),
+        expiresInSeconds: Number(expiresInSeconds || 0),
+      };
+    },
+
+    async deleteArtifactPackage({ packageId }) {
+      const safeId = sanitizePackageId(packageId);
+      const existing = state.packages.get(safeId);
+      if (!existing)
+        return { deleted: false, code: ARTIFACT_STORAGE_NOT_FOUND };
+      const deleted = deletedRecord(safeId, existing, now);
+      state.packages.set(safeId, deleted);
+      return { deleted: true, record: visibleStorageRecord(deleted) };
+    },
+
+    async listArtifactPackages({ projectId, userId } = {}) {
+      const records = [...state.packages.values()]
+        .filter((record) => record.status !== "deleted")
+        .filter((record) =>
+          projectId ? record.manifest?.projectId === projectId : true,
+        )
+        .filter((record) =>
+          userId ? record.metadata?.userId === userId : true,
+        )
+        .sort((a, b) =>
+          [b.storedAt || "", b.packageId || ""]
+            .join(":")
+            .localeCompare([a.storedAt || "", a.packageId || ""].join(":")),
+        )
+        .map(visibleStorageRecord);
+      return records;
+    },
+  };
+}
+
+export function clearInMemoryArtifactStorage() {
+  getMemoryState().packages.clear();
+}
+
+async function ensureDir(pathValue) {
+  const fs = await import("node:fs/promises");
+  await fs.mkdir(pathValue, { recursive: true });
+}
+
+async function fileExists(pathValue) {
+  try {
+    const fs = await import("node:fs/promises");
+    await fs.access(pathValue);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+export function createFilesystemArtifactStorageAdapter(options = {}) {
+  const rootDir = options.rootDir;
+  if (!rootDir) {
+    throw new Error("rootDir is required for filesystem artifact storage");
+  }
+  const signedUrlSecret = options.signedUrlSecret || null;
+  const signedUrlBaseUrl =
+    options.signedUrlBaseUrl || "/api/project/export/artifact-package";
+  const adapterName = "filesystem";
+  const now = options.now;
+  const adapterCapabilities = Object.freeze({
+    adapter: adapterName,
+    persistent: true,
+    signedUrls: Boolean(signedUrlSecret),
+    delete: true,
+    list: true,
+  });
+
+  async function pathsFor(packageId) {
+    const path = await import("node:path");
+    const safeId = sanitizePackageId(packageId);
+    const packageDir = path.join(rootDir, "packages");
+    await ensureDir(packageDir);
+    return {
+      safeId,
+      zipPath: path.join(packageDir, `${safeId}.zip`),
+      manifestPath: path.join(packageDir, `${safeId}.manifest.json`),
+      metadataPath: path.join(packageDir, `${safeId}.metadata.json`),
+    };
+  }
+
+  async function readRecord(packageId) {
+    const fs = await import("node:fs/promises");
+    const paths = await pathsFor(packageId);
+    if (!(await fileExists(paths.manifestPath))) {
+      return null;
+    }
+    const [manifestText, metadataText] = await Promise.all([
+      fs.readFile(paths.manifestPath, "utf8"),
+      fileExists(paths.metadataPath).then((exists) =>
+        exists ? fs.readFile(paths.metadataPath, "utf8") : "{}",
+      ),
+    ]);
+    const metadata = JSON.parse(metadataText || "{}");
+    const deleted = metadata.status === "deleted";
+    const zipBytes = deleted
+      ? null
+      : new Uint8Array(await fs.readFile(paths.zipPath));
+    return {
+      packageId: paths.safeId,
+      packageHash: JSON.parse(manifestText).packageHash,
+      manifest: JSON.parse(manifestText),
+      metadata,
+      zipBytes,
+      byteLength: zipBytes?.byteLength || metadata.byteLength || 0,
+      storageKey: paths.zipPath,
+      adapterName,
+      storedAt: metadata.storedAt || null,
+      status: metadata.status || "stored",
+      deletedAt: metadata.deletedAt || null,
+    };
+  }
+
+  return {
+    adapterCapabilities,
+
+    async putArtifactPackage({ packageId, zipBytes, manifest, metadata = {} }) {
+      const fs = await import("node:fs/promises");
+      const safeId = sanitizePackageId(packageId || manifest?.packageId);
+      if (!safeId) {
+        throw new Error("packageId is required to store artifact package");
+      }
+      const paths = await pathsFor(safeId);
+      const record = storageRecord({
+        packageId: safeId,
+        zipBytes,
+        manifest,
+        metadata,
+        storageKey: paths.zipPath,
+        adapterName,
+        now,
+      });
+      await Promise.all([
+        fs.writeFile(paths.zipPath, bytesToBuffer(record.zipBytes)),
+        fs.writeFile(
+          paths.manifestPath,
+          `${JSON.stringify(record.manifest, null, 2)}\n`,
+        ),
+        fs.writeFile(
+          paths.metadataPath,
+          `${JSON.stringify(
+            {
+              ...record.metadata,
+              storedAt: record.storedAt,
+              byteLength: record.byteLength,
+              status: record.status,
+            },
+            null,
+            2,
+          )}\n`,
+        ),
+      ]);
+      return visibleStorageRecord(record);
+    },
+
+    async getArtifactPackage({ packageId }) {
+      const record = await readRecord(packageId);
+      if (!record) return { found: false, code: ARTIFACT_STORAGE_NOT_FOUND };
+      if (record.status === "deleted") {
+        return {
+          found: false,
+          code: ARTIFACT_STORAGE_DELETED,
+          record: visibleStorageRecord(record),
+        };
+      }
+      return { found: true, record: visibleStorageRecord(record) };
+    },
+
+    async createSignedDownloadUrl({
+      packageId,
+      expiresInSeconds = DEFAULT_SIGNED_URL_EXPIRES_SECONDS,
+    }) {
+      if (!signedUrlSecret) {
+        return {
+          supported: false,
+          capability: "signedUrls=false",
+          code: ARTIFACT_STORAGE_SIGNED_URL_UNSUPPORTED,
+        };
+      }
+      const safeId = sanitizePackageId(packageId);
+      const expiresAtMs =
+        nowDate(now).getTime() + Number(expiresInSeconds || 0) * 1000;
+      const payload = `${safeId}:${expiresAtMs}`;
+      const signature = await signPayload(payload, signedUrlSecret);
+      return {
+        supported: true,
+        signedUrl: signedUrlPath({
+          packageId: safeId,
+          baseUrl: signedUrlBaseUrl,
+          expiresAtMs,
+          signature,
+        }),
+        expiresAt: new Date(expiresAtMs).toISOString(),
+        expiresInSeconds: Number(expiresInSeconds || 0),
+      };
+    },
+
+    async deleteArtifactPackage({ packageId }) {
+      const fs = await import("node:fs/promises");
+      const paths = await pathsFor(packageId);
+      const existing = await readRecord(packageId);
+      if (!existing) {
+        return { deleted: false, code: ARTIFACT_STORAGE_NOT_FOUND };
+      }
+      const deleted = deletedRecord(paths.safeId, existing, now);
+      await fs.writeFile(
+        paths.metadataPath,
+        `${JSON.stringify(
+          {
+            ...(existing.metadata || {}),
+            status: "deleted",
+            deletedAt: deleted.deletedAt,
+            storedAt: existing.storedAt,
+            byteLength: existing.byteLength,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      return { deleted: true, record: visibleStorageRecord(deleted) };
+    },
+
+    async listArtifactPackages({ projectId, userId } = {}) {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const packageDir = path.join(rootDir, "packages");
+      if (!(await fileExists(packageDir))) return [];
+      const fileNames = await fs.readdir(packageDir);
+      const manifestNames = fileNames.filter((name) =>
+        name.endsWith(".manifest.json"),
+      );
+      const records = [];
+      for (const name of manifestNames) {
+        const packageId = name.replace(/\.manifest\.json$/, "");
+        const record = await readRecord(packageId);
+        if (!record || record.status === "deleted") continue;
+        if (projectId && record.manifest?.projectId !== projectId) continue;
+        if (userId && record.metadata?.userId !== userId) continue;
+        records.push(visibleStorageRecord(record));
+      }
+      return records.sort((a, b) =>
+        [b.storedAt || "", b.packageId || ""]
+          .join(":")
+          .localeCompare([a.storedAt || "", a.packageId || ""].join(":")),
+      );
+    },
+  };
+}
+
+export function resolveArtifactStorageAdapter(env = undefined, options = {}) {
+  const effectiveEnv = env || globalThis.process?.env || {};
+  const rootDir =
+    options.rootDir ||
+    effectiveEnv.ARTIFACT_PACKAGE_STORAGE_DIR ||
+    effectiveEnv.ARTIFACT_STORAGE_DIR ||
+    null;
+  const signedUrlSecret =
+    options.signedUrlSecret ||
+    effectiveEnv.ARTIFACT_PACKAGE_SIGNING_SECRET ||
+    effectiveEnv.ARTIFACT_SIGNING_SECRET ||
+    null;
+  const signedUrlBaseUrl =
+    options.signedUrlBaseUrl ||
+    effectiveEnv.ARTIFACT_PACKAGE_SIGNED_URL_BASE ||
+    "/api/project/export/artifact-package";
+  if (rootDir) {
+    return createFilesystemArtifactStorageAdapter({
+      rootDir,
+      signedUrlSecret,
+      signedUrlBaseUrl,
+      now: options.now,
+    });
+  }
+  return createInMemoryArtifactStorageAdapter({
+    signedUrlSecret,
+    signedUrlBaseUrl,
+    now: options.now,
+  });
+}
+
+export function getDefaultArtifactStorageAdapter() {
+  if (!globalThis.__archiaiDefaultArtifactStorageAdapter) {
+    globalThis.__archiaiDefaultArtifactStorageAdapter =
+      resolveArtifactStorageAdapter();
+  }
+  return globalThis.__archiaiDefaultArtifactStorageAdapter;
+}
+
+export function setDefaultArtifactStorageAdapter(adapter) {
+  globalThis.__archiaiDefaultArtifactStorageAdapter = adapter;
+}
+
+export async function verifySignedDownloadToken({
+  packageId,
+  expires,
+  signature,
+  secret,
+  now,
+}) {
+  if (!secret) return { valid: false, reason: "signedUrls=false" };
+  const expiresAtMs = Number(expires);
+  if (!Number.isFinite(expiresAtMs)) {
+    return { valid: false, reason: "invalid_expires" };
+  }
+  if (expiresAtMs < nowDate(now).getTime()) {
+    return { valid: false, reason: ARTIFACT_STORAGE_EXPIRED };
+  }
+  const safeId = sanitizePackageId(packageId);
+  const expected = await signPayload(`${safeId}:${expiresAtMs}`, secret);
+  if (!timingSafeEqualString(expected, signature)) {
+    return { valid: false, reason: "invalid_signature" };
+  }
+  return {
+    valid: true,
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    tokenHash: computeCDSHashSync({ packageId: safeId, expires: expiresAtMs }),
+  };
+}
+
+export default {
+  ARTIFACT_STORAGE_SERVICE_VERSION,
+  ARTIFACT_STORAGE_NOT_FOUND,
+  ARTIFACT_STORAGE_DELETED,
+  ARTIFACT_STORAGE_EXPIRED,
+  ARTIFACT_STORAGE_SIGNED_URL_UNSUPPORTED,
+  DEFAULT_SIGNED_URL_EXPIRES_SECONDS,
+  createInMemoryArtifactStorageAdapter,
+  createFilesystemArtifactStorageAdapter,
+  resolveArtifactStorageAdapter,
+  getDefaultArtifactStorageAdapter,
+  setDefaultArtifactStorageAdapter,
+  clearInMemoryArtifactStorage,
+  verifySignedDownloadToken,
+};

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -176,6 +176,7 @@ class ExportService {
         sheet?.projectGraph?.project_id ||
         artifacts?.projectGraphId ||
         null,
+      userId: sheet?.userId || sheet?.metadata?.userId || null,
       projectGraph: sheet?.projectGraph || null,
       compiledProject,
       geometryHash:
@@ -267,6 +268,95 @@ class ExportService {
     );
     const url = await this.downloadResponseBlob(response, filename);
     logger.success("Deliverables ZIP export complete", { filename });
+    return { success: true, url, filename, format: "ZIP" };
+  }
+
+  async storeDeliverablesPackage({ sheet, expiresInSeconds } = {}) {
+    if (!this.hasDeliverableArtifacts(sheet)) {
+      throw new Error("Generate a design before saving deliverables.");
+    }
+
+    const payload = this.buildArtifactPackagePayload(sheet);
+    const response = await fetch("/api/project/export/artifact-package/store", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...payload,
+        ...(expiresInSeconds ? { expiresInSeconds } : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      const message = await this.readJsonError(
+        response,
+        `Deliverables package storage failed: ${response.status}`,
+      );
+      throw new Error(message);
+    }
+
+    const result = await response.json();
+    logger.success("Deliverables package stored", {
+      packageId: result.packageId,
+      packageHash: result.packageHash,
+    });
+    return {
+      success: true,
+      format: "ZIP",
+      ...result,
+    };
+  }
+
+  async listDeliverablesPackageHistory({ projectId, userId, sheet } = {}) {
+    const payload = sheet ? this.buildArtifactPackagePayload(sheet) : {};
+    const params = new URLSearchParams();
+    const resolvedProjectId = projectId || payload.projectId;
+    const resolvedUserId = userId || payload.userId;
+    if (resolvedProjectId) params.set("projectId", resolvedProjectId);
+    if (resolvedUserId) params.set("userId", resolvedUserId);
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    const response = await fetch(
+      `/api/project/export/artifact-package/history${suffix}`,
+      {
+        method: "GET",
+      },
+    );
+
+    if (!response.ok) {
+      const message = await this.readJsonError(
+        response,
+        `Deliverables package history failed: ${response.status}`,
+      );
+      throw new Error(message);
+    }
+
+    return response.json();
+  }
+
+  async downloadStoredDeliverablesPackage({ packageRecord }) {
+    const downloadUrl =
+      packageRecord?.signedUrl ||
+      packageRecord?.downloadUrl ||
+      packageRecord?.downloadRoute;
+    if (!downloadUrl) {
+      throw new Error("Stored deliverables package has no download URL.");
+    }
+    const response = await fetch(downloadUrl, { method: "GET" });
+    if (!response.ok) {
+      const message = await this.readJsonError(
+        response,
+        `Stored deliverables download failed: ${response.status}`,
+      );
+      throw new Error(message);
+    }
+    const fallbackFilename = `${this.safeProjectName(
+      packageRecord?.projectId || packageRecord?.packageId,
+    )}-deliverables.zip`;
+    const filename = this.filenameFromContentDisposition(
+      response.headers?.get?.("content-disposition"),
+      fallbackFilename,
+    );
+    const url = await this.downloadResponseBlob(response, filename);
+    logger.success("Stored deliverables ZIP download complete", { filename });
     return { success: true, url, filename, format: "ZIP" };
   }
 


### PR DESCRIPTION
## Summary

Adds Phase 4 of the professional deliverable package system: storage, signed/download URL support, and artifact package history.

## Changes

- Adds artifact package storage adapter.
- Adds package history metadata.
- Stores real ZIP bytes from the deterministic package builder.
- Preserves deterministic `packageHash`.
- Adds capability-based signed URL support.
- Falls back to direct authenticated download route when signed URLs are unsupported.
- Adds package history listing.
- Keeps existing direct ZIP endpoint working.
- Updates roadmap for storage/history phase.

## Validation

- Focused artifact package/storage/history tests passed.
- `npm run lint`
- `git diff --check`
- `npm run check:env`
- `npm run check:contracts`
- `npm run build:active`

## Safety and scope

- No fake DWG/IFC output.
- No new drawing engines.
- No image-generation path added.
- Existing authority gates were not weakened.
- History responses do not include huge ZIP bytes.
- `packageHash` remains deterministic; history timestamps are operational metadata.

## Current limitations

- Production cloud storage provider can be added later.
- Signed URLs are returned only when the configured adapter supports them.
- Retention policies, permissions, and full artifact browser UI are future work.