### PR TITLE
Update CORS Allow-Origin to archiaisolution.com for domain migration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -152,7 +152,7 @@
       "headers": [
         {
           "key": "Access-Control-Allow-Origin",
-          "value": "https://www.archiaisolution.pro"
+          "value": "https://archiaisolution.com"
         },
         {
           "key": "Access-Control-Allow-Methods",


### PR DESCRIPTION
## Summary
- Switches `Access-Control-Allow-Origin` in `vercel.json` from `https://www.archiaisolution.pro` to `https://archiaisolution.com`
- Unblocks `/api/*` calls from the new primary domain (`archiaisolution.com`) once it becomes the canonical host
- Required as part of the `.pro` -> `.com` migration before `archiaisolution.pro` expires on 2026-07-14

## Deploy ordering (important)
Merge this PR *before* setting `archiaisolution.pro` to redirect in the Vercel dashboard. There's a brief window after merge where old `.pro` visitors would get CORS errors on API calls; that window closes as soon as the `.pro` 301 redirect is configured (no app loads on `.pro` after that).

Sequence:
1. Merge this PR -> Vercel auto-deploys.
2. Vercel dashboard -> Settings -> Domains:
   - Set `archiaisolution.com` as Primary Domain.
   - Edit `archiaisolution.pro` -> Redirect to `archiaisolution.com`, status 301.
   - Edit `www.archiaisolution.pro` -> Redirect to `archiaisolution.com`, status 301.
3. Verify HTTP probes (separate step).

## Test plan
- [ ] Production deploy succeeds after merge.
- [ ] In browser at `https://archiaisolution.com`, an `/api/health` (or equivalent) call succeeds with no CORS console error.
- [ ] After Vercel `.pro` redirect is configured: `Invoke-WebRequest -Uri https://archiaisolution.pro -Method Head -MaximumRedirection 0` returns `301` with `Location: https://archiaisolution.com/`.
- [ ] Same probe against `https://www.archiaisolution.pro` returns `301` to `https://archiaisolution.com/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)