### PR TITLE
Add provider health preflight dashboard

### DIFF
--- a/api/admin/provider-health.js
+++ b/api/admin/provider-health.js
@@ -1,0 +1,72 @@
+/* global globalThis */
+import { setCorsHeaders, handlePreflight } from "../_shared/cors.js";
+import { buildProviderHealthSnapshot } from "../../src/services/health/providerHealthService.js";
+
+const ADMIN_TOKEN_ENV = "ADMIN_HEALTH_TOKEN";
+
+function resolveAdminAuth(req) {
+  const token =
+    req.headers?.["x-admin-token"] ||
+    req.headers?.["X-Admin-Token"] ||
+    req.query?.adminToken ||
+    null;
+  const expected = globalThis.process?.env?.[ADMIN_TOKEN_ENV] || null;
+  if (!expected) {
+    // Local-dev posture: if no admin token is configured, allow only when
+    // not running production (mirrors the artifact stack's local-anonymous
+    // tolerance). Production deployments MUST set ADMIN_HEALTH_TOKEN.
+    if (globalThis.process?.env?.NODE_ENV === "production") {
+      return {
+        ok: false,
+        status: 503,
+        code: "ADMIN_TOKEN_NOT_CONFIGURED",
+        message:
+          "Admin endpoint requires ADMIN_HEALTH_TOKEN env var in production",
+      };
+    }
+    return { ok: true, mode: "local_anonymous" };
+  }
+  if (!token || token !== expected) {
+    return {
+      ok: false,
+      status: 401,
+      code: "ADMIN_TOKEN_INVALID",
+      message: "Invalid or missing X-Admin-Token header",
+    };
+  }
+  return { ok: true, mode: "token_authenticated" };
+}
+
+export default async function handler(req, res) {
+  if (handlePreflight(req, res, { methods: "GET, OPTIONS" })) return;
+  setCorsHeaders(req, res, { methods: "GET, OPTIONS" });
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const auth = resolveAdminAuth(req);
+  if (!auth.ok) {
+    return res
+      .status(auth.status)
+      .json({ error: auth.message, code: auth.code });
+  }
+
+  try {
+    const snapshot = await buildProviderHealthSnapshot();
+    return res.status(200).json({
+      ...snapshot,
+      authMode: auth.mode,
+    });
+  } catch (err) {
+    return res.status(500).json({
+      error: err?.message || "Failed to build provider health snapshot",
+      code: "PROVIDER_HEALTH_FAILED",
+    });
+  }
+}
+
+export const __adminProviderHealthInternals = {
+  resolveAdminAuth,
+  ADMIN_TOKEN_ENV,
+};

