### PR TITLE
Fix live non-residential programme-space UI flow

### DIFF
--- a/src/__tests__/components/ArchitectAIWizardContainer.programmeFlow.test.jsx
+++ b/src/__tests__/components/ArchitectAIWizardContainer.programmeFlow.test.jsx
@@ -1,0 +1,419 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import ArchitectAIWizardContainer, {
+  sanitizeProgrammeAreaInput,
+} from "../../components/ArchitectAIWizardContainer.jsx";
+import { PROJECT_TYPE_ROUTES } from "../../services/project/projectTypeSupportRegistry.js";
+import { UK_RESIDENTIAL_V2_PIPELINE_VERSION } from "../../services/project/v2ProjectContracts.js";
+
+let mockInitialProjectDetails;
+let mockSiteMetrics;
+let mockLastProgramSpaces;
+let mockLastProjectDetails;
+
+jest.mock("framer-motion", () => {
+  const ReactInner = require("react");
+  const createMotionMock = (tagName = "div") => {
+    const MotionMock = ReactInner.forwardRef(
+      (
+        {
+          children,
+          initial,
+          animate,
+          exit,
+          transition,
+          whileHover,
+          whileTap,
+          variants,
+          layout,
+          ...props
+        },
+        ref,
+      ) => ReactInner.createElement(tagName, { ref, ...props }, children),
+    );
+    MotionMock.displayName = `MotionMock.${tagName}`;
+    return MotionMock;
+  };
+  const motionMocks = new Map();
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: (_target, property) => {
+          const tagName = typeof property === "string" ? property : "div";
+          if (!motionMocks.has(tagName)) {
+            motionMocks.set(tagName, createMotionMock(tagName));
+          }
+          return motionMocks.get(tagName);
+        },
+      },
+    ),
+    AnimatePresence: ({ children }) => <>{children}</>,
+    useMotionValue: () => ({ get: () => 0, set: () => {} }),
+    useSpring: (value) => value,
+    useTransform: () => 0,
+  };
+});
+
+jest.mock("../../components/layout", () => ({
+  AppShell: ({ children }) => <div>{children}</div>,
+  PageTransition: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock("../../components/DesignHistoryMenu.jsx", () => () => null);
+
+jest.mock("../../services/auth/clerkFacade.js", () => ({
+  AuthSignInButton: ({ children }) => <>{children}</>,
+  AuthSignedIn: ({ children }) => <>{children}</>,
+  AuthSignedOut: ({ children }) => <>{children}</>,
+  clerkAuthConfigured: false,
+}));
+
+jest.mock("../../utils/portfolioFileProcessing.js", () => ({
+  processPortfolioUploadFiles: jest.fn(),
+  releasePortfolioFilePreviewUrls: jest.fn(),
+}));
+
+jest.mock("../../hooks/useArchitectAIWorkflow.js", () => ({
+  useArchitectAIWorkflow: () => ({
+    loading: false,
+    error: null,
+    result: null,
+    progress: {},
+    generateSheet: jest.fn(),
+    modifySheetWorkflow: jest.fn(),
+    exportSheetWorkflow: jest.fn(),
+    loadDesign: jest.fn(),
+    listDesigns: jest.fn(() => []),
+    clearError: jest.fn(),
+    loadDemoResult: jest.fn(),
+  }),
+}));
+
+jest.mock("../../hooks/useWizardState.js", () => {
+  const ReactInner = require("react");
+  return {
+    useWizardState: () => {
+      const [projectDetails, setProjectDetailsState] = ReactInner.useState(
+        mockInitialProjectDetails,
+      );
+      const [programSpaces, setProgramSpacesState] = ReactInner.useState([]);
+      const [programWarnings, setProgramWarnings] = ReactInner.useState([]);
+      const [isGeneratingSpaces, setIsGeneratingSpaces] =
+        ReactInner.useState(false);
+
+      const setProjectDetails = (value) => {
+        setProjectDetailsState((prev) => {
+          const next = typeof value === "function" ? value(prev) : value;
+          mockLastProjectDetails = next;
+          return next;
+        });
+      };
+
+      const setProgramSpaces = (value) => {
+        setProgramSpacesState((prev) => {
+          const next = typeof value === "function" ? value(prev) : value;
+          mockLastProgramSpaces = next;
+          return next;
+        });
+      };
+
+      return {
+        currentStep: 4,
+        setCurrentStep: jest.fn(),
+        address: "10 Downing Street, London, UK",
+        setAddress: jest.fn(),
+        isDetectingLocation: false,
+        setIsDetectingLocation: jest.fn(),
+        locationData: {
+          coordinates: { lat: 51.5034, lng: -0.1276 },
+          address: "10 Downing Street, London, UK",
+        },
+        setLocationData: jest.fn(),
+        sitePolygon: [],
+        setSitePolygon: jest.fn(),
+        siteMetrics: mockSiteMetrics,
+        setSiteMetrics: jest.fn(),
+        locationAccuracy: null,
+        setLocationAccuracy: jest.fn(),
+        portfolioFiles: [],
+        setPortfolioFiles: jest.fn(),
+        materialWeight: 0.7,
+        setMaterialWeight: jest.fn(),
+        characteristicWeight: 0.7,
+        setCharacteristicWeight: jest.fn(),
+        isUploading: false,
+        setIsUploading: jest.fn(),
+        projectDetails,
+        setProjectDetails,
+        programSpaces,
+        setProgramSpaces,
+        programWarnings,
+        setProgramWarnings,
+        isGeneratingSpaces,
+        setIsGeneratingSpaces,
+        isDetectingEntrance: false,
+        setIsDetectingEntrance: jest.fn(),
+        autoDetectResult: null,
+        setAutoDetectResult: jest.fn(),
+        generatedDesignId: null,
+        setGeneratedDesignId: jest.fn(),
+      };
+    },
+  };
+});
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function baseProjectDetails(overrides = {}) {
+  return {
+    category: "commercial",
+    subType: "office",
+    customNotes: "",
+    area: 1200,
+    floorCount: 3,
+    floorCountLocked: true,
+    autoDetectedFloorCount: null,
+    floorMetrics: null,
+    footprintArea: "",
+    entranceDirection: "N",
+    entranceManualOverride: true,
+    entranceAutoDetected: false,
+    entranceConfidence: 1,
+    mainEntry: null,
+    mainEntryDirection: null,
+    mainEntryBearingDeg: null,
+    frontageEdgeId: null,
+    mainEntryEdgeId: null,
+    program: "office",
+    qualityTier: "mid",
+    pipelineVersion: UK_RESIDENTIAL_V2_PIPELINE_VERSION,
+    projectTypeExplicitlySetByUser: true,
+    ...overrides,
+  };
+}
+
+function renderComponent(projectDetails, { siteMetrics = null } = {}) {
+  mockInitialProjectDetails = projectDetails;
+  mockLastProjectDetails = projectDetails;
+  mockLastProgramSpaces = [];
+  mockSiteMetrics = siteMetrics;
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<ArchitectAIWizardContainer />);
+  });
+  return {
+    container,
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function clickGenerate(container) {
+  const button = [...container.querySelectorAll("button")].find((entry) =>
+    /Generate Program|Compile Program/.test(entry.textContent || ""),
+  );
+  expect(button).toBeTruthy();
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+  });
+  await flushPromises();
+}
+
+function expectProgrammeRows({
+  floorCount,
+  route = PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+}) {
+  expect(mockLastProgramSpaces.length).toBeGreaterThan(0);
+  mockLastProgramSpaces.forEach((space) => {
+    expect(space).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        name: expect.any(String),
+        label: expect.any(String),
+        area: expect.any(Number),
+        count: expect.any(Number),
+        type: expect.any(String),
+        category: expect.any(String),
+        spaceType: expect.any(String),
+        level: expect.any(String),
+        levelIndex: expect.any(Number),
+        level_index: expect.any(Number),
+      }),
+    );
+    expect(space.area).toBeGreaterThan(0);
+    expect(space.levelIndex).toBeGreaterThanOrEqual(0);
+    expect(space.levelIndex).toBeLessThan(floorCount);
+    if (route === PROJECT_TYPE_ROUTES.PROJECT_GRAPH) {
+      expect(space.source).toBe("deterministic_project_graph_template");
+    }
+  });
+}
+
+const supportedUiCases = [
+  ["commercial > office", "commercial", "office", 1200, 3],
+  ["healthcare > clinic", "healthcare", "clinic", 1300, 2],
+  ["education > school", "education", "school", 1800, 3],
+  ["commercial > retail", "commercial", "retail", 1400, 2],
+  ["hospitality > hotel", "hospitality", "hotel", 2600, 4],
+  ["industrial > warehouse", "industrial", "warehouse", 2200, 2],
+];
+
+describe("ArchitectAIWizardContainer programme UI flow", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn(() =>
+      Promise.reject(new Error("OpenAI should not be required for UI rows")),
+    );
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  test("accepts realistic non-residential total areas above dimension limits", () => {
+    expect(sanitizeProgrammeAreaInput(1200)).toBe(1200);
+    expect(sanitizeProgrammeAreaInput("2600 m2")).toBe(2600);
+    expect(sanitizeProgrammeAreaInput("")).toBeNull();
+  });
+
+  test.each(supportedUiCases)(
+    "%s populates rendered programme rows through the wizard handler",
+    async (_label, category, subType, area, floorCount) => {
+      const { container, unmount } = renderComponent(
+        baseProjectDetails({
+          category,
+          subType,
+          program: subType,
+          area,
+          floorCount,
+          floorCountLocked: true,
+        }),
+      );
+
+      await clickGenerate(container);
+
+      expectProgrammeRows({ floorCount });
+      expect(mockLastProjectDetails).toEqual(
+        expect.objectContaining({
+          category,
+          subType,
+          projectTypeRoute: PROJECT_TYPE_ROUTES.PROJECT_GRAPH,
+        }),
+      );
+      expect(container.querySelectorAll("tbody tr").length).toBe(
+        mockLastProgramSpaces.length + 1,
+      );
+      expect(container.querySelectorAll("tbody select").length).toBe(
+        mockLastProgramSpaces.length,
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+      unmount();
+    },
+  );
+
+  test("unsupported type fails clearly without silently returning empty rows", async () => {
+    const { container, unmount } = renderComponent(
+      baseProjectDetails({
+        category: "commercial",
+        subType: "casino",
+        program: "casino",
+        area: 1200,
+      }),
+    );
+
+    await clickGenerate(container);
+
+    expect(mockLastProgramSpaces).toEqual([]);
+    expect(container.textContent).toMatch(/Experimental\/off|not enabled/i);
+    unmount();
+  });
+
+  test("detached-house still uses Residential V2 deterministic compile", async () => {
+    const { container, unmount } = renderComponent(
+      baseProjectDetails({
+        category: "residential",
+        subType: "detached-house",
+        program: "detached-house",
+        area: 180,
+        floorCount: 2,
+      }),
+    );
+
+    await clickGenerate(container);
+
+    expect(mockLastProgramSpaces.length).toBeGreaterThan(0);
+    expect(mockLastProjectDetails).toEqual(
+      expect.objectContaining({
+        projectTypeRoute: PROJECT_TYPE_ROUTES.RESIDENTIAL_V2,
+        pipelineVersion: UK_RESIDENTIAL_V2_PIPELINE_VERSION,
+      }),
+    );
+    expect(container.textContent).toMatch(
+      /Compiled deterministic UK residential program/i,
+    );
+    unmount();
+  });
+
+  test("OpenAI reasoning failure does not block non-residential deterministic rows", async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error("network down")));
+    const { container, unmount } = renderComponent(
+      baseProjectDetails({
+        category: "healthcare",
+        subType: "clinic",
+        program: "clinic",
+        area: 1300,
+        floorCount: 2,
+      }),
+    );
+
+    await clickGenerate(container);
+
+    expectProgrammeRows({ floorCount: 2 });
+    expect(global.fetch).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test("auto floor-count sync keeps generated rows and level assignments", async () => {
+    const { container, unmount } = renderComponent(
+      baseProjectDetails({
+        category: "education",
+        subType: "school",
+        program: "school",
+        area: 1800,
+        floorCount: 3,
+        floorCountLocked: false,
+      }),
+      {
+        siteMetrics: { areaM2: 900 },
+      },
+    );
+
+    await clickGenerate(container);
+    await flushPromises();
+
+    expectProgrammeRows({
+      floorCount: mockLastProjectDetails.autoDetectedFloorCount || 3,
+    });
+    expect(container.querySelectorAll("tbody tr").length).toBeGreaterThan(1);
+    unmount();
+  });
+});

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -43,10 +43,7 @@ import {
   getCurrentPipelineMode,
   PIPELINE_MODE,
 } from "../config/pipelineMode.js";
