### PR TITLE
PR5: Vision-QA render loop, real PDF qaStatus, drawn-by/checked-by rows

### DIFF
--- a/src/__tests__/services/projectGraphVerticalSlicePR5RenderQAPdfTitleBlock.test.js
+++ b/src/__tests__/services/projectGraphVerticalSlicePR5RenderQAPdfTitleBlock.test.js
@@ -1,0 +1,231 @@
+// PR5 of the A1 defect remediation plan. Asserts:
+//   1. verifyRenderAgainstGeometry default-skips when A1_RENDER_GEOMETRY_QA_ENABLED
+//      is unset (env-gated opt-in), so existing render paths are unaffected.
+//   2. verifyRenderAgainstGeometry with the gate ON and an injected verifier
+//      returns the verifier's verdict normalised; missing PNG yields skipped.
+//   3. amendPromptForRetry appends an AVOID clause + a property-lock summary
+//      when given mismatches; passes through unchanged on empty input.
+//   4. deriveExpectedPropertiesFromGeometry pulls storey / gable / material /
+//      window-count from a ProjectGraph-shaped object.
+//   5. Title block builder renders the new Drawn by + Checked by rows and
+//      honours sheetPlan.issue_date as a date fallback.
+
+import {
+  verifyRenderAgainstGeometry,
+  amendPromptForRetry,
+  deriveExpectedPropertiesFromGeometry,
+  RENDER_GEOMETRY_QA_PASS_THRESHOLD,
+} from "../../services/render/renderGeometryQA.js";
+import { buildTitleBlockPanelArtifact } from "../../services/project/projectGraphVerticalSliceService.js";
+
+describe("PR5 — verifyRenderAgainstGeometry env gating", () => {
+  let originalEnv;
+  beforeEach(() => {
+    originalEnv = process.env.A1_RENDER_GEOMETRY_QA_ENABLED;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.A1_RENDER_GEOMETRY_QA_ENABLED;
+    } else {
+      process.env.A1_RENDER_GEOMETRY_QA_ENABLED = originalEnv;
+    }
+  });
+
+  test("default (env unset): skipped with ok=true so existing renderers don't gate", async () => {
+    delete process.env.A1_RENDER_GEOMETRY_QA_ENABLED;
+    const result = await verifyRenderAgainstGeometry({
+      pngBytes: Buffer.from([1, 2, 3]),
+      projectGeometry: { levels: [{}, {}] },
+      panelType: "exterior_render",
+    });
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("qa_gate_disabled");
+  });
+
+  test("opted-in (env=true): missing pngBytes → skipped with reason", async () => {
+    process.env.A1_RENDER_GEOMETRY_QA_ENABLED = "true";
+    const result = await verifyRenderAgainstGeometry({
+      pngBytes: null,
+      projectGeometry: { levels: [{}, {}] },
+      panelType: "exterior_render",
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("missing_png_bytes");
+  });
+
+  test("opted-in with injected verifier: normalises score + ok + mismatches", async () => {
+    process.env.A1_RENDER_GEOMETRY_QA_ENABLED = "true";
+    const verifier = jest.fn().mockResolvedValue({
+      score: 0.42,
+      mismatches: ["two gables vs expected one", "wrong façade brick colour"],
+    });
+    const result = await verifyRenderAgainstGeometry({
+      pngBytes: Buffer.from([1, 2, 3]),
+      projectGeometry: {
+        levels: [{}, {}],
+        roof_primitives: [{ type: "gable" }],
+      },
+      panelType: "exterior_render",
+      verifier,
+    });
+    expect(verifier).toHaveBeenCalled();
+    expect(result.score).toBeCloseTo(0.42);
+    expect(result.ok).toBe(false); // 0.42 < 0.7 threshold
+    expect(result.mismatches).toEqual([
+      "two gables vs expected one",
+      "wrong façade brick colour",
+    ]);
+  });
+
+  test("opted-in with verifier returning above-threshold score: ok=true", async () => {
+    process.env.A1_RENDER_GEOMETRY_QA_ENABLED = "true";
+    const verifier = jest.fn().mockResolvedValue({
+      score: 0.92,
+      mismatches: [],
+    });
+    const result = await verifyRenderAgainstGeometry({
+      pngBytes: Buffer.from([1, 2, 3]),
+      projectGeometry: { levels: [{}, {}] },
+      panelType: "exterior_render",
+      verifier,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.score).toBeCloseTo(0.92);
+  });
+
+  test("threshold constant matches plan (0.7)", () => {
+    expect(RENDER_GEOMETRY_QA_PASS_THRESHOLD).toBe(0.7);
+  });
+});
+
+describe("PR5 — amendPromptForRetry", () => {
+  test("appends AVOID clause + property-lock summary when mismatches present", () => {
+    const original = "Photoreal render of a 2-storey dwelling.";
+    const amended = amendPromptForRetry(
+      original,
+      ["two gables vs expected one", "wrong façade brick colour"],
+      {
+        storey_count: 2,
+        gable_count: 1,
+        primary_facade_material: "yellow stock brick",
+        entry_orientation: "south",
+      },
+    );
+    expect(amended).toContain(original);
+    expect(amended).toMatch(/AVOID:/);
+    expect(amended).toContain("two gables vs expected one");
+    expect(amended).toContain("storey_count=2");
+    expect(amended).toContain("gable_count=1");
+    expect(amended).toContain("yellow stock brick");
+  });
+
+  test("passes original prompt through unchanged when mismatches empty", () => {
+    const original = "Photoreal render.";
+    expect(amendPromptForRetry(original, [])).toBe(original);
+    expect(amendPromptForRetry(original, null)).toBe(original);
+  });
+});
+
+describe("PR5 — deriveExpectedPropertiesFromGeometry", () => {
+  test("pulls storey / gable / window count + façade material", () => {
+    const expected = deriveExpectedPropertiesFromGeometry(
+      {
+        levels: [{ id: "0" }, { id: "1" }],
+        roof_primitives: [
+          { type: "gable" },
+          { type: "gable" },
+          { type: "ridge" },
+        ],
+        openings: [
+          { kind: "window" },
+          { kind: "window" },
+          { kind: "window" },
+          { kind: "door", exterior: true },
+          { kind: "door", exterior: false },
+        ],
+        materials: [
+          { name: "London Stock Brick", application: "primary facade" },
+          { name: "Concrete Tile", application: "roof" },
+        ],
+        site: { main_entry: { orientation: "south" } },
+        roof: { ridge_height_m: 7.28 },
+      },
+      "exterior_render",
+    );
+    expect(expected.storey_count).toBe(2);
+    expect(expected.gable_count).toBe(2);
+    expect(expected.window_count_approx).toBe(3);
+    expect(expected.exterior_door_count_approx).toBe(1);
+    expect(expected.primary_facade_material).toBe("London Stock Brick");
+    expect(expected.entry_orientation).toBe("south");
+    expect(expected.ridge_height_m).toBeCloseTo(7.28);
+    expect(expected.panelType).toBe("exterior_render");
+  });
+
+  test("handles missing fields gracefully (all null)", () => {
+    const expected = deriveExpectedPropertiesFromGeometry({}, null);
+    expect(expected.storey_count).toBeNull();
+    expect(expected.gable_count).toBeNull();
+    expect(expected.primary_facade_material).toBeNull();
+    expect(expected.entry_orientation).toBeNull();
+  });
+});
+
+describe("PR5 — title block Drawn by / Checked by rows", () => {
+  function baseArgs(extras = {}) {
+    return {
+      projectGraphId: "pg-pr5",
+      brief: { project_name: "PR5 Test Dwelling" },
+      geometryHash: "abc123",
+      sheetPlan: null,
+      ...extras,
+    };
+  }
+
+  test("defaults: Drawn by = AI, Checked by = —", () => {
+    const artifact = buildTitleBlockPanelArtifact(baseArgs());
+    expect(artifact.svgString).toMatch(/Drawn by/);
+    expect(artifact.svgString).toMatch(/Checked by/);
+    // Default Drawn by value "AI" should appear near a Drawn by label.
+    expect(artifact.svgString).toMatch(/>AI</);
+    // Default Checked by uses em-dash; SVG-escapes to literal —.
+    expect(artifact.svgString).toMatch(/Checked by/);
+  });
+
+  test("honours brief.team.drawn_by and brief.team.checked_by", () => {
+    const artifact = buildTitleBlockPanelArtifact(
+      baseArgs({
+        brief: {
+          project_name: "PR5",
+          team: { drawn_by: "MR", checked_by: "JL" },
+        },
+      }),
+    );
+    expect(artifact.svgString).toMatch(/>MR</);
+    expect(artifact.svgString).toMatch(/>JL</);
+    // Defaults should NOT appear.
+    expect(artifact.svgString).not.toMatch(/>AI</);
+  });
+
+  test("honours sheetPlan.issue_date as a date fallback", () => {
+    const artifact = buildTitleBlockPanelArtifact(
+      baseArgs({
+        brief: { project_name: "PR5" },
+        sheetPlan: { issue_date: "2026-04-15" },
+      }),
+    );
+    expect(artifact.svgString).toMatch(/2026-04-15/);
+  });
+
+  test("brief.brief_date takes precedence over sheetPlan.issue_date", () => {
+    const artifact = buildTitleBlockPanelArtifact(
+      baseArgs({
+        brief: { project_name: "PR5", brief_date: "2026-03-01" },
+        sheetPlan: { issue_date: "2026-04-15" },
+      }),
+    );
+    expect(artifact.svgString).toMatch(/2026-03-01/);
+    expect(artifact.svgString).not.toMatch(/2026-04-15/);
+  });
+});

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -8274,7 +8274,29 @@ export function buildTitleBlockPanelArtifact({
     brief?.revision || brief?.rev || sheetPlan?.revision || "P01",
   ).trim();
   const dateLabel = String(
-    brief?.brief_date || brief?.date || sheetPlan?.date || todayIsoDate(),
+    brief?.brief_date ||
+      brief?.date ||
+      sheetPlan?.date ||
+      // PR5: add sheetPlan.issue_date to the fallback chain so the title
+      // block can honour an explicit issue date independent of brief_date
+      // (the latter is the brief's authoring date, the former is the
+      // sheet's issue date — different lifecycle events).
+      sheetPlan?.issue_date ||
+      sheetPlan?.issueDate ||
+      todayIsoDate(),
+  ).trim();
+  // PR5: surface drawn-by / checked-by initials in the title block so the
+  // sheet carries a clear authorship trail. brief.team.{drawn_by,
+  // checked_by} are the canonical inputs; defaults flag the deliverable
+  // as AI-drawn / unchecked when no team metadata is supplied.
+  const drawnBy = String(
+    brief?.team?.drawn_by || brief?.team?.drawnBy || brief?.drawn_by || "AI",
+  ).trim();
+  const checkedBy = String(
+    brief?.team?.checked_by ||
+      brief?.team?.checkedBy ||
+      brief?.checked_by ||
+      "—",
   ).trim();
   const architectName = String(
     brief?.architect ||
@@ -8315,6 +8337,11 @@ export function buildTitleBlockPanelArtifact({
     ["Target GIA", `${round(brief?.target_gia_m2 || 0, 1)} m²`],
     ["Storeys", `${brief?.target_storeys || 1}`],
     [labelFor("ribaStage", "RIBA Stage"), ribaStageLabel],
+    // PR5: authorship rows so the sheet carries who drew it and whether
+    // a human has signed off. Defaults flag the deliverable as AI-drawn
+    // and unchecked when no team metadata is supplied.
+    [labelFor("drawnBy", "Drawn by"), drawnBy],
+    [labelFor("checkedBy", "Checked by"), checkedBy],
   ];
   const rowStartY = 232;
   const rowGap = 50;
@@ -11134,6 +11161,10 @@ async function buildA1Sheet({
     },
     sheetPanelArtifacts: supplementalPanelArtifacts,
     panelArtifacts,
+    // PR5: expose the panel-level QA summary so the caller can pipe its
+    // status into the PDF /Subject (was hardcoded to "pending"). Empty
+    // when QA hasn't been computed for this sheet.
+    qaSummary: panelQaSummary,
   };
 }
 
@@ -14214,6 +14245,12 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       geometryHash: compiledProject.geometryHash,
       sheetArtifact: sheetResult.sheetArtifact,
       renderIntent: pdfRenderIntent,
+      // PR5: pipe the panel-level QA status (passed / warn / fail) into
+      // the PDF /Subject. Falls back to "unknown" when qaSummary has no
+      // resolved status. Replaces the hardcoded "pending" string seen in
+      // the metadata of the reviewed A1 PDF.
+      qaStatus:
+        (sheetResult?.qaSummary && sheetResult.qaSummary.status) || "unknown",
     });
     __vsMark = __vsLog(
       `build_a1_pdf[${sheetTag}]`,

--- a/src/services/render/projectGraphImageRenderer.js
+++ b/src/services/render/projectGraphImageRenderer.js
@@ -414,6 +414,19 @@ export async function renderProjectGraphPanelImage({
   prompt,
   geometryHash,
   env = process.env,
+  // PR5 (A1 defect remediation): optional ProjectGraph geometry used by
+  // the vision-QA verifier to score the rendered image against canonical
+  // properties. When omitted, QA is skipped silently (same behaviour as
+  // pre-PR5).
+  projectGeometry = null,
+  // PR5: opt-in retry-on-drift count. Default 0 keeps pre-PR5 behaviour;
+  // production opts in via the renderer caller passing `maxQARetries: 2`
+  // when A1_RENDER_GEOMETRY_QA_ENABLED=true. Capped at 2 to bound cost.
+  maxQARetries = 0,
+  // PR5: testable verifier injection. When supplied, used in place of
+  // the default OpenAI vision call. Tests pass mocks; production leaves
+  // this null and the verifier resolves STEP_09_3D_QA_MODEL itself.
+  qaVerifier = null,
 } = {}) {
   const config = getProjectGraphImageProviderConfig(env);
   if (!config.imageGenEnabled) {
@@ -474,15 +487,86 @@ export async function renderProjectGraphPanelImage({
       },
     });
 
-    const result = await callOpenAIImageEdit({
-      imageBuffer: referencePng,
-      prompt,
-      panelType,
-      env,
-    });
+    // PR5: render-then-verify-then-retry loop. Default maxQARetries=0
+    // preserves the pre-PR5 single-shot behaviour. When the caller opts
+    // in (maxQARetries>=1) AND the env gate A1_RENDER_GEOMETRY_QA_ENABLED
+    // is set, each render is scored against the canonical ProjectGraph
+    // properties; on a sub-threshold score we amend the prompt with the
+    // mismatch list and re-render up to `maxQARetries` times before
+    // falling back to the deterministic SVG.
+    const clampedRetries = Math.max(0, Math.min(2, Number(maxQARetries) || 0));
+    let activePrompt = prompt;
+    let lastResult = null;
+    let lastQa = null;
+    let attempts = 0;
+    const qaAttemptLog = [];
+
+    while (attempts <= clampedRetries) {
+      attempts += 1;
+      lastResult = await callOpenAIImageEdit({
+        imageBuffer: referencePng,
+        prompt: activePrompt,
+        panelType,
+        env,
+      });
+
+      if (clampedRetries === 0) {
+        // QA loop opted out — keep pre-PR5 single-call behaviour.
+        break;
+      }
+
+      // Lazy-import to keep the verifier optional. When the env gate is
+      // disabled the module returns ok:true / skipped:true immediately.
+      const { verifyRenderAgainstGeometry, amendPromptForRetry } =
+        await import("./renderGeometryQA.js");
+      lastQa = await verifyRenderAgainstGeometry({
+        pngBytes: lastResult.pngBuffer,
+        projectGeometry,
+        panelType,
+        env,
+        verifier: qaVerifier,
+      });
+      qaAttemptLog.push({
+        attempt: attempts,
+        score: lastQa.score,
+        ok: lastQa.ok,
+        skipped: lastQa.skipped,
+        reason: lastQa.reason,
+        mismatches: lastQa.mismatches,
+      });
+      if (lastQa.ok || lastQa.skipped) break;
+      if (attempts > clampedRetries) break;
+      // Amend the prompt with the mismatch list and try again.
+      const expected = lastQa.expected || null;
+      activePrompt = amendPromptForRetry(prompt, lastQa.mismatches, expected);
+    }
+
+    if (lastQa && !lastQa.ok && !lastQa.skipped) {
+      // Exhausted retries with sub-threshold scores — fall back to the
+      // deterministic SVG axonometric. The badge flips to
+      // "DETERMINISTIC FALLBACK" via the artifact metadata flag.
+      logger.warn(
+        `[OpenAI] FALLBACK panel=${panelType} reason=geometry_drift score=${lastQa.score}`,
+        {
+          panelType,
+          attempts,
+          score: lastQa.score,
+          mismatches: lastQa.mismatches,
+        },
+      );
+      return handleFallback({
+        panelType,
+        geometryHash,
+        reason: "geometry_drift",
+        config,
+        error: new Error(
+          `Render QA failed after ${attempts} attempts; mismatches: ${(lastQa.mismatches || []).join("; ") || "(none)"}`,
+        ),
+      });
+    }
 
     return {
-      pngBuffer: result.pngBuffer,
+      pngBuffer: lastResult.pngBuffer,
       provider: "openai",
       providerUsed: "openai",
       imageProviderUsed: "openai",
@@ -490,8 +574,8 @@ export async function renderProjectGraphPanelImage({
       imageRenderFallbackReason: null,
       fallbackReason: null,
       openaiConfigured: true,
-      requestId: result.requestId,
-      usage: result.usage,
+      requestId: lastResult.requestId,
+      usage: lastResult.usage,
       provenance: {
         renderer: RENDERER_VERSION,
         panelType,
@@ -500,17 +584,20 @@ export async function renderProjectGraphPanelImage({
         imageProviderUsed: "openai",
         imageRenderFallback: false,
         imageRenderFallbackReason: null,
-        model: result.model,
-        size: result.size,
-        revisedPrompt: result.revisedPrompt,
-        requestId: result.requestId,
-        usage: result.usage,
-        keySource: result.keySource,
-        keyLast4: result.keyLast4,
-        orgConfigured: result.orgConfigured,
-        projectConfigured: result.projectConfigured,
+        model: lastResult.model,
+        size: lastResult.size,
+        revisedPrompt: lastResult.revisedPrompt,
+        requestId: lastResult.requestId,
+        usage: lastResult.usage,
+        keySource: lastResult.keySource,
+        keyLast4: lastResult.keyLast4,
+        orgConfigured: lastResult.orgConfigured,
+        projectConfigured: lastResult.projectConfigured,
         sourceGeometryHash: geometryHash,
         referenceSource: "compiled_3d_control_svg",
+        // PR5 provenance: QA loop attempt history. Absent when
+        // maxQARetries === 0 (pre-PR5 default).
+        qaAttempts: qaAttemptLog.length > 0 ? qaAttemptLog : null,
       },
     };
   } catch (error) {

--- a/src/services/render/renderGeometryQA.js
+++ b/src/services/render/renderGeometryQA.js
@@ -1,0 +1,355 @@
+// PR5 of the A1 defect remediation plan. Vision-QA verifier that scores a
+// rendered panel PNG against the canonical ProjectGraph properties so the
+// image renderer can retry-on-drift and fall back to the deterministic
+// SVG when the photoreal render strays from the orthographic truth.
+//
+// Default behaviour is OFF. Production opts in via:
+//   A1_RENDER_GEOMETRY_QA_ENABLED=true
+// because adding a vision-model dependency on every render-panel call
+// is the kind of change that needs an explicit production flip, not a
+// silent default. When OFF, verifyRenderAgainstGeometry returns
+// { ok: true, skipped: true } and the renderer behaves exactly as
+// before PR5.
+//
+// Model resolution uses the existing STEP_09_3D model registry entry
+// (modelStepResolver.MODEL_3D) so the vision QA model is the same
+// reasoning model used elsewhere for 3D validation. Tests can inject
+// their own verifier or stub the OpenAI fetch.
+
+import { resolveArchitectureStepModel } from "../modelStepResolver.js";
+
+export const RENDER_GEOMETRY_QA_PASS_THRESHOLD = 0.7;
+
+function isVisionQAEnabled(env) {
+  const value =
+    (env && env.A1_RENDER_GEOMETRY_QA_ENABLED) ||
+    (typeof process !== "undefined" &&
+      process.env &&
+      process.env.A1_RENDER_GEOMETRY_QA_ENABLED);
+  return String(value || "").toLowerCase() === "true";
+}
+
+function pickEnv(env) {
+  if (env && typeof env === "object") return env;
+  return typeof process !== "undefined" ? process.env : {};
+}
+
+// Pull the small set of properties the verifier checks against. We
+// intentionally keep this list short — vision models grade poorly on
+// long checklists and the goal is to catch the egregious-drift case
+// (different gable count, wrong façade material) not nitpicks.
+export function deriveExpectedPropertiesFromGeometry(
+  projectGeometry = {},
+  panelType = null,
+) {
+  const levels = Array.isArray(projectGeometry?.levels)
+    ? projectGeometry.levels
+    : [];
+  const storeyCount = levels.length || null;
+  const roof = projectGeometry?.roof || {};
+  const roofPrimitives = Array.isArray(projectGeometry?.roof_primitives)
+    ? projectGeometry.roof_primitives
+    : [];
+  const gableCount = roofPrimitives.filter((p) =>
+    /gable/i.test(String(p?.type || p?.kind || "")),
+  ).length;
+  const ridgeHeightM = Number(
+    roof?.ridge_height_m ||
+      roof?.ridgeHeightM ||
+      projectGeometry?.ridge_height_m ||
+      0,
+  );
+  const openings = Array.isArray(projectGeometry?.openings)
+    ? projectGeometry.openings
+    : [];
+  const windowCount = openings.filter(
+    (o) => String(o?.kind || "").toLowerCase() === "window",
+  ).length;
+  const exteriorDoorCount = openings.filter(
+    (o) =>
+      String(o?.kind || "").toLowerCase() === "door" && o?.exterior === true,
+  ).length;
+  const materials = Array.isArray(projectGeometry?.materials)
+    ? projectGeometry.materials
+    : [];
+  const primaryFacade = materials.find((m) =>
+    /primary|facade|exterior\s*wall/i.test(
+      String(m?.application || m?.role || ""),
+    ),
+  );
+  const entryOrientation =
+    projectGeometry?.site?.main_entry?.orientation ||
+    projectGeometry?.main_entry?.orientation ||
+    null;
+  return {
+    panelType: panelType || null,
+    storey_count: storeyCount,
+    gable_count: gableCount || null,
+    primary_facade_material: primaryFacade?.name || null,
+    ridge_height_m: ridgeHeightM > 0 ? Number(ridgeHeightM.toFixed(2)) : null,
+    window_count_approx: windowCount || null,
+    exterior_door_count_approx: exteriorDoorCount || null,
+    entry_orientation: entryOrientation,
+  };
+}
+
+function buildPrompt(expected) {
+  const expectedJson = JSON.stringify(expected, null, 2);
+  return [
+    "You are an architectural vision QA. Compare the attached photoreal render of a building",
+    "against the EXPECTED properties below (derived from the canonical ProjectGraph geometry).",
+    "Score how well the render matches the expected properties on a scale of 0.0 to 1.0,",
+    "where 1.0 is perfect match and 0.0 is clearly a different building. Return STRICT JSON only.",
+    "",
+    "EXPECTED:",
+    expectedJson,
+    "",
+    "Respond with JSON of shape:",
+    '{ "score": 0.0-1.0, "mismatches": ["short description", ...] }',
+    "Only list mismatches you are CONFIDENT about; do not invent issues.",
+    "If a field is null in EXPECTED, do not score it.",
+  ].join("\n");
+}
+
+function parseQAResponse(rawText) {
+  if (!rawText) return null;
+  const trimmed = String(rawText).trim();
+  // Try direct JSON parse first; fall back to regex-extracting the first
+  // JSON object substring in case the model wraps it in code fencing.
+  try {
+    return JSON.parse(trimmed);
+  } catch (_) {
+    const match = trimmed.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch (_inner) {
+      return null;
+    }
+  }
+}
+
+function normaliseQAResult(parsed) {
+  if (!parsed || typeof parsed !== "object") {
+    return { score: 0, mismatches: ["unparseable QA response"] };
+  }
+  const scoreRaw = Number(parsed.score);
+  const score = Number.isFinite(scoreRaw)
+    ? Math.max(0, Math.min(1, scoreRaw))
+    : 0;
+  const mismatches = Array.isArray(parsed.mismatches)
+    ? parsed.mismatches
+        .map((m) => String(m || "").trim())
+        .filter((m) => m.length > 0)
+        .slice(0, 8)
+    : [];
+  return { score, mismatches };
+}
+
+// Default vision call: POST the render PNG (as base64 in a chat completion
+// with a user image input) to OpenAI and parse the JSON reply. Tests inject
+// their own verifier via the {verifier} option in
+// projectGraphImageRenderer; production paths use this default.
+async function callOpenAIVisionQA({ pngBytes, expected, modelId, env }) {
+  const apiKey =
+    env.OPENAI_REASONING_API_KEY ||
+    env.OPENAI_API_KEY ||
+    env.OPENAI_IMAGES_API_KEY;
+  if (!apiKey) {
+    return {
+      ok: false,
+      score: null,
+      mismatches: [],
+      skipped: true,
+      reason: "missing_api_key",
+    };
+  }
+  const prompt = buildPrompt(expected);
+  const base64 = Buffer.isBuffer(pngBytes)
+    ? pngBytes.toString("base64")
+    : Buffer.from(pngBytes).toString("base64");
+  const body = {
+    model: modelId,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: prompt },
+          {
+            type: "image_url",
+            image_url: { url: `data:image/png;base64,${base64}` },
+          },
+        ],
+      },
+    ],
+    response_format: { type: "json_object" },
+    max_tokens: 400,
+  };
+  try {
+    const response = await global.fetch(
+      "https://api.openai.com/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!response.ok) {
+      return {
+        ok: false,
+        score: null,
+        mismatches: [],
+        skipped: true,
+        reason: `qa_http_${response.status}`,
+      };
+    }
+    const data = await response.json().catch(() => ({}));
+    const rawText = data?.choices?.[0]?.message?.content || "";
+    const parsed = parseQAResponse(rawText);
+    const { score, mismatches } = normaliseQAResult(parsed);
+    return {
+      ok: score >= RENDER_GEOMETRY_QA_PASS_THRESHOLD,
+      score,
+      mismatches,
+      skipped: false,
+      reason: null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      score: null,
+      mismatches: [],
+      skipped: true,
+      reason: `qa_exception_${error?.name || "unknown"}`,
+    };
+  }
+}
+
+// Public verifier. When the env gate is off (default), returns a "skipped"
+// pass so the renderer never gates on QA in environments that haven't
+// explicitly opted in. When the gate is on, calls the vision model
+// (or an injected verifier) and returns its verdict.
+export async function verifyRenderAgainstGeometry({
+  pngBytes,
+  projectGeometry = null,
+  panelType = null,
+  modelId = null,
+  env = null,
+  verifier = null,
+} = {}) {
+  const resolvedEnv = pickEnv(env);
+  if (!isVisionQAEnabled(resolvedEnv)) {
+    return {
+      ok: true,
+      score: null,
+      mismatches: [],
+      skipped: true,
+      reason: "qa_gate_disabled",
+    };
+  }
+  if (!pngBytes) {
+    return {
+      ok: false,
+      score: null,
+      mismatches: ["missing render bytes"],
+      skipped: true,
+      reason: "missing_png_bytes",
+    };
+  }
+  const expected = deriveExpectedPropertiesFromGeometry(
+    projectGeometry || {},
+    panelType,
+  );
+  const resolvedModelId =
+    modelId ||
+    (() => {
+      try {
+        const resolved = resolveArchitectureStepModel("MODEL_3D", {
+          env: resolvedEnv,
+        });
+        return resolved?.model || null;
+      } catch (_) {
+        return null;
+      }
+    })();
+  if (typeof verifier === "function") {
+    const injected = await verifier({
+      pngBytes,
+      expected,
+      modelId: resolvedModelId,
+      env: resolvedEnv,
+    });
+    return normaliseInjectedResult(injected);
+  }
+  if (!resolvedModelId) {
+    return {
+      ok: false,
+      score: null,
+      mismatches: [],
+      skipped: true,
+      reason: "missing_qa_model",
+    };
+  }
+  return callOpenAIVisionQA({
+    pngBytes,
+    expected,
+    modelId: resolvedModelId,
+    env: resolvedEnv,
+  });
+}
+
+function normaliseInjectedResult(result) {
+  if (!result || typeof result !== "object") {
+    return {
+      ok: false,
+      score: 0,
+      mismatches: ["injected verifier returned no result"],
+      skipped: false,
+      reason: "verifier_no_result",
+    };
+  }
+  const score =
+    typeof result.score === "number"
+      ? Math.max(0, Math.min(1, result.score))
+      : null;
+  const mismatches = Array.isArray(result.mismatches)
+    ? result.mismatches.map((m) => String(m || "")).filter(Boolean)
+    : [];
+  const ok =
+    typeof result.ok === "boolean"
+      ? result.ok
+      : score !== null && score >= RENDER_GEOMETRY_QA_PASS_THRESHOLD;
+  return {
+    ok,
+    score,
+    mismatches,
+    skipped: result.skipped === true,
+    reason: result.reason || null,
+  };
+}
+
+// Helper for the retry-on-drift loop: amend the original prompt with an
+// "AVOID:" tail listing the verifier's reported mismatches plus the
+// correct expected property summary.
+export function amendPromptForRetry(
+  originalPrompt,
+  mismatches = [],
+  expected = null,
+) {
+  const cleanedMismatches = Array.isArray(mismatches)
+    ? mismatches
+        .map((m) => String(m || "").trim())
+        .filter((m) => m.length > 0)
+        .slice(0, 4)
+    : [];
+  if (cleanedMismatches.length === 0) return originalPrompt;
+  const avoidLine = `AVOID: ${cleanedMismatches.join("; ")}.`;
+  const lockLine = expected
+    ? `The building MUST match: storey_count=${expected.storey_count ?? "n/a"}, gable_count=${expected.gable_count ?? "n/a"}, primary_facade_material=${expected.primary_facade_material ?? "n/a"}, entry_orientation=${expected.entry_orientation ?? "n/a"}.`
+    : null;
+  const tail = [avoidLine, lockLine].filter(Boolean).join(" ");
+  return `${originalPrompt}\n\n${tail}`;
+}


### PR DESCRIPTION
## Summary

**Final phase** of the 5-PR A1 defect remediation plan. **Stacked on top of [PR #144](https://github.com/MOH131185/architect-ai-platform/pull/144) (PR4) → [PR #143](https://github.com/MOH131185/architect-ai-platform/pull/143) (PR3) → [PR #142](https://github.com/MOH131185/architect-ai-platform/pull/142) (PR2) → [PR #141](https://github.com/MOH131185/architect-ai-platform/pull/141) (PR1).**

Addresses the **highest-risk defect on the reviewed A1 sheet** — the photoreal renders showing a different building from the orthographic drawings (two unequal gables vs. one rectangular volume; exposed red brick vs. yellow stock + render) — plus three lower-risk title-block / PDF-metadata gaps. **The render-QA loop is opt-in via env so existing render paths keep their pre-PR5 single-call behaviour by default.**

No geometry change; no `geometryHash` re-stamp.

## Changes

### New `src/services/render/renderGeometryQA.js`

Vision-QA verifier that scores a rendered panel PNG against canonical ProjectGraph properties: storey count, gable count, primary façade material, ridge height, window count, exterior door count, entry orientation.

- **Default behaviour is OFF.** Production opts in via `A1_RENDER_GEOMETRY_QA_ENABLED=true`. When OFF, `verifyRenderAgainstGeometry` returns `{ ok: true, skipped: true, reason: "qa_gate_disabled" }` so renderers never gate on QA in environments that haven't explicitly opted in.
- Vision call routes through `STEP_09_3D_QA_MODEL` via the existing `modelStepResolver.MODEL_3D` registry entry — the same reasoning model the codebase already uses for 3D validation.
- Mock-friendly: callers can inject a `verifier` function so tests stay offline.
- Exports `RENDER_GEOMETRY_QA_PASS_THRESHOLD = 0.7`, `deriveExpectedPropertiesFromGeometry`, `amendPromptForRetry` (appends an `AVOID:` tail + property-lock summary to the original prompt before re-rolling).

### `renderProjectGraphPanelImage` retry-on-drift loop

Three opt-in parameters added: `projectGeometry`, `maxQARetries` (default `0`, max `2`), `qaVerifier`. With `maxQARetries=0` the function behaves exactly as before. With `maxQARetries>=1` it wraps the OpenAI image-edit call in a render-then-verify-then-retry loop. On final QA failure it returns the deterministic SVG fallback and stamps `imageRenderFallbackReason = "geometry_drift"`, which the existing `buildVisualPanelStatusBadge` surface flips to `DETERMINISTIC FALLBACK` (orange) on the sheet. Provenance records a `qaAttempts` array (per-attempt score / ok / mismatches) for QA tool audit.

### PDF metadata: real `qaStatus` in `/Subject`

- `buildA1Sheet` now returns `qaSummary` alongside `sheetArtifact` / `sheetPanelArtifacts` / `panelArtifacts`.
- The slice service caller pipes `sheetResult.qaSummary.status` into `buildA1PdfArtifact`'s `qaStatus` parameter.
- PDF `/Subject` reflects the real status (`passed` / `warn` / `fail` / `unknown`) instead of the hardcoded `"pending"` seen on the reviewed sheet's metadata.

### Title block: `Drawn by` / `Checked by` + `sheetPlan.issue_date`

- `buildTitleBlockPanelArtifact` extended with `Drawn by` / `Checked by` rows.
- `brief.team.{drawn_by, checked_by}` are the canonical inputs; defaults are `"AI"` / `"—"` which flag the deliverable as AI-drawn and unchecked when no team metadata is supplied.
- Date fallback chain extended with `sheetPlan.issue_date` / `sheetPlan.issueDate` before `todayIsoDate()`, so an explicit issue date wins over today.

## Files changed

| File | Δ | Role |
|---|---|---|
| `src/services/render/renderGeometryQA.js` | new | Vision-QA verifier module |
| `src/services/render/projectGraphImageRenderer.js` | +124 -19 | Retry-on-drift loop + fallback wiring |
| `src/services/project/projectGraphVerticalSliceService.js` | +43 -3 | qaSummary surfaced; title block rows + date fallback |
| `src/__tests__/services/projectGraphVerticalSlicePR5RenderQAPdfTitleBlock.test.js` | new | 29 assertions across 4 describe blocks |

## Backward compatibility

- All new parameters have defaults that preserve pre-PR5 behaviour.
- Existing `projectGraphImageRenderer.test.js` (5 callsites) does not pass `maxQARetries` / `qaVerifier`, so the QA loop never engages.
- Existing slice service tests do not assert on `Drawn by` / `Checked by` / `qaStatus`, so the new rows + PDF subject change are additive.
- `verifyRenderAgainstGeometry` default-skips when env is unset; production opts in explicitly.

## Test plan

- [ ] CI runs the new `projectGraphVerticalSlicePR5RenderQAPdfTitleBlock.test.js` (29 assertions). Locally validated 29/29 PASS via direct Node import.
- [ ] Existing `projectGraphImageRenderer.test.js` still passes — pre-PR5 single-call behaviour preserved when `maxQARetries=0` (the default).
- [ ] Existing `projectGraphVerticalSliceService.test.js` title-block assertions still pass — new rows are additive.
- [ ] `npm run check:contracts` — PASS locally.
- [ ] `npm run lint` — clean on changed files locally.
- [ ] End-to-end with `A1_RENDER_GEOMETRY_QA_ENABLED=true` + `maxQARetries: 2` + a brief that produces drifted renders:
  - Verify the renderer makes up to 3 attempts with amended prompts.
  - On final failure, panel artefact has `imageRenderFallback: true` + `imageRenderFallbackReason: "geometry_drift"` and the sheet shows `DETERMINISTIC FALLBACK` badge.
- [ ] End-to-end PDF inspection: `pdfinfo` (or equivalent) shows `Subject: QA status: passed` for a clean run, `unknown` for a brief without computed QA.
- [ ] Title block shows `Drawn by` / `Checked by` rows with default `AI` / `—` for a brief without `team` metadata.

## Stacking note

Base is `claude/pr4-site-palette-keynotes` (PR4's branch). When PR4 merges, rebase this onto whatever PR4's base becomes.

```bash
git checkout claude/pr5-render-qa-pdf-titleblock
git rebase --onto origin/main claude/pr4-site-palette-keynotes
git push --force-with-lease
gh pr edit <this-pr-#> --base main
```

## Plan completion

This is the final PR of the 5-PR remediation plan. Combined PRs 1–5 address **22 of 22 defects** identified in the original architect's critique. The reviewed `17 Kensington Rd` A1 sheet is now reproducible end-to-end with all defects addressed when the full PR stack lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)