--- a/server.cjs
+++ b/server.cjs
@@ -429,6 +429,10 @@ mountDynamicApiRoute('post', '/api/generation-jobs/start',                  'api
 mountDynamicApiRoute('get',  '/api/generation-jobs',                        'api/generation-jobs/index.js');
 mountDynamicApiRoute('get',  '/api/generation-jobs/:jobId',                 'api/generation-jobs/[jobId].js');
 mountDynamicApiRoute('post', '/api/generation-jobs/:jobId/cancel',          'api/generation-jobs/[jobId]/cancel.js');
+// Admin provider-health preflight dashboard (Phase D). Active checks against
+// OpenAI key validity, image-edit model access, storage adapter capabilities,
+// DWG converter / IFC engine env presence. Admin-token gated in production.
+mountDynamicApiRoute('get',  '/api/admin/provider-health',                  'api/admin/provider-health.js');
 // Artifact-package storage + history routes. The serverless handlers under
 // api/project/export/artifact-package/* run natively on Vercel; mount them
 // on the Express dev server too so npm run dev exercises the same surface.

--- a/src/__tests__/api/adminProviderHealth.test.js
+++ b/src/__tests__/api/adminProviderHealth.test.js
@@ -1,0 +1,153 @@
+/**
+ * /api/admin/provider-health — admin-token gating + no-secrets snapshot.
+ *
+ * Verifies the admin endpoint refuses unauthenticated requests in production,
+ * accepts X-Admin-Token, and surfaces the snapshot from
+ * providerHealthService without leaking raw API keys or Authorization
+ * headers.
+ */
+
+import providerHealthHandler from "../../../api/admin/provider-health.js";
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+const SAVED = {};
+const ENV_KEYS = [
+  "ADMIN_HEALTH_TOKEN",
+  "NODE_ENV",
+  "OPENAI_REASONING_API_KEY",
+  "OPENAI_IMAGES_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_IMAGE_MODEL",
+  "DWG_CONVERTER_URL",
+];
+
+beforeEach(() => {
+  ENV_KEYS.forEach((k) => {
+    SAVED[k] = process.env[k];
+    delete process.env[k];
+  });
+  // Default to a fetch that always returns 200 to keep snapshot calls fast
+  global.__originalFetch = global.fetch;
+  global.fetch = jest.fn(async () => ({
+    status: 200,
+    headers: { get: () => "req-mock" },
+  }));
+});
+
+afterEach(() => {
+  ENV_KEYS.forEach((k) => {
+    if (SAVED[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED[k];
+  });
+  if (global.__originalFetch) global.fetch = global.__originalFetch;
+});
+
+describe("/api/admin/provider-health", () => {
+  test("local dev (no NODE_ENV=production, no token configured) — allows anonymous", async () => {
+    const req = { method: "GET", headers: {}, query: {} };
+    const res = createMockResponse();
+    await providerHealthHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.authMode).toBe("local_anonymous");
+    expect(res.body.status).toBeDefined();
+    expect(res.body.checks).toEqual(expect.any(Object));
+  });
+
+  test("production without ADMIN_HEALTH_TOKEN — 503 ADMIN_TOKEN_NOT_CONFIGURED", async () => {
+    process.env.NODE_ENV = "production";
+    const req = { method: "GET", headers: {}, query: {} };
+    const res = createMockResponse();
+    await providerHealthHandler(req, res);
+    expect(res.statusCode).toBe(503);
+    expect(res.body.code).toBe("ADMIN_TOKEN_NOT_CONFIGURED");
+  });
+
+  test("production with token configured — without header → 401 ADMIN_TOKEN_INVALID", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ADMIN_HEALTH_TOKEN = "secret-admin-token-xyz";
+    const req = { method: "GET", headers: {}, query: {} };
+    const res = createMockResponse();
+    await providerHealthHandler(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(res.body.code).toBe("ADMIN_TOKEN_INVALID");
+  });
+
+  test("production with token + correct header → 200 with snapshot", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ADMIN_HEALTH_TOKEN = "secret-admin-token-xyz";
+    const req = {
+      method: "GET",
+      headers: { "x-admin-token": "secret-admin-token-xyz" },
+      query: {},
+    };
+    const res = createMockResponse();
+    await providerHealthHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.authMode).toBe("token_authenticated");
+    expect(res.body.status).toBeDefined();
+  });
+
+  test("response carries no raw keys / Authorization / Bearer / sk- prefix", async () => {
+    process.env.OPENAI_REASONING_API_KEY = "sk-reasoning-FULL-SECRET-TEST-KEY";
+    process.env.OPENAI_IMAGES_API_KEY = "sk-images-DIFFERENT-SECRET-TEST";
+    process.env.OPENAI_IMAGE_MODEL = "gpt-image-2";
+    const req = { method: "GET", headers: {}, query: {} };
+    const res = createMockResponse();
+    await providerHealthHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    const json = JSON.stringify(res.body);
+    expect(json).not.toContain("sk-reasoning-FULL-SECRET-TEST-KEY");
+    expect(json).not.toContain("sk-images-DIFFERENT-SECRET-TEST");
+    expect(json).not.toContain("Bearer ");
+    expect(json).not.toContain("Authorization");
+    // BUT key last4 is allowed (safe to surface for diagnostics)
+    expect(json).toContain("-KEY"); // last4 of OPENAI_REASONING_API_KEY
+  });
+
+  test("non-GET method → 405", async () => {
+    const req = { method: "POST", headers: {}, query: {} };
+    const res = createMockResponse();
+    await providerHealthHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  test("upstream OpenAI 401 propagates as unavailable status without leaking the key", async () => {
+    process.env.OPENAI_REASONING_API_KEY = "sk-bad-key-ABCD";
+    process.env.OPENAI_IMAGE_MODEL = "gpt-image-2";
+    process.env.OPENAI_IMAGES_API_KEY = "sk-bad-key-ABCD";
+    global.fetch = jest.fn(async () => ({
+      status: 401,
+      headers: { get: () => null },
+    }));
+    const req = { method: "GET", headers: {}, query: {} };
+    const res = createMockResponse();
+    await providerHealthHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.checks.openaiReasoning.status).toBe("unavailable");
+    expect(res.body.checks.openaiImages.status).toBe("unavailable");
+    expect(JSON.stringify(res.body)).not.toContain("sk-bad-key-ABCD");
+  });
+});

--- a/src/__tests__/services/health/providerHealthService.test.js
+++ b/src/__tests__/services/health/providerHealthService.test.js
@@ -1,0 +1,242 @@
+import {
+  buildProviderHealthSnapshot,
+  HEALTH_STATUS,
+  __providerHealthInternals,
+} from "../../../services/health/providerHealthService.js";
+
+const {
+  checkOpenAIKey,
+  checkOpenAIImageEditAccess,
+  checkArtifactStorageHealth,
+  checkDwgConverter,
+  checkIfcEngine,
+  rollupOverall,
+} = __providerHealthInternals;
+
+function fakeFetch(scriptedResponses) {
+  const calls = [];
+  return {
+    calls,
+    fn: async (url, init) => {
+      calls.push({ url, init });
+      const next = scriptedResponses.shift() || {
+        status: 500,
+        headers: { get: () => null },
+      };
+      if (typeof next === "function") return next();
+      return next;
+    },
+  };
+}
+
+function fakeAdapter(caps = {}) {
+  return {
+    adapterCapabilities: {
+      adapter: "memory",
+      persistent: false,
+      signedUrls: false,
+      delete: true,
+      list: true,
+      retention: true,
+      ...caps,
+    },
+  };
+}
+
+describe("providerHealthService — checkOpenAIKey", () => {
+  test("missing key returns missing_config and never calls fetch", async () => {
+    const f = fakeFetch([]);
+    const result = await checkOpenAIKey({ key: null, fetchImpl: f.fn });
+    expect(result.status).toBe(HEALTH_STATUS.MISSING_CONFIG);
+    expect(f.calls).toHaveLength(0);
+  });
+
+  test("200 returns ok with last4 of key + requestId", async () => {
+    const f = fakeFetch([
+      {
+        status: 200,
+        headers: { get: (h) => (h === "x-request-id" ? "req-123" : null) },
+      },
+    ]);
+    const result = await checkOpenAIKey({
+      key: "sk-test-abcdEFGH",
+      fetchImpl: f.fn,
+    });
+    expect(result.status).toBe(HEALTH_STATUS.OK);
+    expect(result.keyLast4).toBe("EFGH");
+    expect(result.requestId).toBe("req-123");
+    // Must NOT echo the full key
+    expect(JSON.stringify(result)).not.toContain("sk-test-abcdEFGH");
+  });
+
+  test("401 / 403 → unavailable", async () => {
+    const f = fakeFetch([{ status: 401, headers: { get: () => null } }]);
+    const result = await checkOpenAIKey({ key: "sk-bad", fetchImpl: f.fn });
+    expect(result.status).toBe(HEALTH_STATUS.UNAVAILABLE);
+    expect(result.upstreamStatus).toBe(401);
+  });
+
+  test("5xx → degraded", async () => {
+    const f = fakeFetch([{ status: 503, headers: { get: () => null } }]);
+    const result = await checkOpenAIKey({ key: "sk-x", fetchImpl: f.fn });
+    expect(result.status).toBe(HEALTH_STATUS.DEGRADED);
+    expect(result.upstreamStatus).toBe(503);
+  });
+
+  test("network error → degraded", async () => {
+    const f = fakeFetch([
+      () => Promise.reject(new TypeError("Failed to fetch")),
+    ]);
+    const result = await checkOpenAIKey({ key: "sk-x", fetchImpl: f.fn });
+    expect(result.status).toBe(HEALTH_STATUS.DEGRADED);
+    expect(result.error.code).toBe("NETWORK_ERROR");
+  });
+});
+
+describe("providerHealthService — checkOpenAIImageEditAccess", () => {
+  test("missing model → missing_config", async () => {
+    const f = fakeFetch([]);
+    const result = await checkOpenAIImageEditAccess({
+      key: "sk-x",
+      model: null,
+      fetchImpl: f.fn,
+    });
+    expect(result.status).toBe(HEALTH_STATUS.MISSING_CONFIG);
+    expect(f.calls).toHaveLength(0);
+  });
+
+  test("404 → unavailable (model not accessible)", async () => {
+    const f = fakeFetch([{ status: 404, headers: { get: () => null } }]);
+    const result = await checkOpenAIImageEditAccess({
+      key: "sk-x",
+      model: "gpt-image-2",
+      fetchImpl: f.fn,
+    });
+    expect(result.status).toBe(HEALTH_STATUS.UNAVAILABLE);
+    expect(result.reason).toMatch(/not accessible/i);
+    expect(result.model).toBe("gpt-image-2");
+  });
+
+  test("200 → ok with model + last4", async () => {
+    const f = fakeFetch([{ status: 200, headers: { get: () => "req-img-1" } }]);
+    const result = await checkOpenAIImageEditAccess({
+      key: "sk-test-1234ZYXW",
+      model: "gpt-image-2",
+      fetchImpl: f.fn,
+    });
+    expect(result.status).toBe(HEALTH_STATUS.OK);
+    expect(result.keyLast4).toBe("ZYXW");
+    expect(result.model).toBe("gpt-image-2");
+    expect(JSON.stringify(result)).not.toContain("sk-test-1234ZYXW");
+  });
+});
+
+describe("providerHealthService — checkArtifactStorageHealth", () => {
+  test("no adapter → missing_config", () => {
+    const result = checkArtifactStorageHealth({ adapter: null });
+    expect(result.status).toBe(HEALTH_STATUS.MISSING_CONFIG);
+  });
+
+  test("memory adapter without signed-url secret → degraded", () => {
+    const result = checkArtifactStorageHealth({
+      adapter: fakeAdapter({ signedUrls: false }),
+    });
+    expect(result.status).toBe(HEALTH_STATUS.DEGRADED);
+    expect(result.reason).toMatch(/signed URLs/i);
+  });
+
+  test("adapter with signed-url support → ok", () => {
+    const result = checkArtifactStorageHealth({
+      adapter: fakeAdapter({
+        signedUrls: true,
+        persistent: true,
+        adapter: "s3",
+      }),
+    });
+    expect(result.status).toBe(HEALTH_STATUS.OK);
+    expect(result.adapter).toBe("s3");
+    expect(result.persistent).toBe(true);
+  });
+});
+
+describe("providerHealthService — DWG / IFC", () => {
+  test("DWG: no env → missing_config", () => {
+    expect(checkDwgConverter({ env: {} }).status).toBe(
+      HEALTH_STATUS.MISSING_CONFIG,
+    );
+  });
+  test("DWG: env present → ok", () => {
+    expect(
+      checkDwgConverter({ env: { DWG_CONVERTER_URL: "http://x" } }).status,
+    ).toBe(HEALTH_STATUS.OK);
+  });
+  test("IFC: missing env is missing_config (optional, not unavailable)", () => {
+    expect(checkIfcEngine({ env: {} }).status).toBe(
+      HEALTH_STATUS.MISSING_CONFIG,
+    );
+  });
+});
+
+describe("providerHealthService — rollupOverall", () => {
+  test("any unavailable → unavailable", () => {
+    expect(
+      rollupOverall({
+        a: { status: HEALTH_STATUS.OK },
+        b: { status: HEALTH_STATUS.UNAVAILABLE },
+        c: { status: HEALTH_STATUS.DEGRADED },
+      }),
+    ).toBe(HEALTH_STATUS.UNAVAILABLE);
+  });
+  test("any degraded (no unavailable) → degraded", () => {
+    expect(
+      rollupOverall({
+        a: { status: HEALTH_STATUS.OK },
+        b: { status: HEALTH_STATUS.DEGRADED },
+        c: { status: HEALTH_STATUS.MISSING_CONFIG },
+      }),
+    ).toBe(HEALTH_STATUS.DEGRADED);
+  });
+  test("all ok → ok", () => {
+    expect(
+      rollupOverall({
+        a: { status: HEALTH_STATUS.OK },
+        b: { status: HEALTH_STATUS.OK },
+      }),
+    ).toBe(HEALTH_STATUS.OK);
+  });
+});
+
+describe("providerHealthService — buildProviderHealthSnapshot", () => {
+  test("composes all five checks and returns rollup status + checkedAt", async () => {
+    const f = fakeFetch([
+      { status: 200, headers: { get: () => "req-r" } }, // reasoning
+      { status: 200, headers: { get: () => "req-i" } }, // images
+    ]);
+    const env = {
+      OPENAI_REASONING_API_KEY: "sk-reasoning-abcd",
+      OPENAI_IMAGES_API_KEY: "sk-images-wxyz",
+      OPENAI_IMAGE_MODEL: "gpt-image-2",
+      DWG_CONVERTER_URL: "http://dwg.example",
+    };
+    const snapshot = await buildProviderHealthSnapshot({
+      env,
+      fetchImpl: f.fn,
+      adapter: fakeAdapter({ signedUrls: true }),
+    });
+
+    expect(snapshot.status).toBe(HEALTH_STATUS.MISSING_CONFIG); // ifcEngine
+    expect(snapshot.checks.openaiReasoning.status).toBe(HEALTH_STATUS.OK);
+    expect(snapshot.checks.openaiImages.status).toBe(HEALTH_STATUS.OK);
+    expect(snapshot.checks.artifactStorage.status).toBe(HEALTH_STATUS.OK);
+    expect(snapshot.checks.dwgConverter.status).toBe(HEALTH_STATUS.OK);
+    expect(snapshot.checks.ifcEngine.status).toBe(HEALTH_STATUS.MISSING_CONFIG);
+    expect(snapshot.checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // No raw keys / Authorization headers / sk- in serialised snapshot
+    const json = JSON.stringify(snapshot);
+    expect(json).not.toContain("sk-reasoning-abcd");
+    expect(json).not.toContain("sk-images-wxyz");
+    expect(json).not.toContain("Bearer ");
+    expect(json).not.toContain("Authorization");
+  });
+});

--- a/src/services/health/providerHealthService.js
+++ b/src/services/health/providerHealthService.js
@@ -1,0 +1,359 @@
+/* global globalThis */
+/**
+ * Provider health / preflight service.
+ *
+ * Composes a single snapshot of "are we ready to serve requests" suitable
+ * for an admin dashboard. Each check returns one of four canonical statuses:
+ *
+ *   ok              — configured and reachable
+ *   degraded        — configured but a non-fatal issue (e.g. signed URLs
+ *                     unavailable but storage adapter responds)
+ *   missing_config  — env vars missing; user action required to enable
+ *   unavailable     — configured but upstream rejected access (401/403/etc)
+ *
+ * Each check carries a safe `detail` field — provider request id where
+ * available, error code, last4 of api key — but NEVER the raw key, env, or
+ * authorization header. Callers (api/admin/provider-health.js) can echo the
+ * full snapshot back to an authenticated admin without leaking secrets.
+ *
+ * Dependency injection (`fetchImpl`, env override, adapter override) keeps
+ * the service unit-testable without touching real upstreams.
+ */
+
+import { getDefaultArtifactStorageAdapter } from "../export/artifactStorageService.js";
+
+export const HEALTH_STATUS = Object.freeze({
+  OK: "ok",
+  DEGRADED: "degraded",
+  MISSING_CONFIG: "missing_config",
+  UNAVAILABLE: "unavailable",
+});
+
+const SAFE_KEY_LAST4 = (key) => {
+  if (typeof key !== "string" || key.length < 4) return null;
+  return key.slice(-4);
+};
+
+function resolveOpenAIReasoningKey(env) {
+  return (
+    env.OPENAI_REASONING_API_KEY ||
+    env.OPENAI_API_KEY ||
+    env.STEP_00_ORCHESTRATOR_API_KEY ||
+    null
+  );
+}
+
+function resolveOpenAIImagesKey(env) {
+  return env.OPENAI_IMAGES_API_KEY || env.OPENAI_API_KEY || null;
+}
+
+function describeFetchError(err) {
+  if (!err) return { code: "UNKNOWN", message: "unknown error" };
+  if (err.name === "AbortError") {
+    return { code: "TIMEOUT", message: "Provider request timed out" };
+  }
+  if (err instanceof TypeError) {
+    return { code: "NETWORK_ERROR", message: err.message || "network error" };
+  }
+  return {
+    code: err.code || "FETCH_ERROR",
+    message: err.message || String(err),
+  };
+}
+
+/**
+ * GET https://api.openai.com/v1/models — cheapest way to verify a key works.
+ * Returns ok if 200, unavailable if 401/403, degraded on 5xx (transient).
+ */
+async function checkOpenAIKey({ key, fetchImpl, timeoutMs = 5000 }) {
+  if (!key) {
+    return {
+      status: HEALTH_STATUS.MISSING_CONFIG,
+      reason: "Key not configured",
+      detail: null,
+    };
+  }
+  let controller;
+  try {
+    controller =
+      typeof globalThis.AbortController === "function"
+        ? new globalThis.AbortController()
+        : null;
+    const timer = controller
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+    const res = await fetchImpl("https://api.openai.com/v1/models", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${key}` },
+      signal: controller?.signal,
+    });
+    if (timer) clearTimeout(timer);
+    const requestId =
+      res.headers?.get?.("x-request-id") ||
+      res.headers?.get?.("openai-request-id") ||
+      null;
+
+    if (res.status === 200) {
+      return {
+        status: HEALTH_STATUS.OK,
+        keyLast4: SAFE_KEY_LAST4(key),
+        requestId,
+      };
+    }
+    if (res.status === 401 || res.status === 403) {
+      return {
+        status: HEALTH_STATUS.UNAVAILABLE,
+        reason: `Provider rejected key (${res.status})`,
+        keyLast4: SAFE_KEY_LAST4(key),
+        requestId,
+        upstreamStatus: res.status,
+      };
+    }
+    return {
+      status: HEALTH_STATUS.DEGRADED,
+      reason: `Provider returned ${res.status}`,
+      keyLast4: SAFE_KEY_LAST4(key),
+      requestId,
+      upstreamStatus: res.status,
+    };
+  } catch (err) {
+    return {
+      status: HEALTH_STATUS.DEGRADED,
+      reason: "Could not reach provider",
+      keyLast4: SAFE_KEY_LAST4(key),
+      error: describeFetchError(err),
+    };
+  }
+}
+
+/**
+ * gpt-image edit access requires the image-edit endpoint to accept a
+ * multipart request without a 401/403/404. We do a lightweight HEAD-style
+ * probe by checking model existence for the configured image model.
+ */
+async function checkOpenAIImageEditAccess({
+  key,
+  model,
+  fetchImpl,
+  timeoutMs = 5000,
+}) {
+  if (!key) {
+    return {
+      status: HEALTH_STATUS.MISSING_CONFIG,
+      reason: "OPENAI_IMAGES_API_KEY (or OPENAI_API_KEY) not configured",
+    };
+  }
+  if (!model) {
+    return {
+      status: HEALTH_STATUS.MISSING_CONFIG,
+      reason: "OPENAI_IMAGE_MODEL not configured",
+    };
+  }
+  let controller;
+  try {
+    controller =
+      typeof globalThis.AbortController === "function"
+        ? new globalThis.AbortController()
+        : null;
+    const timer = controller
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+    const res = await fetchImpl(
+      `https://api.openai.com/v1/models/${encodeURIComponent(model)}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${key}` },
+        signal: controller?.signal,
+      },
+    );
+    if (timer) clearTimeout(timer);
+    const requestId =
+      res.headers?.get?.("x-request-id") ||
+      res.headers?.get?.("openai-request-id") ||
+      null;
+
+    if (res.status === 200) {
+      return {
+        status: HEALTH_STATUS.OK,
+        model,
+        keyLast4: SAFE_KEY_LAST4(key),
+        requestId,
+      };
+    }
+    if (res.status === 404) {
+      return {
+        status: HEALTH_STATUS.UNAVAILABLE,
+        reason: `Image model "${model}" not accessible to this account`,
+        model,
+        keyLast4: SAFE_KEY_LAST4(key),
+        requestId,
+        upstreamStatus: 404,
+      };
+    }
+    if (res.status === 401 || res.status === 403) {
+      return {
+        status: HEALTH_STATUS.UNAVAILABLE,
+        reason: `Provider rejected key for image model (${res.status})`,
+        model,
+        keyLast4: SAFE_KEY_LAST4(key),
+        requestId,
+        upstreamStatus: res.status,
+      };
+    }
+    return {
+      status: HEALTH_STATUS.DEGRADED,
+      reason: `Provider returned ${res.status} for image model probe`,
+      model,
+      keyLast4: SAFE_KEY_LAST4(key),
+      requestId,
+      upstreamStatus: res.status,
+    };
+  } catch (err) {
+    return {
+      status: HEALTH_STATUS.DEGRADED,
+      reason: "Could not reach provider for image model probe",
+      model,
+      keyLast4: SAFE_KEY_LAST4(key),
+      error: describeFetchError(err),
+    };
+  }
+}
+
+/**
+ * Storage adapter health: capability snapshot + (where possible) a tiny
+ * round-trip that doesn't write anything. We rely on adapterCapabilities
+ * since memory/filesystem/S3 all expose it; signed-URL absence is
+ * `degraded`, not `unavailable`.
+ */
+function checkArtifactStorageHealth({ adapter }) {
+  if (!adapter) {
+    return {
+      status: HEALTH_STATUS.MISSING_CONFIG,
+      reason: "Storage adapter not initialised",
+    };
+  }
+  const caps = adapter.adapterCapabilities || {};
+  const status = caps.signedUrls ? HEALTH_STATUS.OK : HEALTH_STATUS.DEGRADED;
+  return {
+    status,
+    adapter: caps.adapter || "unknown",
+    persistent: Boolean(caps.persistent),
+    signedUrls: Boolean(caps.signedUrls),
+    retention: Boolean(caps.retention),
+    list: Boolean(caps.list),
+    delete: Boolean(caps.delete),
+    reason:
+      status === HEALTH_STATUS.DEGRADED
+        ? "Adapter does not support signed URLs (set ARTIFACT_PACKAGE_SIGNING_SECRET to enable)"
+        : null,
+  };
+}
+
+/**
+ * DWG converter: env presence only; actual round-trip is too expensive for
+ * a health check. The artifact ZIP path emits a sourceGap when the
+ * converter is unreachable.
+ */
+function checkDwgConverter({ env }) {
+  const configured =
+    Boolean(env.DWG_CONVERTER_URL) ||
+    Boolean(env.DWG_CONVERTER_API_KEY) ||
+    Boolean(env.LIBREDWG_PATH);
+  if (!configured) {
+    return {
+      status: HEALTH_STATUS.MISSING_CONFIG,
+      reason:
+        "No DWG converter configured (set DWG_CONVERTER_URL or LIBREDWG_PATH)",
+    };
+  }
+  return {
+    status: HEALTH_STATUS.OK,
+    transport: env.DWG_CONVERTER_URL ? "remote" : "local",
+  };
+}
+
+/**
+ * IFC engine: env presence only. Optional — absent is missing_config (not
+ * unavailable) so dashboards don't false-alarm.
+ */
+function checkIfcEngine({ env }) {
+  const configured =
+    Boolean(env.IFC_ENGINE_URL) || Boolean(env.IFC_OPENBIM_PATH);
+  if (!configured) {
+    return {
+      status: HEALTH_STATUS.MISSING_CONFIG,
+      reason: "No IFC engine configured (optional)",
+    };
+  }
+  return { status: HEALTH_STATUS.OK };
+}
+
+function rollupOverall(checks) {
+  const statuses = Object.values(checks).map((c) => c?.status);
+  if (statuses.includes(HEALTH_STATUS.UNAVAILABLE)) {
+    return HEALTH_STATUS.UNAVAILABLE;
+  }
+  if (statuses.includes(HEALTH_STATUS.DEGRADED)) {
+    return HEALTH_STATUS.DEGRADED;
+  }
+  if (statuses.every((s) => s === HEALTH_STATUS.OK)) {
+    return HEALTH_STATUS.OK;
+  }
+  return HEALTH_STATUS.MISSING_CONFIG;
+}
+
+export async function buildProviderHealthSnapshot({
+  env = globalThis.process?.env || {},
+  fetchImpl = globalThis.fetch?.bind(globalThis),
+  adapter = null,
+  timeoutMs = 5000,
+} = {}) {
+  const reasoningKey = resolveOpenAIReasoningKey(env);
+  const imagesKey = resolveOpenAIImagesKey(env);
+  const imageModel =
+    env.OPENAI_IMAGE_MODEL || env.STEP_07_PROJECT_GRAPH_MODEL || null;
+  const resolvedAdapter = adapter || tryGetAdapter();
+
+  const [openaiReasoning, openaiImages] = await Promise.all([
+    checkOpenAIKey({ key: reasoningKey, fetchImpl, timeoutMs }),
+    checkOpenAIImageEditAccess({
+      key: imagesKey,
+      model: imageModel,
+      fetchImpl,
+      timeoutMs,
+    }),
+  ]);
+
+  const checks = {
+    openaiReasoning,
+    openaiImages,
+    artifactStorage: checkArtifactStorageHealth({ adapter: resolvedAdapter }),
+    dwgConverter: checkDwgConverter({ env }),
+    ifcEngine: checkIfcEngine({ env }),
+  };
+
+  return {
+    status: rollupOverall(checks),
+    checkedAt: new Date().toISOString(),
+    pipelineMode:
+      env.PIPELINE_MODE || env.REACT_APP_PIPELINE_MODE || "project_graph",
+    checks,
+  };
+}
+
+function tryGetAdapter() {
+  try {
+    return getDefaultArtifactStorageAdapter();
+  } catch (_err) {
+    return null;
+  }
+}
+
+export const __providerHealthInternals = {
+  checkOpenAIKey,
+  checkOpenAIImageEditAccess,
+  checkArtifactStorageHealth,
+  checkDwgConverter,
+  checkIfcEngine,
+  rollupOverall,
+};


### PR DESCRIPTION
## Why

Admins (and ops smoke checks) need a single endpoint that answers "is the platform actually configured + reachable for OpenAI reasoning, OpenAI image edit, artifact storage, DWG converter, and IFC engine?" without running a full generation. The existing `/api/health` endpoint only echoes key presence — useful for liveness probes but not for "will my next generation actually work?". This phase adds an admin-only endpoint that does live preflight checks and rolls up to a single overall status.

## What

**`src/services/health/providerHealthService.js`** — composable preflight service:

| Check | Method | OK condition | unavailable | degraded | missing_config |
|---|---|---|---|---|---|
| `checkOpenAIKey` | GET `/v1/models` | 200 | 401 / 403 | 5xx, network | no key |
| `checkOpenAIImageEditAccess` | GET `/v1/models/{OPENAI_IMAGE_MODEL}` | 200 | 404 (model not entitled) / 401 / 403 | 5xx, network | no key or model |
| `checkArtifactStorageHealth` | adapter capabilities | signedUrls=true | — | signedUrls=false (hint to set `ARTIFACT_PACKAGE_SIGNING_SECRET`) | no adapter |
| `checkDwgConverter` | env presence | `DWG_CONVERTER_URL` / `DWG_CONVERTER_API_KEY` / `LIBREDWG_PATH` | — | — | none configured |
| `checkIfcEngine` | env presence (optional) | `IFC_ENGINE_URL` / `IFC_OPENBIM_PATH` | — | — | none configured |

`rollupOverall` precedence: any **unavailable** wins, else any **degraded**, else all-OK, else **missing_config**.

Each check returns only safe diagnostic fields: `keyLast4` (4 chars), `requestId` (provider-supplied), `upstreamStatus`, model name. **NEVER** raw API key, Authorization header, or env value (locked in by tests).

**`api/admin/provider-health.js`** — admin-only endpoint:

- `GET /api/admin/provider-health` mounted on Express + Vercel.
- Auth: `X-Admin-Token` header against `ADMIN_HEALTH_TOKEN` env.
  - Local dev (`NODE_ENV != production`) and no token configured → anonymous allowed (mirrors the artifact stack's local-anonymous tolerance).
  - Production with no token → 503 `ADMIN_TOKEN_NOT_CONFIGURED` — production deployments MUST set `ADMIN_HEALTH_TOKEN`.
  - Production with wrong token → 401 `ADMIN_TOKEN_INVALID`.
- Response merges the snapshot with `authMode: token_authenticated | local_anonymous`.

## Scope notes

- **No admin UI in this PR.** There's no existing admin/settings surface in the client. Adding one would balloon the PR. The JSON endpoint + this description is enough for ops curls / external dashboards. UI panel can be its own follow-up.
- Existing `/api/health` endpoint untouched — still useful for liveness probes.

## Tests (25/25 pass)

- 18 service tests: each check-fn under missing-config / 200 / 401 / 404 / 5xx / network-error scenarios; rollup precedence; key last4 surfacing without leaking the full key.
- 7 API tests: local-anonymous in dev, 503 in production w/o token, 401 with wrong token, 200 with right token, no-secrets snapshot (raw keys / `Bearer ` / `Authorization` scrubbed), 405 on POST, upstream 401 propagates as `unavailable` without leaking the key.

## Validation

- `npm run lint` ✅ · `git diff --check` ✅ · `npm run check:env` ✅ · `npm run check:contracts` ✅ · `npm run build:active` ✅

## Blocker audit

- ✅ No secrets / env / tokens in any response body (locked in by 3 separate tests).
- ✅ No fake DWG/IFC/PDF outputs.
- ✅ No image-generated technical drawings.
- ✅ Authority gates untouched.
- ✅ `packageHash` deterministic — pre-bake from PR #119 unchanged; no package builder code touched.
- ✅ No changes to ProjectGraph / A1 / CAD / DWG / IFC / structural / MEP / details engines.
- ✅ Production posture: token gate REQUIRED in production (503 otherwise), so the endpoint never goes anonymous on a live deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)