### PR TITLE
Lazy-load wizard steps and defer pdfjs/html2canvas/pdf-lib (-31% first-load JS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ genarch/.pytest_cache/
 build/
 dist/
 
+# Bundle analyzer output
+bundle-report.html
+
 # misc
 .DS_Store
 .env.local

--- a/docs/performance/frontend-bundle-plan.md
+++ b/docs/performance/frontend-bundle-plan.md
@@ -1,0 +1,199 @@
+# Frontend bundle plan
+
+## Goal
+
+Shrink the JavaScript downloaded on first paint of the landing page, without
+changing product behaviour, generation logic, authority gates, or artifact
+determinism (per [CLAUDE.md](../../CLAUDE.md) and the original PR brief).
+
+Two techniques only, no bundler config changes (Create React App 5 / plain
+`react-scripts`):
+
+1. **`React.lazy` + `<Suspense>`** for wizard step components and full-page
+   modal views.
+2. **Dynamic `import()` at call site** for heavy third-party libraries that
+   are only needed inside `async` service functions.
+
+## Baseline (before this PR)
+
+Production build with source maps. Measured via the new `npm run analyze`
+script (`source-map-explorer`).
+
+| Chunk                                |     Raw |        Gzip |
+| ------------------------------------ | ------: | ----------: |
+| `main.js` (initial bundle)           | 3.85 MB | **1.05 MB** |
+| `238.chunk.js` (xlsx, lazy)          |  418 KB |      138 KB |
+| `762.chunk.js` (lazy)                |  347 KB |      111 KB |
+| `228.chunk.js` (lazy)                |  176 KB |       49 KB |
+| `435.chunk.js` (three.core.js, lazy) |  182 KB |       48 KB |
+| `239.chunk.js` (html2canvas, lazy)   |  203 KB |       46 KB |
+| `455.chunk.js` (lazy)                |  138 KB |       43 KB |
+
+CRA flagged the initial bundle as "significantly larger than recommended"
+(~244 KB gzip target). Top groups inside `main.js`:
+
+|    KB raw | % main.js | Group                                    |
+| --------: | --------: | ---------------------------------------- |
+|     416.6 |     10.8% | `lucide-react`                           |
+| **415.3** | **10.8%** | **`pdfjs-dist`** (via `pdfToImages.js`)  |
+|     126.7 |      3.3% | `react-dom`                              |
+|      98.4 |      2.6% | `motion-dom` (framer-motion)             |
+|      88.2 |      2.3% | `@clerk/clerk-react`                     |
+|      70.8 |      1.8% | `services/dnaWorkflowOrchestrator.js`    |
+|      67.5 |      1.8% | `services/drawing/svgSectionRenderer.js` |
+|      62.5 |      1.6% | `crypto-js`                              |
+
+## Changes shipped
+
+### Wizard step lazy-loading
+
+Static imports → `React.lazy` in
+[ArchitectAIWizardContainer.jsx](../../src/components/ArchitectAIWizardContainer.jsx):
+
+- `LocationStep`, `IntelligenceStep`, `PortfolioStep`, `SpecsStep`,
+  `GenerateStep`, `ResultsStep`, `PricingPage`.
+- `LandingPage` and `DesignHistoryMenu` stay eager (rendered on first paint).
+- Each step gets a stable `webpackChunkName` (`step-location`, etc.).
+- `renderStep()` now wraps its content in a single `<Suspense>` with the new
+  [StepLoadingSkeleton](../../src/components/StepLoadingSkeleton.jsx) as the
+  fallback; the case-6 inner Suspense is gone (one boundary covers every
+  lazy case).
+- `PricingPage` render site has its own `<Suspense>`.
+- On `currentStep === 0` the container schedules a `requestIdleCallback`
+  prefetch of `step-location` (with a 1.5 s `setTimeout` fallback) so the
+  click-to-step-1 transition feels instant on warm networks.
+
+### Heavy library imports → dynamic `import()` at call site
+
+Each file moves the heavy `import` out of the module top level and into a
+cached async loader called from the `async` function that needs it. The
+public function signatures are unchanged; only load timing shifts.
+
+| Library       | File                                                                                                         | New chunk name |
+| ------------- | ------------------------------------------------------------------------------------------------------------ | -------------- |
+| `pdfjs-dist`  | [src/utils/pdfToImages.js](../../src/utils/pdfToImages.js)                                                   | `pdfjs-dist`   |
+| `html2canvas` | [src/services/siteMapCapture.js](../../src/services/siteMapCapture.js)                                       | `html2canvas`  |
+| `pdf-lib`     | [src/services/a1/composeRuntime.js](../../src/services/a1/composeRuntime.js)                                 | `pdf-lib`      |
+| `pdf-lib`     | [src/services/render/buildVectorPdfFromSheetSvg.js](../../src/services/render/buildVectorPdfFromSheetSvg.js) | `pdf-lib`      |
+
+The loader is the same pattern in every file:
+
+```js
+let _libPromise = null;
+async function loadLib() {
+  if (!_libPromise) {
+    _libPromise = import(/* webpackChunkName: "lib" */ "lib");
+  }
+  return _libPromise;
+}
+```
+
+This preserves determinism: nothing about the artifact pipeline's ordering
+changes — the same `async` calls happen at the same point, with one extra
+`await` for the (cached) module fetch.
+
+### Skipped on purpose
+
+- **xlsx** — already isolated as `238.chunk.js` (pure xlsx). `ProgramImportExportService` is already dynamically imported by the container, so the chunk only loads when a user imports/exports a program.
+- **three.js** — already isolated as `435.chunk.js` (100% `three.core.js`). Webpack's default `splitChunks` already gave it its own chunk; per-caller dynamic imports would not improve the graph.
+- **@turf/turf** — 31 synchronous call sites in [boundaryGeometry.js](../../src/components/map/boundaryGeometry.js); converting cascades through every consumer and is too invasive for a perf-only PR.
+- **jspdf** — not imported anywhere in `src/`.
+- **`svgToPdfWalker.js`** — its `pdf-lib` imports (`rgb`, `degrees`) are called from synchronous `parseSvgColor` helper. The walker is only reached through the (lazy) export flow, so it stays eager inside its lazy chunk.
+- **`projectGraphVerticalSliceService.js`** — listed in [CLAUDE.md](../../CLAUDE.md) as a key entrypoint; left untouched.
+
+### Bundle analysis tooling
+
+New `devDependency`: `source-map-explorer ^2.5.3`. Two scripts in
+[package.json](../../package.json):
+
+- `npm run build:analyze` — production build with `GENERATE_SOURCEMAP=true`
+- `npm run analyze` — opens `bundle-report.html` from
+  `source-map-explorer` against the latest `build/`
+
+`bundle-report.html` is added to [.gitignore](../../.gitignore).
+
+### Base64 in React state (audit only)
+
+`ExportPanel.jsx` line 54 passes `panel.base64` as a **prop**, not state, so
+no large base64 lives in `useState`. No refactor needed — and the artifact
+flow is out of scope per CLAUDE.md.
+
+## After this PR
+
+Same `build:analyze` + `analyze` pipeline, post-changes:
+
+| Chunk                                      |         Raw |       Gzip | Loads when              |
+| ------------------------------------------ | ----------: | ---------: | ----------------------- |
+| **`main.js`** (initial)                    | **2.73 MB** | **736 KB** | First paint             |
+| `463.chunk.js` (lucide-react, shared)      |      561 KB |     138 KB | First step / lazy chunk |
+| `238.chunk.js` (xlsx)                      |      418 KB |     137 KB | Program import/export   |
+| **`pdfjs-dist.chunk.js`** (new, named)     |      482 KB | **129 KB** | Portfolio PDF upload    |
+| `435.chunk.js` (three)                     |      182 KB |      48 KB | 3D preview              |
+| `239.chunk.js` (html2canvas in lazy graph) |      203 KB |      46 KB | Site-map capture        |
+| `step-location.chunk.js`                   |       85 KB |      22 KB | Step 1 navigation       |
+| `step-results.chunk.js`                    |       75 KB |      20 KB | Step 6 navigation       |
+| `step-specs.chunk.js`                      |       45 KB |      13 KB | Step 4 navigation       |
+| `step-generate.chunk.js`                   |       19 KB |       6 KB | Step 5 navigation       |
+| `step-portfolio.chunk.js`                  |       18 KB |       6 KB | Step 3 navigation       |
+| `step-intelligence.chunk.js`               |       12 KB |       4 KB | Step 2 navigation       |
+| `page-pricing.chunk.js`                    |       11 KB |       4 KB | Pricing view            |
+
+`build/index.html` still references only `main.js` — everything else is
+on-demand.
+
+### main.js delta vs. baseline
+
+|      | Baseline |   After |                  Δ |
+| ---- | -------: | ------: | -----------------: |
+| Raw  |  3.85 MB | 2.73 MB |       **−1.12 MB** |
+| Gzip |  1.05 MB |  736 KB | **−330 KB (−31%)** |
+
+Top groups inside `main.js` after the change (pdfjs-dist is gone):
+
+| KB raw | % main.js | Group                                         |
+| -----: | --------: | --------------------------------------------- |
+|  126.7 |      4.8% | `react-dom` (required)                        |
+|   97.3 |      3.7% | `motion-dom` (LandingPage uses framer-motion) |
+|   88.3 |      3.3% | `@clerk/clerk-react` (auth on landing)        |
+|   70.8 |      2.7% | `services/dnaWorkflowOrchestrator.js`         |
+|   67.5 |      2.5% | `services/drawing/svgSectionRenderer.js`      |
+|   62.5 |      2.3% | `crypto-js` (follow-up candidate)             |
+|   55.1 |      2.1% | `ArchitectAIWizardContainer.jsx`              |
+
+## Remaining risks / follow-ups (not in this PR)
+
+1. **Tree-shake `lucide-react` icons.** ~400 KB raw across the lazy chunks
+   (notably `463.chunk.js`). Migrate barrel imports
+   (`import { X } from "lucide-react"`) to specific-icon imports
+   (`import X from "lucide-react/dist/esm/icons/x"`) to shrink the shared
+   lucide chunk.
+2. **Tree-shake `crypto-js`** (62.5 KB in main.js). The codebase likely only
+   needs `crypto-js/sha256` or similar; barrel imports pull the whole lib.
+3. **Lazy-load `useArchitectAIWorkflow.js`.** This hook (46 KB) + its
+   transitive imports (DNA orchestrator, drawing renderers, project pipeline
+   V2) are the next-largest tranche in `main.js`. They're only needed once
+   the user starts working in step 1+, but the container imports them
+   eagerly. Moving them behind a per-step or per-action lazy load requires
+   restructuring the workflow hook and was deemed out of scope here.
+4. **`@turf/turf` boundary geometry.** 31 synchronous call sites in
+   `boundaryGeometry.js`. To defer turf, the helper exports would need to
+   become async and propagate through `SiteBoundaryEditorV2` / boundary
+   policy modules.
+5. **Verify `pdfjs-dist` worker still resolves.** The lazy loader sets
+   `GlobalWorkerOptions.workerSrc = ${origin}/pdf.worker.min.mjs` on first
+   import. The worker file is shipped at `/public/pdf.worker.min.mjs` and
+   must remain at that path for the lazy loader to find it.
+
+## How to re-run the analysis
+
+```powershell
+# 1. Produce a build with source maps
+npm run build:analyze
+
+# 2. Generate bundle-report.html (auto-opens in browser)
+npm run analyze
+```
+
+For a comparison run during development, keep two `build/` snapshots and run
+`source-map-explorer "<dir>/static/js/main.*.js" --json out.json` against
+each.

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,8 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "playwright": "^1.57.0",
-        "prettier": "^3.2.5"
+        "prettier": "^3.2.5",
+        "source-map-explorer": "^2.5.3"
       },
       "engines": {
         "node": ">=18.0.0 <23.0.0"
@@ -25466,6 +25467,162 @@
         "node": ">= 12"
       }
     },
