### PR TITLE
Enhance proportion-based auto-detect of programme storeys

### DIFF
--- a/src/__tests__/components/ArchitectAIWizardContainer.programmeFlow.test.jsx
+++ b/src/__tests__/components/ArchitectAIWizardContainer.programmeFlow.test.jsx
@@ -416,4 +416,63 @@ describe("ArchitectAIWizardContainer programme UI flow", () => {
     expect(container.querySelectorAll("tbody tr").length).toBeGreaterThan(1);
     unmount();
   });
+
+  test("live auto-detect effect resets to null when site area is 0", async () => {
+    const { unmount } = renderComponent(
+      baseProjectDetails({
+        category: "commercial",
+        subType: "office",
+        program: "office",
+        area: 1200,
+        floorCount: 3,
+        floorCountLocked: false,
+        autoDetectedFloorCount: 4,
+        floorMetrics: { optimalFloors: 4 },
+      }),
+      {
+        siteMetrics: { areaM2: 0 },
+      },
+    );
+
+    await flushPromises();
+
+    expect(mockLastProjectDetails.autoDetectedFloorCount).toBeNull();
+    expect(mockLastProjectDetails.floorMetrics).toBeNull();
+    unmount();
+  });
+
+  test("live auto-detect surfaces programToSiteRatio + exceedsSubtypeCap for non-residential over-cap", async () => {
+    // Warehouse cap = 2 storeys. With siteArea 600 m² and programme 2400 m²
+    // even at circulation 1.0 the demand exceeds cap (2400 / (600 × 0.665) ≈ 6),
+    // so exceedsSubtypeCap=true regardless of template variance.
+    const { container, unmount } = renderComponent(
+      baseProjectDetails({
+        category: "industrial",
+        subType: "warehouse",
+        program: "warehouse",
+        area: 2400,
+        floorCount: 2,
+        floorCountLocked: false,
+      }),
+      {
+        siteMetrics: { areaM2: 600 },
+      },
+    );
+
+    await clickGenerate(container);
+    await flushPromises();
+
+    expect(mockLastProjectDetails.floorMetrics).toEqual(
+      expect.objectContaining({
+        programToSiteRatio: expect.any(Number),
+        setbackReduction: expect.any(Number),
+        effectiveCoverage: expect.any(Number),
+        exceedsSubtypeCap: true,
+      }),
+    );
+    expect(container.textContent).toMatch(
+      /Programme density.*demands.*warehouse caps at 2/i,
+    );
+    unmount();
+  });
 });

--- a/src/__tests__/services/autoLevelAssignmentService.test.js
+++ b/src/__tests__/services/autoLevelAssignmentService.test.js
@@ -1,5 +1,125 @@
 import autoLevelAssignmentService from "../../services/autoLevelAssignmentService.js";
 