-import {
-  sanitizePromptInput,
-  sanitizeDimensionInput,
-} from "../utils/promptSanitizer.js";
+import { sanitizePromptInput } from "../utils/promptSanitizer.js";
 import buildingFootprintService from "../services/buildingFootprintService.js";
 import { resolveUiSiteBoundaryAuthority } from "../services/siteBoundaryUiAuthority.js";
 import { selectContextualBoundaryPolygon } from "../services/siteBoundaryAutoDetectPolicy.js";
@@ -74,10 +71,7 @@ import {
   syncProgramToFloorCount,
 } from "../services/project/floorCountAuthority.js";
 import { normalizeProgramSpaces } from "../services/project/levelUtils.js";
-import {
-  generateDeterministicProgramSpaces,
-  getProgrammeGuidanceForProjectType,
-} from "../services/project/programmeSpaceGenerator.js";
+import { generateDeterministicProgramSpaces } from "../services/project/programmeSpaceGenerator.js";
 import PricingPage from "./PricingPage.jsx";
 import DesignHistoryMenu from "./DesignHistoryMenu.jsx";
 
@@ -104,6 +98,79 @@ import {
 } from "../services/auth/clerkFacade.js";
 
 const ResultsStep = lazy(() => import("./steps/ResultsStep.jsx"));