+    "node_modules/source-map-explorer": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-explorer/-/source-map-explorer-2.5.3.tgz",
+      "integrity": "sha512-qfUGs7UHsOBE5p/lGfQdaAj/5U/GWYBw2imEpD6UQNkqElYonkow8t+HBL1qqIl3CuGZx7n8/CQo4x1HwSHhsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "btoa": "^1.2.1",
+        "chalk": "^4.1.0",
+        "convert-source-map": "^1.7.0",
+        "ejs": "^3.1.5",
+        "escape-html": "^1.0.3",
+        "glob": "^7.1.6",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "open": "^7.3.1",
+        "source-map": "^0.7.4",
+        "temp": "^0.9.4",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "sme": "bin/cli.js",
+        "source-map-explorer": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/source-map-explorer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/source-map-explorer/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/source-map-explorer/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -26534,6 +26691,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -26541,6 +26712,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/tempy": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "build": "react-scripts build",
     "build:active": "node scripts/run-build-active.cjs",
     "build:vercel": "CI=false GENERATE_SOURCEMAP=false react-scripts build",
+    "build:analyze": "GENERATE_SOURCEMAP=true react-scripts build",
+    "analyze": "source-map-explorer \"build/static/js/*.js\" --html bundle-report.html",
     "test": "react-scripts test",
     "test:compose:routing": "node scripts/tests/test-compose-core-and-routing.mjs",
     "test:a1:tofu": "node scripts/tests/test-a1-tofu-render.mjs",
