### PR TITLE
fix: history filter accepts wizard projectId or slice projectGraphId

### DIFF
--- a/api/project/export/artifact-package/history.js
+++ b/api/project/export/artifact-package/history.js
@@ -36,9 +36,21 @@ async function withDownloadUrls(records, adapter, accessContext) {
     DEFAULT_SIGNED_URL_EXPIRES_SECONDS;
   const hydrated = await Promise.all(
     records.map(async (record) => {
+      // listArtifactPackageHistory matches by record.projectId OR
+      // record.projectGraphId. The per-record access check needs the same
+      // either-or semantics: pass whichever id the caller's accessContext
+      // actually matches, so projectAllowed doesn't deny a row that the
+      // listing layer already authorized.
+      const queriedProjectId = accessContext?.projectId || null;
+      const manifestProjectIdForCheck =
+        queriedProjectId &&
+        queriedProjectId !== record.projectId &&
+        queriedProjectId === record.projectGraphId
+          ? record.projectGraphId
+          : record.projectId;
       const accessDecision = canReadArtifactPackage(accessContext, {
         manifest: {
-          projectId: record.projectId,
+          projectId: manifestProjectIdForCheck,
         },
         metadata: {
           userId: record.userId,

--- a/api/project/export/artifact-package/store.js
+++ b/api/project/export/artifact-package/store.js
@@ -166,15 +166,28 @@ export default async function handler(req, res) {
           storageRecord.metadata?.packageHash,
         manifest: storageRecord.manifest || {},
       };
-      const historyRecord = recordArtifactPackageHistory(
-        createArtifactHistoryRecord({
-          packageResult: packageResultLike,
-          storageRecord,
-          userId,
-          signedUrlInfo,
-          downloadRoute: fallbackDownloadRoute,
-        }),
-      );
+      // Compact-ref Save: the body.projectId is the wizard's
+      // client-generated designId (the panel's filter key). The storage
+      // manifest's projectId is the slice's auto-generated id (kept on
+      // the record as projectGraphId). Override history.projectId with
+      // the body value so the panel's per-project filter finds the row.
+      // listArtifactPackageHistory matches by projectId OR projectGraphId,
+      // so the slice's id is still queryable too.
+      const baseHistoryRecord = createArtifactHistoryRecord({
+        packageResult: packageResultLike,
+        storageRecord,
+        userId,
+        signedUrlInfo,
+        downloadRoute: fallbackDownloadRoute,
+      });
+      const wizardProjectId =
+        (typeof req.body?.projectId === "string" &&
+          req.body.projectId.trim()) ||
+        null;
+      const historyRecord = recordArtifactPackageHistory({
+        ...baseHistoryRecord,
+        projectId: wizardProjectId || baseHistoryRecord.projectId,
+      });
       return res.status(200).json({
         packageId: storageRecord.packageId,
         packageHash: packageResultLike.packageHash,

--- a/src/__tests__/services/export/artifactHistoryProjectIdOrGraphId.test.js
+++ b/src/__tests__/services/export/artifactHistoryProjectIdOrGraphId.test.js
@@ -1,0 +1,172 @@
+/**
+ * Regression: listArtifactPackageHistory must match by either projectId or
+ * projectGraphId so the panel can find a saved row from EITHER the wizard's
+ * client-generated designId (which becomes the record's projectId during
+ * compact-mode store) or the slice service's auto-generated projectGraphId
+ * (the case the wizard hits today because designId isn't generated until
+ * AFTER the slice request).
+ *
+ * Without this, Save Package returns 200 and the row exists in storage, but
+ * the panel's per-project filter returns empty because the projectId the
+ * panel queries with doesn't equal the projectId on the record.
+ */
+
+import {
+  clearArtifactPackageHistory,
+  listArtifactPackageHistory,
+  recordArtifactPackageHistory,
+} from "../../../services/export/artifactHistoryService.js";
+
+function fixture(overrides = {}) {
+  return {
+    schemaVersion: "artifact-package-history-record-v1",
+    packageId: `pkg-${Math.random().toString(36).slice(2, 10)}`,
+    packageHash: `hash-${Math.random().toString(36).slice(2, 10)}`,
+    projectId: "alpha-design",
+    projectGraphId: "graph-alpha",
+    userId: "user-1",
+    createdAt: new Date().toISOString(),
+    artifactCount: 1,
+    sourceGapCount: 0,
+    status: "stored",
+    flags: {},
+    producerVersions: {},
+    ...overrides,
+  };
+}
+
+describe("listArtifactPackageHistory — projectId OR projectGraphId filter", () => {
+  beforeEach(() => clearArtifactPackageHistory());
+  afterEach(() => clearArtifactPackageHistory());
+
+  test("matches by projectId (existing behaviour)", () => {
+    recordArtifactPackageHistory(fixture({ packageId: "pkg-a" }));
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-b",
+        projectId: "beta-design",
+        projectGraphId: "graph-beta",
+      }),
+    );
+
+    const result = listArtifactPackageHistory({ projectId: "alpha-design" });
+    expect(result).toHaveLength(1);
+    expect(result[0].packageId).toBe("pkg-a");
+  });
+
+  test("matches by projectGraphId when projectId differs (the wizard case)", () => {
+    // Storage filed this entry under the slice's auto-generated projectGraphId
+    // because the wizard's designId wasn't available at slice time.
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-wiz",
+        projectId: "graph-auto-from-slice",
+        projectGraphId: "graph-auto-from-slice",
+      }),
+    );
+
+    // The wizard later queries with its client-generated designId. The
+    // record's projectGraphId was returned to the client in result.package.*
+    // and is also visible on designData.metadata.projectGraphId, so the
+    // panel can supply EITHER id and find the row.
+    const byGraphId = listArtifactPackageHistory({
+      projectId: "graph-auto-from-slice",
+    });
+    expect(byGraphId).toHaveLength(1);
+    expect(byGraphId[0].packageId).toBe("pkg-wiz");
+  });
+
+  test("matches by projectGraphId when record's projectId is a separate id", () => {
+    // Defensive scenario: storage entry has BOTH ids populated and they
+    // differ. The filter must accept either lookup key.
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-dual",
+        projectId: "wizard-design-id",
+        projectGraphId: "slice-graph-id",
+      }),
+    );
+
+    expect(
+      listArtifactPackageHistory({ projectId: "wizard-design-id" }),
+    ).toHaveLength(1);
+    expect(
+      listArtifactPackageHistory({ projectId: "slice-graph-id" }),
+    ).toHaveLength(1);
+    expect(
+      listArtifactPackageHistory({ projectId: "neither-of-them" }),
+    ).toHaveLength(0);
+  });
+
+  test("does not cross-leak between unrelated designs", () => {
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-1",
+        projectId: "design-1",
+        projectGraphId: "graph-1",
+      }),
+    );
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-2",
+        projectId: "design-2",
+        projectGraphId: "graph-2",
+      }),
+    );
+
+    const byDesign1 = listArtifactPackageHistory({ projectId: "design-1" });
+    expect(byDesign1).toHaveLength(1);
+    expect(byDesign1[0].packageId).toBe("pkg-1");
+
+    const byGraph2 = listArtifactPackageHistory({ projectId: "graph-2" });
+    expect(byGraph2).toHaveLength(1);
+    expect(byGraph2[0].packageId).toBe("pkg-2");
+
+    expect(
+      listArtifactPackageHistory({ projectId: "graph-1" }).map(
+        (r) => r.packageId,
+      ),
+    ).toEqual(["pkg-1"]);
+  });
+
+  test("no projectId filter returns all non-deleted records (unchanged)", () => {
+    recordArtifactPackageHistory(fixture({ packageId: "pkg-1" }));
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-2",
+        projectId: "other",
+        projectGraphId: "graph-other",
+      }),
+    );
+    expect(
+      listArtifactPackageHistory({})
+        .map((r) => r.packageId)
+        .sort(),
+    ).toEqual(["pkg-1", "pkg-2"]);
+  });
+
+  test("respects userId filter alongside the dual-id projectId match", () => {
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-mine",
+        userId: "me",
+        projectGraphId: "shared-graph",
+      }),
+    );
+    recordArtifactPackageHistory(
+      fixture({
+        packageId: "pkg-theirs",
+        userId: "someone-else",
+        projectId: "their-design",
+        projectGraphId: "shared-graph",
+      }),
+    );
+
+    const result = listArtifactPackageHistory({
+      projectId: "shared-graph",
+      userId: "me",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].packageId).toBe("pkg-mine");
+  });
+});