+
+const MAX_PROGRAMME_AREA_M2 = 100000;
+
+export function sanitizeProgrammeAreaInput(value) {
+  if (value == null || value === "") return null;
+  const numericToken = String(value)
+    .replace(/,/g, "")
+    .match(/\d+(?:\.\d+)?/);
+  const parsed = numericToken ? parseFloat(numericToken[0]) : NaN;
+  if (
+    !Number.isFinite(parsed) ||
+    parsed <= 0 ||
+    parsed > MAX_PROGRAMME_AREA_M2
+  ) {
+    return null;
+  }
+  return Math.round(parsed * 100) / 100;
+}
+
+function logCompileBreadcrumb(label, payload) {
+  if (process.env.NODE_ENV === "production") return;
+  console.info(`[compileProgram] ${label}`, payload);
+}
+
+function normalizeUiProgramSpaces(spaces = [], source = "programme_compile") {
+  const normalized = (Array.isArray(spaces) ? spaces : []).map(
+    (space, index) => {
+      const name = String(space?.name || space?.label || `Space ${index + 1}`);
+      const rawLevelIndex = Number(space?.levelIndex ?? space?.level_index);
+      const fallbackType =
+        space?.type || space?.spaceType || space?.category || "generic";
+      return {
+        ...space,
+        id: space?.id || `space_${source}_${index + 1}`,
+        name,
+        label: String(space?.label || name),
+        area: Math.max(0, Number(space?.area || 0)),
+        count: Math.max(1, Number(space?.count || 1)),
+        type: fallbackType,
+        category: space?.category || fallbackType,
+        spaceType: space?.spaceType || fallbackType,
+        level: space?.level || "Ground",
+        levelIndex: Number.isFinite(rawLevelIndex) ? rawLevelIndex : undefined,
+        level_index: Number.isFinite(rawLevelIndex) ? rawLevelIndex : undefined,
+        source: space?.source || source,
+      };
+    },
+  );
+  normalized._calculatedFloorCount = spaces?._calculatedFloorCount;
+  normalized._floorMetrics = spaces?._floorMetrics ?? null;
+  return normalized;
+}
+
+function uniqueProgramWarnings(...groups) {
+  return Array.from(new Set(groups.flat().filter(Boolean)));
+}
+
+function programSpacesCoverFloorCount(spaces = [], floorCount = 1) {
+  const safeFloorCount = Math.max(1, Math.floor(Number(floorCount) || 1));
+  if (!Array.isArray(spaces) || spaces.length === 0) return false;
+  const calculated = Number(spaces._calculatedFloorCount);
+  const levels = new Set(
+    spaces
+      .map((space) => Number(space?.levelIndex ?? space?.level_index))
+      .filter(Number.isFinite),
+  );
+  return (
+    calculated === safeFloorCount &&
+    Array.from({ length: safeFloorCount }, (_, index) => index).every((index) =>
+      levels.has(index),
+    )
+  );
+}
 
 // Step Progress Bar Component — compact form on mobile, full circles on md+
 const StepProgressBar = ({ steps, currentStep }) => {
@@ -1229,7 +1296,7 @@ const ArchitectAIWizardContainer = () => {
         maxLength: 120,
         allowNewlines: false,
       });