@@ -166,7 +168,8 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "playwright": "^1.57.0",
-    "prettier": "^3.2.5"
+    "prettier": "^3.2.5",
+    "source-map-explorer": "^2.5.3"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/src/components/ArchitectAIWizardContainer.jsx
+++ b/src/components/ArchitectAIWizardContainer.jsx
@@ -72,18 +72,13 @@ import {
 } from "../services/project/floorCountAuthority.js";
 import { normalizeProgramSpaces } from "../services/project/levelUtils.js";
 import { generateDeterministicProgramSpaces } from "../services/project/programmeSpaceGenerator.js";
-import PricingPage from "./PricingPage.jsx";
 import DesignHistoryMenu from "./DesignHistoryMenu.jsx";
 
-// Step Components
-import LocationStep from "./steps/LocationStep.jsx";
-import IntelligenceStep from "./steps/IntelligenceStep.jsx";
-import PortfolioStep from "./steps/PortfolioStep.jsx";
-import SpecsStep from "./steps/SpecsStep.jsx";
-import GenerateStep from "./steps/GenerateStep.jsx";
-
-// Landing page
+// Landing page (kept eager — first paint)
 import LandingPage from "./LandingPage.jsx";
+
+// Suspense fallback for lazy step + page chunks
+import StepLoadingSkeleton from "./StepLoadingSkeleton.jsx";
 
 // Import new UI components and layout
 import { Card, Modal } from "./ui";
@@ -97,7 +92,39 @@ import {
   clerkAuthConfigured,
 } from "../services/auth/clerkFacade.js";
 
-const ResultsStep = lazy(() => import("./steps/ResultsStep.jsx"));
+// Step components and full-page views — lazy-loaded so the initial
+// landing-page bundle stays lean. Each becomes its own async chunk;
+// webpackChunkName hints keep build output readable in source-map-explorer.
+const LocationStep = lazy(
+  () =>
+    import(/* webpackChunkName: "step-location" */ "./steps/LocationStep.jsx"),
+);
+const IntelligenceStep = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "step-intelligence" */ "./steps/IntelligenceStep.jsx"
+    ),
+);
+const PortfolioStep = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "step-portfolio" */ "./steps/PortfolioStep.jsx"
+    ),
+);
+const SpecsStep = lazy(
+  () => import(/* webpackChunkName: "step-specs" */ "./steps/SpecsStep.jsx"),
+);
+const GenerateStep = lazy(
+  () =>
+    import(/* webpackChunkName: "step-generate" */ "./steps/GenerateStep.jsx"),
+);
+const ResultsStep = lazy(
+  () =>
+    import(/* webpackChunkName: "step-results" */ "./steps/ResultsStep.jsx"),
+);
+const PricingPage = lazy(
+  () => import(/* webpackChunkName: "page-pricing" */ "./PricingPage.jsx"),
+);
 
 const MAX_PROGRAMME_AREA_M2 = 100000;
 
@@ -428,6 +455,30 @@ const ArchitectAIWizardContainer = () => {
     (result?.a1Sheet?.panelMap &&
       Object.keys(result.a1Sheet.panelMap).length > 0),
   );
