### PR TITLE
fix: mount TooltipProvider at app root

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,15 +8,18 @@ import React from "react";
 import ArchitectAIWizardContainer from "./components/ArchitectAIWizardContainer.jsx";
 import ForceHybridMode from "./components/ForceHybridMode.jsx";
 import ToastProvider from "./components/ui/ToastProvider.jsx";
+import { TooltipProvider } from "./components/ui/feedback/Tooltip.jsx";
 import "./styles/deepgram.css";
 import "./App.css";
 
 function App() {
   return (
-    <ToastProvider position="bottom-right">
-      <ForceHybridMode />
-      <ArchitectAIWizardContainer />
-    </ToastProvider>
+    <TooltipProvider delayDuration={300}>
+      <ToastProvider position="bottom-right">
+        <ForceHybridMode />
+        <ArchitectAIWizardContainer />
+      </ToastProvider>
+    </TooltipProvider>
   );
 }
 

--- a/src/__tests__/App.tooltipProvider.test.js
+++ b/src/__tests__/App.tooltipProvider.test.js
@@ -1,0 +1,50 @@
+/**
+ * Regression lock-in for the missing-TooltipProvider crash.
+ *
+ * Without a TooltipProvider mounted at the app root, every component that
+ * renders <Tooltip> (radix-ui) throws:
+ *
+ *   Error: `Tooltip` must be used within `TooltipProvider`
+ *
+ * ExportPanel uses <Tooltip> in ExportRow, so opening the
+ * "DXF / BIM / Cost Export" surface from ResultsStep crashes into the
+ * AsyncErrorBoundary in dev. Production may differ silently.
+ *
+ * This test asserts:
+ *   1. App.js imports TooltipProvider from the canonical Tooltip module.
+ *   2. App.js wraps its tree with <TooltipProvider> (i.e. the import is
+ *      actually used, not dead).
+ *   3. The Tooltip module still exports TooltipProvider (catch a future
+ *      rename / removal in the UI layer).
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+describe("App root TooltipProvider mount", () => {
+  test("App.js imports TooltipProvider from the Tooltip module", () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, "../App.js"),
+      "utf8",
+    );
+    expect(source).toMatch(
+      /import\s*\{\s*[^}]*\bTooltipProvider\b[^}]*\}\s*from\s*["'][^"']*Tooltip(?:\.jsx)?["']/,
+    );
+  });
+
+  test("App.js wraps its tree with <TooltipProvider>", () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, "../App.js"),
+      "utf8",
+    );
+    expect(source).toMatch(/<TooltipProvider\b[\s\S]*<\/TooltipProvider>/);
+  });
+
+  test("Tooltip module still exports TooltipProvider", () => {
+    const tooltipSource = fs.readFileSync(
+      path.resolve(__dirname, "../components/ui/feedback/Tooltip.jsx"),
+      "utf8",
+    );
+    expect(tooltipSource).toMatch(/export\s*\{[^}]*\bTooltipProvider\b[^}]*\}/);
+  });
+});


### PR DESCRIPTION
## Why

`ExportPanel` uses radix-ui `<Tooltip>` in its `ExportRow` component, but no `TooltipProvider` was ever mounted at the app root. Opening **DXF / BIM / Cost Export** from `ResultsStep` crashed every time into the global error boundary:

```
Error: `Tooltip` must be used within `TooltipProvider`
  at Tooltip
  at ExportRow      ← pre-existing component
  at ExportSection
  at ExportPanel
```

Nobody noticed in dev until now because, until PR #120 (vertical-slice 500 fix) merged, generation never reached `ResultsStep` at all in the local dev pipeline. Once #120 unblocked the Results page, clicking the export trigger immediately hit this radix invariant. Verified this is **not** introduced by PR #118 — the `ExportRow` Tooltip count is identical on `main` and on every recent feature branch.

## What

- **`src/App.js`** — wrap the existing `<ToastProvider>` in `<TooltipProvider>` (imported from the existing Tooltip module's named export). Outer placement keeps `TooltipProvider` stable even if inner providers are reordered. No other file touched.
- **`src/__tests__/App.tooltipProvider.test.js`** — source-pattern regression test asserting that:
  1. `App.js` imports `TooltipProvider` from the canonical Tooltip module.
  2. `App.js` wraps its tree with `<TooltipProvider>`.
  3. The Tooltip module still exports `TooltipProvider` (catches future rename / removal in the UI layer).

## Out of scope (per your instruction)

- PR #118 files — untouched.
- ProjectGraph, A1, CAD/DXF, structural, MEP, details, package generation, storage, PDF stitching, authority gates — untouched.
- No other UI component touched (the `<Tooltip>` usage in `ExportRow` is unchanged; only the missing provider is added).

## Validation

- New unit test — 3/3 pass
- `npm run lint` — clean
- `git diff --check` — clean
- `npm run check:env` — pass
- `npm run check:contracts` — pass
- `npm run build:active` — pass

## Manual smoke (verified end-to-end)

1. `npm run dev` on this branch
2. Wizard for `Detached House` 150 m² 2 levels
3. Generation reaches ResultsStep (vertical-slice 200 — PR #120 unchanged)
4. Click **DXF / BIM / Cost Export**
5. **ExportPanel mounts cleanly** with `Documents` / `Engineering` / `Download Deliverables ZIP` button visible. **No TooltipProvider crash.**

## Test plan

- [x] Unit regression test catches App.js source pattern
- [x] Manual end-to-end smoke confirms ExportPanel renders without crash
- [ ] After merge, PR #118 (artifact browser UI) can be re-rebased and its full manual smoke (ArtifactHistoryPanel render, refresh, save, signed/direct download, expired/deleted disable, no-secrets) can run

## Blocker audit

- ✅ No fake DWG/IFC introduced.
- ✅ No image-generated technical drawings.
- ✅ No changes to ProjectGraph, A1, CAD/DXF, structural, MEP, details, package generation, PDF stitching, storage, or authority gates.
- ✅ No changes to PR #118 files.
- ✅ Provider order: `<TooltipProvider>` wraps `<ToastProvider>` — both contexts independent, outer placement is the safer default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)