### PR TITLE
Add artifact package history browser UI

### DIFF
--- a/src/__tests__/api/artifactPackageExport.test.js
+++ b/src/__tests__/api/artifactPackageExport.test.js
@@ -345,6 +345,26 @@ describe("/api/project/export/artifact-package", () => {
     expect(JSON.stringify(historyRes.body)).not.toContain(
       "secret-value-that-must-not-appear",
     );
+    // Per-record forbidden-keys lock-in for the artifact browser UI:
+    // history responses must never expose raw bytes, secrets, env, or tokens.
+    const FORBIDDEN_HISTORY_KEYS = [
+      "zipBytes",
+      "rawBytes",
+      "secret",
+      "secrets",
+      "env",
+      "environment",
+      "token",
+      "apiKey",
+      "openaiApiKey",
+    ];
+    historyRes.body.history.forEach((record) => {
+      FORBIDDEN_HISTORY_KEYS.forEach((forbidden) => {
+        expect(Object.prototype.hasOwnProperty.call(record, forbidden)).toBe(
+          false,
+        );
+      });
+    });
   });
 
   test("artifact package storage, history, metadata, and download enforce access policy", async () => {

--- a/src/__tests__/components/ArtifactHistoryPanel.test.js
+++ b/src/__tests__/components/ArtifactHistoryPanel.test.js
@@ -1,0 +1,443 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+
+const mockToast = {
+  success: jest.fn(),
+  error: jest.fn(),
+  warning: jest.fn(),
+  info: jest.fn(),
+};
+
+jest.mock("framer-motion", () => {
+  const ReactInner = require("react");
+  const passthrough = ReactInner.forwardRef(
+    (
+      {
+        children,
+        initial,
+        animate,
+        exit,
+        transition,
+        whileHover,
+        whileTap,
+        layout,
+        ...props
+      },
+      ref,
+    ) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    ),
+  );
+  passthrough.displayName = "MotionDivMock";
+  return {
+    motion: { div: passthrough },
+    AnimatePresence: ({ children }) => <>{children}</>,
+  };
+});
+
+jest.mock("../../components/ui/ToastProvider.jsx", () => ({
+  __esModule: true,
+  useToastContext: () => ({ toast: mockToast }),
+  ToastProvider: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("../../components/ui/feedback/Tooltip.jsx", () => ({
+  __esModule: true,
+  Tooltip: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("../../services/exportService.js", () => {
+  const listDeliverablesPackageHistory = jest.fn();
+  const downloadStoredDeliverablesPackage = jest.fn();
+  const buildArtifactPackagePayload = jest.fn();
+  return {
+    __esModule: true,
+    default: {
+      listDeliverablesPackageHistory,
+      downloadStoredDeliverablesPackage,
+      buildArtifactPackagePayload,
+    },
+  };
+});
+
+import exportService from "../../services/exportService.js";
+import ArtifactHistoryPanel from "../../components/export/ArtifactHistoryPanel.jsx";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function renderComponent(ui) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return {
+    container,
+    rerender(next) {
+      act(() => {
+        root.render(next);
+      });
+    },
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const FIXED_NOW = "2026-05-10T12:00:00.000Z";
+
+const RECORD_STORED = {
+  packageId: "pkg-stored-1",
+  packageHash: "hash-stored-1234567890abcdef",
+  status: "stored",
+  createdAt: "2026-05-10T11:00:00.000Z",
+  expiresAt: "2026-05-17T11:00:00.000Z",
+  signedUrl: "https://signed.example/pkg-stored-1?sig=token",
+  signedUrlAvailable: true,
+  downloadUrl: "https://signed.example/pkg-stored-1?sig=token",
+  artifactCount: 12,
+  sourceGapCount: 2,
+  qaStatus: "pass",
+  jurisdictionId: "uk-eng",
+  countryCode: "GB",
+  flags: {
+    structuralEnabled: true,
+    mepEnabled: false,
+    detailsEnabled: true,
+    dwgEnabled: true,
+    ifcEnabled: false,
+  },
+};
+
+const RECORD_EXPIRED = {
+  packageId: "pkg-expired-1",
+  packageHash: "hash-expired-1234567890abcdef",
+  status: "expired",
+  createdAt: "2026-04-01T00:00:00.000Z",
+  signedUrl: null,
+  signedUrlAvailable: false,
+  downloadUrl: "/api/project/export/artifact-package/pkg-expired-1/download",
+  artifactCount: 8,
+  sourceGapCount: 0,
+  qaStatus: "warning",
+  jurisdictionId: "fr",
+  countryCode: "FR",
+  flags: { dwgEnabled: true },
+};
+
+const RECORD_DELETED = {
+  packageId: "pkg-deleted-1",
+  packageHash: "hash-deleted-1234567890abcdef",
+  status: "deleted",
+  createdAt: "2026-03-01T00:00:00.000Z",
+  signedUrl: null,
+  signedUrlAvailable: false,
+  downloadUrl: null,
+  artifactCount: 4,
+  sourceGapCount: 1,
+  qaStatus: "fail",
+  jurisdictionId: "dz",
+  countryCode: "DZ",
+  flags: {},
+};
+
+const RECORD_DIRECT = {
+  packageId: "pkg-direct-1",
+  packageHash: "hash-direct-1234567890abcdef",
+  status: "stored",
+  createdAt: "2026-05-10T10:00:00.000Z",
+  signedUrl: null,
+  signedUrlAvailable: false,
+  downloadUrl: "/api/project/export/artifact-package/pkg-direct-1/download",
+  downloadRoute: "/api/project/export/artifact-package/pkg-direct-1/download",
+  artifactCount: 6,
+  sourceGapCount: 0,
+  qaStatus: "pass",
+  jurisdictionId: "uk-eng",
+  countryCode: "GB",
+  flags: { mepEnabled: true },
+};
+
+beforeEach(() => {
+  exportService.listDeliverablesPackageHistory.mockReset();
+  exportService.downloadStoredDeliverablesPackage.mockReset();
+  exportService.buildArtifactPackagePayload.mockReset();
+  exportService.buildArtifactPackagePayload.mockImplementation((sheet) => ({
+    projectId: sheet?.projectId || null,
+  }));
+  mockToast.success.mockClear();
+  mockToast.error.mockClear();
+});
+
+describe("ArtifactHistoryPanel", () => {
+  test("renders empty state when no project context is available", () => {
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{}} now={FIXED_NOW} />,
+    );
+    expect(
+      container.querySelector('[data-testid="artifact-history-empty"]'),
+    ).toBeTruthy();
+    expect(exportService.listDeliverablesPackageHistory).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test("renders all required fields per record", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [RECORD_STORED],
+      storageProvider: "filesystem",
+    });
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    const rows = container.querySelectorAll(
+      '[data-testid="artifact-history-row"]',
+    );
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    // packageHash truncated, with full hash on aria-label
+    const hashSpan = row.querySelector('span[aria-label^="Package hash "]');
+    expect(hashSpan).toBeTruthy();
+    expect(hashSpan.getAttribute("aria-label")).toContain(
+      "hash-stored-1234567890abcdef",
+    );
+    // createdAt + expiresAt + jurisdiction
+    expect(
+      row.querySelector('[data-testid="artifact-created-at"]')?.textContent,
+    ).toMatch(/ago|just now/);
+    expect(
+      row.querySelector('[data-testid="artifact-expires-at"]')?.textContent,
+    ).toMatch(/expires/);
+    expect(
+      row.querySelector('[data-testid="artifact-jurisdiction"]')?.textContent,
+    ).toBe("uk-eng");
+    // status + QA chips
+    expect(
+      row.querySelector('[data-testid="artifact-status-chip"]')?.textContent,
+    ).toBe("Stored");
+    expect(
+      row.querySelector('[data-testid="artifact-qa-chip"]')?.textContent,
+    ).toBe("QA Pass");
+    // counts + flags
+    expect(
+      row.querySelector('[data-testid="artifact-counts"]')?.textContent,
+    ).toContain("12 artifacts");
+    expect(
+      row.querySelector('[data-testid="artifact-gaps"]')?.textContent,
+    ).toContain("2 gaps");
+    const flagText =
+      row.querySelector('[data-testid="artifact-flag-chips"]')?.textContent ||
+      "";
+    expect(flagText).toContain("STR");
+    expect(flagText).toContain("DTL");
+    expect(flagText).toContain("DWG");
+    expect(flagText).not.toContain("MEP");
+    expect(flagText).not.toContain("IFC");
+    unmount();
+  });
+
+  test("expired package shows Expired chip and disables download", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [RECORD_EXPIRED],
+      storageProvider: "filesystem",
+    });
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    const row = container.querySelector('[data-testid="artifact-history-row"]');
+    expect(
+      row.querySelector('[data-testid="artifact-status-chip"]')?.textContent,
+    ).toBe("Expired");
+    const button = row.querySelector(
+      '[data-testid="artifact-download-button"]',
+    );
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toContain("Unavailable");
+    unmount();
+  });
+
+  test("deleted package shows Deleted chip and disables download", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [RECORD_DELETED],
+      storageProvider: "filesystem",
+    });
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    const row = container.querySelector('[data-testid="artifact-history-row"]');
+    expect(
+      row.querySelector('[data-testid="artifact-status-chip"]')?.textContent,
+    ).toBe("Deleted");
+    const button = row.querySelector(
+      '[data-testid="artifact-download-button"]',
+    );
+    expect(button.disabled).toBe(true);
+    unmount();
+  });
+
+  test("downloads with signed URL when signedUrlAvailable === true", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [RECORD_STORED],
+      storageProvider: "s3",
+    });
+    exportService.downloadStoredDeliverablesPackage.mockResolvedValue({
+      success: true,
+    });
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    const row = container.querySelector('[data-testid="artifact-history-row"]');
+    expect(
+      row.querySelector('[data-testid="artifact-download-mode"]')?.textContent,
+    ).toContain("signed");
+    const button = row.querySelector(
+      '[data-testid="artifact-download-button"]',
+    );
+    expect(button.disabled).toBe(false);
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      exportService.downloadStoredDeliverablesPackage,
+    ).toHaveBeenCalledTimes(1);
+    const call =
+      exportService.downloadStoredDeliverablesPackage.mock.calls[0][0];
+    expect(call.packageRecord.signedUrl).toBe(RECORD_STORED.signedUrl);
+    expect(call.packageRecord.signedUrlAvailable).toBe(true);
+    expect(mockToast.success).toHaveBeenCalled();
+    unmount();
+  });
+
+  test("falls back to direct downloadUrl when no signed URL", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [RECORD_DIRECT],
+      storageProvider: "memory",
+    });
+    exportService.downloadStoredDeliverablesPackage.mockResolvedValue({
+      success: true,
+    });
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    const row = container.querySelector('[data-testid="artifact-history-row"]');
+    expect(
+      row.querySelector('[data-testid="artifact-download-mode"]')?.textContent,
+    ).toContain("direct");
+    const button = row.querySelector(
+      '[data-testid="artifact-download-button"]',
+    );
+    expect(button.disabled).toBe(false);
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const call =
+      exportService.downloadStoredDeliverablesPackage.mock.calls[0][0];
+    expect(call.packageRecord.signedUrl).toBeNull();
+    expect(call.packageRecord.downloadUrl).toBe(RECORD_DIRECT.downloadUrl);
+    unmount();
+  });
+
+  test("hides gaps chip when sourceGapCount === 0", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [RECORD_DIRECT],
+      storageProvider: "memory",
+    });
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    expect(container.querySelector('[data-testid="artifact-gaps"]')).toBeNull();
+    unmount();
+  });
+
+  test("never renders forbidden zipBytes/secret/env/token strings", async () => {
+    const polluted = {
+      ...RECORD_STORED,
+      zipBytes: "ZZZ-SHOULD-NOT-RENDER-ZZZ",
+      rawBytes: "RAW-SHOULD-NOT-RENDER",
+      secret: "SECRET-SHOULD-NOT-RENDER",
+      env: { OPENAI_API_KEY: "KEY-SHOULD-NOT-RENDER" },
+      token: "TOKEN-SHOULD-NOT-RENDER",
+      apiKey: "API-KEY-SHOULD-NOT-RENDER",
+      openaiApiKey: "OPENAI-SHOULD-NOT-RENDER",
+    };
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [polluted],
+      storageProvider: "filesystem",
+    });
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    const html = container.innerHTML;
+    [
+      "ZZZ-SHOULD-NOT-RENDER-ZZZ",
+      "RAW-SHOULD-NOT-RENDER",
+      "SECRET-SHOULD-NOT-RENDER",
+      "KEY-SHOULD-NOT-RENDER",
+      "TOKEN-SHOULD-NOT-RENDER",
+      "API-KEY-SHOULD-NOT-RENDER",
+      "OPENAI-SHOULD-NOT-RENDER",
+      "OPENAI_API_KEY",
+    ].forEach((needle) => {
+      expect(html).not.toContain(needle);
+    });
+    // Sanity: the download mock must still be reachable and signed
+    const call = exportService.downloadStoredDeliverablesPackage.mock.calls[0];
+    expect(call).toBeUndefined();
+    unmount();
+  });
+
+  test("shows error state and recovers via Try again", async () => {
+    exportService.listDeliverablesPackageHistory.mockRejectedValueOnce(
+      new Error("network down"),
+    );
+    const { container, unmount } = renderComponent(
+      <ArtifactHistoryPanel sheet={{ projectId: "proj-1" }} now={FIXED_NOW} />,
+    );
+    await flushPromises();
+    const errorBox = container.querySelector(
+      '[data-testid="artifact-history-error"]',
+    );
+    expect(errorBox).toBeTruthy();
+    expect(errorBox.textContent).toContain("network down");
+    exportService.listDeliverablesPackageHistory.mockResolvedValueOnce({
+      history: [RECORD_STORED],
+      storageProvider: "memory",
+    });
+    const tryAgain = errorBox.querySelector("button");
+    await act(async () => {
+      tryAgain.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="artifact-history-error"]'),
+    ).toBeNull();
+    expect(
+      container.querySelectorAll('[data-testid="artifact-history-row"]'),
+    ).toHaveLength(1);
+    unmount();
+  });
+});

