### PR TITLE
fix: preserve wizard project id for prebaked artifact packages

### DIFF
--- a/api/project/generate-vertical-slice.js
+++ b/api/project/generate-vertical-slice.js
@@ -52,6 +52,33 @@ function downloadRouteFor(packageId) {
   )}/download`;
 }
 
+// The wizard sends its own projectId/designId on the request payload; the
+// slice service generates an unrelated projectId on the result (typically
+// derived from projectGraph.project_id). For the prebaked artifact package
+// to be filterable from the panel by the same projectId the wizard's
+// designData carries, the wizard's id MUST win — otherwise Save Package
+// succeeds but the per-project history filter shows nothing.
+//
+// Exported via __verticalSlicePrebakeInternals so the precedence is unit-
+// testable without spinning up the full slice service.
+function resolveWizardProjectId(payload = {}, result = {}) {
+  return (
+    payload?.projectId ||
+    payload?.project_id ||
+    payload?.designId ||
+    payload?.metadata?.projectId ||
+    result?.projectId ||
+    result?.projectGraph?.project_id ||
+    result?.projectGraph?.projectGraphId ||
+    result?.metadata?.projectId ||
+    null
+  );
+}
+
+export const __verticalSlicePrebakeInternals = {
+  resolveWizardProjectId,
+};
+
 // Pre-bake the deliverables ZIP into storage during the generation request so
 // the client never has to re-upload tens of MB of artifacts at Save time.
 // Returns a small reference object the client stores on designData.package and
@@ -67,12 +94,24 @@ async function prebakeArtifactPackage({ result, payload, req }) {
       payload?.metadata?.projectName ||
       result?.projectName ||
       "ArchiAI_Project";
+    // Explicit projectId override: the wizard's id must beat the
+    // slice-generated one regardless of spread order. Without this, the
+    // panel's history filter (queried with the wizard's projectId) returns
+    // empty after a successful Save because the storage entry was filed
+    // under the slice's auto-generated projectId.
+    //
+    // CRITICAL: do not pass a `result` key here. buildPackageInput's
+    // resolvePayload helper preferences body.result over body, which would
+    // cause the explicit projectId set at body level to be dropped on the
+    // floor. The spread `...result` already exposes artifacts, projectGraph,
+    // compiledProject, etc. at top level for buildPackageInput to find.
+    const wizardProjectId = resolveWizardProjectId(payload, result);
     const packageInput = buildPackageInput({
       ...payload,
       ...result,
+      projectId: wizardProjectId,
       projectName,
       userId,
-      result,
     });
     if (!hasPackageSource(packageInput)) return null;
     const packageResult =

--- a/src/__tests__/api/generateVerticalSlicePrebakeProjectId.test.js
+++ b/src/__tests__/api/generateVerticalSlicePrebakeProjectId.test.js
@@ -1,0 +1,118 @@
+/**
+ * Regression: prebaked artifact package must file storage under the wizard's
+ * projectId, not the slice service's auto-generated one.
+ *
+ * Background: PR #123 introduced server-side prebake of the deliverables ZIP
+ * during /api/project/generate-vertical-slice so Save Package becomes a tiny
+ * compact-ref body (~100 B) instead of re-uploading the full design bundle.
+ * The prebake helper called buildPackageInput({ ...payload, ...result, ... }),
+ * and `result.projectId` (auto-generated from projectGraph.project_id) won
+ * over `payload.projectId`. Save Package returned 200 but the panel's
+ * history filter — querying with the wizard's projectId — returned empty
+ * because the storage entry was filed under the slice's id.
+ *
+ * Fix: explicit `resolveWizardProjectId(payload, result)` override that
+ * makes the wizard / design id authoritative.
+ *
+ * This test pins the precedence at the helper level so a future refactor
+ * of the spread order can't silently re-introduce the bug.
+ */
+
+import { __verticalSlicePrebakeInternals } from "../../../api/project/generate-vertical-slice.js";
+
+const { resolveWizardProjectId } = __verticalSlicePrebakeInternals;
+
+describe("generate-vertical-slice prebake — wizard projectId precedence", () => {
+  test("payload.projectId wins over result.projectId", () => {
+    const payload = { projectId: "design_wizard_001" };
+    const result = {
+      projectId: "project-graph-auto-xyz",
+      projectGraph: { project_id: "project-graph-auto-xyz" },
+    };
+    expect(resolveWizardProjectId(payload, result)).toBe("design_wizard_001");
+  });
+
+  test("payload.designId wins over result.projectGraph.project_id", () => {
+    const payload = { designId: "design_via_designId" };
+    const result = {
+      projectGraph: { project_id: "project-graph-auto-xyz" },
+    };
+    expect(resolveWizardProjectId(payload, result)).toBe("design_via_designId");
+  });
+
+  test("payload.project_id (snake_case) wins over result", () => {
+    const payload = { project_id: "design_snake_001" };
+    const result = { projectId: "project-graph-auto-xyz" };
+    expect(resolveWizardProjectId(payload, result)).toBe("design_snake_001");
+  });
+
+  test("payload.metadata.projectId wins over result", () => {
+    const payload = { metadata: { projectId: "design_meta_001" } };
+    const result = { projectId: "project-graph-auto-xyz" };
+    expect(resolveWizardProjectId(payload, result)).toBe("design_meta_001");
+  });
+
+  test("falls through to result.projectId when payload has none", () => {
+    const payload = {};
+    const result = { projectId: "project-graph-auto-xyz" };
+    expect(resolveWizardProjectId(payload, result)).toBe(
+      "project-graph-auto-xyz",
+    );
+  });
+
+  test("falls through to result.projectGraph.project_id when payload has none and no result.projectId", () => {
+    const payload = {};
+    const result = { projectGraph: { project_id: "project-graph-auto-xyz" } };
+    expect(resolveWizardProjectId(payload, result)).toBe(
+      "project-graph-auto-xyz",
+    );
+  });
+
+  test("returns null when neither payload nor result has any projectId form", () => {
+    expect(resolveWizardProjectId({}, {})).toBeNull();
+    expect(resolveWizardProjectId(undefined, undefined)).toBeNull();
+  });
+
+  test("ignores empty-string ids in payload (treated as falsy)", () => {
+    const payload = { projectId: "", designId: "" };
+    const result = { projectId: "project-graph-auto-xyz" };
+    expect(resolveWizardProjectId(payload, result)).toBe(
+      "project-graph-auto-xyz",
+    );
+  });
+
+  test("preserves precedence priority within payload (projectId > project_id > designId > metadata.projectId)", () => {
+    expect(
+      resolveWizardProjectId(
+        {
+          projectId: "a",
+          project_id: "b",
+          designId: "c",
+          metadata: { projectId: "d" },
+        },
+        { projectId: "z" },
+      ),
+    ).toBe("a");
+
+    expect(
+      resolveWizardProjectId(
+        { project_id: "b", designId: "c", metadata: { projectId: "d" } },
+        { projectId: "z" },
+      ),
+    ).toBe("b");
+
+    expect(
+      resolveWizardProjectId(
+        { designId: "c", metadata: { projectId: "d" } },
+        { projectId: "z" },
+      ),
+    ).toBe("c");
+
+    expect(
+      resolveWizardProjectId(
+        { metadata: { projectId: "d" } },
+        { projectId: "z" },
+      ),
+    ).toBe("d");
+  });
+});


### PR DESCRIPTION
## Why

After PR #123 merged, Save Package returned HTTP 200 with a tiny compact-ref body (architecture worked) but the panel's per-project history filter — queried with the wizard's `projectId` (e.g. `design_1778426784161_b2iaqzp`) — returned **empty** for every saved package. The saved row only showed up under the slice service's auto-generated id (e.g. `project-graph-jy3kz2`).

Two compounding bugs in the prebake helper at `api/project/generate-vertical-slice.js`:

1. **Spread order**: `buildPackageInput({ ...payload, ...result, ... })` meant `result.projectId` (auto-generated from `projectGraph.project_id`) clobbered `payload.projectId` from the wizard.
2. **`resolvePayload` navigation**: even an explicit `projectId: wizardProjectId` set at body level was silently dropped because `buildPackageInput`'s `resolvePayload(body)` returns `body.result` first when present, bypassing every body-level override. The prebake passed `result` as a key for nested-resolution fallbacks, which triggered the navigation.

## What

- New helper `resolveWizardProjectId(payload, result)` with explicit precedence:
  `payload.projectId > payload.project_id > payload.designId > payload.metadata.projectId > result.projectId > result.projectGraph.project_id > result.projectGraph.projectGraphId > result.metadata.projectId > null`
- Inject the resolved id explicitly via `projectId: wizardProjectId` AFTER the spreads so it can't be clobbered.
- **Drop** the `result` key from the `buildPackageInput` input. The `...result` spread already exposes `artifacts`, `projectGraph`, and `compiledProject` at top level, so the redundant `result` key is no longer needed and removing it stops `resolvePayload` from navigating away from the body.
- Export `__verticalSlicePrebakeInternals = { resolveWizardProjectId }` so the precedence is unit-testable without spinning up the full slice service.

## Out of scope (per your instruction)

- ProjectGraph / A1 / CAD / DXF / DWG / IFC / structural / MEP / details engines — untouched.
- Authority gates, image generation, package hashing logic — untouched.
- ArtifactHistoryPanel and any PR #118 file — untouched.
- `buildPackageInput` / `artifactPackageService` / `artifactStorageService` themselves — untouched (the bug is in *how* the helper passes inputs, not in the helper).

## Verified end-to-end (npm run dev, residential detached house)

| Step | Before fix | After fix |
|---|---|---|
| `POST /generate-vertical-slice` (`projectId: wizard-design-002`) | result.package exists | result.package exists |
| `POST /artifact-package/store` compact ref | 200 but `history.projectId` = `project-graph-jy3kz2` | 200 with `history.projectId` = **`wizard-design-002`** |
| `GET /history?projectId=wizard-design-002` | empty | **returns the saved row** |
| `GET /history?projectId=<slice-id>` | row appears (wrong filter) | empty (correct) |
| `manifest.projectId` | `project-graph-jy3kz2` | `wizard-design-002` |
| `projectGraphId` | preserved separately | preserved separately |
| `packageHash` | (varies per run) | (deterministic for same inputs — unchanged behavior) |

## Tests

- 9 new tests in `src/__tests__/api/generateVerticalSlicePrebakeProjectId.test.js`:
  - payload.projectId / payload.project_id / payload.designId / payload.metadata.projectId all win over result
  - fall-through to result.projectId, result.projectGraph.project_id when payload has none
  - empty-string ids treated as falsy
  - returns null when neither has a projectId
  - precedence priority within payload locked in
- 21 existing artifact-package compact + legacy tests pass unchanged (no regression to the legacy full-payload path or the no-zipBytes/no-secrets invariants)

## Validation

- `npm run lint` ✅ · `git diff --check` ✅ · `npm run check:env` ✅ · `npm run check:contracts` ✅ · `npm run build:active` ✅
- 30/30 focused tests pass

## Acceptance checklist (per your spec)

1. ✅ Generate detached-house vertical slice
2. ✅ `result.package` exists
3. ✅ Package storage/history uses the wizard/design projectId
4. ✅ Save Package compact ref sends ~100–200 byte body and returns 200
5. ✅ `GET /history?projectId={wizardProjectId}` returns the saved row
6. ✅ `GET /history` unfiltered still returns the row
7. ✅ `GET /artifact-package/{packageId}/download` returns 200 application/zip (66 MB, valid PK header)
8. ✅ `packageHash` remains deterministic
9. ✅ No fake DWG/IFC
10. ✅ No image-generated technical drawings
11. ✅ Authority gates untouched

## Files

- `api/project/generate-vertical-slice.js` (only file changed in src)
- `src/__tests__/api/generateVerticalSlicePrebakeProjectId.test.js` (new, 9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)