### PR TITLE
Fix vertical-slice 500: add JSON import attributes to jurisdiction packs

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -95,12 +95,27 @@ function mountDynamicApiRoute(method, route, relativePath, middlewares = []) {
       const handler = await loadDynamicApiHandler(relativePath);
       return handler(req, res);
     } catch (error) {
-      console.error(`[Dynamic API] Failed to load ${relativePath}:`, error);
-      return res.status(500).json({
+      // Always log the full stack server-side so import-time and
+      // synchronous-throw failures (e.g. ERR_IMPORT_ATTRIBUTE_MISSING) are
+      // diagnosable from the dev console without redeploying.
+      console.error(
+        `[Dynamic API] Failed to load ${relativePath}:`,
+        error?.stack || error,
+      );
+      const isProduction = process.env.NODE_ENV === 'production';
+      const body = {
         error: 'Dynamic API route failed',
-        message: error.message,
+        message: error?.message || String(error),
         route,
-      });
+      };
+      // In dev, surface the upstream error name + code + stack so the client
+      // gets actionable detail. Stripped in production to avoid leaking paths.
+      if (!isProduction) {
+        if (error?.name) body.errorName = error.name;
+        if (error?.code) body.errorCode = error.code;
+        if (error?.stack) body.errorStack = error.stack;
+      }
+      return res.status(500).json(body);
     }
   });
 }

--- a/src/__tests__/services/jurisdiction/jurisdictionPackService.test.js
+++ b/src/__tests__/services/jurisdiction/jurisdictionPackService.test.js
@@ -76,4 +76,31 @@ describe("jurisdictionPackService", () => {
       expect(text).toMatch(/Preliminary advisory checklist/i);
     });
   });
+
+  // Regression lock-in for ERR_IMPORT_ATTRIBUTE_MISSING (Node 22+/25 ESM):
+  // bare `import x from "y.json"` fails at module-load time when the dynamic
+  // API wrapper (server.cjs) imports this service. Jest's babel transform
+  // tolerates bare JSON imports, so the runtime check above passes either way;
+  // this source-pattern check is what catches the regression.
+  test('every JSON import declares `with { type: "json" }`', () => {
+    // eslint-disable-next-line global-require
+    const fs = require("fs");
+    // eslint-disable-next-line global-require
+    const path = require("path");
+    const file = path.resolve(
+      __dirname,
+      "../../../services/jurisdiction/jurisdictionPackService.js",
+    );
+    const source = fs.readFileSync(file, "utf8");
+    const offenders = source
+      .split(/\r?\n/)
+      .map((text, idx) => ({ line: idx + 1, text }))
+      .filter(({ text }) =>
+        /^\s*import\s+\S+\s+from\s+["'][^"']+\.json["']/.test(text),
+      )
+      .filter(
+        ({ text }) => !/with\s*\{\s*type\s*:\s*["']json["']\s*\}/.test(text),
+      );
+    expect(offenders).toEqual([]);
+  });
 });

--- a/src/services/jurisdiction/jurisdictionPackService.js
+++ b/src/services/jurisdiction/jurisdictionPackService.js
@@ -1,7 +1,7 @@
-import ukPack from "./data/uk.json";
-import francePack from "./data/france.json";
-import algeriaPack from "./data/algeria.json";
-import genericPack from "./data/generic.json";
+import ukPack from "./data/uk.json" with { type: "json" };
+import francePack from "./data/france.json" with { type: "json" };
+import algeriaPack from "./data/algeria.json" with { type: "json" };
+import genericPack from "./data/generic.json" with { type: "json" };
 
 export const JURISDICTION_PACK_SERVICE_VERSION = "jurisdiction-pack-service-v1";
 


### PR DESCRIPTION
## Why

`POST /api/project/generate-vertical-slice` returned **HTTP 500** for every request — residential and non-residential alike — on Node 22+/25:

```
TypeError [ERR_IMPORT_ATTRIBUTE_MISSING]:
Module ".../src/services/jurisdiction/data/uk.json" needs an import attribute of "type: json"
```

Root cause: `src/services/jurisdiction/jurisdictionPackService.js:1-4` loaded its country JSON packs with bare `import x from "y.json"`. Node's ESM loader requires the explicit `with { type: "json" }` attribute. Worse, the dynamic-API wrapper at `server.cjs:78` caches the resulting rejected promise per module URL, so the first failure poisons every subsequent request to the same endpoint until restart.

The handler's own try/catch never saw this — it's an import-time failure caught by `mountDynamicApiRoute`'s outer try block, where the generic "Dynamic API route failed" message hid the real cause. Surfaced by reproducing with a minimal curl POST to the dev server.

## What

- **`jurisdictionPackService.js`** — add `with { type: "json" }` to all four pack imports (uk, france, algeria, generic). Matches the syntax already in use by `programmeAdjacencyValidator.js:26-27`.
- **`server.cjs` `mountDynamicApiRoute`** — log the full `error.stack` and, in non-production, include `errorName` / `errorCode` / `errorStack` in the JSON response body so the next dynamic-route failure surfaces actionable detail instead of a guessing game. Stripped in production to avoid path leakage.
- **`jurisdictionPackService.test.js`** — lock-in regression test that scans the source file for any JSON import lacking the attribute. Catches the regression *class*: jest's babel transform tolerates bare imports, so a runtime jest test alone would not have caught this.

## Verified end-to-end via dev proxy

| Type | Brief | HTTP | geometryHash |
|---|---|---|---|
| Office (non-residential) | `office_studio`, 350 m², 2 levels | **200** | `7a0e0a634d22c886` |
| Detached house (residential) | `detached_house`, 150 m², 2 levels | **200** | `121e5dede4c3ddf8` |

Both return `success: true` with valid manifests. `/api/together/chat` still 409s (PR #119 legacy guard intact). `/api/openai-reasoning` still 200s (PR #119's proxy fix intact).

## Out of scope

- Phase A artifact-browser PR #118 — untouched.
- Residential V2 deterministic engine — untouched.
- Building-type templates — untouched (no expansion).

## Validation

- `npx react-scripts test --runTestsByPath src/__tests__/services/jurisdiction/jurisdictionPackService.test.js src/__tests__/services/jurisdiction/jurisdictionProjectGraphIntegration.test.js` — 7/7 green
- `npm run lint` — clean
- `git diff --check` — clean
- `npm run check:env` — pass
- `npm run check:contracts` — pass
- `npm run build:active` — pass

## Test plan

- [x] Endpoint reproduces 500 before fix, 200 after fix (dev proxy curl)
- [x] Residential regression check (200, valid geometry hash)
- [x] Non-residential office regression check (200, valid geometry hash)
- [x] Lock-in unit test catches future bare-JSON-import regressions in this file

## Blocker audit

- ✅ No secrets / env / tokens leaked into client error bodies even in dev mode (only `errorName` / `errorCode` / `errorStack` — these don't carry credentials).
- ✅ Stack output stripped in `NODE_ENV=production`.
- ✅ No fake DWG / IFC introduced.
- ✅ No image-generated technical drawings introduced.
- ✅ Authority gates untouched.
- ✅ PR #119 (program-spaces routing) untouched.
- ✅ PR #118 (artifact browser) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)