### PR TITLE
fix: mount artifact package storage routes in local dev server

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -92,6 +92,30 @@ async function loadDynamicApiHandler(relativePath) {
 function mountDynamicApiRoute(method, route, relativePath, middlewares = []) {
   app[method](route, ...middlewares, async (req, res) => {
     try {
+      // Vercel/Next-style dynamic handlers (api/.../[param].js) read URL
+      // segments from req.query. Express puts them on req.params and
+      // exposes req.query as a prototype-level getter with no setter, so
+      // a plain `req.query = ...` assignment is silently rejected. Shadow
+      // the prototype getter with an own property so the merged values
+      // stick. No-op for static routes (req.params is {}).
+      if (req.params && typeof req.params === 'object') {
+        const merged = { ...(req.query || {}) };
+        let mutated = false;
+        for (const [name, value] of Object.entries(req.params)) {
+          if (value !== undefined && merged[name] === undefined) {
+            merged[name] = value;
+            mutated = true;
+          }
+        }
+        if (mutated) {
+          Object.defineProperty(req, 'query', {
+            value: merged,
+            writable: true,
+            configurable: true,
+            enumerable: true,
+          });
+        }
+      }
       const handler = await loadDynamicApiHandler(relativePath);
       return handler(req, res);
     } catch (error) {
@@ -397,6 +421,15 @@ mountDynamicApiRoute('post', '/api/project/export/dxf',     'api/project/export/
 mountDynamicApiRoute('post', '/api/project/export/ifc',     'api/project/export/ifc.js');
 mountDynamicApiRoute('post', '/api/project/export/xlsx',    'api/project/export/xlsx.js');
 mountDynamicApiRoute('post', '/api/project/export/artifact-package', 'api/project/export/artifact-package.js');
+// Artifact-package storage + history routes. The serverless handlers under
+// api/project/export/artifact-package/* run natively on Vercel; mount them
+// on the Express dev server too so npm run dev exercises the same surface.
+// Dynamic ":packageId" reaches the handler via req.query thanks to the
+// params-into-query merge in mountDynamicApiRoute above.
+mountDynamicApiRoute('get',  '/api/project/export/artifact-package/history',                    'api/project/export/artifact-package/history.js');
+mountDynamicApiRoute('post', '/api/project/export/artifact-package/store',                      'api/project/export/artifact-package/store.js');
+mountDynamicApiRoute('get',  '/api/project/export/artifact-package/:packageId',                 'api/project/export/artifact-package/[packageId].js');
+mountDynamicApiRoute('get',  '/api/project/export/artifact-package/:packageId/download',        'api/project/export/artifact-package/[packageId]/download.js');
 
 // Phase 1/2 architecture backend routes (shared with api/models/* serverless handlers)
 mountDynamicApiRoute('post', '/api/models/generate-style', 'api/models/generate-style.js', [aiApiLimiter]);


### PR DESCRIPTION
## Why

PR #118's ArtifactHistoryPanel cannot be smoked locally because the Express dev server (`server.cjs:412`) only mounts the legacy direct-ZIP route `POST /api/project/export/artifact-package`. The four newer endpoints that back the history browser exist as Vercel serverless functions in `api/project/export/artifact-package/` but never get mounted on Express, so every browser call from the panel **404s** in `npm run dev`. Vercel preview deployments work fine — only local dev was missing the parity.

## What

Mount the four serverless handlers on Express so dev parity matches Vercel:
- `GET  /api/project/export/artifact-package/history` → `history.js`
- `POST /api/project/export/artifact-package/store` → `store.js`
- `GET  /api/project/export/artifact-package/:packageId` → `[packageId].js`
- `GET  /api/project/export/artifact-package/:packageId/download` → `[packageId]/download.js`

The two parameterised routes need a small adapter:
- Vercel/Next-style handlers read URL segments from `req.query.packageId`.
- Express puts them on `req.params.packageId`.
- Express also exposes `req.query` as a **prototype-level getter with no setter**, so a plain `req.query = merged` assignment is silently rejected (verified via `Object.getOwnPropertyDescriptor(req, 'query')` returning undefined).

Extend `mountDynamicApiRoute` to shallow-merge `req.params` into `req.query` via `Object.defineProperty` (own-property shadow over the prototype getter). No overwriting of explicit query-string values. No-op for static routes (`req.params` is `{}`), so the ~50 existing routes that don't use Express params behave exactly as before.

The legacy `POST /api/project/export/artifact-package` route is untouched.

## Out of scope (per your instruction)

- ArtifactHistoryPanel and PR #118 files — untouched.
- ProjectGraph / A1 / CAD / DXF / structural / MEP / details / package generation / PDF stitching / storage logic — untouched.
- No fake DWG/IFC, no image generation changes.

## Local smoke

| Route | HTTP | Body |
|---|---|---|
| `GET /history?projectId=smoke` | **200** | `{"history":[],"count":0,"storageProvider":"memory",...}` |
| `POST /store` (empty body) | **400** | `PACKAGE_ARTIFACTS_REQUIRED` |
| `GET /:packageId` (`abc-123`) | **404** | `ARTIFACT_STORAGE_NOT_FOUND` (handler reached storage layer; param merge works) |
| `GET /:packageId/download` (`abc-123`) | **404** | `ARTIFACT_STORAGE_NOT_FOUND` |
| `POST /` (legacy direct ZIP, no change) | **400** | `PACKAGE_ARTIFACTS_REQUIRED` (unchanged) |
| `POST /api/openai-reasoning` | **200** | (PR #119 unchanged) |
| `POST /api/program/compile` | **200** | (existing route unchanged) |

## Validation

- `npm run lint` — clean
- `git diff --check` — clean
- `npm run check:env` — pass
- `npm run check:contracts` — pass
- `npm run build:active` — pass
- Local smoke (above) — all routes reach their handlers with expected status codes

## Test plan

- [x] No previously-mounted route regresses (verified via `POST /` and `POST /api/openai-reasoning` and `POST /api/program/compile` smokes)
- [x] All four new routes reach their handlers (verified via curl probes returning handler-level errors, not Express's 404)
- [x] Param merge works for `:packageId` (handler reaches storage layer instead of returning `PACKAGE_ID_REQUIRED`)
- [ ] After merge, PR #118 should be re-rebased and the artifact-browser manual smoke should pass against `npm run dev`

## Blocker audit

- ✅ No fake DWG/IFC introduced.
- ✅ No image-generated technical drawings.
- ✅ No changes to ProjectGraph, A1, CAD/DXF, structural, MEP, details, package generation, PDF stitching, or storage logic.
- ✅ No changes to ArtifactHistoryPanel or any PR #118 file.
- ✅ Authority gates untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)