### PR TITLE
Fix ExportPanel export manifest fallback

### DIFF
--- a/src/__tests__/components/exportPanelReadiness.test.jsx
+++ b/src/__tests__/components/exportPanelReadiness.test.jsx
@@ -210,4 +210,103 @@ describe("ExportPanel readiness rendering", () => {
 
     unmount();
   });
+
+  // Belt-and-braces: when the hook didn't attach exportManifest but
+  // compiledProject (with geometry) is on the result, ExportPanel must
+  // synthesise the manifest itself rather than render every engineering
+  // row BLOCKED with no reason. Same builder, same authority gates.
+  test("synthesises manifest in-component when designData has compiledProject but no exportManifest", () => {
+    const designData = {
+      compiledProject: compiledWithGeometry(),
+      // No exportManifest field on purpose — must be synthesised.
+    };
+
+    const { container, unmount } = renderComponent(
+      <ExportPanel designData={designData} onExport={jest.fn()} />,
+    );
+
+    const dxfBtn = rowByLabel(container, "Export as DXF");
+    const ifcBtn = rowByLabel(container, "Export as IFC");
+    const jsonBtn = rowByLabel(container, "Export Authority JSON");
+    const xlsxBtn = rowByLabel(container, "Export Excel Estimate");
+
+    expect(dxfBtn.disabled).toBe(false);
+    expect(ifcBtn.disabled).toBe(false);
+    expect(jsonBtn.disabled).toBe(false);
+    // XLSX is still blocked because there's no takeoff; same builder.
+    expect(xlsxBtn.disabled).toBe(true);
+
+    // The "N/Y exports ready from the compiled bundle" subtitle
+    // proves the synthesised manifest is being honoured.
+    expect(container.textContent).toMatch(
+      /exports ready from the compiled bundle/i,
+    );
+
+    unmount();
+  });
+
+  test("in-component synthesis lights up XLSX when projectQuantityTakeoff has items", () => {
+    const designData = {
+      compiledProject: compiledWithGeometry(),
+      projectQuantityTakeoff: {
+        items: [
+          {
+            category: "areas",
+            item: "Gross Floor Area",
+            quantity: 50,
+            unit: "m2",
+          },
+        ],
+      },
+      // No exportManifest field — must be synthesised.
+    };
+
+    const { container, unmount } = renderComponent(
+      <ExportPanel designData={designData} onExport={jest.fn()} />,
+    );
+
+    const dxfBtn = rowByLabel(container, "Export as DXF");
+    const jsonBtn = rowByLabel(container, "Export Authority JSON");
+    const xlsxBtn = rowByLabel(container, "Export Excel Estimate");
+
+    expect(dxfBtn.disabled).toBe(false);
+    expect(jsonBtn.disabled).toBe(false);
+    expect(xlsxBtn.disabled).toBe(false);
+
+    unmount();
+  });
+
+  test("server-attached exportManifest wins over in-component synthesis", () => {
+    // Build a sentinel manifest with a non-default source value so we can
+    // tell which one ExportPanel rendered against. If the synthesis was
+    // (incorrectly) preferred over the server one, the source would
+    // change to "client_fallback".
+    const serverManifest = buildClientExportManifest({
+      compiledProject: compiledWithGeometry(),
+      projectQuantityTakeoff: {
+        items: [{ category: "areas", item: "GFA", quantity: 100, unit: "m2" }],
+      },
+    });
+    // Mutate the source to mimic an actual server-attached manifest.
+    serverManifest.source = "server_attached_v2";
+
+    const designData = {
+      compiledProject: compiledWithGeometry(),
+      // Server-attached manifest has different XLSX availability than the
+      // synthesis would (server says ready, synthesis without takeoff
+      // would say blocked). We give the synthesis NO takeoff to make the
+      // divergence observable, and rely on the server manifest being the
+      // one that's actually used.
+      exportManifest: serverManifest,
+    };
+
+    const { container, unmount } = renderComponent(
+      <ExportPanel designData={designData} onExport={jest.fn()} />,
+    );
+
+    const xlsxBtn = rowByLabel(container, "Export Excel Estimate");
+    expect(xlsxBtn.disabled).toBe(false);
+
+    unmount();
+  });
 });

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -662,6 +662,19 @@ describe("projectGraphVerticalSliceService", () => {
 
     expect(result.success).toBe(true);
     expect(result.qa.status).toBe("pass");
+    // Engineering-export authority gate (PR follow-up to PR #138):
+    // happy path must declare engineering exports ready with no source
+    // gaps so the ExportPanel renders DXF/IFC/JSON/XLSX correctly.
+    expect(result.engineeringExportReadiness).toEqual({
+      ready: true,
+      sourceGaps: [],
+    });
+    expect(result.metadata.engineeringExportReadiness).toEqual({
+      ready: true,
+      sourceGaps: [],
+    });
+    expect(typeof result.geometryHash).toBe("string");
+    expect(result.geometryHash.length).toBeGreaterThan(0);
     expect(result.projectGraph.schema_version).toBe("project-graph-v1");
     expect(result.projectGraph.programme.spaces.length).toBeGreaterThan(4);
     expect(result.projectGraph.drawings.drawings.length).toBeGreaterThanOrEqual(

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -27,6 +27,7 @@ import StatusChip from "./ui/StatusChip.jsx";
 import { Tooltip } from "./ui/feedback/Tooltip.jsx";
 import { useToastContext } from "./ui/ToastProvider.jsx";
 import exportService from "../services/exportService.js";
+import buildClientExportManifest from "../services/export/buildClientExportManifest.js";
 import ArtifactHistoryPanel from "./export/ArtifactHistoryPanel.jsx";
 
 /**
@@ -245,11 +246,35 @@ const ExportPanel = ({
   const hasBlendFile = !!blenderOutputs?.manifest?.blendFile;
 
   const geometryHash = designData?.compiledProject?.geometryHash || null;
-  const exportManifest =
-    designData?.exportManifest ||
-    designData?.sheetArtifactManifest?.exportManifest ||
-    designData?.metadata?.exportManifest ||
-    null;
+  // Manifest resolution priority: server-attached > sheet-artifact >
+  // metadata > in-component synthesis. The synthesis kicks in only when
+  // (a) no upstream manifest is present and (b) compiledProject exists —
+  // it reuses the same buildClientExportManifest the hook uses, so the
+  // authority gates (IFC_GEOMETRY_INSUFFICIENT etc.) are identical.
+  // Without this fallback a single dropped result.exportManifest would
+  // silently render every engineering row BLOCKED with no reason text.
+  const exportManifest = useMemo(() => {
+    const fromResult =
+      designData?.exportManifest ||
+      designData?.sheetArtifactManifest?.exportManifest ||
+      designData?.metadata?.exportManifest ||
+      null;
+    if (fromResult) return fromResult;
+    if (!designData?.compiledProject) return null;
+    return buildClientExportManifest({
+      compiledProject: designData.compiledProject,
+      projectQuantityTakeoff:
+        designData?.projectQuantityTakeoff ||
+        designData?.artifacts?.projectQuantityTakeoff ||
+        null,
+      geometryHash:
+        designData?.geometryHash ||
+        designData?.compiledProject?.geometryHash ||
+        null,
+      projectName: designData?.projectGraph?.brief?.project_name,
+      pipelineVersion: designData?.pipelineVersion,
+    });
+  }, [designData]);
   const exportsMap = exportManifest?.exports || {};
   const availableExportCount = Object.values(exportsMap).filter(
     (entry) => entry?.available,

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -1728,11 +1728,31 @@ export function useArchitectAIWorkflow() {
           params.designSpec?.deliveryStages ||
           params.designSpec?.v2Bundle?.deliveryStages ||
           null;
-        const exportManifest =
+        // Parity with the PROJECT_GRAPH branch at line 1484: if no
+        // server-attached manifest is available and compiledProject is
+        // present, synthesise a client_fallback manifest from the same
+        // builder. Without this fallback the V2 / multi_panel result
+        // would render every engineering row BLOCKED with no specific
+        // blockedReason (root cause C in the export-manifest debug).
+        const serverExportManifest =
           multiPanelResult?.metadata?.exportManifest ||
           params.designSpec?.exportManifest ||
           params.designSpec?.v2Bundle?.exportManifest ||
           null;
+        const exportManifest =
+          serverExportManifest ||
+          (compiledProject
+            ? buildClientExportManifest({
+                compiledProject,
+                projectQuantityTakeoff,
+                geometryHash,
+                projectName:
+                  params.designSpec?.projectName ||
+                  multiPanelResult?.projectName ||
+                  null,
+                pipelineVersion,
+              })
+            : null);
         const reviewSurface =
           multiPanelResult?.metadata?.reviewSurface ||
           params.designSpec?.reviewSurface ||

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -14786,6 +14786,46 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     },
   };
 
+  // Engineering-export authority gate. ProjectGraph generation can
+  // succeed for document outputs (A1 sheet, PDF, PNG) while engineering
+  // exports (DXF, IFC, JSON, XLSX) are blocked because compiled-project
+  // geometry is missing or unhashed. Capture this as a structured
+  // sourceGap so the QA report and downstream auditors can see the
+  // exact code, while keeping the document path intact.
+  // The hook's buildClientExportManifest call already produces the
+  // correct per-row blockedReason from these same conditions; this
+  // record is for visibility and for the manual smoke probe.
+  const engineeringExportGaps = (() => {
+    if (!compiledProject) {
+      return [
+        {
+          code: "COMPILED_PROJECT_MISSING",
+          surface: "engineering_exports",
+          severity: "blocking",
+          message:
+            "Engineering exports cannot be generated because compiled project geometry is missing.",
+        },
+      ];
+    }
+    const hash = compiledProject.geometryHash;
+    if (typeof hash !== "string" || hash.length === 0) {
+      return [
+        {
+          code: "GEOMETRY_HASH_MISSING",
+          surface: "engineering_exports",
+          severity: "blocking",
+          message:
+            "Engineering exports cannot be generated because the compiled project has no geometry hash.",
+        },
+      ];
+    }
+    return [];
+  })();
+  const engineeringExportReadiness = {
+    ready: engineeringExportGaps.length === 0,
+    sourceGaps: engineeringExportGaps,
+  };
+
   return {
     success: qa.status === "pass",
     pipelineVersion: PROJECT_GRAPH_VERTICAL_SLICE_VERSION,
@@ -14795,6 +14835,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     seedSource: generationLifecycle.seedSource,
     variationMode: generationLifecycle.variationMode,
     generationLifecycle,
+    engineeringExportReadiness,
     metadata: {
       generationSeed: generationLifecycle.generationSeed,
       seedSource: generationLifecycle.seedSource,
@@ -14803,6 +14844,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       geometryHash: compiledProject.geometryHash,
       visualManifestHash: visualManifest.manifestHash,
       styleBlendManifestHash: styleBlendManifest.manifestHash,
+      engineeringExportReadiness,
       jurisdictionPack: jurisdictionPackSummary,
       jurisdictionPackResolution: {
         source: jurisdictionPackResolution.source,


### PR DESCRIPTION
## Summary

After PR #138 merged the deterministic DXF / IFC / Authority JSON / quantity-takeoff exports, the live ExportPanel still rendered every engineering row as **BLOCKED** with no specific reason. The chain was wired correctly server-side (`compiledProject`, `geometryHash`, `projectQuantityTakeoff` all land on the response), but a single dropped `designData.exportManifest` field at render time silently disabled every engineering row via `isAvailable(key, false)`'s empty-map fallback.

Screenshot evidence (no `N/8 exports ready` subtitle, no `geometryHash` authority banner, all four engineering rows blocked with the generic "Not part of the current compiled bundle" tooltip) pointed to `designData.exportManifest` being null at render time — either because the hook V2 / multi_panel path didn't synthesise one, or because the manifest was stripped in transit.

This change makes the readiness contract self-healing **without weakening any authority gate**:

- **ExportPanel** ([src/components/ExportPanel.jsx](src/components/ExportPanel.jsx)) synthesises the manifest in-component via the existing `buildClientExportManifest` builder when `designData.exportManifest` is missing but `designData.compiledProject` is present. Same builder, same `blockedReason` codes (`IFC_GEOMETRY_INSUFFICIENT`, `QUANTITY_TAKEOFF_UNAVAILABLE`, `COMPILED_PROJECT_MISSING`). Server-attached manifests still win; `compiledProject` is never fabricated.
- **Hook** ([src/hooks/useArchitectAIWorkflow.js](src/hooks/useArchitectAIWorkflow.js) — V2 / multi_panel return path at line 1731) falls through to `buildClientExportManifest` when no server manifest is available, matching the PROJECT_GRAPH branch's existing fallback.
- **Service** ([src/services/project/projectGraphVerticalSliceService.js](src/services/project/projectGraphVerticalSliceService.js)) emits a structured `engineeringExportReadiness` gate with `COMPILED_PROJECT_MISSING` / `GEOMETRY_HASH_MISSING` sourceGaps when the compiled project is missing or unhashed. Document outputs (A1 sheet, PDF, PNG) are not destroyed when engineering exports are blocked — only the engineering rows surface the specific reason.

## Authority gates preserved

- No new code paths produce fake DWG / IFC / PDF outputs.
- IFC stays blocked with `IFC_GEOMETRY_INSUFFICIENT` when walls/levels are empty.
- XLSX stays blocked with `QUANTITY_TAKEOFF_UNAVAILABLE` when items are empty.
- All readiness decisions use the existing `buildClientExportManifest` rules.
- No technical drawings are routed through image generation.
- No secrets exposed, no env files touched.

## Test plan

- [x] `npm run lint` — clean
- [x] `git diff --check` — no whitespace errors
- [x] `npm run check:contracts` — PASSED
- [x] `npm run build:active` — Compiled successfully
- [x] `npm run smoke:production-readiness` — 14/15 PASS (1 SKIP for provider preflight; mock mode). Key checks: `NO_FAKE_DWG_IFC_WHEN_UNAVAILABLE`, `NO_IMAGE_GEN_TECHNICAL_DRAWING`, `NO_SECRET_LEAKAGE`, `CAD_DXF_DETERMINISTIC`, `DXF_PAPER_SPACE_MARKERS`, `ARTIFACT_PACKAGE_BUILDS` all PASS.
- [x] New tests added:
  - 3 new ExportPanel readiness cases in `exportPanelReadiness.test.jsx` covering the in-component synthesis path (DXF/IFC/JSON ready without server manifest; XLSX ready when takeoff present; server manifest wins over synthesis).
  - New service-level assertions for `engineeringExportReadiness` shape on the Reading Room happy-path test.

## Manual smoke (post-deploy)

- [ ] Hard-refresh deployed URL; confirm Sources tab shows `buildClientExportManifest` and `client_fallback` literals (rule out stale deploy).
- [ ] Fresh generation: Office Studio at 190 Corporation St, Birmingham B4 6QD.
- [ ] ExportPanel: subtitle shows "N/8 exports ready from the compiled bundle"; geometryHash authority banner visible.
- [ ] DXF chip READY → real DXF downloads.
- [ ] Authority JSON chip READY → real JSON downloads.
- [ ] XLSX chip READY when `projectQuantityTakeoff.items.length > 0` → workbook downloads with quantities + rates.
- [ ] IFC chip READY only if walls + levels are non-empty; otherwise BLOCKED with "Not enough compiled geometry for a meaningful IFC export."
- [ ] DWG stays BLOCKED with "DWG conversion provider not configured."
- [ ] Network tab shows no calls to `/api/together/*` or image endpoints for these exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)