--- a/src/services/export/artifactHistoryService.js
+++ b/src/services/export/artifactHistoryService.js
@@ -142,9 +142,19 @@ export function listArtifactPackageHistory(
   { projectId = null, userId = null, includeDeleted = false } = {},
   state = getHistoryState(),
 ) {
+  // The wizard generates its own designId on the client AFTER the slice
+  // returns; the slice service generates an unrelated projectGraphId on the
+  // server inside the same generation. Either may end up as the panel's
+  // history filter — match on either record.projectId OR
+  // record.projectGraphId so the saved row is findable from both ids
+  // without forcing the wizard to align them upstream.
   return [...state.records.values()]
     .filter((record) => (includeDeleted ? true : record.status !== "deleted"))
-    .filter((record) => (projectId ? record.projectId === projectId : true))
+    .filter((record) =>
+      projectId
+        ? record.projectId === projectId || record.projectGraphId === projectId
+        : true,
+    )
     .filter((record) => (userId ? record.userId === userId : true))
     .sort((a, b) =>
       [b.createdAt || "", b.packageId || ""]


### PR DESCRIPTION
## Why

After PR #123 (compact-ref Save) and PR #124 (prebake projectId precedence), Save Package returned 200 and the storage entry was correctly created — but the panel's per-project history filter still returned **empty**.

Root cause: the wizard's `designId` is generated **client-side AFTER** the slice request returns (`designHistoryRepository.generateDesignId`), so the slice payload carries no `projectId` for the prebake helper to honour. The prebake fell through to the slice's auto-generated `projectGraphId` (e.g. `project-graph-1of3jif`), and the panel later queried with the wizard's client-generated designId (e.g. `design_1778428185140_gmem9ii`). Two ids — neither matching the other on the storage record.

## What

Server-only fix in three small pieces — **no client / wizard / PR-#118 changes**:

1. **`listArtifactPackageHistory`** (`src/services/export/artifactHistoryService.js`): match on `record.projectId === projectId || record.projectGraphId === projectId`. The wizard can query with either id and find the row.

2. **Compact-ref branch in `/artifact-package/store`**: override the history record's `projectId` with `body.projectId` (the wizard's designId) when provided. The slice's id stays on the record as `record.projectGraphId`. The dual-id filter then matches both keys without forcing them to be equal.

3. **Per-record access check in `/artifact-package/history`**: was using `record.projectId` for the `projectAllowed` gate, which would deny rows when the caller queried with `projectGraphId`. It now picks whichever of the two ids the caller's `accessContext.projectId` actually matches, keeping the listing layer's either-or semantics consistent through the access policy.

## Out of scope (per your instruction)

- Wizard's design lifecycle, `useArchitectAIWorkflow`, design-id generation timing — untouched.
- ArtifactHistoryPanel and any PR #118 file — untouched.
- ProjectGraph / A1 / CAD / DWG / IFC / structural / MEP / details engines — untouched.
- Authority gates, image generation, package hashing — untouched.
- `artifactPackageService.buildArtifactPackage`, `artifactStorageService` — untouched.

## End-to-end smoke (verified before commit)

`npm run dev`, residential detached house, **simulating the wizard's actual flow with no projectId in the slice payload** (matching what `useArchitectAIWorkflow` sends today):

| Step | Body | Result |
|---|---|---|
| `POST /generate-vertical-slice` | brief only | response includes `package.packageId` |
| `POST /artifact-package/store` | `{ packageId, projectId: design_wizard_local_777 }` | 200; `history.projectId = design_wizard_local_777`, `history.projectGraphId = project-graph-88kt7` |
| `GET /history?projectId=design_wizard_local_777` | (none) | **returns the row** ✅ |
| `GET /history?projectId=project-graph-88kt7` | (none) | **also returns the row** ✅ |
| `GET /history?projectId=unrelated-zzz` | (none) | empty (no false positive) ✅ |

## Tests

- 6 new tests in `src/__tests__/services/export/artifactHistoryProjectIdOrGraphId.test.js`:
  - matches by projectId (existing behaviour)
  - matches by projectGraphId when projectId differs (the wizard case)
  - matches by either when both ids on the record differ
  - no cross-leak between unrelated designs
  - no projectId filter still returns everything
  - userId filter still applies alongside the dual-id projectId match
- 33 existing artifact-package compact + legacy + prebake + storage-history tests pass unchanged

## Validation

- `npm run lint` ✅ · `git diff --check` ✅ · `npm run check:env` ✅ · `npm run check:contracts` ✅ · `npm run build:active` ✅
- 39/39 focused tests pass

## Files

- `src/services/export/artifactHistoryService.js` — dual-id filter
- `api/project/export/artifact-package/store.js` — compact-ref writes wizard designId onto history record
- `api/project/export/artifact-package/history.js` — per-record access check picks the matching id
- `src/__tests__/services/export/artifactHistoryProjectIdOrGraphId.test.js` (new, 6 tests)

## Blocker audit

- ✅ No fake DWG/IFC introduced.
- ✅ No image-generated technical drawings.
- ✅ No changes to authority gates, PR #118 files, or ArtifactHistoryPanel.
- ✅ No changes to package hashing — record carries both ids without altering the deterministic ZIP/manifest.
- ✅ No secrets / no zipBytes leaked into history responses (existing safeRecord guard at `artifactHistoryService.js:42-48` still applies; existing test in `artifactPackageExport.test.js:343-348` still passes).
- ✅ No cross-leak between designs (verified by test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)