+
+  // Warm the first lazy step chunk while the user reads the landing page,
+  // so clicking "Start designing" feels instant. No-op past step 0; uses
+  // requestIdleCallback so slow networks aren't penalised.
+  useEffect(() => {
+    if (currentStep !== 0 || typeof window === "undefined") {
+      return undefined;
+    }
+    const prefetch = () => {
+      import(
+        /* webpackChunkName: "step-location" */ "./steps/LocationStep.jsx"
+      ).catch(() => {});
+    };
+    if (typeof window.requestIdleCallback === "function") {
+      const handle = window.requestIdleCallback(prefetch, { timeout: 2500 });
+      return () => {
+        if (typeof window.cancelIdleCallback === "function") {
+          window.cancelIdleCallback(handle);
+        }
+      };
+    }
+    const timer = window.setTimeout(prefetch, 1500);
+    return () => window.clearTimeout(timer);
+  }, [currentStep]);
 
   // Real-time timer while generation is in progress
   useEffect(() => {
@@ -2784,12 +2835,17 @@ const ArchitectAIWizardContainer = () => {
   );
 
   /**
-   * Render current step
+   * Render current step.
+   *
+   * Wizard steps (1–5), ResultsStep (6) and PricingPage are React.lazy
+   * chunks. A single Suspense boundary here covers every case; LandingPage
+   * (case 0 / default) is eager so the fallback never paints on first load.
    */
   const renderStep = () => {
+    let content;
     switch (currentStep) {
       case 0:
-        return (
+        content = (
           <LandingPage
             onStart={() => setCurrentStep(1)}
             onDemo={() => {
@@ -2798,9 +2854,10 @@ const ArchitectAIWizardContainer = () => {
             historyControl={historyControl}
           />
         );
+        break;
 
       case 1:
-        return (
+        content = (
           <LocationStep
             address={address}
             isDetectingLocation={isDetectingLocation}
@@ -2815,9 +2872,10 @@ const ArchitectAIWizardContainer = () => {
             error={error}
           />
         );
+        break;
 
       case 2:
-        return (
+        content = (
           <IntelligenceStep
             locationData={locationData}
             sitePolygon={sitePolygon}
@@ -2829,9 +2887,10 @@ const ArchitectAIWizardContainer = () => {
             onSitePolygonChange={handleSitePolygonChange}
           />
         );
+        break;
 
       case 3:
-        return (
+        content = (
           <PortfolioStep
             portfolioFiles={portfolioFiles}
             materialWeight={materialWeight}
@@ -2847,9 +2906,10 @@ const ArchitectAIWizardContainer = () => {
             fileInputRef={fileInputRef}
           />
         );
+        break;
 
       case 4:
-        return (
+        content = (
           <SpecsStep
             projectDetails={projectDetails}
             programSpaces={programSpaces}
@@ -2868,9 +2928,10 @@ const ArchitectAIWizardContainer = () => {
             onBack={handleBack}
           />
         );
+        break;
 
       case 5:
-        return (
+        content = (
           <GenerateStep
             isGenerating={loading}
             progress={progress}
@@ -2881,38 +2942,47 @@ const ArchitectAIWizardContainer = () => {
             onViewResults={() => setCurrentStep(6)}
           />
         );
+        break;
 
       case 6:
-        return (
-          <Suspense
-            fallback={
-              <Card className="border border-navy-700 bg-navy-950/70 p-8 text-center text-white">
-                Preparing results workspace...
-              </Card>
-            }
-          >
-            <ResultsStep
-              result={result}
-              designId={generatedDesignId}
-              generationElapsedSeconds={generationElapsedSeconds}
-              onModify={handleModify}
-              onExport={handleExport}
-              onExportCAD={handleExportCAD}
-              onExportBIM={handleExportBIM}
-              onBack={handleBack}
-              onStartNew={handleStartNew}
-            />
-          </Suspense>
+        content = (
+          <ResultsStep
+            result={result}
+            designId={generatedDesignId}
+            generationElapsedSeconds={generationElapsedSeconds}
+            onModify={handleModify}
+            onExport={handleExport}
+            onExportCAD={handleExportCAD}
+            onExportBIM={handleExportBIM}
+            onBack={handleBack}
+            onStartNew={handleStartNew}
+          />
         );
+        break;
 
       default:
-        return (
+        content = (
           <LandingPage
             onStart={() => setCurrentStep(1)}
             historyControl={historyControl}
           />
         );
     }
+    return (
+      <Suspense
+        fallback={
+          <StepLoadingSkeleton
+            label={
+              currentStep === 6
+                ? "Preparing results workspace..."
+                : "Loading..."
+            }
+          />
+        }
+      >
+        {content}
+      </Suspense>
+    );
   };
 
   // Pricing view (full-page, no auth gate needed — users can browse plans)
@@ -2929,7 +2999,9 @@ const ArchitectAIWizardContainer = () => {
         background="default"
         noise={true}
       >
-        <PricingPage onBack={() => setView("wizard")} />
+        <Suspense fallback={<StepLoadingSkeleton label="Loading pricing..." />}>
+          <PricingPage onBack={() => setView("wizard")} />
+        </Suspense>
       </AppShell>
     );
   }

--- a/src/components/StepLoadingSkeleton.jsx
+++ b/src/components/StepLoadingSkeleton.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import Card from "./ui/Card.jsx";
+
+const StepLoadingSkeleton = ({ label = "Loading..." }) => (
+  <Card
+    role="status"
+    aria-live="polite"
+    className="mx-auto flex min-h-[40vh] max-w-3xl items-center justify-center border border-navy-700 bg-navy-950/70 p-10 text-center text-white"
+  >
+    <div className="flex flex-col items-center gap-4">
+      <div
+        aria-hidden="true"
+        className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white"
+      />
+      <span className="text-sm text-white/70">{label}</span>
+    </div>
+  </Card>
+);
+
+export default StepLoadingSkeleton;

--- a/src/services/a1/composeRuntime.js
+++ b/src/services/a1/composeRuntime.js
@@ -1,8 +1,14 @@
 import path from "path";
 
-import { PDFDocument } from "pdf-lib";
-
 import { A1_WIDTH, A1_HEIGHT } from "./composeCore.js";
+
+let _pdfLibPromise = null;
+async function loadPdfLib() {
+  if (!_pdfLibPromise) {
+    _pdfLibPromise = import(/* webpackChunkName: "pdf-lib" */ "pdf-lib");
+  }
+  return _pdfLibPromise;
+}
 
 // Phase A close-out: final A1 PDFs must embed a 300 DPI raster of the A1
 // sheet (~9933 x 7016 px). Anything below 95% of that is preview density and
@@ -381,6 +387,7 @@ export async function buildPrintReadyPdfFromPng(pngBuffer, options = {}) {
 
   const plan = planPrintReadyPdfBuild(options);
 
+  const { PDFDocument } = await loadPdfLib();
   const pdf = await PDFDocument.create();
   const page = pdf.addPage([plan.widthPt, plan.heightPt]);
   const image = await pdf.embedPng(pngBuffer);

--- a/src/services/render/buildVectorPdfFromSheetSvg.js
+++ b/src/services/render/buildVectorPdfFromSheetSvg.js
@@ -21,9 +21,16 @@
  * those when no explicit `fonts` arg is supplied.
  */
 
-import { PDFDocument, StandardFonts } from "pdf-lib";
 import { parseSvg } from "./_lib/lightweightSvgParser.js";
 import { walkSvgIntoPdf } from "./_lib/svgToPdfWalker.js";
+
+let _pdfLibPromise = null;
+async function loadPdfLib() {
+  if (!_pdfLibPromise) {
+    _pdfLibPromise = import(/* webpackChunkName: "pdf-lib" */ "pdf-lib");
+  }
+  return _pdfLibPromise;
+}
 
 export const VECTOR_PDF_RENDER_MODE = "vector_textpaths_off";
 export const VECTOR_PDF_SCHEMA_VERSION = "vector-pdf-v1";
@@ -161,6 +168,8 @@ export async function buildVectorPdfFromSheetSvg({
     return { ...baseResult, error: "no_view_box" };
   }
   const fontBytes = fonts || extractEmbeddedFonts(svgString);
+
+  const { PDFDocument, StandardFonts } = await loadPdfLib();
 
   let pdfDoc;
   try {

--- a/src/services/siteMapCapture.js
+++ b/src/services/siteMapCapture.js
@@ -4,9 +4,17 @@
  * Includes polygon overlay and scale bar
  */
 
-import html2canvas from 'html2canvas';
-import logger from '../utils/logger.js';
+import logger from "../utils/logger.js";
 
+let _html2canvasPromise = null;
+async function loadHtml2Canvas() {
+  if (!_html2canvasPromise) {
+    _html2canvasPromise = import(
+      /* webpackChunkName: "html2canvas" */ "html2canvas"
+    ).then((mod) => mod.default || mod);
+  }
+  return _html2canvasPromise;
+}
 
 /**
  * Capture site using Google Static Maps API
@@ -16,30 +24,33 @@ import logger from '../utils/logger.js';
 export async function captureStaticMap({ center, polygon = [], zoom = 19 }) {
   const googleMapsApiKey = process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
   if (!googleMapsApiKey) {
-    throw new Error('Google Maps API key not configured');
+    throw new Error("Google Maps API key not configured");
   }
 
-  logger.info('🗺️ Using Google Static Maps for accurate capture...');
+  logger.info("🗺️ Using Google Static Maps for accurate capture...");
 
   // Build Static Maps URL
-  const baseUrl = 'https://maps.googleapis.com/maps/api/staticmap';
+  const baseUrl = "https://maps.googleapis.com/maps/api/staticmap";
   const params = new URLSearchParams({
     center: `${center.lat},${center.lng}`,
     zoom: zoom.toString(),
-    size: '1024x768',
-    scale: '2',
-    maptype: 'satellite',
-    key: googleMapsApiKey
+    size: "1024x768",
+    scale: "2",
+    maptype: "satellite",
+    key: googleMapsApiKey,
   });
 
   // Add polygon overlay
   if (polygon.length > 0) {
-    const polygonPath = polygon.map(p => `${p.lat},${p.lng}`).join('|');
-    params.append('path', `color:0xff0000ff|weight:3|fillcolor:0xff000033|${polygonPath}`);
+    const polygonPath = polygon.map((p) => `${p.lat},${p.lng}`).join("|");
+    params.append(
+      "path",
+      `color:0xff0000ff|weight:3|fillcolor:0xff000033|${polygonPath}`,
+    );
   }
 
   // Add center marker
-  params.append('markers', `color:red|${center.lat},${center.lng}`);
+  params.append("markers", `color:red|${center.lat},${center.lng}`);
 
   const url = `${baseUrl}?${params.toString()}`;
 
@@ -67,58 +78,65 @@ export async function captureOverheadMap(containerEl, options = {}) {
     polygon = null,
     zoom = 18,
     center = null,
-    mapInstance = null
+    mapInstance = null,
   } = options;
 
   // Prefer static map capture when possible (exact coordinates, no placeholder math)
   if (!mapInstance && center && polygon) {
     try {
-      logger.info('🗺️ Using Google Static Maps for accurate capture...');
+      logger.info("🗺️ Using Google Static Maps for accurate capture...");
       return await captureStaticMap({ center, polygon, zoom });
     } catch (error) {
-      console.warn('Static Maps failed, falling back to html2canvas...', error);
+      console.warn("Static Maps failed, falling back to html2canvas...", error);
     }
   }
 
   if (!containerEl) {
-    throw new Error('Container element is required');
+    throw new Error("Container element is required");
   }
 
-  logger.info('📸 Capturing overhead site map with html2canvas...');
+  logger.info("📸 Capturing overhead site map with html2canvas...");
 
   try {
     // Step 1: Ensure map is in overhead (orthographic) view
     if (mapInstance) {
       await ensureOverheadMapState(mapInstance, { zoom, center });
     } else {
-      logger.info('ℹ️ Map instance not provided - capturing current view as-is');
+      logger.info(
+        "ℹ️ Map instance not provided - capturing current view as-is",
+      );
     }
 
     // Step 2: Wait for map to stabilize
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Step 3: Render polygon overlay if provided
     let polygonOverlayEl = null;
     if (polygon && Array.isArray(polygon) && polygon.length > 0) {
-      polygonOverlayEl = await renderPolygonOverlay(containerEl, polygon, mapInstance);
+      polygonOverlayEl = await renderPolygonOverlay(
+        containerEl,
+        polygon,
+        mapInstance,
+      );
     }
 
     // Step 4: Render scale bar
     const scaleBarEl = await renderScaleBar(containerEl, center, zoom);
 
-    // Step 5: Capture the map container with html2canvas
+    // Step 5: Capture the map container with html2canvas (loaded on demand)
+    const html2canvas = await loadHtml2Canvas();
     const canvas = await html2canvas(containerEl, {
       useCORS: true,
       allowTaint: true,
-      backgroundColor: '#ffffff',
+      backgroundColor: "#ffffff",
       scale: 1,
       logging: false,
       width: containerEl.offsetWidth,
-      height: containerEl.offsetHeight
+      height: containerEl.offsetHeight,
     });
 
     // Step 6: Convert to data URL
-    const dataURL = canvas.toDataURL('image/png');
+    const dataURL = canvas.toDataURL("image/png");
 
     // Step 7: Cleanup overlay elements
     if (polygonOverlayEl) {
@@ -128,11 +146,10 @@ export async function captureOverheadMap(containerEl, options = {}) {
       scaleBarEl.remove();
     }
 
-    logger.info('✅ Site map captured successfully');
+    logger.info("✅ Site map captured successfully");
     return dataURL;
-
   } catch (error) {
-    logger.error('❌ Failed to capture site map:', error);
+    logger.error("❌ Failed to capture site map:", error);
     throw error;
   }
 }
@@ -150,7 +167,7 @@ async function ensureOverheadMapState(mapInstance, { zoom, center }) {
     // Set map to overhead view
     mapInstance.setHeading(0);
     mapInstance.setTilt(0);
-    
+
     if (zoom) {
       mapInstance.setZoom(zoom);
     }
@@ -160,10 +177,9 @@ async function ensureOverheadMapState(mapInstance, { zoom, center }) {
     }
 
     // Wait for map to update
-    await new Promise(resolve => setTimeout(resolve, 500));
-
+    await new Promise((resolve) => setTimeout(resolve, 500));
   } catch (error) {
-    console.warn('⚠️ Could not set map to overhead state:', error);
+    console.warn("⚠️ Could not set map to overhead state:", error);
   }
 }
 
@@ -176,50 +192,57 @@ async function renderPolygonOverlay(containerEl, polygon, mapInstance) {
   }
 
   // Create overlay container
-  const overlay = document.createElement('div');
-  overlay.style.position = 'absolute';
-  overlay.style.top = '0';
-  overlay.style.left = '0';
-  overlay.style.width = '100%';
-  overlay.style.height = '100%';
-  overlay.style.pointerEvents = 'none';
-  overlay.style.zIndex = '1000';
+  const overlay = document.createElement("div");
+  overlay.style.position = "absolute";
+  overlay.style.top = "0";
+  overlay.style.left = "0";
+  overlay.style.width = "100%";
+  overlay.style.height = "100%";
+  overlay.style.pointerEvents = "none";
+  overlay.style.zIndex = "1000";
 
   // Create SVG for polygon
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('width', '100%');
-  svg.setAttribute('height', '100%');
-  svg.style.position = 'absolute';
-  svg.style.top = '0';
-  svg.style.left = '0';
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("width", "100%");
+  svg.setAttribute("height", "100%");
+  svg.style.position = "absolute";
+  svg.style.top = "0";
+  svg.style.left = "0";
 
   // Convert lat/lng to pixel coordinates using proper projection
   let points;
 
-  if (mapInstance && mapInstance.getProjection && window.google && window.google.maps) {
+  if (
+    mapInstance &&
+    mapInstance.getProjection &&
+    window.google &&
+    window.google.maps
+  ) {
     // Use Google Maps projection if available
     const projection = mapInstance.getProjection();
     const bounds = mapInstance.getBounds();
     const ne = bounds.getNorthEast();
     const sw = bounds.getSouthWest();
 
-    points = polygon.map(point => {
-      const latLng = new window.google.maps.LatLng(point.lat, point.lng);
-      const worldPoint = projection.fromLatLngToPoint(latLng);
-      const topLeftWorldPoint = projection.fromLatLngToPoint(ne);
-      const bottomRightWorldPoint = projection.fromLatLngToPoint(sw);
+    points = polygon
+      .map((point) => {
+        const latLng = new window.google.maps.LatLng(point.lat, point.lng);
+        const worldPoint = projection.fromLatLngToPoint(latLng);
+        const topLeftWorldPoint = projection.fromLatLngToPoint(ne);
+        const bottomRightWorldPoint = projection.fromLatLngToPoint(sw);
 
-      // Scale to container dimensions
-      const scale = Math.pow(2, mapInstance.getZoom());
-      const x = (worldPoint.x - topLeftWorldPoint.x) * scale;
-      const y = (worldPoint.y - topLeftWorldPoint.y) * scale;
+        // Scale to container dimensions
+        const scale = Math.pow(2, mapInstance.getZoom());
+        const x = (worldPoint.x - topLeftWorldPoint.x) * scale;
+        const y = (worldPoint.y - topLeftWorldPoint.y) * scale;
 
-      return `${x},${y}`;
-    }).join(' ');
+        return `${x},${y}`;
+      })
+      .join(" ");
   } else {
     // Fallback: Calculate relative positions based on polygon bounds
-    const lats = polygon.map(p => p.lat);
-    const lngs = polygon.map(p => p.lng);
+    const lats = polygon.map((p) => p.lat);
+    const lngs = polygon.map((p) => p.lng);
     const minLat = Math.min(...lats);
     const maxLat = Math.max(...lats);
     const minLng = Math.min(...lngs);
@@ -232,26 +255,36 @@ async function renderPolygonOverlay(containerEl, polygon, mapInstance) {
     const containerWidth = containerEl.offsetWidth;
     const containerHeight = containerEl.offsetHeight;
 
-    points = polygon.map(point => {
-      // Normalize coordinates to 0-1 range with padding
-      const normalizedX = (point.lng - (minLng - lngPadding)) / ((maxLng + lngPadding) - (minLng - lngPadding));
-      const normalizedY = 1 - ((point.lat - (minLat - latPadding)) / ((maxLat + latPadding) - (minLat - latPadding)));
+    points = polygon
+      .map((point) => {
+        // Normalize coordinates to 0-1 range with padding
+        const normalizedX =
+          (point.lng - (minLng - lngPadding)) /
+          (maxLng + lngPadding - (minLng - lngPadding));
+        const normalizedY =
+          1 -
+          (point.lat - (minLat - latPadding)) /
+            (maxLat + latPadding - (minLat - latPadding));
 
-      // Scale to container dimensions with margin
-      const margin = 0.05; // 5% margin on each side
-      const x = (margin + normalizedX * (1 - 2 * margin)) * containerWidth;
-      const y = (margin + normalizedY * (1 - 2 * margin)) * containerHeight;
+        // Scale to container dimensions with margin
+        const margin = 0.05; // 5% margin on each side
+        const x = (margin + normalizedX * (1 - 2 * margin)) * containerWidth;
+        const y = (margin + normalizedY * (1 - 2 * margin)) * containerHeight;
 
-      return `${x},${y}`;
-    }).join(' ');
+        return `${x},${y}`;
+      })
+      .join(" ");
   }
 
-  const polygonEl = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
-  polygonEl.setAttribute('points', points);
-  polygonEl.setAttribute('fill', 'rgba(255, 0, 0, 0.2)');
-  polygonEl.setAttribute('stroke', '#ff0000');
-  polygonEl.setAttribute('stroke-width', '3');
-  polygonEl.setAttribute('stroke-dasharray', '5,2');
+  const polygonEl = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "polygon",
+  );
+  polygonEl.setAttribute("points", points);
+  polygonEl.setAttribute("fill", "rgba(255, 0, 0, 0.2)");
+  polygonEl.setAttribute("stroke", "#ff0000");
+  polygonEl.setAttribute("stroke-width", "3");
+  polygonEl.setAttribute("stroke-dasharray", "5,2");
 
   svg.appendChild(polygonEl);
   overlay.appendChild(svg);
@@ -274,52 +307,52 @@ async function renderScaleBar(containerEl, center, zoom) {
   const scaleMeters = calculateScaleMeters(zoom, center?.lat || 52.5); // Default to UK latitude
 
   // Create scale bar element
-  const scaleBar = document.createElement('div');
-  scaleBar.style.position = 'absolute';
-  scaleBar.style.bottom = '20px';
-  scaleBar.style.left = '20px';
-  scaleBar.style.backgroundColor = 'rgba(255, 255, 255, 0.9)';
-  scaleBar.style.padding = '8px 12px';
-  scaleBar.style.borderRadius = '4px';
-  scaleBar.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
-  scaleBar.style.fontFamily = 'Arial, sans-serif';
-  scaleBar.style.fontSize = '12px';
-  scaleBar.style.fontWeight = 'bold';
-  scaleBar.style.color = '#333';
-  scaleBar.style.zIndex = '1001';
-  scaleBar.style.border = '2px solid #000';
+  const scaleBar = document.createElement("div");
+  scaleBar.style.position = "absolute";
+  scaleBar.style.bottom = "20px";
+  scaleBar.style.left = "20px";
+  scaleBar.style.backgroundColor = "rgba(255, 255, 255, 0.9)";
+  scaleBar.style.padding = "8px 12px";
+  scaleBar.style.borderRadius = "4px";
+  scaleBar.style.boxShadow = "0 2px 4px rgba(0,0,0,0.2)";
+  scaleBar.style.fontFamily = "Arial, sans-serif";
+  scaleBar.style.fontSize = "12px";
+  scaleBar.style.fontWeight = "bold";
+  scaleBar.style.color = "#333";
+  scaleBar.style.zIndex = "1001";
+  scaleBar.style.border = "2px solid #000";
 
   // Create scale bar visual
-  const scaleBarVisual = document.createElement('div');
-  scaleBarVisual.style.width = '100px';
-  scaleBarVisual.style.height = '4px';
-  scaleBarVisual.style.backgroundColor = '#000';
-  scaleBarVisual.style.marginBottom = '4px';
+  const scaleBarVisual = document.createElement("div");
+  scaleBarVisual.style.width = "100px";
+  scaleBarVisual.style.height = "4px";
+  scaleBarVisual.style.backgroundColor = "#000";
+  scaleBarVisual.style.marginBottom = "4px";
 
   scaleBar.appendChild(scaleBarVisual);
 
   // Add scale text
-  const scaleText = document.createElement('div');
+  const scaleText = document.createElement("div");
   scaleText.textContent = `${scaleMeters}m`;
   scaleBar.appendChild(scaleText);
 
   // Add compass rose (simplified)
-  const compassRose = document.createElement('div');
-  compassRose.style.position = 'absolute';
-  compassRose.style.top = '20px';
-  compassRose.style.right = '20px';
-  compassRose.style.width = '60px';
-  compassRose.style.height = '60px';
-  compassRose.style.border = '2px solid #000';
-  compassRose.style.borderRadius = '50%';
-  compassRose.style.backgroundColor = 'rgba(255, 255, 255, 0.9)';
-  compassRose.style.display = 'flex';
-  compassRose.style.alignItems = 'center';
-  compassRose.style.justifyContent = 'center';
-  compassRose.style.fontSize = '24px';
-  compassRose.style.fontWeight = 'bold';
-  compassRose.textContent = 'N';
-  compassRose.style.zIndex = '1001';
+  const compassRose = document.createElement("div");
+  compassRose.style.position = "absolute";
+  compassRose.style.top = "20px";
+  compassRose.style.right = "20px";
+  compassRose.style.width = "60px";
+  compassRose.style.height = "60px";
+  compassRose.style.border = "2px solid #000";
+  compassRose.style.borderRadius = "50%";
+  compassRose.style.backgroundColor = "rgba(255, 255, 255, 0.9)";
+  compassRose.style.display = "flex";
+  compassRose.style.alignItems = "center";
+  compassRose.style.justifyContent = "center";
+  compassRose.style.fontSize = "24px";
+  compassRose.style.fontWeight = "bold";
+  compassRose.textContent = "N";
+  compassRose.style.zIndex = "1001";
 
   containerEl.appendChild(scaleBar);
   containerEl.appendChild(compassRose);
@@ -333,11 +366,12 @@ async function renderScaleBar(containerEl, center, zoom) {
 function calculateScaleMeters(zoom, latitude) {
   // Approximate meters per pixel at given zoom and latitude
   // Formula: metersPerPixel = (156543.03392 * Math.cos(lat * Math.PI / 180)) / (2^zoom)
-  const metersPerPixel = (156543.03392 * Math.cos(latitude * Math.PI / 180)) / Math.pow(2, zoom);
-  
+  const metersPerPixel =
+    (156543.03392 * Math.cos((latitude * Math.PI) / 180)) / Math.pow(2, zoom);
+
   // Scale bar width in pixels (100px) * meters per pixel
   const scaleMeters = 100 * metersPerPixel;
-  
+
   // Round to nearest nice number
   if (scaleMeters < 10) {
     return Math.round(scaleMeters);
@@ -352,6 +386,5 @@ function calculateScaleMeters(zoom, latitude) {
 
 export default {
   captureOverheadMap,
-  captureStaticMap
+  captureStaticMap,
 };
-

--- a/src/utils/pdfToImages.js
+++ b/src/utils/pdfToImages.js
@@ -4,13 +4,33 @@
  * Uses pdfjs selectable text and page rendering only. OCR is intentionally not
  * used: image-only PDFs receive a sourceGap so downstream style prompts cannot
  * invent evidence.
+ *
+ * pdfjs-dist is loaded lazily on first PDF read — it's ~470 KB raw / ~140 KB
+ * gzipped and is only needed for the optional portfolio-PDF upload path.
  */
-
-import * as pdfjsLib from "pdfjs-dist/build/pdf.mjs";
 
 export const PDF_TEXT_NOT_SELECTABLE = "PDF_TEXT_NOT_SELECTABLE";
 
 const PDF_WORKER_FILE = "/pdf.worker.min.mjs";
+
+let _pdfjsPromise = null;
+async function loadPdfjs() {
+  if (!_pdfjsPromise) {
+    _pdfjsPromise = import(
+      /* webpackChunkName: "pdfjs-dist" */ "pdfjs-dist/build/pdf.mjs"
+    ).then((mod) => {
+      if (
+        typeof window !== "undefined" &&
+        mod.GlobalWorkerOptions &&
+        !mod.GlobalWorkerOptions.workerSrc
+      ) {
+        mod.GlobalWorkerOptions.workerSrc = `${window.location.origin}${PDF_WORKER_FILE}`;
+      }
+      return mod;
+    });
+  }
+  return _pdfjsPromise;
+}
 const DEFAULT_THUMBNAIL_PAGES = 3;
 const DEFAULT_THUMBNAIL_MAX_SIZE = 900;
 const TEXT_SAMPLE_LIMIT = 700;
@@ -113,12 +133,6 @@ const KEYWORD_GROUPS = Object.freeze({
   ],
 });
 
-function configurePdfWorker() {
-  if (typeof window === "undefined") return;
-  if (pdfjsLib.GlobalWorkerOptions.workerSrc) return;
-  pdfjsLib.GlobalWorkerOptions.workerSrc = `${window.location.origin}${PDF_WORKER_FILE}`;
-}
-
 function compactText(value) {
   return String(value || "")
     .replace(/\s+/g, " ")
@@ -157,7 +171,7 @@ export function extractPortfolioEvidenceFromPdfText(text = "") {
 }
 
 async function loadPdfDocument(pdfFile) {
-  configurePdfWorker();
+  const pdfjsLib = await loadPdfjs();
   const arrayBuffer = await pdfFile.arrayBuffer();
   const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer });
   return loadingTask.promise;


### PR DESCRIPTION
## Summary

Shrinks the JavaScript downloaded on first paint of the landing page by **31% gzipped** without changing any product behaviour, generation logic, authority gates, or artifact determinism. Two techniques only — no bundler config / CRA changes.

| Metric | Baseline | After | Δ |
|---|---:|---:|---:|
| `main.js` raw | 3.85 MB | 2.73 MB | **−1.12 MB** |
| `main.js` gzip | **1.05 MB** | **736 kB** | **−330 kB (−31%)** |

CRA's "bundle significantly larger than recommended" warning still fires post-PR — main.js is 736 kB gzip vs the ~244 kB recommendation. See follow-ups in [docs/performance/frontend-bundle-plan.md](../blob/claude/recursing-williamson-d3d878/docs/performance/frontend-bundle-plan.md) for the next wins (lucide-react / crypto-js tree-shaking, lazy-loading `useArchitectAIWorkflow`).

## What changed

**1. Wizard step lazy-loading** — [src/components/ArchitectAIWizardContainer.jsx](../blob/claude/recursing-williamson-d3d878/src/components/ArchitectAIWizardContainer.jsx)
- `LocationStep`, `IntelligenceStep`, `PortfolioStep`, `SpecsStep`, `GenerateStep`, `ResultsStep`, `PricingPage` → `React.lazy` with stable `webpackChunkName` (`step-location`, `step-intelligence`, …, `page-pricing`).
- `LandingPage` + `DesignHistoryMenu` stay eager — needed on first paint.
- Single `<Suspense fallback={<StepLoadingSkeleton/>}>` boundary inside `renderStep()` replaces the case-6 inner Suspense. `PricingPage` gets its own Suspense at its render site.
- New tiny [StepLoadingSkeleton.jsx](../blob/claude/recursing-williamson-d3d878/src/components/StepLoadingSkeleton.jsx) (≈20 lines, reuses existing UI primitives).
- `useEffect` schedules a `requestIdleCallback` prefetch of `step-location` while on the landing page (with a 1.5 s `setTimeout` fallback) so the first click is instant on warm networks.

**2. Heavy library imports → dynamic `import()` at call site** (cached per-module loader pattern; public function signatures unchanged):
- `pdfjs-dist` in [src/utils/pdfToImages.js](../blob/claude/recursing-williamson-d3d878/src/utils/pdfToImages.js) — biggest win, was 470 kB raw / 140 kB gzip inside `main.js`.
- `html2canvas` in [src/services/siteMapCapture.js](../blob/claude/recursing-williamson-d3d878/src/services/siteMapCapture.js)
- `pdf-lib` in [src/services/a1/composeRuntime.js](../blob/claude/recursing-williamson-d3d878/src/services/a1/composeRuntime.js) and [src/services/render/buildVectorPdfFromSheetSvg.js](../blob/claude/recursing-williamson-d3d878/src/services/render/buildVectorPdfFromSheetSvg.js).

Artifact-pipeline ordering is preserved: same `async` calls happen at the same point, with one extra `await` for the (cached) module fetch on first invocation.

**3. Bundle analysis tooling** — `source-map-explorer ^2.5.3` devDep + `npm run build:analyze` + `npm run analyze` scripts. `bundle-report.html` added to `.gitignore`.

**4. Performance note** — [docs/performance/frontend-bundle-plan.md](../blob/claude/recursing-williamson-d3d878/docs/performance/frontend-bundle-plan.md) with baseline + after numbers, full chunk table, and follow-up list.

## Explicitly **not** changed (per [CLAUDE.md](../blob/claude/recursing-williamson-d3d878/CLAUDE.md) + PR brief)

- ProjectGraph compilation, geometry hashing
- A1 / CAD / structural / MEP / detail generation logic
- Artifact-package determinism
- image2 routing
- Fake DWG / IFC safeguards
- No bundler config (no craco / react-app-rewired / eject)
- `src/services/project/projectGraphVerticalSliceService.js` (CLAUDE.md key entrypoint)

## Skipped on purpose (documented in the perf note)

| Library | Reason |
|---|---|
| `xlsx` | Already isolated as `238.chunk.js` (pure xlsx); `ProgramImportExportService` is already dynamically imported by the container. |
| `three.js` | Already isolated as `435.chunk.js` (100% `three.core.js`) by webpack's default `splitChunks`. |
| `@turf/turf` | 31 sync call sites in `boundaryGeometry.js`; cascades through every consumer — too invasive for a perf-only PR. |
| `jspdf` | Not imported anywhere in `src/`. |
| `svgToPdfWalker.js` | `pdf-lib`'s `rgb`/`degrees` are called from the sync `parseSvgColor` helper. |

## Validation

| Gate | Result |
|---|---|
| `npm run lint` | ✅ exit 0 |
| `git diff --check` | ✅ exit 0 |
| `npm run check:env` | ⚠️ warn-only (script exits 0; 14 missing local env vars unrelated to this PR) |
| `npm run check:contracts` | ✅ exit 0 — Design DNA contracts pass |
| `npm run check:genarch-contracts` | ✅ exit 0 — 11/11 genarch checks pass |
| `npm run test:compose:routing` | ✅ exit 0 — **22 / 22** |
| `npm run build:active` | ✅ exit 0 — final `main.js` 736.4 kB gzip |

`build/index.html` references only `main.js` — every other chunk is on-demand.

## Test plan

- [ ] Reviewer runs `npm run build:analyze && npm run analyze` and confirms `main.js` ≈ 736 kB gzip with `pdfjs-dist` no longer in the top-15 of `main.js`
- [ ] `npm start`, walk landing → location → intelligence → portfolio → specs → generate → results — every step transition shows the skeleton briefly then renders identical UI to `main`
- [ ] Portfolio PDF upload still extracts thumbnails + selectable text (lazy `pdfjs-dist` loads on first PDF read; worker still resolves at `/pdf.worker.min.mjs`)
- [ ] A1 sheet export still produces the same PDF (cached `pdf-lib` dynamic load preserves artifact bytes)
- [ ] Site map capture still works (lazy `html2canvas` loads on first capture)
- [ ] Pricing view (header link) still loads

## Related work

- Parallel **draft** PR #133 `codex/fix-programme-pdf-evidence` touches `public/pdf.worker.min.mjs` + 3 test files + `styleBlendManifestService.js`. **No file overlap with this PR** — either merge order works. PR #134 `codex/sync-pdfjs-worker` (worker bytes refresh) is already merged into the base of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)