--- a/src/__tests__/hooks/useArtifactPackageHistory.test.js
+++ b/src/__tests__/hooks/useArtifactPackageHistory.test.js
@@ -1,0 +1,194 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+
+jest.mock("../../services/exportService.js", () => {
+  const listDeliverablesPackageHistory = jest.fn();
+  const buildArtifactPackagePayload = jest.fn();
+  return {
+    __esModule: true,
+    default: {
+      listDeliverablesPackageHistory,
+      buildArtifactPackagePayload,
+    },
+  };
+});
+
+import exportService from "../../services/exportService.js";
+import useArtifactPackageHistory from "../../hooks/useArtifactPackageHistory.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function renderHook(callback) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const hookResult = { current: null };
+
+  function HookHost(props) {
+    hookResult.current = callback(props);
+    return null;
+  }
+
+  function update(props) {
+    act(() => {
+      root.render(<HookHost {...props} />);
+    });
+  }
+
+  function unmount() {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  }
+
+  return { hookResult, update, unmount };
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  exportService.listDeliverablesPackageHistory.mockReset();
+  exportService.buildArtifactPackagePayload.mockReset();
+  exportService.buildArtifactPackagePayload.mockImplementation((sheet) => ({
+    projectId: sheet?.projectId || sheet?.metadata?.projectId || null,
+    userId: sheet?.userId || null,
+  }));
+});
+
+describe("useArtifactPackageHistory", () => {
+  test("does not fetch when no projectId/sheet is provided", () => {
+    const { hookResult, update, unmount } = renderHook((props) =>
+      useArtifactPackageHistory(props || {}),
+    );
+    update({});
+    expect(exportService.listDeliverablesPackageHistory).not.toHaveBeenCalled();
+    expect(hookResult.current.history).toEqual([]);
+    expect(hookResult.current.isLoading).toBe(false);
+    unmount();
+  });
+
+  test("seeds from initialHistory and fetches when projectId is present", async () => {
+    const seed = [{ packageId: "seed-1", packageHash: "seed-hash" }];
+    const fetched = [
+      { packageId: "p-1", packageHash: "h-1" },
+      { packageId: "p-2", packageHash: "h-2" },
+    ];
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: fetched,
+      storageProvider: "memory",
+    });
+    const { hookResult, update, unmount } = renderHook((props) =>
+      useArtifactPackageHistory(props),
+    );
+    update({ projectId: "proj-1", initialHistory: seed });
+    expect(hookResult.current.history).toEqual(seed);
+    await flushPromises();
+    expect(exportService.listDeliverablesPackageHistory).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(hookResult.current.history).toEqual(fetched);
+    expect(hookResult.current.storageProvider).toBe("memory");
+    expect(hookResult.current.isLoading).toBe(false);
+    unmount();
+  });
+
+  test("refetches when refreshSignal changes", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [],
+      storageProvider: "memory",
+    });
+    const { update, unmount } = renderHook((props) =>
+      useArtifactPackageHistory(props),
+    );
+    update({ projectId: "proj-1", refreshSignal: 0 });
+    await flushPromises();
+    expect(exportService.listDeliverablesPackageHistory).toHaveBeenCalledTimes(
+      1,
+    );
+    update({ projectId: "proj-1", refreshSignal: 1 });
+    await flushPromises();
+    expect(exportService.listDeliverablesPackageHistory).toHaveBeenCalledTimes(
+      2,
+    );
+    unmount();
+  });
+
+  test("ignores resolved response after unmount", async () => {
+    let resolveFetch;
+    exportService.listDeliverablesPackageHistory.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    const { hookResult, update, unmount } = renderHook((props) =>
+      useArtifactPackageHistory(props),
+    );
+    update({ projectId: "proj-1" });
+    expect(exportService.listDeliverablesPackageHistory).toHaveBeenCalledTimes(
+      1,
+    );
+    const ref = hookResult.current;
+    unmount();
+    await act(async () => {
+      resolveFetch({
+        history: [{ packageId: "late-1" }],
+        storageProvider: "memory",
+      });
+      await Promise.resolve();
+    });
+    // After unmount, hookResult.current still points to the last render's value;
+    // the assertion is that we never throw and never apply the late state.
+    expect(ref.history).toEqual([]);
+  });
+
+  test("surfaces error from service rejection and clears it on refresh()", async () => {
+    exportService.listDeliverablesPackageHistory.mockRejectedValueOnce(
+      new Error("boom"),
+    );
+    const { hookResult, update, unmount } = renderHook((props) =>
+      useArtifactPackageHistory(props),
+    );
+    update({ projectId: "proj-1" });
+    await flushPromises();
+    expect(hookResult.current.error?.message).toBe("boom");
+    expect(hookResult.current.isLoading).toBe(false);
+    exportService.listDeliverablesPackageHistory.mockResolvedValueOnce({
+      history: [{ packageId: "ok-1" }],
+      storageProvider: "memory",
+    });
+    await act(async () => {
+      hookResult.current.refresh();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(hookResult.current.error).toBeNull();
+    expect(hookResult.current.history).toEqual([{ packageId: "ok-1" }]);
+    unmount();
+  });
+
+  test("resolves projectId from sheet when not given explicitly", async () => {
+    exportService.listDeliverablesPackageHistory.mockResolvedValue({
+      history: [],
+      storageProvider: "memory",
+    });
+    const { update, unmount } = renderHook((props) =>
+      useArtifactPackageHistory(props),
+    );
+    update({ sheet: { projectId: "from-sheet" } });
+    await flushPromises();
+    expect(exportService.buildArtifactPackagePayload).toHaveBeenCalledWith({
+      projectId: "from-sheet",
+    });
+    expect(exportService.listDeliverablesPackageHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "from-sheet" }),
+    );
+    unmount();
+  });
+});

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -10,7 +10,7 @@
  * Emits success/error toasts via ToastProvider.
  */
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   Download,
   Archive,