+describe("autoLevelAssignmentService.calculateOptimalLevels — proportion-based auto-detect", () => {
+  test("returns null shape when site area is missing or non-positive", () => {
+    const zero = autoLevelAssignmentService.calculateOptimalLevels(200, 0, {
+      subType: "detached-house",
+    });
+    expect(zero.optimalFloors).toBeNull();
+    expect(zero.fallbackReason).toBe("no-site-area");
+    expect(zero.programToSiteRatio).toBeNull();
+    expect(zero.effectiveCoverage).toBeNull();
+    expect(zero.exceedsSubtypeCap).toBe(false);
+
+    const negative = autoLevelAssignmentService.calculateOptimalLevels(
+      200,
+      -10,
+      { subType: "detached-house" },
+    );
+    expect(negative.optimalFloors).toBeNull();
+    expect(negative.fallbackReason).toBe("no-site-area");
+
+    const missing = autoLevelAssignmentService.calculateOptimalLevels(
+      200,
+      undefined,
+      { subType: "detached-house" },
+    );
+    expect(missing.optimalFloors).toBeNull();
+    expect(missing.fallbackReason).toBe("no-site-area");
+  });
+
+  test("detached 200m² on 500m² site → 2 storeys with subtype setback 0.75", () => {
+    const result = autoLevelAssignmentService.calculateOptimalLevels(200, 500, {
+      buildingType: "house",
+      subType: "detached-house",
+    });
+    expect(result.optimalFloors).toBe(2);
+    expect(result.programToSiteRatio).toBeCloseTo(0.4, 2);
+    expect(result.setbackReduction).toBeCloseTo(0.75, 2);
+    expect(result.coverageRatio).toBeCloseTo(0.35, 2);
+    expect(result.effectiveCoverage).toBeCloseTo(0.2625, 3);
+    expect(result.exceedsSubtypeCap).toBe(false);
+    expect(result.subtypeMaxFloors).toBe(3);
+    expect(result.reasoning).toMatch(/ratio 0\.40/);
+  });
+
+  test("terraced 300m² on 100m² site → demand exceeds subtype cap (4), exceedsSubtypeCap=true", () => {
+    const result = autoLevelAssignmentService.calculateOptimalLevels(300, 100, {
+      buildingType: "house",
+      subType: "terraced-house",
+    });
+    expect(result.demandFloors).toBeGreaterThan(4);
+    expect(result.optimalFloors).toBe(4);
+    expect(result.exceedsSubtypeCap).toBe(true);
+    expect(result.subtypeMaxFloors).toBe(4);
+    expect(result.programToSiteRatio).toBeCloseTo(3.0, 2);
+    expect(result.setbackReduction).toBeCloseTo(0.95, 2);
+    expect(result.reasoning).toMatch(/terraced-house cap 4/);
+  });
+
+  test("apartment 600m² on 200m² site → 7 storeys under cap 8, exceedsSubtypeCap=false", () => {
+    const result = autoLevelAssignmentService.calculateOptimalLevels(600, 200, {
+      buildingType: "apartment",
+      subType: "apartment-building",
+    });
+    expect(result.optimalFloors).toBe(7);
+    expect(result.exceedsSubtypeCap).toBe(false);
+    expect(result.subtypeMaxFloors).toBe(8);
+    expect(result.programToSiteRatio).toBeCloseTo(3.0, 2);
+    expect(result.setbackReduction).toBeCloseTo(0.85, 2);
+  });
+
+  test("warehouse 1000m² on 800m² site → cap at 2 with exceedsSubtypeCap=true", () => {
+    const result = autoLevelAssignmentService.calculateOptimalLevels(
+      1000,
+      800,
+      { buildingType: "industrial", subType: "warehouse" },
+    );
+    expect(result.demandFloors).toBeGreaterThan(2);
+    expect(result.optimalFloors).toBe(2);
+    expect(result.exceedsSubtypeCap).toBe(true);
+    expect(result.subtypeMaxFloors).toBe(2);
+    expect(result.setbackReduction).toBeCloseTo(0.95, 2);
+    expect(result.coverageRatio).toBeCloseTo(0.7, 2);
+  });
+
+  test("office 1200m² on 400m² site → 8 storeys, fits within cap 10", () => {
+    const result = autoLevelAssignmentService.calculateOptimalLevels(
+      1200,
+      400,
+      { buildingType: "commercial", subType: "office" },
+    );
+    expect(result.optimalFloors).toBe(8);
+    expect(result.exceedsSubtypeCap).toBe(false);
+    expect(result.subtypeMaxFloors).toBe(10);
+    expect(result.programToSiteRatio).toBeCloseTo(3.0, 2);
+    expect(result.coverageRatio).toBeCloseTo(0.55, 2);
+    expect(result.setbackReduction).toBeCloseTo(0.85, 2);
+  });
+
+  test("unknown subtype falls back to default setback (0.85) and keyword coverage", () => {
+    const result = autoLevelAssignmentService.calculateOptimalLevels(200, 500, {
+      buildingType: "commercial",
+      subType: "some-niche-unknown-subtype",
+    });
+    expect(result.setbackReduction).toBeCloseTo(0.85, 2);
+    expect(result.coverageRatio).toBeCloseTo(0.7, 2);
+    expect(result.subtypeMaxFloors).toBeNull();
+  });
+
+  test("autoAssignComplete returns success=false when site area missing", () => {
+    const result = autoLevelAssignmentService.autoAssignComplete(
+      [{ name: "Living Room", area: 30, count: 1 }],
+      0,
+      "detached-house",
+    );
+    expect(result.success).toBe(false);
+    expect(result.floorCount).toBeNull();
+    expect(result.fallbackReason).toBe("no-site-area");
+    expect(result.floorMetrics.optimalFloors).toBeNull();
+  });
+});
+
 describe("autoLevelAssignmentService", () => {
   test("keeps levelIndex aligned with assigned level names", () => {
     const spaces = [

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -507,10 +507,26 @@ const ArchitectAIWizardContainer = () => {
     };
   }, []);
 
-  // Auto-detect optimal floor count from site + area (unless locked by user)
+  // Auto-detect optimal floor count from site + area (unless locked by user).
+  // Input priority: sum of current programme spaces (when populated) →
+  // projectDetails.area as a fallback before Compile has run. The compile-time
+  // call sites also use the sum-of-spaces input, so this keeps live and
+  // post-Compile auto-detect in lock-step.
   useEffect(() => {
     const siteArea = siteMetrics?.areaM2;
-    const totalArea = parseFloat(projectDetails?.area);
+    const programmeAreaSum = Array.isArray(programSpaces)
+      ? programSpaces.reduce(
+          (sum, space) =>
+            sum +
+            Math.max(0, parseFloat(space?.area || 0)) *
+              Math.max(1, parseInt(space?.count || 1, 10) || 1),
+          0,
+        )
+      : 0;
+    const totalArea =
+      programmeAreaSum > 0
+        ? programmeAreaSum
+        : parseFloat(projectDetails?.area);
 
     const hasInputs =
       typeof siteArea === "number" &&
@@ -551,6 +567,22 @@ const ArchitectAIWizardContainer = () => {
         },
       );
 
+      // Service may return optimalFloors=null when its own siteArea guard
+      // trips (e.g. siteMetrics flipped to 0 between render and effect).
+      // Treat that as "no auto value" — do not stomp the previous count.
+      if (floorMetrics.optimalFloors == null) {
+        setProjectDetails((prev) => {
+          if (!prev) return prev;
+          if (
+            prev.autoDetectedFloorCount === null &&
+            prev.floorMetrics === null
+          )
+            return prev;
+          return { ...prev, autoDetectedFloorCount: null, floorMetrics: null };
+        });
+        return;
+      }
+
       setProjectDetails((prev) => {
         if (!prev) return prev;
 
@@ -575,7 +607,11 @@ const ArchitectAIWizardContainer = () => {
           prev.floorMetrics?.actualFootprint ===
             next.floorMetrics?.actualFootprint &&
           prev.floorMetrics?.maxFloorsAllowed ===
-            next.floorMetrics?.maxFloorsAllowed;
+            next.floorMetrics?.maxFloorsAllowed &&
+          prev.floorMetrics?.programToSiteRatio ===
+            next.floorMetrics?.programToSiteRatio &&
+          prev.floorMetrics?.exceedsSubtypeCap ===
+            next.floorMetrics?.exceedsSubtypeCap;
 
         return unchanged ? prev : next;
       });
@@ -587,6 +623,7 @@ const ArchitectAIWizardContainer = () => {
     projectDetails?.program,
     projectDetails?.subType,
     projectDetails?.category,
+    programSpaces,
     projectDetails?.floorCountLocked,
     siteMetrics?.areaM2,
     setProjectDetails,
@@ -1364,7 +1401,6 @@ const ArchitectAIWizardContainer = () => {
                 {
                   buildingType: sanitizedProgram,
                   subType,
-                  maxFloors: 4,
                   circulationFactor: 1.0,
                 },
               )
@@ -1413,7 +1449,6 @@ const ArchitectAIWizardContainer = () => {
                 {
                   buildingType: sanitizedProgram,
                   subType,
-                  maxFloors: 4,
                   circulationFactor: 1.0,
                 },
               )
@@ -1493,6 +1528,18 @@ const ArchitectAIWizardContainer = () => {
         if (recommendedFloorCount !== authoritativeFloorCount) {
           baseWarnings.push(
             `Site-fit recommends ${recommendedFloorCount} level${recommendedFloorCount === 1 ? "" : "s"}; programme uses ${authoritativeFloorCount} (${auth.source}).`,
+          );
+        }
+        if (
+          floorMetrics?.exceedsSubtypeCap &&
+          Number.isFinite(floorMetrics?.demandFloors) &&
+          Number.isFinite(floorMetrics?.maxFloorsAllowed)
+        ) {
+          const ratioText = Number.isFinite(floorMetrics?.programToSiteRatio)
+            ? floorMetrics.programToSiteRatio.toFixed(2)
+            : "n/a";
+          baseWarnings.push(
+            `Programme density (ratio ${ratioText}) demands ${floorMetrics.demandFloors} storey${floorMetrics.demandFloors === 1 ? "" : "s"} but ${subType} caps at ${floorMetrics.maxFloorsAllowed} — trim programme or pick a denser subtype.`,
           );
         }
         if (programBrief.clampedBy === "subtype-max") {
@@ -1575,7 +1622,6 @@ const ArchitectAIWizardContainer = () => {
           {
             buildingType: sanitizedProgram,
             subType: projectDetails.subType || null,
-            maxFloors: 10,
             circulationFactor: hasExplicitCirculation ? 1.0 : 1.15,
           },
         );
@@ -1641,6 +1687,20 @@ const ArchitectAIWizardContainer = () => {
       } else if (autoFloors) {
         genericWarnings.push(
           `Auto-detected ${autoFloors} level${autoFloors === 1 ? "" : "s"} from ${Math.round(siteArea)} m² site.`,
+        );
+      }
+      if (
+        floorMetrics?.exceedsSubtypeCap &&
+        Number.isFinite(floorMetrics?.demandFloors) &&
+        Number.isFinite(floorMetrics?.maxFloorsAllowed)
+      ) {
+        const ratioText = Number.isFinite(floorMetrics?.programToSiteRatio)
+          ? floorMetrics.programToSiteRatio.toFixed(2)
+          : "n/a";
+        const subtypeLabel =
+          projectDetails.subType || sanitizedProgram || "subtype";
+        genericWarnings.push(
+          `Programme density (ratio ${ratioText}) demands ${floorMetrics.demandFloors} storey${floorMetrics.demandFloors === 1 ? "" : "s"} but ${subtypeLabel} caps at ${floorMetrics.maxFloorsAllowed} — trim programme or pick a denser subtype.`,
         );
       }
       setProgramWarnings((prev) =>

--- a/src/components/steps/SpecsStep.jsx
+++ b/src/components/steps/SpecsStep.jsx
@@ -487,11 +487,57 @@ const SpecsStep = ({
                           auto
                         </span>
                       </div>
-                      {projectDetails.floorMetrics?.reasoning && (
-                        <p className="mt-1 line-clamp-2 text-xs text-white/55">
-                          {projectDetails.floorMetrics.reasoning}
+                      {Number.isFinite(
+                        projectDetails.floorMetrics?.programToSiteRatio,
+                      ) &&
+                      Number.isFinite(
+                        projectDetails.floorMetrics?.coverageRatio,
+                      ) ? (
+                        <p
+                          className="mt-1 text-xs tabular-nums text-white/65"
+                          title={
+                            projectDetails.floorMetrics?.reasoning || undefined
+                          }
+                        >
+                          Programme{" "}
+                          {projectDetails.floorMetrics.programToSiteRatio.toFixed(
+                            2,
+                          )}
+                          × site at{" "}
+                          {Math.round(
+                            projectDetails.floorMetrics.coverageRatio * 100,
+                          )}
+                          % coverage
                         </p>
+                      ) : (
+                        projectDetails.floorMetrics?.reasoning && (
+                          <p className="mt-1 line-clamp-2 text-xs text-white/55">
+                            {projectDetails.floorMetrics.reasoning}
+                          </p>
+                        )
                       )}
+                      {projectDetails.floorMetrics?.exceedsSubtypeCap &&
+                        Number.isFinite(
+                          projectDetails.floorMetrics?.demandFloors,
+                        ) &&
+                        Number.isFinite(
+                          projectDetails.floorMetrics?.maxFloorsAllowed,
+                        ) && (
+                          <div className="mt-2 rounded border border-warning-500/30 bg-warning-500/5 px-2 py-1 text-[11px] text-warning-200">
+                            Density exceeds{" "}
+                            {projectDetails.subType ||
+                              projectDetails.program ||
+                              "subtype"}{" "}
+                            cap of{" "}
+                            {projectDetails.floorMetrics.maxFloorsAllowed} —
+                            programme demands{" "}
+                            {projectDetails.floorMetrics.demandFloors} storey
+                            {projectDetails.floorMetrics.demandFloors === 1
+                              ? ""
+                              : "s"}
+                            .
+                          </div>
+                        )}
                     </div>
                   )}
 

--- a/src/services/autoLevelAssignmentService.js
+++ b/src/services/autoLevelAssignmentService.js
@@ -82,6 +82,79 @@ const SUBTYPE_COVERAGE_RATIOS = {
 };
 
 /**
+ * Sub-type specific setback reductions
+ * Fraction of the coverage-allowed footprint that survives after typical
+ * front/side/rear setbacks for each sub-type. Lower = more land lost to
+ * setbacks. Terraced and warehouse plots lose almost nothing because the
+ * party walls / industrial yards run to the boundary; detached, villa and
+ * kindergarten plots lose 25–30% to garden / play / shadow setbacks.
+ */
+const SUBTYPE_SETBACK_REDUCTION = {
+  // Residential
+  "detached-house": 0.75,
+  "semi-detached-house": 0.85,
+  "terraced-house": 0.95,
+  villa: 0.7,
+  cottage: 0.8,
+  mansion: 0.7,
+  "multi-family": 0.85,
+  duplex: 0.85,
+  "apartment-building": 0.85,
+  condominium: 0.85,
+  "residential-tower": 0.8,
+
+  // Healthcare
+  clinic: 0.85,
+  "dental-clinic": 0.85,
+  "health-center": 0.85,
+  hospital: 0.8,
+  pharmacy: 0.9,
+
+  // Commercial
+  office: 0.85,
+  coworking: 0.85,
+  retail: 0.95,
+  "shopping-center": 0.85,
+  restaurant: 0.9,
+  cafe: 0.9,
+
+  // Educational
+  school: 0.8,
+  kindergarten: 0.75,
+  "training-center": 0.85,
+  library: 0.85,
+
+  // Hospitality
+  hotel: 0.85,
+  hostel: 0.85,
+  "bed-breakfast": 0.85,
+
+  // Industrial
+  warehouse: 0.95,
+  factory: 0.9,
+  workshop: 0.9,
+  "logistics-center": 0.9,
+
+  // Cultural & Public
+  museum: 0.85,
+  gallery: 0.85,
+  theater: 0.85,
+  "community-center": 0.85,
+
+  // Sports & Recreation
+  gym: 0.85,
+  "sports-hall": 0.85,
+  "swimming-pool": 0.85,
+
+  // Religious
+  church: 0.85,
+  mosque: 0.85,
+  temple: 0.85,
+};
+
+const DEFAULT_SETBACK_REDUCTION = 0.85;
+
+/**
  * Sub-type specific maximum floor limits (UK typical)
  */
 const SUBTYPE_MAX_FLOORS = {
@@ -166,7 +239,24 @@ class AutoLevelAssignmentService {
   }
 
   /**
-   * Calculate optimal number of levels based on program area and site area
+   * Calculate optimal number of levels based on program area and site area.
+   *
+   * Returned `floorMetrics` shape (stable contract for callers):
+   *   - optimalFloors          number|null  null when site area is missing
+   *   - fallbackReason         string|null  "no-site-area" when guarded out
+   *   - programToSiteRatio     number|null  totalProgramArea / siteArea
+   *   - effectiveCoverage      number|null  coverage × setbackReduction
+   *   - setbackReduction       number|null  the value actually used
+   *   - exceedsSubtypeCap      boolean      true when programme demanded
+   *                                          more floors than subtype/maxFloors cap
+   *   - subtypeMaxFloors       number|null  the subtype cap when known
+   *   - reasoning              string       human-readable explanation
+   *   - (legacy)               minFloorsNeeded, maxFloorsAllowed,
+   *                            actualFootprint, maxFootprintArea,
+   *                            siteCoveragePercent, fitsWithinSite,
+   *                            floorHeight, totalHeight, coverageRatio,
+   *                            subType, floorPolicy
+   *
    * @param {number} totalProgramArea - Total area of all program spaces (m²)
    * @param {number} siteArea - Site area from location (m²)
    * @param {Object} options - Optional parameters
@@ -176,25 +266,67 @@ class AutoLevelAssignmentService {
   calculateOptimalLevels(totalProgramArea, siteArea, options = {}) {
     const {
       buildingType = "mixed-use",
-      subType = null, // NEW: Specific sub-type ID for precise ratios
+      subType = null, // Specific sub-type ID for precise ratios
       maxHeight = Infinity,
-      maxFloors = 10,
+      maxFloors = null, // null = let subtype table decide; falls back to 10
       minFloorHeight = 2.7, // meters
       typicalFloorHeight = 3.0, // meters
       coverageRatio = 0.6, // 60% default site coverage
       circulationFactor = 1.15, // 15% circulation allowance
     } = options;
 
+    const numericProgramArea = Number(totalProgramArea);
+    const numericSiteArea = Number(siteArea);
+    const safeProgramArea = Number.isFinite(numericProgramArea)
+      ? Math.max(0, numericProgramArea)
+      : 0;
+    const safeSiteArea = Number.isFinite(numericSiteArea) ? numericSiteArea : 0;
+
     logger.info(
       "Calculating optimal floor count",
       {
-        programArea: totalProgramArea,
-        siteArea,
+        programArea: safeProgramArea,
+        siteArea: safeSiteArea,
         buildingType,
         subType,
       },
       "🏢",
     );
+
+    // Guard: without a positive site area the program/site ratio is undefined.
+    // Returning a null shape avoids the previous Infinity → silent clamp at
+    // maxFloors pattern. Callers must skip writing autoDetectedFloorCount.
+    if (!(safeSiteArea > 0)) {
+      logger.warn(
+        "Skipping floor auto-detect: site area is missing or non-positive",
+        { siteArea: safeSiteArea },
+      );
+      return {
+        optimalFloors: null,
+        fallbackReason: "no-site-area",
+        programToSiteRatio: null,
+        effectiveCoverage: null,
+        setbackReduction: null,
+        exceedsSubtypeCap: false,
+        subtypeMaxFloors:
+          subType && SUBTYPE_MAX_FLOORS[subType]
+            ? SUBTYPE_MAX_FLOORS[subType]
+            : null,
+        minFloorsNeeded: null,
+        maxFloorsAllowed: null,
+        actualFootprint: null,
+        maxFootprintArea: null,
+        siteCoveragePercent: null,
+        fitsWithinSite: false,
+        floorHeight: typicalFloorHeight,
+        totalHeight: null,
+        coverageRatio: null,
+        subType,
+        floorPolicy: null,
+        reasoning:
+          "Site area unknown — auto floor detection skipped. Provide a site location to enable proportion-based level recommendation.",
+      };
+    }
 
     // Step 1: Adjust coverage ratio - prioritize sub-type specific ratio
     let adjustedCoverage = coverageRatio;
@@ -224,38 +356,58 @@ class AutoLevelAssignmentService {
       adjustedCoverage = 0.65; // 65% for medium-density
     }
 
-    // Step 2: Calculate buildable footprint
-    const setbackReduction = 0.85; // 15% lost to setbacks
-    const maxFootprintArea = siteArea * adjustedCoverage * setbackReduction;
+    // Step 2: Calculate buildable footprint with subtype-aware setback
+    const setbackReduction =
+      subType && SUBTYPE_SETBACK_REDUCTION[subType]
+        ? SUBTYPE_SETBACK_REDUCTION[subType]
+        : DEFAULT_SETBACK_REDUCTION;
+    const effectiveCoverage = adjustedCoverage * setbackReduction;
+    const maxFootprintArea = safeSiteArea * effectiveCoverage;
 
-    logger.info(`   Site area: ${siteArea.toFixed(0)}m²`);
+    logger.info(`   Site area: ${safeSiteArea.toFixed(0)}m²`);
     logger.info(`   Coverage ratio: ${(adjustedCoverage * 100).toFixed(0)}%`);
+    logger.info(
+      `   Setback reduction: ${(setbackReduction * 100).toFixed(0)}%`,
+    );
+    logger.info(
+      `   Effective coverage: ${(effectiveCoverage * 100).toFixed(0)}%`,
+    );
     logger.info(`   Max footprint: ${maxFootprintArea.toFixed(0)}m²`);
 
     // Step 3: Account for circulation
-    const totalAreaWithCirculation = totalProgramArea * circulationFactor;
+    const totalAreaWithCirculation = safeProgramArea * circulationFactor;
+    const programToSiteRatio = safeProgramArea / safeSiteArea;
 
-    logger.info(`   Program area: ${totalProgramArea.toFixed(0)}m²`);
+    logger.info(`   Program area: ${safeProgramArea.toFixed(0)}m²`);
     logger.info(
       `   With circulation: ${totalAreaWithCirculation.toFixed(0)}m²`,
     );
+    logger.info(`   Program/site ratio: ${programToSiteRatio.toFixed(2)}`);
 
-    // Step 4: Calculate minimum floors needed
-    const minFloorsNeeded = Math.ceil(
-      totalAreaWithCirculation / maxFootprintArea,
-    );
+    // Step 4: Calculate minimum floors needed. If maxFootprintArea is 0
+    // (impossible coverage), treat minFloors as 1 to avoid Infinity. The
+    // siteArea guard above already covers the common no-site case.
+    const minFloorsNeeded =
+      maxFootprintArea > 0
+        ? Math.ceil(totalAreaWithCirculation / maxFootprintArea)
+        : 1;
 
     logger.info(`   Min floors needed: ${minFloorsNeeded}`);
 
     // Step 5: Check height restrictions and sub-type limits
-    let maxFloorsAllowed = maxFloors;
+    const callerMaxFloors =
+      Number.isFinite(Number(maxFloors)) && Number(maxFloors) > 0
+        ? Math.max(1, Math.floor(Number(maxFloors)))
+        : 10;
+    let maxFloorsAllowed = callerMaxFloors;
 
-    // First, apply sub-type specific max floors if available (UK typical limits)
-    if (subType && SUBTYPE_MAX_FLOORS[subType]) {
-      maxFloorsAllowed = Math.min(
-        maxFloorsAllowed,
-        SUBTYPE_MAX_FLOORS[subType],
-      );
+    // Subtype-specific max floors (UK typical limits)
+    const subtypeMaxFloors =
+      subType && SUBTYPE_MAX_FLOORS[subType]
+        ? SUBTYPE_MAX_FLOORS[subType]
+        : null;
+    if (subtypeMaxFloors !== null) {
+      maxFloorsAllowed = Math.min(maxFloorsAllowed, subtypeMaxFloors);
       logger.info(`   Max floors (sub-type ${subType}): ${maxFloorsAllowed}`);
     }
 
@@ -266,17 +418,18 @@ class AutoLevelAssignmentService {
       logger.info(`   Max floors allowed (height): ${maxFloorsAllowed}`);
     }
 
-    // Step 6: Determine optimal floor count
-    let optimalFloors = Math.min(
-      Math.max(minFloorsNeeded, 1),
-      maxFloorsAllowed,
-    );
+    // Step 6: Determine optimal floor count. The clamp is the policy
+    // (subtype cap wins over demand), but we record exceedsSubtypeCap so
+    // the UI can surface a warning instead of silently capping.
+    const demandFloors = Math.max(minFloorsNeeded, 1);
+    const exceedsSubtypeCap = demandFloors > maxFloorsAllowed;
+    let optimalFloors = Math.min(demandFloors, maxFloorsAllowed);
     const floorPolicy = resolveResidentialFloorCountPolicy(
       {
         buildingType,
         subType,
-        area: totalProgramArea,
-        targetAreaM2: totalProgramArea,
+        area: safeProgramArea,
+        targetAreaM2: safeProgramArea,
         floorCountLocked: options.floorCountLocked === true,
       },
       optimalFloors,
@@ -294,76 +447,108 @@ class AutoLevelAssignmentService {
 
     // Step 8: Check if fits within site
     const fitsWithinSite = actualFootprint <= maxFootprintArea;
-    const siteCoveragePercent = (actualFootprint / siteArea) * 100;
+    const siteCoveragePercent = (actualFootprint / safeSiteArea) * 100;
 
     logger.info(`   Optimal floors: ${optimalFloors}`);
     logger.info(`   Actual footprint: ${actualFootprint.toFixed(0)}m²`);
     logger.info(`   Site coverage: ${siteCoveragePercent.toFixed(1)}%`);
     logger.info(`   Fits within site: ${fitsWithinSite ? "YES ✅" : "NO ❌"}`);
+    if (exceedsSubtypeCap) {
+      logger.warn(
+        `   Programme demands ${demandFloors} storeys but ${subType || buildingType} caps at ${maxFloorsAllowed} — clamped to ${optimalFloors} with exceedsSubtypeCap=true`,
+      );
+    }
 
     return {
       optimalFloors,
+      fallbackReason: null,
       minFloorsNeeded,
       maxFloorsAllowed,
+      demandFloors,
       actualFootprint,
       maxFootprintArea,
       siteCoveragePercent,
       fitsWithinSite,
       floorHeight: typicalFloorHeight,
       totalHeight: optimalFloors * typicalFloorHeight,
-      coverageRatio: adjustedCoverage, // Include for UI display
-      subType, // Include for reference
+      coverageRatio: adjustedCoverage,
+      effectiveCoverage,
+      setbackReduction,
+      programToSiteRatio,
+      exceedsSubtypeCap,
+      subtypeMaxFloors,
+      subType,
       floorPolicy,
-      reasoning: this._generateFloorCountReasoning(
-        optimalFloors,
-        totalProgramArea,
-        siteArea,
-        actualFootprint,
-        maxFootprintArea,
+      reasoning: this._generateFloorCountReasoning({
+        floors: optimalFloors,
+        programArea: safeProgramArea,
+        siteArea: safeSiteArea,
+        circulationFactor,
+        adjustedCoverage,
+        setbackReduction,
+        programToSiteRatio,
+        demandFloors,
+        maxFloorsAllowed,
+        subtypeMaxFloors,
+        exceedsSubtypeCap,
         buildingType,
-      ),
+        subType,
+      }),
     };
   }
 
   /**
-   * Generate reasoning for floor count decision
+   * Generate reasoning for floor count decision. Signature is an options
+   * object so callers can pass the ratio + setback + cap context.
    * @private
    */
-  _generateFloorCountReasoning(
+  _generateFloorCountReasoning({
     floors,
     programArea,
     siteArea,
-    footprint,
-    maxFootprint,
-    buildingType,
-  ) {
+    circulationFactor,
+    adjustedCoverage,
+    setbackReduction,
+    programToSiteRatio,
+    demandFloors,
+    maxFloorsAllowed,
+    subtypeMaxFloors,
+    exceedsSubtypeCap,
+    subType,
+  } = {}) {
     const reasons = [];
 
+    const ratioText =
+      Number.isFinite(programToSiteRatio) && programToSiteRatio > 0
+        ? programToSiteRatio.toFixed(2)
+        : "n/a";
+    const coveragePct = Number.isFinite(adjustedCoverage)
+      ? Math.round(adjustedCoverage * 100)
+      : null;
+    const setbackPct = Number.isFinite(setbackReduction)
+      ? Math.round(setbackReduction * 100)
+      : null;
+
     reasons.push(
-      `${floors} floors optimal to fit ${programArea.toFixed(0)}m² program within ${siteArea.toFixed(0)}m² site`,
+      `Programme ${programArea.toFixed(0)}m² × ${circulationFactor.toFixed(2)} circulation ÷ (site ${siteArea.toFixed(0)}m² × ${coveragePct}% coverage × ${setbackPct}% setback) ⇒ ratio ${ratioText} ⇒ ${demandFloors} storey${demandFloors === 1 ? "" : "s"} required`,
     );
 
-    if (footprint > maxFootprint * 0.9) {
+    if (exceedsSubtypeCap) {
+      const capLabel = subType ? `${subType} cap` : "subtype cap";
       reasons.push(
-        `Footprint utilization high (${((footprint / maxFootprint) * 100).toFixed(0)}%) - efficient site usage`,
+        `Clamped to ${floors} storey${floors === 1 ? "" : "s"} (${capLabel} ${maxFloorsAllowed}) — consider trimming programme or picking a denser subtype`,
       );
-    } else if (footprint < maxFootprint * 0.5) {
-      reasons.push(
-        `Footprint utilization low (${((footprint / maxFootprint) * 100).toFixed(0)}%) - consider reducing floors or increasing program`,
-      );
+    } else if (subtypeMaxFloors && demandFloors === maxFloorsAllowed) {
+      reasons.push(`At subtype cap ${maxFloorsAllowed}`);
     }
 
     if (floors === 1) {
-      reasons.push(
-        "Single-story design - ideal for accessibility and horizontal circulation",
-      );
+      reasons.push("Single-storey: accessible, horizontal circulation only");
     } else if (floors === 2) {
-      reasons.push(
-        "Two-story design - good balance of compactness and accessibility",
-      );
+      reasons.push("Two-storey: compact, accessible with one stair core");
     } else if (floors >= 3) {
       reasons.push(
-        `${floors}-story design - vertical circulation (stairs/lift) required`,
+        `${floors}-storey: vertical circulation (stairs/lift) required`,
       );
     }
 
@@ -707,6 +892,31 @@ class AutoLevelAssignmentService {
       buildingType,
       ...constraints,
     });
+
+    // Step 2b: If site area was missing, the service returns optimalFloors=null.
+    // Pass spaces through unchanged so callers can fall back to their own count
+    // (locked, manual, or fallback) without crashing autoAssignSpacesToLevels.
+    if (floorCalc.optimalFloors == null) {
+      logger.warn(
+        "AUTO-ASSIGNMENT: skipped (no site area). Passing spaces through.",
+      );
+      return {
+        success: false,
+        fallbackReason: floorCalc.fallbackReason || "no-site-area",
+        assignedSpaces: programSpaces,
+        floorCount: null,
+        floorMetrics: floorCalc,
+        summary: {
+          totalSpaces: programSpaces.length,
+          totalArea: totalProgramArea,
+          siteArea,
+          floors: null,
+          footprint: null,
+          siteCoverage: null,
+          reasoning: floorCalc.reasoning,
+        },
+      };
+    }
 
     // Step 3: Auto-assign spaces to levels
     const assignedSpaces = this.autoAssignSpacesToLevels(

--- a/src/services/project/projectPipelineV2Service.js
+++ b/src/services/project/projectPipelineV2Service.js
@@ -139,6 +139,12 @@ function alignProgramSpacesToResolvedLevels({
     0,
   );
 
+  // maxFloors is intentionally omitted: the subtype table inside
+  // autoLevelAssignmentService caps each residential subtype accurately
+  // (detached/semi/villa = 3, terraced = 4, apartment-building = 8, etc.),
+  // and the returned floorMetrics now includes programToSiteRatio,
+  // effectiveCoverage, setbackReduction and exceedsSubtypeCap which
+  // propagate automatically via stampProgramSpaceMetadata.
   const floorMetrics =
     Number.isFinite(Number(siteAreaM2)) && Number(siteAreaM2) > 0
       ? autoLevelAssignmentService.calculateOptimalLevels(
@@ -147,7 +153,6 @@ function alignProgramSpacesToResolvedLevels({
           {
             buildingType: subType || "residential",
             subType: subType || null,
-            maxFloors: 4,
           },
         )
       : null;


### PR DESCRIPTION
## Summary

The wizard's number-of-levels auto-detect already used the proportion between programme area and site area (in `autoLevelAssignmentService.calculateOptimalLevels`), but the ratio was wired in inconsistently:

- The live effect at [ArchitectAIWizardContainer.jsx:543](src/components/ArchitectAIWizardContainer.jsx:543) fed `projectDetails.area`, while three other call sites fed `sum(programSpaces.area × count)`. The two inputs diverged across Compile passes.
- The effect had no `siteArea > 0` guard, so when `siteMetrics.areaM2` was missing the formula produced `Infinity` floors then silently clamped to `maxFloors = 10` — the exact "silent cap" pattern called out in the floor-count auto-detect memory.
- `maxFloors` was hard-coded per call site (residential V2 = 4, generic = 10), so the same project produced different recommendations.
- `setbackReduction` was a flat `0.85` regardless of subtype, even though terraced/warehouse setbacks are near zero and detached/villa setbacks are 25–30%.
- The actual ratio was never surfaced. The UI showed "auto: 3" with no explanation.

This change makes `programArea ÷ siteArea` the single, transparent, subtype-aware driver of the auto-detected floor count across both residential V2 and non-residential paths.

## Changes

- **`src/services/autoLevelAssignmentService.js`**: subtype setback table (35+ subtypes), `siteArea > 0` guard returning null shape, `programToSiteRatio` / `effectiveCoverage` / `setbackReduction` / `demandFloors` / `exceedsSubtypeCap` / `subtypeMaxFloors` / `fallbackReason` first-class fields, richer reasoning string. `autoAssignComplete` tolerates `optimalFloors: null`.
- **`src/components/ArchitectAIWizardContainer.jsx`**: live effect uses sum-of-programme-spaces (with fallback to `projectDetails.area`), handles the new null return cleanly. Dropped hard-coded `maxFloors: 4 / 10` at 3 call sites — the subtype table inside the service caps each subtype accurately. Surfaces `exceedsSubtypeCap` as a programme warning for both residential V2 and non-residential paths.
- **`src/components/steps/SpecsStep.jsx`**: compact ratio line `"Programme {ratio}× site at {coverage}% coverage"` under the auto badge with full reasoning on hover; over-cap warning chip when programme density exceeds the subtype cap.
- **`src/services/project/projectPipelineV2Service.js`**: dropped server-side `maxFloors: 4`; new fields propagate via the existing `stampProgramSpaceMetadata` chain.

## Manual lock contract is unchanged

- `resolveAuthoritativeFloorCount` precedence (`locked > auto > manual > fallback`) untouched.
- `exceedsSubtypeCap` is informational only — never overrides a locked count, never silently inflates the unlocked auto value.
- `clampedFromUser` continues to fire when callers pass an explicit `maxFloors`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run check:contracts` — PASSED
- [x] `npm run test:compose:routing` — 22/22 passed
- [x] `npm run build:active` — Compiled successfully
- [x] 7 new unit tests in `src/__tests__/services/autoLevelAssignmentService.test.js` covering siteArea≤0 guard, residential detached / terraced / apartment, non-residential warehouse / office, unknown subtype fallback, `autoAssignComplete` null tolerance.
- [x] 2 new integration tests in `src/__tests__/components/ArchitectAIWizardContainer.programmeFlow.test.jsx` covering live-effect null reset + over-cap warning DOM render.
- [x] Node smoke against `calculateOptimalLevels`: 10/10 assertions match expected ratio + floor counts + setback reductions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)