-      const sanitizedArea = sanitizeDimensionInput(projectDetails.area);
+      const sanitizedArea = sanitizeProgrammeAreaInput(projectDetails.area);
       const siteArea = siteMetrics?.areaM2 || 0;
       // Single source of truth for floor count. Every downstream call -
       // residential engine, generic AI prompt, post-gen sync, setProjectDetails -
@@ -1257,10 +1324,20 @@ const ArchitectAIWizardContainer = () => {
         }`,
         compileAuthorityLog,
       );
+      logCompileBreadcrumb("projectTypeSupport", {
+        categoryId: projectTypeSupport.categoryId,
+        subtypeId: projectTypeSupport.subtypeId,
+        route: projectTypeSupport.route,
+        supportStatus: projectTypeSupport.supportStatus,
+        enabledInUi: projectTypeSupport.enabledInUi,
+      });
+      logCompileBreadcrumb("canonicalBuildingType", {
+        canonicalBuildingType: projectTypeSupport.canonicalBuildingType,
+      });
 
       if (!sanitizedProgram || !sanitizedArea) {
         setProgramWarnings([
-          "Provide building type and area to generate a program.",
+          "Provide a supported building type and a valid total area to generate a program.",
         ]);
         return;
       }
@@ -1445,100 +1522,30 @@ const ArchitectAIWizardContainer = () => {
         return spaces;
       }
 
-      // Generic AI path uses the same authoritative floor count as the
-      // residential path. Locked > autoDetected > manual > fallback.
-      const floorCountForPrompt = authoritativeFloorCount;
+      // ProjectGraph non-residential programme rows must appear without
+      // waiting on model availability. The deterministic template is the
+      // runtime source for the visible UI schedule; downstream ProjectGraph
+      // generation receives these rows as the programme lock.
+      const floorCountForProgram = authoritativeFloorCount;
+      const deterministic = generateDeterministicProgramSpaces({
+        projectDetails,
+        projectTypeSupport,
+        floorCount: floorCountForProgram,
+        targetAreaM2: sanitizedArea,
+      });
+      const programSource = deterministic.source;
 
-      const ordinal = (n) => {
-        const mod10 = n % 10;
-        const mod100 = n % 100;
-        if (mod10 === 1 && mod100 !== 11) return `${n}st`;
-        if (mod10 === 2 && mod100 !== 12) return `${n}nd`;
-        if (mod10 === 3 && mod100 !== 13) return `${n}rd`;
-        return `${n}th`;
-      };
-
-      const levelNames = (() => {
-        const levels = ["Ground"];
-        if (floorCountForPrompt >= 2) levels.push("First");
-        if (floorCountForPrompt >= 3) levels.push("Second");
-        if (floorCountForPrompt >= 4) levels.push("Third");
-        for (let i = 5; i <= floorCountForPrompt; i++)
-          levels.push(ordinal(i - 1));
-        return levels;
-      })();
-
-      const programmeGuidance = getProgrammeGuidanceForProjectType(
-        projectTypeSupport.canonicalBuildingType,
+      let spaces = normalizeUiProgramSpaces(
+        deterministic.spaces,
+        programSource,
       );
-      const prompt = `You are an architectural programming expert. Generate a JSON array of spaces for a ${projectTypeSupport.label || sanitizedProgram} totaling ~${sanitizedArea} m². Ensure the total area (area * count sum) is within ±5% of ${sanitizedArea}. Assign each space to ONE of these level names only: ${levelNames.join(", ")}. ${programmeGuidance} Return ONLY the JSON array, no commentary.`;
-      let parsed = [];
-      let programSource = "openai_reasoning";
-      try {
-        const openaiReasoningService = (
-          await import("../services/openaiReasoningService")
-        ).default;
-        const response = await openaiReasoningService.chatCompletion(
-          [
-            {
-              role: "system",
-              content:
-                "Return ONLY a JSON array of objects with: name (string), area (number), count (number), level (string), type/category (string where applicable), notes (optional string).",
-            },
-            { role: "user", content: prompt },
-          ],
-          {
-            max_tokens: 900,
-            temperature: 0.55,
-            task_type: "wizard-program-compile",
-          },
+      if (spaces.length === 0) {
+        const emptyErr = new Error(
+          "Supported project type returned no programme spaces.",
         );
-
-        const content =
-          response?.choices?.[0]?.message?.content || response?.content || "[]";
-        const jsonMatch = content.match(/\[[\s\S]*\]/);
-        if (jsonMatch) {
-          try {
-            parsed = JSON.parse(jsonMatch[0]);
-          } catch (err) {
-            logger.warn("Failed to parse AI program JSON, falling back", err);
-          }
-        }
-      } catch (reasoningErr) {
-        logger.warn(
-          "OpenAI programme compile unavailable; using deterministic template",
-          reasoningErr,
-        );
+        emptyErr.code = "PROGRAMME_SPACES_EMPTY";
+        throw emptyErr;
       }
-
-      if (!Array.isArray(parsed) || parsed.length === 0) {
-        const deterministic = generateDeterministicProgramSpaces({
-          projectDetails,
-          projectTypeSupport,
-          floorCount: floorCountForPrompt,
-          targetAreaM2: parseFloat(projectDetails.area),
-        });
-        parsed = deterministic.spaces;
-        programSource = deterministic.source;
-      }
-
-      // Map to UI schema
-      let spaces = parsed.map((space, index) => ({
-        id: `space_${Date.now()}_${index}`,
-        spaceType:
-          space.spaceType || space.type || space.category || space.name,
-        type: space.type || space.spaceType || space.category || null,
-        category: space.category || space.type || space.spaceType || null,
-        name: String(space.name || space.label || `Space ${index + 1}`),
-        label: String(space.label || space.name || `Space ${index + 1}`),
-        area: Math.max(0, parseFloat(space.area) || 0),
-        count: Math.max(1, parseInt(space.count, 10) || 1),
-        level: space.level || "Ground",
-        levelIndex: space.levelIndex ?? space.level_index ?? undefined,
-        level_index: space.level_index ?? space.levelIndex ?? undefined,
-        notes: space.notes || "",
-        source: space.source || programSource,
-      }));
 
       // Auto level assignment. We always run syncProgramToFloorCount with
       // the authoritative count so that manual floor counts work even when
@@ -1575,16 +1582,19 @@ const ArchitectAIWizardContainer = () => {
         autoFloors = floorMetrics?.optimalFloors || autoFloors;
       }
 
-      const syncResult = syncProgramToFloorCount(
-        spaces,
-        authoritativeFloorCount,
-        {
+      let syncResult = { spaces, warnings: [], changed: false };
+      if (!programSpacesCoverFloorCount(spaces, authoritativeFloorCount)) {
+        syncResult = syncProgramToFloorCount(spaces, authoritativeFloorCount, {
           buildingType: sanitizedProgram,
           projectDetails: { ...projectDetails, floorMetrics },
-        },
-      );
-      spaces = syncResult.spaces;
+        });
+        spaces = normalizeUiProgramSpaces(syncResult.spaces, programSource);
+      }
       spaces._floorMetrics = floorMetrics;
+      logCompileBreadcrumb("generatorSource", {
+        generatorSource: programSource,
+        spacesCount: spaces.length,
+      });
 
       console.info("[compileProgram] generatedProgram", {
         ...compileAuthorityLog,
@@ -1633,11 +1643,14 @@ const ArchitectAIWizardContainer = () => {
           `Auto-detected ${autoFloors} level${autoFloors === 1 ? "" : "s"} from ${Math.round(siteArea)} m² site.`,
         );
       }
-      setProgramWarnings((prev) => [
-        ...prev,
-        ...genericWarnings,
-        ...syncResult.warnings,
-      ]);
+      setProgramWarnings((prev) =>
+        uniqueProgramWarnings(
+          prev,
+          genericWarnings,
+          deterministic.warnings,
+          syncResult.warnings,
+        ),
+      );
 
       setProgramSpaces(spaces);
 
@@ -1649,6 +1662,12 @@ const ArchitectAIWizardContainer = () => {
       return spaces; // Return for callers that need immediate access
     } catch (err) {
       logger.error("Space generation failed", err);
+      setProgramWarnings([
+        err?.code === "PROJECT_TYPE_UNSUPPORTED"
+          ? err.message ||
+            "This project type is not enabled for production generation."
+          : "Programme spaces could not be generated for this project type. Check the building type and area, then try again.",
+      ]);
       setProgramSpaces([]);
       return [];
     } finally {


### PR DESCRIPTION
## Summary

Fixes the live wizard programme-space flow for UI-enabled non-residential ProjectGraph types.

## Root Cause

The real Specs-step handler was still using the generic dimension sanitizer for total programme area. Realistic non-residential areas above 1000 m2 were rejected before programme generation ran, so the table stayed empty even though lower-area residential flows worked.

## Changes

- Added a programme-area sanitizer that accepts realistic non-residential total areas while still bounding invalid values.
- Made the non-residential ProjectGraph UI schedule populate from deterministic programme templates, independent of OpenAI availability.
- Normalized generated UI programme rows to include id, name/label, area, count, type/category/spaceType, level, levelIndex/level_index, and source.
- Preserved the Residential V2 deterministic route for detached-house/residential flows.
- Added safe development breadcrumbs for project type support, canonical building type, generator source, and space count.
- Added full wizard-handler tests for supported project types, unsupported handling, OpenAI failure fallback, and floor-count sync.

## Programme Types Tested

- commercial > office
- healthcare > clinic
- education > school
- commercial > retail
- hospitality > hotel
- industrial > warehouse
- residential > detached-house regression
- unsupported commercial > casino clear failure path

## Validation

- Focused programme/UI/API/registry tests: 7 suites, 49 tests passed.
- Browser smoke through the real wizard flow: all listed supported types rendered programme rows; no `/api/together/chat`, `/api/openai-reasoning`, or `/api/program/compile` calls were made for the visible table.
- `npm run smoke:production-readiness` passed: 14 passed, 0 failed, 1 skipped in mock mode.
- `npm run lint` passed.
- `git diff --check` passed.
- `npm run check:env` passed with redacted status output.
- `npm run check:contracts` passed.
- `npm run build:active` passed.

## Blocker Audit

SAFE TO COMMIT.

- No secrets, env values, tokens, raw bytes, or Authorization headers added.
- No fake DWG/IFC/PDF output added.
- No image-generated technical drawings added.
- No ProjectGraph/A1/CAD/structural/MEP/detail/package authority gates weakened.
- Programme spaces work in the real UI flow for the supported tested ProjectGraph types.
- Unsupported types fail clearly instead of silently returning empty rows.
- Performance/bundle/lazy-loading optimisation was not started.

## Remaining Limitations

- Non-residential programme rows intentionally use deterministic templates for the visible UI table; model-based enrichment remains outside this scoped live-flow fix.
- Existing build-size warnings remain unchanged and are deferred to the separate performance optimisation work.