@@ -27,6 +27,7 @@ import StatusChip from "./ui/StatusChip.jsx";
 import { Tooltip } from "./ui/feedback/Tooltip.jsx";
 import { useToastContext } from "./ui/ToastProvider.jsx";
 import exportService from "../services/exportService.js";
+import ArtifactHistoryPanel from "./export/ArtifactHistoryPanel.jsx";
 
 /**
  * Download a base64 data URL as a file.
@@ -182,12 +183,8 @@ const ExportPanel = ({
       [];
     return Array.isArray(history) ? history : [];
   }, [designData]);
-  const [packageHistory, setPackageHistory] = useState(initialPackageHistory);
   const [packageAction, setPackageAction] = useState(null);
-
-  useEffect(() => {
-    setPackageHistory(initialPackageHistory);
-  }, [initialPackageHistory]);
+  const [historyRefreshTick, setHistoryRefreshTick] = useState(0);
 
   const handleExport = async (format, label) => {
     if (onExportStart) onExportStart(format);
@@ -222,21 +219,10 @@ const ExportPanel = ({
     if (!deliverablesReady) return;
     setPackageAction("storing");
     try {
-      const result = await exportService.storeDeliverablesPackage({
+      await exportService.storeDeliverablesPackage({
         sheet: designData,
       });
-      const record = result.history || {
-        packageId: result.packageId,
-        packageHash: result.packageHash,
-        artifactCount: result.manifest?.artifactCount,
-        sourceGapCount: result.manifest?.sourceGapCount,
-        createdAt: new Date().toISOString(),
-        downloadUrl: result.signedUrl || result.downloadRoute,
-      };
-      setPackageHistory((current) => [
-        record,
-        ...current.filter((item) => item.packageId !== record.packageId),
-      ]);
+      setHistoryRefreshTick((tick) => tick + 1);
       toast.success(
         "Package saved",
         "Deliverables ZIP stored for this project.",
@@ -245,21 +231,6 @@ const ExportPanel = ({
       toast.error(
         "Save failed",
         err?.message || "Could not store deliverables ZIP.",
-      );
-    } finally {
-      setPackageAction(null);
-    }
-  };
-
-  const handleDownloadStoredPackage = async (packageRecord) => {
-    setPackageAction(packageRecord.packageId);
-    try {
-      await exportService.downloadStoredDeliverablesPackage({ packageRecord });
-      toast.success("Export complete", "Saved deliverables ZIP downloaded.");
-    } catch (err) {
-      toast.error(
-        "Download failed",
-        err?.message || "Could not download saved deliverables ZIP.",
       );
     } finally {
       setPackageAction(null);
@@ -344,39 +315,11 @@ const ExportPanel = ({
           tooltip="Persist the deterministic deliverables package and record package history."
           onClick={() => void handleSavePackage()}
         />
-        {packageHistory.length > 0 && (
-          <div className="rounded-lg border border-white/8 bg-white/[0.025] px-3 py-2">
-            <div className="mb-2 flex items-center justify-between gap-2">
-              <span className="text-eyebrow">Saved Packages</span>
-              <span className="font-mono text-[10px] text-white/45">
-                {packageHistory.length}
-              </span>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              {packageHistory.slice(0, 3).map((record) => (
-                <button
-                  key={record.packageId}
-                  type="button"
-                  onClick={() => void handleDownloadStoredPackage(record)}
-                  className="flex w-full items-center gap-2 rounded-md border border-white/8 bg-white/[0.025] px-2 py-1.5 text-left text-xs text-white/70 hover:border-white/15 hover:bg-white/[0.05] focus:outline-none focus:ring-2 focus:ring-royal-500/30"
-                >
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate font-mono text-white/80">
-                      {record.packageHash || record.packageId}
-                    </span>
-                    <span className="block text-[10px] text-white/45">
-                      {(record.artifactCount ?? 0).toString()} artifacts /{" "}
-                      {(record.sourceGapCount ?? 0).toString()} gaps
-                    </span>
-                  </span>
-                  <span className="text-[10px] uppercase tracking-wider text-royal-300">
-                    {packageAction === record.packageId ? "..." : "Download"}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
+        <ArtifactHistoryPanel
+          sheet={designData}
+          initialHistory={initialPackageHistory}
+          refreshSignal={historyRefreshTick}
+        />
         <ExportRow
           icon={FileText}
           label="Export as PDF"

--- a/src/components/export/ArtifactHistoryPanel.jsx
+++ b/src/components/export/ArtifactHistoryPanel.jsx
@@ -1,0 +1,415 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Archive,
+  Download,
+  RefreshCcw,
+  ShieldCheck,
+  Link as LinkIcon,
+} from "lucide-react";
+import StatusChip from "../ui/StatusChip.jsx";
+import { Tooltip } from "../ui/feedback/Tooltip.jsx";
+import { useToastContext } from "../ui/ToastProvider.jsx";
+import exportService from "../../services/exportService.js";
+import useArtifactPackageHistory from "../../hooks/useArtifactPackageHistory.js";
+
+const FORBIDDEN_KEYS = new Set([
+  "zipBytes",
+  "rawBytes",
+  "secret",
+  "secrets",
+  "env",
+  "environment",
+  "token",
+  "apiKey",
+  "openaiApiKey",
+]);
+
+const STATUS_CHIP = {
+  stored: { status: "ready", label: "Stored" },
+  expired: { status: "warning", label: "Expired" },
+  deleted: { status: "blocked", label: "Deleted" },
+  failed: { status: "fail", label: "Failed" },
+};
+
+const QA_CHIP = {
+  pass: { status: "pass", label: "QA Pass" },
+  ok: { status: "pass", label: "QA Pass" },
+  warning: { status: "warning", label: "QA Warning" },
+  warn: { status: "warning", label: "QA Warning" },
+  fail: { status: "fail", label: "QA Fail" },
+  error: { status: "fail", label: "QA Fail" },
+};
+
+const FLAG_KEYS = [
+  { key: "structuralEnabled", label: "STR" },
+  { key: "mepEnabled", label: "MEP" },
+  { key: "detailsEnabled", label: "DTL" },
+  { key: "dwgEnabled", label: "DWG" },
+  { key: "ifcEnabled", label: "IFC" },
+];
+
+function recordStatus(record) {
+  const raw = record?.status || record?.packageHistoryStatus || "stored";
+  return String(raw).toLowerCase();
+}
+
+function isDownloadable(record) {
+  if (recordStatus(record) !== "stored") return false;
+  return Boolean(
+    record?.signedUrl || record?.downloadUrl || record?.downloadRoute,
+  );
+}
+
+function shortHash(value) {
+  if (!value || typeof value !== "string") return "";
+  if (value.length <= 16) return value;
+  return `${value.slice(0, 8)}…${value.slice(-6)}`;
+}
+
+function formatRelative(iso, nowIso) {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const now = nowIso ? new Date(nowIso).getTime() : Date.now();
+  const diffMs = now - then;
+  const abs = Math.abs(diffMs);
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (abs < minute) return diffMs >= 0 ? "just now" : "in <1m";
+  if (abs < hour) {
+    const m = Math.round(abs / minute);
+    return diffMs >= 0 ? `${m}m ago` : `in ${m}m`;
+  }
+  if (abs < day) {
+    const h = Math.round(abs / hour);
+    return diffMs >= 0 ? `${h}h ago` : `in ${h}h`;
+  }
+  const d = Math.round(abs / day);
+  return diffMs >= 0 ? `${d}d ago` : `in ${d}d`;
+}
+
+function formatAbsolute(iso) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().replace("T", " ").replace(/\..+$/, " UTC");
+}
+
+function StatusChipFor({ record }) {
+  const config = STATUS_CHIP[recordStatus(record)] || {
+    status: "neutral",
+    label: recordStatus(record),
+  };
+  return (
+    <StatusChip
+      status={config.status}
+      label={config.label}
+      size="sm"
+      data-testid="artifact-status-chip"
+    />
+  );
+}
+
+function QaChipFor({ qaStatus }) {
+  if (!qaStatus) return null;
+  const config = QA_CHIP[String(qaStatus).toLowerCase()] || {
+    status: "neutral",
+    label: `QA ${qaStatus}`,
+  };
+  return (
+    <StatusChip
+      status={config.status}
+      label={config.label}
+      size="sm"
+      data-testid="artifact-qa-chip"
+    />
+  );
+}
+
+function FlagChips({ flags }) {
+  if (!flags) return null;
+  const active = FLAG_KEYS.filter((entry) => Boolean(flags[entry.key]));
+  if (active.length === 0) return null;
+  return (
+    <span className="flex flex-wrap gap-1" data-testid="artifact-flag-chips">
+      {active.map((entry) => (
+        <span
+          key={entry.key}
+          className="rounded-md border border-white/10 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-white/65"
+        >
+          {entry.label}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function safeRecord(record) {
+  if (!record || typeof record !== "object") return record;
+  const clone = {};
+  Object.entries(record).forEach(([key, value]) => {
+    if (FORBIDDEN_KEYS.has(key)) return;
+    clone[key] = value;
+  });
+  return clone;
+}
+
+export const ArtifactHistoryPanel = ({
+  sheet,
+  projectId,
+  userId,
+  initialHistory,
+  refreshSignal = 0,
+  className = "",
+  // Tests can inject a fixed clock for relative-time stability.
+  now,
+}) => {
+  const { toast } = useToastContext();
+  const [downloadingId, setDownloadingId] = useState(null);
+
+  const { history, isLoading, error, refresh, storageProvider } =
+    useArtifactPackageHistory({
+      sheet,
+      projectId,
+      userId,
+      initialHistory,
+      refreshSignal,
+    });
+
+  const sanitized = useMemo(
+    () => (Array.isArray(history) ? history.map(safeRecord) : []),
+    [history],
+  );
+
+  const handleDownload = useCallback(
+    async (record) => {
+      if (!isDownloadable(record)) return;
+      setDownloadingId(record.packageId);
+      try {
+        await exportService.downloadStoredDeliverablesPackage({
+          packageRecord: record,
+        });
+        toast.success("Export complete", "Saved deliverables ZIP downloaded.");
+      } catch (err) {
+        toast.error(
+          "Download failed",
+          err?.message || "Could not download saved deliverables ZIP.",
+        );
+      } finally {
+        setDownloadingId(null);
+      }
+    },
+    [toast],
+  );
+
+  const headerCount = sanitized.length;
+
+  return (
+    <section
+      data-testid="artifact-history-panel"
+      className={`rounded-lg border border-white/10 bg-white/[0.025] px-3 py-3 ${className}`.trim()}
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Archive className="h-3.5 w-3.5 text-white/55" strokeWidth={1.75} />
+          <span className="text-eyebrow">Saved Packages</span>
+          <span
+            className="font-mono text-[10px] text-white/45"
+            data-testid="artifact-history-count"
+          >
+            {headerCount}
+          </span>
+          {storageProvider && (
+            <span className="font-mono text-[10px] uppercase tracking-wider text-white/40">
+              {storageProvider}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => refresh()}
+          disabled={isLoading}
+          aria-label="Refresh saved packages"
+          className="inline-flex items-center gap-1 rounded-md border border-white/10 bg-white/[0.03] px-2 py-1 text-[10px] uppercase tracking-wider text-white/65 hover:border-white/20 hover:bg-white/[0.05] focus:outline-none focus:ring-2 focus:ring-royal-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <RefreshCcw
+            className={`h-3 w-3 ${isLoading ? "animate-spin" : ""}`}
+            strokeWidth={2}
+          />
+          {isLoading ? "Loading" : "Refresh"}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-2 rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-200"
+          data-testid="artifact-history-error"
+        >
+          <span className="font-medium">Could not load saved packages.</span>{" "}
+          <span className="text-red-200/80">
+            {error?.message || "Unknown error."}
+          </span>{" "}
+          <button
+            type="button"
+            onClick={() => refresh()}
+            className="underline underline-offset-2 hover:text-red-100"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {!error && headerCount === 0 && !isLoading && (
+        <div
+          className="rounded-md border border-dashed border-white/10 px-3 py-3 text-[11px] text-white/55"
+          data-testid="artifact-history-empty"
+        >
+          No saved packages yet. Click{" "}
+          <span className="text-white/75">Save Package</span> above to persist a
+          deterministic deliverables ZIP for this project.
+        </div>
+      )}
+
+      {headerCount > 0 && (
+        <ul className="flex flex-col gap-2">
+          {sanitized.map((record) => {
+            const downloadable = isDownloadable(record);
+            const fullHash = record.packageHash || record.packageId;
+            const created = formatRelative(record.createdAt, now);
+            const expires = formatRelative(record.expiresAt, now);
+            const jurisdictionLabel =
+              record.jurisdictionId || record.countryCode || null;
+            const isBusy = downloadingId === record.packageId;
+            const signedAvailable = record.signedUrlAvailable === true;
+            return (
+              <li
+                key={record.packageId}
+                data-testid="artifact-history-row"
+                data-package-id={record.packageId}
+                className="rounded-md border border-white/10 bg-white/[0.03] px-3 py-2"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <Tooltip content={fullHash} side="top">
+                      <span
+                        className="block truncate font-mono text-xs text-white/85"
+                        aria-label={`Package hash ${fullHash}`}
+                      >
+                        {shortHash(fullHash)}
+                      </span>
+                    </Tooltip>
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] text-white/55">
+                      {created && (
+                        <Tooltip
+                          content={formatAbsolute(record.createdAt)}
+                          side="top"
+                        >
+                          <span data-testid="artifact-created-at">
+                            {created}
+                          </span>
+                        </Tooltip>
+                      )}
+                      {expires && (
+                        <Tooltip
+                          content={`Expires ${formatAbsolute(record.expiresAt)}`}
+                          side="top"
+                        >
+                          <span
+                            data-testid="artifact-expires-at"
+                            className="text-white/45"
+                          >
+                            · expires {expires}
+                          </span>
+                        </Tooltip>
+                      )}
+                      {jurisdictionLabel && (
+                        <span
+                          className="rounded border border-white/10 bg-white/5 px-1 py-0.5 font-mono uppercase tracking-wider text-white/65"
+                          data-testid="artifact-jurisdiction"
+                        >
+                          {jurisdictionLabel}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex flex-shrink-0 flex-col items-end gap-1">
+                    <StatusChipFor record={record} />
+                    <QaChipFor qaStatus={record.qaStatus} />
+                  </div>
+                </div>
+
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-white/55">
+                  <span data-testid="artifact-counts">
+                    {Number(record.artifactCount ?? 0)} artifacts
+                  </span>
+                  {Number(record.sourceGapCount ?? 0) > 0 && (
+                    <Tooltip
+                      content="Source-gap details available on the package metadata endpoint."
+                      side="top"
+                    >
+                      <span
+                        className="rounded border border-amber-500/30 bg-amber-500/10 px-1 py-0.5 font-mono text-amber-200"
+                        data-testid="artifact-gaps"
+                      >
+                        {Number(record.sourceGapCount)} gaps
+                      </span>
+                    </Tooltip>
+                  )}
+                  <FlagChips flags={record.flags} />
+                </div>
+
+                <div className="mt-2 flex items-center justify-between gap-2">
+                  <Tooltip
+                    content={
+                      signedAvailable
+                        ? "Signed URL — direct from storage provider"
+                        : "Direct download endpoint"
+                    }
+                    side="top"
+                  >
+                    <span
+                      className="inline-flex items-center gap-1 rounded border border-white/10 bg-white/5 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-white/55"
+                      data-testid="artifact-download-mode"
+                    >
+                      {signedAvailable ? (
+                        <ShieldCheck
+                          className="h-3 w-3 text-emerald-300"
+                          strokeWidth={2}
+                        />
+                      ) : (
+                        <LinkIcon
+                          className="h-3 w-3 text-white/55"
+                          strokeWidth={2}
+                        />
+                      )}
+                      {signedAvailable ? "signed" : "direct"}
+                    </span>
+                  </Tooltip>
+                  <button
+                    type="button"
+                    onClick={() => void handleDownload(record)}
+                    disabled={!downloadable || isBusy}
+                    data-testid="artifact-download-button"
+                    aria-label={`Download package ${fullHash}`}
+                    className="inline-flex items-center gap-1 rounded-md border border-white/10 bg-white/[0.04] px-2 py-1 text-[11px] text-white/85 hover:border-white/20 hover:bg-white/[0.07] focus:outline-none focus:ring-2 focus:ring-royal-500/30 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    <Download className="h-3 w-3" strokeWidth={2} />
+                    {isBusy
+                      ? "Downloading…"
+                      : downloadable
+                        ? "Download"
+                        : "Unavailable"}
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+};
+
+export default ArtifactHistoryPanel;

--- a/src/hooks/useArtifactPackageHistory.js
+++ b/src/hooks/useArtifactPackageHistory.js
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import exportService from "../services/exportService.js";
+
+function normalizeInitial(initialHistory) {
+  if (!Array.isArray(initialHistory)) return [];
+  return initialHistory.filter(
+    (record) => record && typeof record === "object" && record.packageId,
+  );
+}
+
+function resolveProjectIdFromSheet(sheet) {
+  if (!sheet) return null;
+  try {
+    const payload = exportService.buildArtifactPackagePayload(sheet);
+    return payload?.projectId || null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+export function useArtifactPackageHistory({
+  projectId,
+  userId,
+  sheet,
+  initialHistory,
+  refreshSignal = 0,
+} = {}) {
+  const initialSeed = useMemo(
+    () => normalizeInitial(initialHistory),
+    [initialHistory],
+  );
+  const [history, setHistory] = useState(initialSeed);
+  const [storageProvider, setStorageProvider] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const inFlightRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const resolvedProjectId =
+    projectId || resolveProjectIdFromSheet(sheet) || null;
+
+  const load = useCallback(async () => {
+    if (!resolvedProjectId) return;
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    if (mountedRef.current) {
+      setIsLoading(true);
+      setError(null);
+    }
+    try {
+      const response = await exportService.listDeliverablesPackageHistory({
+        projectId: resolvedProjectId,
+        userId,
+        sheet,
+      });
+      if (!mountedRef.current) return;
+      const records = Array.isArray(response?.history) ? response.history : [];
+      setHistory(records);
+      setStorageProvider(response?.storageProvider || null);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      inFlightRef.current = false;
+      if (mountedRef.current) setIsLoading(false);
+    }
+  }, [resolvedProjectId, userId, sheet]);
+
+  useEffect(() => {
+    if (!resolvedProjectId) return;
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolvedProjectId, refreshSignal]);
+
+  const refresh = useCallback(() => {
+    void load();
+  }, [load]);
+
+  return {
+    history,
+    storageProvider,
+    isLoading,
+    error,
+    refresh,
+    resolvedProjectId,
+  };
+}
+
+export default useArtifactPackageHistory;


### PR DESCRIPTION
## Summary
- Adds a dedicated `ArtifactHistoryPanel` (under `src/components/export/`) that surfaces the full server-side history record for stored deliverables packages: status (Stored / Expired / Deleted / Failed), createdAt, expiresAt, QA status, jurisdiction, flags (STR / MEP / DTL / DWG / IFC), artifact + source-gap counts, and signed-vs-direct download mode.
- Adds `useArtifactPackageHistory` hook that auto-fetches `/api/project/export/artifact-package/history` on mount when a `projectId` is resolvable (directly or via `sheet`), refetches when the parent bumps `refreshSignal`, and ignores stale responses on unmount.
- Wires the panel into `ExportPanel`'s Documents section, replacing today's truncated 3-item inline preview. The existing `Download Deliverables ZIP` button stays untouched, and `Save Package` now bumps a `refreshSignal` so the panel reloads automatically.
- Records are spread through a `safeRecord` whitelist that strips `zipBytes`, `rawBytes`, `secret`, `secrets`, `env`, `environment`, `token`, `apiKey`, `openaiApiKey`. A new per-record assertion in `src/__tests__/api/artifactPackageExport.test.js` locks in that the `/history` API never carries those keys.

## Phase context
This is **Phase A** of the production-readiness rollout described in `Full Artifact Browser UI.md`. Phases B–G (job queue, provider concurrency/quotas, health dashboard, env hardening, load testing, smoke suite) are deferred to dedicated PRs per the phased-execution policy.

## Blocker audit
- ✅ No secrets / env / tokens rendered or logged (forbidden-keys filter + dedicated test).
- ✅ No fake DWG/IFC, no image-generated technical drawings, no changes to authority gates (`projectGraphVerticalSliceService.js`, `generate-vertical-slice.js`, `modelStepResolver.js` untouched).
- ✅ `packageHash` is read-only display.
- ✅ Deterministic package hashing untouched.

## Test plan
- [x] `npx react-scripts test ... --runTestsByPath src/__tests__/components/ArtifactHistoryPanel.test.js src/__tests__/hooks/useArtifactPackageHistory.test.js src/__tests__/api/artifactPackageExport.test.js` — 24 / 24 green
- [x] `npm run lint`
- [x] `git diff --check`
- [x] `npm run check:env`
- [x] `npm run check:contracts`
- [x] `npm run build:active`
- [ ] Manual smoke once a real project has stored packages: panel renders, refresh works, signed and direct downloads succeed, expired/deleted rows disable the download button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)