### PR TITLE
feat(style-pack): structured Style Pack extractor + STEP 06/11 integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -307,6 +307,14 @@ STEP_05_PROGRAMME_SCHEMA_PATH=schemas/programme.schema.json
 PROGRAMME_LIBRARY_PATH=data/programmes/uk_typologies
 AREA_STANDARD_LIBRARY_PATH=data/standards/area-benchmarks
 
+# --- Portfolio Style Pack (parametric portfolio constraints, STEP 06 + STEP 11)
+STYLE_PACK_ENABLED=true
+# Optional: deterministic seed override; default = sha256(portfolio bytes)
+STYLE_PACK_SEED=
+# Future LLM-assisted extraction (v2). Keep false in v1.
+STYLE_PACK_LLM_FALLBACK=false
+# STEP_05_STYLE_EXTRACT_MODEL=          # uncomment when v2 lands
+
 # -----------------------------------------------------------------------------
 # Step 06 — concept, massing, urban response, architectural language
 # -----------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ build_active_*/
 build_active_ci/
 build_phase*/
 genarch/tmp_*/
+outputs/style-pack-smoke/
 .codex-push-gitdata/
 .codex-write-test/
 .codex-git-publish/

--- a/api/style-pack/extract.js
+++ b/api/style-pack/extract.js
@@ -1,0 +1,48 @@
+import {
+  computeStylePackHash,
+  extractStylePack,
+} from "../../src/services/style/stylePackExtractor.js";
+import { STYLE_PACK_VERSION } from "../../src/schemas/stylePack.js";
+
+export const runtime = "nodejs";
+export const config = {
+  runtime: "nodejs",
+  maxDuration: 60,
+};
+
+function isStylePackEnabled(env = process.env) {
+  const flag = String(env.STYLE_PACK_ENABLED || "")
+    .trim()
+    .toLowerCase();
+  if (flag === "true") return true;
+  if (flag === "false") return false;
+  return !(env.VERCEL || env.NODE_ENV === "production");
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const body = req.body || {};
+    const stylePack = isStylePackEnabled()
+      ? extractStylePack({
+          portfolioFiles: body.portfolioFiles || [],
+          briefHints: body.briefHints || {},
+          extractorVersion: body.extractorVersion || STYLE_PACK_VERSION,
+        })
+      : null;
+    return res.status(200).json({
+      success: true,
+      style_pack: stylePack,
+      stylePack,
+      stylePackHash: stylePack ? computeStylePackHash(stylePack) : null,
+    });
+  } catch (error) {
+    return res.status(400).json({
+      success: false,
+      error: error?.message || "Style Pack extraction failed",
+    });
+  }
+}

--- a/docs/style-pack/IMPLEMENTATION_NOTES.md
+++ b/docs/style-pack/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,6 @@
+# Implementation Notes
+
+- `// PLAN-AMBIGUITY:` `PLAN.md` says `portfolio_style_pack_hash` is audit-only, while the implementation prompt marks Style Pack hash inclusion in the `geometryHash` input set as a hard rule. The implementation includes the hash only when a pack exists, preserving the no-portfolio hash.
+- `// PLAN-AMBIGUITY:` `extractedAt` is schema-required, but the Style Pack JSON must be deterministic. v1 uses a stable timestamp, and the hash also excludes `provenance.extractedAt`.
+- `// PLAN-AMBIGUITY:` null Style Pack audit fields would change no-portfolio outputs. v1 emits pack audit fields only when a pack exists.
+- `// PLAN-AMBIGUITY:` the current option generator only emits rectangular footprints, so non-rectangular Style Pack massing forms are represented by deterministic aspect-aligned rectangular proxy options.

--- a/docs/style-pack/IMPLEMENTATION_PROMPTS.md
+++ b/docs/style-pack/IMPLEMENTATION_PROMPTS.md
@@ -1,0 +1,290 @@
+# Structured Style Pack — Implementation Prompts
+
+Feature: extend `portfolioFileProcessing.js` to emit a per-architect **Style Pack** JSON, and consume it as parametric constraints inside **STEP 06** (concept/massing) and **STEP 11** (materials). The Style Pack must influence ProjectGraph parameters, never bypass them. No image models for technical drawings. Determinism preserved (same inputs + seed → same `geometryHash`).
+
+Workflow:
+
+1. Run **PROMPT 1** in Claude Code → produces `docs/style-pack/PLAN.md`.
+2. Run **PROMPT 2** in Codex GPT-5.5 with `PLAN.md` attached → produces the diff + tests.
+3. Run **PROMPT 3** in a fresh Claude Code session → produces `docs/style-pack/AUDIT.md`.
+4. Address audit findings. Repeat 2 + 3 if needed.
+
+---
+
+## PROMPT 1 — Plan (run in Claude Code)
+
+You are working in the `architect-ai-platform` repository. Read `CLAUDE.md` and `AGENTS.md` first and treat them as binding. Do not write any code yet — your only deliverable is a precise implementation plan.
+
+**Feature to plan:** "Structured Style Pack from portfolio uploads, consumed by STEP 06 and STEP 11 as parametric constraints."
+
+**Background you must verify by reading the code, not assume:**
+
+- The pipeline runs steps 01–13, resolved via `src/services/modelStepResolver.js`.
+- Portfolio uploads are currently parsed in `src/services/.../portfolioFileProcessing.js` (find the exact path).
+- Style is currently blended via `localStylePack.js` with portfolio weighted ~15%. Confirm the actual weighting code path.
+- STEP 06 produces concept narrative + massing JSON. STEP 11 produces material/palette strategy. Find the exact entry points and the shape of the data they currently emit.
+- `ProjectGraph` (STEP 07) is the single geometry authority. 2D and 3D share a `geometryHash`. The Style Pack must influence parameters that _feed into_ ProjectGraph, not anything downstream of it — otherwise the hash will desync.
+- Output formats: SVG (deterministic), PDF, DXF, IFC, XLSX. None of these may regress.
+
+**What the Style Pack must contain (minimum):**
+
+- `windowToWallRatio`: `{ overall: number, byElevation: { N, S, E, W } }`
+- `roofPitchDistribution`: `{ flatPct, lowPct, mediumPct, steepPct, dominant: 'flat'|'low'|'medium'|'steep' }`
+- `openingRhythm`: `{ moduleMm: number, repetition: 'regular'|'asymmetric'|'paired', sillHeightMm: number }`
+- `materialFamilies`: `{ primary: string[], secondary: string[], accents: string[] }` (e.g., `['brick','stone','timber']`)
+- `massingTendency`: `{ form: 'compact'|'L'|'U'|'courtyard'|'articulated', floorCount: { min, mode, max }, aspectRatioRange: [min, max] }`
+- `facadeModule`: `{ baySpacingMm: number, floorHeightMm: number }`
+- `provenance`: `{ sourceFiles: string[], extractedAt: ISOString, extractorVersion: string, confidence: number }`
+
+**Required deliverable — write to `docs/style-pack/PLAN.md` with these sections:**
+
+1. **Files to create.** Full path, purpose, exported symbols.
+2. **Files to modify.** For each: file path, function or section to change, why, and a 5–15 line illustrative diff (pseudo-diff is fine).
+3. **Style Pack JSON schema.** Final, locked schema (extend the minimum above where the codebase suggests it). Include a JSON Schema fragment.
+4. **Extractor design.** How `portfolioFileProcessing.js` will turn N PDFs/images into one Style Pack. Where heuristics live, where LLM-assisted extraction is acceptable, and which model env var (`STEP_*_MODEL`) it should resolve through. Must be deterministic given the same inputs.
+5. **STEP 06 integration.** Exactly how the Style Pack constrains massing JSON (e.g., clamps `aspectRatioRange`, biases `floorCount`, restricts roof pitch). Show the function signature change.
+6. **STEP 11 integration.** Exactly how `materialFamilies` becomes a parametric constraint on the materials/palette strategy.
+7. **ProjectGraph contract.** Confirm the Style Pack is consumed _upstream_ of STEP 07 so it folds into the `geometryHash`. List every place the hash input set is computed, and confirm Style Pack is included.
+8. **Determinism plan.** How seeded runs stay reproducible. Where the Style Pack is hashed and threaded.
+9. **Env vars and config.** Any new entries for `.env.example`, plus updates to `scripts/check-env.cjs` if needed. Default behavior when no portfolio is uploaded (system must work as today).
+10. **Tests to add.** List Jest test files and the cases each must cover. At minimum:
+    - `src/__tests__/services/styleExtractor.test.js` — extractor produces stable schema; deterministic given fixed inputs.
+    - `src/__tests__/services/styleConstraintApplier.test.js` — STEP 06 and STEP 11 honor constraints; absence of pack falls back to current behavior.
+    - Extend `src/__tests__/services/projectGraphVerticalSliceService.test.js` to cover: same brief + pack → same hash; same brief + no pack → existing hash unchanged.
+11. **Validation matrix.** The exact commands to run before declaring success:
+    ```powershell
+    npm run check:env
+    npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/modelStepResolver.test.js src/__tests__/services/projectGraphVerticalSliceService.test.js src/__tests__/services/styleExtractor.test.js src/__tests__/services/styleConstraintApplier.test.js
+    npm run check:contracts
+    npm run test:compose:routing
+    npm run build:active
+    npm run lint
+    ```
+12. **Risks and non-goals.** Explicitly call out: no LoRA, no fine-tuning of architect work, no image-model involvement in technical drawings, no change to SVG/DXF/IFC exporters, no change to the QA report contract at STEP 13.
+13. **Rollback plan.** How to disable the feature via env flag (e.g., `STYLE_PACK_ENABLED=false`) without touching code.
+
+Constraints you must not violate:
+
+- Never route plans, elevations, sections, or geometry authority through image models.
+- Do not edit real `.env`, `.env.local`, or `.env.production`.
+- 2D and 3D must continue to share the same `geometryHash`.
+- `multi_panel` mode must remain untouched.
+
+When `PLAN.md` is written, stop. Do not begin implementation.
+
+---
+
+## PROMPT 2 — Implementation (run in Codex GPT-5.5)
+
+You are implementing a feature in the `architect-ai-platform` repository. The complete plan is in `docs/style-pack/PLAN.md` — read it first and treat it as the contract. Also read `CLAUDE.md` and `AGENTS.md` and treat them as binding architectural constraints.
+
+**Your job:** implement the plan exactly as written. Do not invent new files, do not change function signatures the plan didn't authorize, and do not refactor adjacent code. If the plan is ambiguous on a point, prefer the option that minimizes blast radius and add a `// PLAN-AMBIGUITY:` comment with one sentence explaining the call you made.
+
+**Hard rules — violating any of these is a failed implementation:**
+
+1. Style Pack data flows into STEP 06 and STEP 11 _before_ STEP 07 (ProjectGraph) computes its geometry. The `geometryHash` input set must include the Style Pack hash.
+2. With no portfolio uploaded, every existing test must still pass and every existing output (SVG, PDF, DXF, IFC, XLSX) must be byte-identical to today's output for the same brief and seed.
+3. No image-model code path may be added or touched for technical drawings (STEP 08 / STEP 09).
+4. Determinism: same brief + same portfolio + same seed → same Style Pack JSON → same `geometryHash`. Use stable JSON serialization (sorted keys) where you hash.
+5. Add a feature flag `STYLE_PACK_ENABLED` (default `true` in dev, false-safe in prod per the plan). When false, the extractor short-circuits and STEP 06 / STEP 11 see no pack.
+6. Do not edit `.env`, `.env.local`, or `.env.production`. Only update `.env.example` and `scripts/check-env.cjs`.
+
+**Deliverables, in this order:**
+
+1. New file: the Style Pack extractor (path per plan).
+2. New file: the Style Pack constraint applier (path per plan).
+3. Edits to STEP 06 entry point.
+4. Edits to STEP 11 entry point.
+5. Edits to `projectGraphVerticalSliceService.js` to thread the pack and include it in the hash input.
+6. Edits to `modelStepResolver.js` if a new model resolution is required.
+7. New `.env.example` entries and `scripts/check-env.cjs` updates.
+8. Jest tests listed in the plan, all green.
+9. A short `IMPLEMENTATION_NOTES.md` in `docs/style-pack/` describing any `PLAN-AMBIGUITY` decisions.
+
+**Validation — run all of these and paste the output in your final message:**
+
+```powershell
+npm run check:env
+npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/modelStepResolver.test.js src/__tests__/services/projectGraphVerticalSliceService.test.js src/__tests__/services/styleExtractor.test.js src/__tests__/services/styleConstraintApplier.test.js
+npm run check:contracts
+npm run test:compose:routing
+npm run build:active
+npm run lint
+```
+
+If any command fails, fix the cause and re-run. Do not silence errors. Do not mark the work done with red tests.
+
+When complete, your final message must contain: (a) a list of files created and modified with short rationale per file, (b) the full validation command output, (c) the contents of `IMPLEMENTATION_NOTES.md`.
+
+---
+
+## PROMPT 3 — Audit (run in a fresh Claude Code session)
+
+You are an independent reviewer. You did not write this code and you have no context from the implementation session. Read these documents in order before looking at any diff:
+
+1. `CLAUDE.md`
+2. `AGENTS.md`
+3. `docs/style-pack/PLAN.md`
+4. `docs/style-pack/IMPLEMENTATION_NOTES.md`
+
+Then audit the implementation. Use `git diff main...HEAD` (or the equivalent) to see exactly what changed.
+
+**Your audit must answer each of these questions with a verdict (PASS / FAIL / PARTIAL) and the specific file:line evidence:**
+
+1. **Plan adherence.** Does every file the plan said to create or modify exist and match the plan's intent? Are there extra files or extra edits the plan did not authorize?
+2. **Geometry authority preserved.** Is the Style Pack consumed strictly upstream of STEP 07? Trace the data flow from extractor → STEP 06 → STEP 11 → STEP 07. Confirm the `geometryHash` input set now includes the Style Pack hash and is stably serialized.
+3. **No image-model regression.** Confirm STEP 08 (2D drawings) and STEP 09 (3D validation) were not modified to depend on image models. Confirm `multi_panel` mode is untouched.
+4. **Backward compatibility.** With `STYLE_PACK_ENABLED=false` or with no portfolio uploaded, do existing tests pass and does the pipeline produce byte-identical output to pre-change for at least one canonical brief? If a regression test was not added for this, that itself is a FAIL.
+5. **Determinism.** Same brief + same portfolio + same seed: does the new code paths produce a stable Style Pack JSON (stable key order, no timestamps inside the hashed payload)? Where is the hash computed, and is the input canonicalized?
+6. **Schema correctness.** Does the emitted Style Pack JSON match the schema in `PLAN.md` exactly? Are all fields present, typed, and within reasonable ranges? Is `provenance` populated?
+7. **Test coverage.** Were the test files listed in the plan added? Do they actually exercise the constraint logic (not just snapshot the schema)? Run them.
+8. **Validation matrix.** Run every command in the plan's validation matrix yourself. All must pass. Paste output.
+9. **Env contract.** Is `.env.example` updated? Does `scripts/check-env.cjs` know about new variables? Were real `.env*` files left alone?
+10. **CAD/IFC/PDF integrity.** Diff a generated DXF and IFC pre/post change for the no-portfolio case. They must be identical (or differ only in timestamp metadata). Document what you compared.
+11. **Architectural rule violations.** List any place the diff bends or breaks rules from `CLAUDE.md` or `AGENTS.md`, even if subtle. Be picky.
+12. **Hidden coupling.** Did the implementation introduce a dependency from a downstream step (08/09/12/13) back into the Style Pack? It should not.
+
+**Deliverable:** write `docs/style-pack/AUDIT.md` containing:
+
+- Per-question verdict table (PASS/FAIL/PARTIAL + evidence).
+- A "Must-fix before merge" list (only the FAILs).
+- A "Should-fix soon" list (the PARTIALs).
+- A final overall verdict: APPROVE / REQUEST CHANGES / REJECT.
+
+Be honest. If the implementation is good, say so plainly. If it's broken, say exactly where. Do not soften findings.
+
+---
+
+## PROMPT 2.1 — Hardened re-implementation (run in Codex CLI after a phantom-completion failure)
+
+**Context:** a previous Codex run produced a completion report describing files and tests that did not exist on disk. This run must prove every claim with evidence. Reports without evidence will be rejected.
+
+You are implementing the Style Pack feature in the `architect-ai-platform` repository. Read `docs/style-pack/PLAN.md`, `CLAUDE.md`, and `AGENTS.md` first and treat them as binding. Implement strictly to the plan; same hard rules as the original PROMPT 2 apply (geometry authority, no image models for technical drawings, `STYLE_PACK_ENABLED` flag, no edits to real `.env*`, byte-identical output with no portfolio).
+
+**Mandatory verification gates — your work is incomplete until every gate passes:**
+
+### Gate 0 — Confirm working directory and branch
+
+Before doing anything else, run and paste the output of:
+
+```powershell
+Get-Location
+git rev-parse --show-toplevel
+git status
+git rev-parse --abbrev-ref HEAD
+git rev-parse HEAD
+```
+
+If `Get-Location` is not inside `C:\Users\21366\OneDrive\Documents\GitHub\architect-ai-platform`, STOP and report the mismatch. Do not proceed.
+
+### Gate 1 — After every file write, prove the file exists
+
+After creating or modifying any file, immediately run:
+
+```powershell
+Get-Item <path> | Select-Object FullName, Length, LastWriteTime
+Get-FileHash <path> -Algorithm SHA256
+```
+
+Paste both lines into your output. If the file does not appear, the write failed — re-attempt and re-verify before moving on.
+
+### Gate 2 — Don't trust your memory; query the filesystem
+
+At any point where you would say "I created X" or "I modified Y", run `Get-ChildItem <path>` first. If the file is not there, do not claim it.
+
+### Gate 3 — Run the validation matrix and capture exit codes
+
+Run each command separately, paste full output, and on the next line paste `$LASTEXITCODE`:
+
+```powershell
+npm run check:env;            "EXIT=$LASTEXITCODE"
+npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/modelStepResolver.test.js src/__tests__/services/projectGraphVerticalSliceService.test.js src/__tests__/services/styleExtractor.test.js src/__tests__/services/styleConstraintApplier.test.js; "EXIT=$LASTEXITCODE"
+npm run check:contracts;      "EXIT=$LASTEXITCODE"
+npm run test:compose:routing; "EXIT=$LASTEXITCODE"
+npm run build:active;         "EXIT=$LASTEXITCODE"
+npm run lint;                 "EXIT=$LASTEXITCODE"
+```
+
+Every `EXIT` must be `0`. Do not summarize, paraphrase, or skip. If a test file referenced in the Jest command does not exist on disk, that is a Gate 1 failure — create the file, do not silently drop it from the command.
+
+### Gate 4 — Commit and prove the commit landed
+
+After the matrix is green:
+
+```powershell
+git add -A
+git status
+git commit -m "feat(style-pack): structured Style Pack extractor and STEP 06/11 integration"
+git log -1 --stat
+git rev-parse HEAD
+git diff --stat HEAD~1..HEAD
+```
+
+The `git log -1 --stat` and `git diff --stat` output must list every file you claim to have touched. If a claimed file is missing from this list, it was never written — return to Gate 1.
+
+### Gate 5 — Self-verification script
+
+Before declaring done, write and run this exact script (place it at `scripts/verify-style-pack.ps1`), pasting its output:
+
+```powershell
+$expected = @(
+  # Replace with the actual paths from PLAN.md "Files to create" + "Files to modify"
+  "src/services/style/stylePackExtractor.js",
+  "src/services/style/stylePackConstraintApplier.js",
+  "src/schemas/stylePack.schema.json",
+  "src/__tests__/services/styleExtractor.test.js",
+  "src/__tests__/services/styleConstraintApplier.test.js",
+  "docs/style-pack/IMPLEMENTATION_NOTES.md"
+)
+$missing = @()
+foreach ($p in $expected) {
+  if (-not (Test-Path $p)) { $missing += $p }
+}
+if ($missing.Count -gt 0) {
+  Write-Host "MISSING FILES:" -ForegroundColor Red
+  $missing | ForEach-Object { Write-Host "  $_" }
+  exit 1
+}
+$flagHits = (Select-String -Path ".env.example","scripts/check-env.cjs" -Pattern "STYLE_PACK_ENABLED" -SimpleMatch).Count
+if ($flagHits -lt 2) {
+  Write-Host "FAIL: STYLE_PACK_ENABLED not wired into env.example + check-env.cjs (hits=$flagHits)" -ForegroundColor Red
+  exit 1
+}
+Write-Host "OK: all expected files present, flag wired." -ForegroundColor Green
+```
+
+If this script exits non-zero, the run failed — fix and re-run from Gate 1.
+
+### Final report — paste verbatim, no summary
+
+Your final message must contain, in this order:
+
+1. Gate 0 output.
+2. For each file created/modified: path, SHA-256, line count.
+3. Gate 3 output (every command, every `EXIT`).
+4. Gate 4 output (`git log -1 --stat`, the new commit SHA, `git diff --stat`).
+5. Gate 5 script output ending in `OK: all expected files present, flag wired.`
+6. Contents of `docs/style-pack/IMPLEMENTATION_NOTES.md`.
+
+Reports missing any of these sections will be rejected as phantom completions, the way the previous run was.
+
+---
+
+## PROMPT 3.1 — Re-audit after PROMPT 2.1 (run in a fresh Claude Code session)
+
+Use **PROMPT 3** above, but before answering any of its 12 questions, run this pre-flight and abort with `REJECT — PHANTOM COMPLETION` if any check fails:
+
+```powershell
+git rev-list --count origin/main..HEAD
+git diff --stat origin/main..HEAD
+git log origin/main..HEAD --oneline
+Test-Path src/services/style/stylePackExtractor.js
+Test-Path src/services/style/stylePackConstraintApplier.js
+Test-Path docs/style-pack/IMPLEMENTATION_NOTES.md
+Select-String -Path ".env.example" -Pattern "STYLE_PACK_ENABLED"
+Select-String -Path "scripts/check-env.cjs" -Pattern "STYLE_PACK_ENABLED"
+```
+
+If `git rev-list --count origin/main..HEAD` is `0`, or any `Test-Path` returns `False`, or either `Select-String` returns nothing, stop the audit immediately and write `docs/style-pack/AUDIT.md` with a single section: **REJECT — PHANTOM COMPLETION**, listing exactly which preflight check failed. Do not proceed to the 12 questions.
+
+Only if every preflight check passes, continue with the full audit per PROMPT 3.

--- a/docs/style-pack/PLAN.md
+++ b/docs/style-pack/PLAN.md
@@ -1,0 +1,650 @@
+# Structured Style Pack — Implementation Plan
+
+> **Deliverable location:** This document's full content is what will be written to `docs/style-pack/PLAN.md` once the user approves. Plan-mode constraints prevent me from creating that file yet; the body below IS the planned file content verbatim.
+
+## Context
+
+Architects upload portfolio PDFs/images to bias the design pipeline. Today the influence is implicit: `localStylePack.js` allocates a fixed ~15 % `portfolio` weight to a text-keyword-derived "evidence" object, and STEP 06 (massing) plus STEP 11 (materials) read no structured pack at all. As a result, two RIBA-grade portfolios that look identical (e.g. "Victorian terrace with shopfront base") can yield wildly different geometries because nothing parametrically constrains floor count, aspect ratio, opening rhythm, or material families.
+
+This plan introduces a **locked, schema-validated Style Pack** extracted **deterministically** from uploaded portfolio files. STEP 06 and STEP 11 consume the pack as **parametric constraints** so portfolio identity is reproducible. The pack is consumed **upstream** of STEP 07 so it folds into `geometryHash` indirectly via geometry parameter changes — it is not added to the hash payload itself (which must remain pure geometry).
+
+Determinism contract:
+
+- same brief + same portfolio bytes → same Style Pack → same `geometryHash`
+- same brief + no portfolio → existing `geometryHash` unchanged (regression-pinned)
+- same brief + pack vs no pack → different `geometryHash` (the pack must actually shift geometry)
+
+## Verified codebase facts (load-bearing for this plan)
+
+| Claim                                                                           | Verified at                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Portfolio file processing is client-side                                        | `src/utils/portfolioFileProcessing.js:100-130` (not `services/`)                                                                                                                                                                |
+| "Portfolio ~15 %" weighting                                                     | `src/services/style/localStylePack.js:21` (`PLAN_WEIGHTS.portfolio = 0.15`); dynamic `0.05 + 0.2 * innovation` at line 72                                                                                                       |
+| STEP 06 + STEP 11 env keys present                                              | `src/services/modelStepResolver.js:61-116`; `.env.example` lines 333, 406                                                                                                                                                       |
+| Massing/programme orchestrator                                                  | `buildProgramme()` at `src/services/project/projectGraphVerticalSliceService.js:4267`, called at line 14745                                                                                                                     |
+| **STEP 07 in the active slice is deterministic JS, not LLM**                    | `buildProjectGeometryFromProgramme` at `projectGraphVerticalSliceService.js:5540` — randomness is `seededRotation(brief.generation_seed, …)`. `STEP_07_PROJECT_GRAPH_MODEL` is dormant capacity. Determinism is currently safe. |
+| `geometryHash` payload is PURE geometry                                         | `buildGeometryHashPayload()` at `src/services/compiler/compiledProjectCompiler.js:1241-1348`; hash applied at line 1573                                                                                                         |
+| `metadata.style_dna` is threaded into `geometrySeed.metadata` but NOT into hash | `compileProject()` line 1357 (`geometrySeed.metadata = deepMerge(..., { style_dna })`) vs hash payload above which omits `metadata`                                                                                             |
+| `layout_archetype` is the strongest existing style→footprint lever              | declared `localStylePack.js:421`; consumed at `projectGraphVerticalSliceService.js:5561`                                                                                                                                        |
+| Floor-to-floor height is currently a hardcoded literal                          | `projectGraphVerticalSliceService.js:5640-5641` (`levelIndex * 3.2`)                                                                                                                                                            |
+| optionScorer climate weight can overrule a style match                          | `src/services/design/optionScorer.js:11` (`CATEGORY_WEIGHTS`), archetype bonus `+0.04` at line 118                                                                                                                              |
+| Schemas directory exists                                                        | `src/schemas/` (currently holds `spatialGraph.js`)                                                                                                                                                                              |
+| `docs/style-pack/` directory                                                    | does not exist                                                                                                                                                                                                                  |
+
+---
+
+## 1. Files to create
+
+| Path                                                                    | Purpose                                                                                                                                                                          | Exported symbols                                                                                                                                                             |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/schemas/stylePack.schema.json`                                     | Locked JSON Schema for the Style Pack (draft-07). Single source of truth for shape, types, ranges.                                                                               | (JSON, no exports)                                                                                                                                                           |
+| `src/schemas/stylePack.js`                                              | Thin JS sibling that imports the JSON and exports `STYLE_PACK_SCHEMA`, `STYLE_PACK_VERSION`, `validateStylePack(pack)`, `EMPTY_STYLE_PACK`. Used by extractor + applier + tests. | `STYLE_PACK_SCHEMA`, `STYLE_PACK_VERSION`, `validateStylePack`, `EMPTY_STYLE_PACK`                                                                                           |
+| `src/services/style/stylePackExtractor.js`                              | Pure, deterministic extractor: N processed portfolio records → one Style Pack JSON. Heuristic-only in v1 (no LLM).                                                               | `extractStylePack({ portfolioFiles, briefHints, extractorVersion })`, `computeStylePackHash(pack)`                                                                           |
+| `src/services/style/stylePackConstraintApplier.js`                      | Applies Style Pack to brief / programme inputs (STEP 06) and to material palette inputs (STEP 11). No-op when pack is null.                                                      | `applyStylePackToBrief({ brief, stylePack })`, `applyStylePackToMaterialPaletteInputs({ inputs, stylePack })`, `applyStylePackToOptionScorerWeights({ weights, stylePack })` |
+| `api/style-pack/extract.js`                                             | Vercel Function (Node, Fluid Compute). Accepts already-processed portfolio records (no raw uploads) + brief hints; returns Style Pack + provenance. Calls `extractStylePack`.    | default async handler                                                                                                                                                        |
+| `src/__tests__/services/styleExtractor.test.js`                         | Jest tests for deterministic extraction.                                                                                                                                         | —                                                                                                                                                                            |
+| `src/__tests__/services/styleConstraintApplier.test.js`                 | Jest tests for STEP 06 / STEP 11 constraint application.                                                                                                                         | —                                                                                                                                                                            |
+| `src/__tests__/fixtures/stylePack/portfolio-textPDF.json`               | Pre-processed portfolio record fixture (PDF text bucketed) used by both tests; deterministic input.                                                                              | —                                                                                                                                                                            |
+| `src/__tests__/fixtures/stylePack/expected-pack-portfolio-textPDF.json` | Expected pack output. Regenerated only via a documented script when extractor version bumps.                                                                                     | —                                                                                                                                                                            |
+| `docs/style-pack/PLAN.md`                                               | This plan (final deliverable).                                                                                                                                                   | —                                                                                                                                                                            |
+| `docs/style-pack/SCHEMA.md`                                             | Human-readable schema walkthrough (field meanings, ranges, examples).                                                                                                            | —                                                                                                                                                                            |
+
+---
+
+## 2. Files to modify
+
+### 2a. `src/services/style/localStylePack.js`
+
+**Why:** STEP 11 (materials) integration. `buildLocalStylePackV2` must accept an optional `stylePack`, thread `stylePack.materialFamilies` into the palette computation, and pin it in `style_provenance`.
+
+```diff
+-export function buildLocalStylePackV2({
+-  brief, site, climate, jurisdictionPack = null,
+-  createStableId, paletteSize = 6,
+-} = {}) {
+-  const blend = computeMaterialPalette({ brief, site, climate, jurisdictionPack, paletteSize });
++export function buildLocalStylePackV2({
++  brief, site, climate, jurisdictionPack = null,
++  stylePack = null,                              // NEW
++  createStableId, paletteSize = 6,
++} = {}) {
++  const blend = computeMaterialPalette({
++    brief, site, climate, jurisdictionPack, paletteSize,
++    stylePackMaterialFamilies: stylePack?.materialFamilies || null,   // NEW
++  });
+   ...
+   return {
+     style_pack_id: ...,
++    portfolio_style_pack: stylePack || null,     // NEW (full pack snapshot for downstream provenance)
++    portfolio_style_pack_hash: stylePack ? computeStylePackHash(stylePack) : null,  // NEW (audit-only, NOT hashed into geometry)
+     material_palette: blend.palette,
+     ...
+   };
+ }
+```
+
+`computeMaterialPalette` gets `stylePackMaterialFamilies`: when non-null, the palette is **prefiltered** to entries whose material tokens intersect `primary ∪ secondary ∪ accents`, then re-ranked with weights `primary > secondary > accents > local`. When null, function returns today's output **byte-identical** (snapshot-pinned).
+
+### 2b. `src/services/project/projectGraphVerticalSliceService.js`
+
+**Why:** Orchestrate extraction and apply constraints **before** `buildProgramme` and **before** the deterministic geometry builder. Plumb the pack into `buildLocalStylePack`. Parameterize the floor-to-floor literal.
+
+```diff
++import { extractStylePack, computeStylePackHash } from "../style/stylePackExtractor.js";
++import {
++  applyStylePackToBrief,
++  applyStylePackToOptionScorerWeights,
++} from "../style/stylePackConstraintApplier.js";
+
+ // ...inside buildArchitectureProjectVerticalSlice, after brief normalization,
+ //    before buildProgramme(...) at line ~14745:
+
++  const stylePack = process.env.STYLE_PACK_ENABLED !== "false"
++    ? extractStylePack({
++        portfolioFiles: input.portfolioFiles || [],
++        briefHints: { buildingType: brief.building_type, climate, jurisdictionPack },
++        extractorVersion: STYLE_PACK_VERSION,
++      })
++    : null;
++  const constrainedBrief = applyStylePackToBrief({ brief, stylePack });
+
+-  const draftProgramme = buildProgramme({ brief, programSpaces });
++  const draftProgramme = buildProgramme({ brief: constrainedBrief, programSpaces });
+
+   // ...where buildLocalStylePack is called (line ~14739):
+-  const localStyle = buildLocalStylePack(brief, site, climate, jurisdictionPack);
++  const localStyle = buildLocalStylePack(
++    constrainedBrief, site, climate, jurisdictionPack, { stylePack }
++  );
+
+   // ...in buildProjectGeometryFromProgramme (line ~5640), replace the literal:
+-  elevation_m: levelIndex * 3.2,
++  elevation_m: levelIndex * (stylePack?.facadeModule?.floorHeightMm
++    ? stylePack.facadeModule.floorHeightMm / 1000
++    : 3.2),
+```
+
+Additional wiring (each is a small, surgical edit; full diffs in implementation phase):
+
+- `roofPitchDistribution.dominant` → biases `roof.slope_deg` selection (currently `community ? 8 : 35` at line ~5690).
+- `openingRhythm.{moduleMm, sillHeightMm, repetition}` → seeds `compileOpenings` defaults.
+- `windowToWallRatio.{overall, byElevation}` → constrains opening total area per facade in the seed (clamp-to-pack after the existing climate/regs clamp).
+- `massingTendency.aspectRatioRange` → clamps the bounding-box ratio in the massing seed before option generation.
+- `massingTendency.floorCount.{min, mode, max}` → consumed by `applyStylePackToBrief` to clamp/bias `brief.target_storeys`.
+
+### 2c. `src/services/design/optionGenerator.js`
+
+**Why:** When the pack pins `massingTendency.form` and `layout_archetype`, generated candidates must include pack-aligned options. Currently archetype prepending uses `localStyle.style_provenance.layout_archetype`. Extend it to also read `stylePack.massingTendency.form` and `stylePack.layout_archetype`.
+
+```diff
+-  const archetype = localStyle?.style_provenance?.layout_archetype || null;
++  const archetype =
++    stylePack?.layout_archetype ||
++    localStyle?.style_provenance?.layout_archetype ||
++    null;
++  const massingForm = stylePack?.massingTendency?.form || null;
+```
+
+### 2d. `src/services/design/optionScorer.js`
+
+**Why:** Plan agent flagged that the existing `+0.04` archetype bonus is too small — climate (0.20) can overrule a clear style intent. When a Style Pack is present, add a `styleAlignment` subscore so the pack carries first-class weight.
+
+```diff
+ const CATEGORY_WEIGHTS = {
+   programmeFit: 0.25,
+   climateFit: 0.20,
+-  costFit: 0.15,
++  costFit: 0.15,
++  styleAlignment: 0.0,   // dormant unless Style Pack is active
+   ...
+ };
+
++export function scaleWeightsForStylePack(weights, stylePack) {
++  if (!stylePack) return weights;
++  // Reallocate 0.10 from climateFit and 0.05 from costFit into styleAlignment.
++  return { ...weights, climateFit: weights.climateFit - 0.10,
++           costFit: weights.costFit - 0.05, styleAlignment: 0.15 };
++}
+```
+
+`styleAlignment` score per candidate: fraction of `{archetype, form, aspectRatio∈range, roofPitch∈dominant bucket, floorCount∈[min,max]}` that match the pack. Pure function of geometry + pack — deterministic.
+
+### 2e. `src/services/compiler/compiledProjectCompiler.js`
+
+**Why:** Audit trail only. Carry `portfolio_style_pack_hash` on `compiledProject.metadata` so reviewers can trace a build back to its pack — **without** adding it to `buildGeometryHashPayload`.
+
+```diff
+   geometrySeed.metadata = deepMerge(geometrySeed.metadata || {}, {
+     style_dna: styleDNA,
++    portfolio_style_pack_hash: styleDNA?.portfolio_style_pack_hash || null,
+   });
+   // buildGeometryHashPayload intentionally NOT modified — hash stays geometry-only.
+```
+
+A regression test (see §10) pins the no-pack reference hash so any accidental leak of `style_dna` into the hash payload trips immediately.
+
+### 2f. `src/services/modelStepResolver.js`
+
+**Why:** Add an entry for the style extractor model **only if** we later need LLM assist. For v1 (heuristic-only) no change is required. Skeleton entry pre-wired for future toggle:
+
+```diff
++  STEP_05_STYLE_EXTRACT: {
++    envPrefix: "STEP_05_STYLE_EXTRACT",
++    baseKeys: ["STEP_05_STYLE_EXTRACT_MODEL", "OPENAI_REASONING_MODEL"],
++    fineTunedKey: "STEP_05_STYLE_EXTRACT_FT_MODEL",
++    provider: "openai",
++  },
+```
+
+(Dead code path until `STYLE_PACK_LLM_FALLBACK=true`. Plan agent recommendation: ship v1 with this commented out to avoid premature surface.)
+
+### 2g. `src/hooks/useArchitectAIWorkflow.js`
+
+**Why:** Pass-through. The hook already forwards `portfolioFiles` to the vertical-slice API; no UI change needed. Add `verticalSlice.style_pack` to the returned shape so the UI can display the pack (read-only) for transparency.
+
+### 2h. `.env.example`
+
+Add a clearly-grouped block (placement: after STEP_05_PROGRAMME):
+
+```
+# --- Portfolio Style Pack (parametric portfolio constraints, STEP 06 + STEP 11)
+STYLE_PACK_ENABLED=true
+# Optional: deterministic seed override; default = sha256(portfolio bytes)
+STYLE_PACK_SEED=
+# Future LLM-assisted extraction (v2). Keep false in v1.
+STYLE_PACK_LLM_FALLBACK=false
+# STEP_05_STYLE_EXTRACT_MODEL=          # uncomment when v2 lands
+```
+
+### 2i. `scripts/check-env.cjs`
+
+**Why:** Add `STYLE_PACK_ENABLED` to the **optional flag** block (warnings only). **Do NOT** add it to the strict `REQUIRED` list — that would hard-fail every existing deployment that hasn't set it.
+
+```diff
+   // in the optional flag list (around the A1_RENDER_GEOMETRY_QA_ENABLED block):
++  { name: "STYLE_PACK_ENABLED", description: "Enables Style Pack extraction + STEP 06/11 constraints",
++    expected: "true|false", optional: true },
+```
+
+### 2j. `src/__tests__/services/projectGraphVerticalSliceService.test.js`
+
+Extend (do not rewrite) with three new test cases — see §10.
+
+### 2k. `src/__tests__/services/localStylePack.test.js`
+
+Extend with stylePack-constrained palette tests — see §10.
+
+---
+
+## 3. Style Pack JSON schema (locked)
+
+Schema lives at `src/schemas/stylePack.schema.json`. `STYLE_PACK_VERSION = "1.0.0"`. Bumping any field type/range bumps the major.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://architect-ai-platform/schemas/stylePack/1.0.0",
+  "title": "StylePack",
+  "type": "object",
+  "required": [
+    "version",
+    "windowToWallRatio",
+    "roofPitchDistribution",
+    "openingRhythm",
+    "materialFamilies",
+    "massingTendency",
+    "facadeModule",
+    "layout_archetype",
+    "provenance"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": "1.0.0" },
+    "windowToWallRatio": {
+      "type": "object",
+      "required": ["overall", "byElevation"],
+      "properties": {
+        "overall": { "type": "number", "minimum": 0, "maximum": 0.95 },
+        "byElevation": {
+          "type": "object",
+          "required": ["N", "S", "E", "W"],
+          "properties": {
+            "N": { "type": "number", "minimum": 0, "maximum": 0.95 },
+            "S": { "type": "number", "minimum": 0, "maximum": 0.95 },
+            "E": { "type": "number", "minimum": 0, "maximum": 0.95 },
+            "W": { "type": "number", "minimum": 0, "maximum": 0.95 }
+          }
+        }
+      }
+    },
+    "roofPitchDistribution": {
+      "type": "object",
+      "required": ["flatPct", "lowPct", "mediumPct", "steepPct", "dominant"],
+      "properties": {
+        "flatPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "lowPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "mediumPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "steepPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "dominant": { "enum": ["flat", "low", "medium", "steep"] }
+      }
+    },
+    "openingRhythm": {
+      "type": "object",
+      "required": ["moduleMm", "repetition", "sillHeightMm"],
+      "properties": {
+        "moduleMm": { "type": "integer", "minimum": 600, "maximum": 6000 },
+        "repetition": { "enum": ["regular", "asymmetric", "paired"] },
+        "sillHeightMm": { "type": "integer", "minimum": 0, "maximum": 2200 }
+      }
+    },
+    "materialFamilies": {
+      "type": "object",
+      "required": ["primary", "secondary", "accents"],
+      "properties": {
+        "primary": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "maxItems": 4
+        },
+        "secondary": {
+          "type": "array",
+          "items": { "type": "string" },
+          "maxItems": 6
+        },
+        "accents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "maxItems": 6
+        }
+      }
+    },
+    "massingTendency": {
+      "type": "object",
+      "required": ["form", "floorCount", "aspectRatioRange"],
+      "properties": {
+        "form": { "enum": ["compact", "L", "U", "courtyard", "articulated"] },
+        "floorCount": {
+          "type": "object",
+          "required": ["min", "mode", "max"],
+          "properties": {
+            "min": { "type": "integer", "minimum": 1, "maximum": 12 },
+            "mode": { "type": "integer", "minimum": 1, "maximum": 12 },
+            "max": { "type": "integer", "minimum": 1, "maximum": 12 }
+          }
+        },
+        "aspectRatioRange": {
+          "type": "array",
+          "items": { "type": "number", "minimum": 0.2, "maximum": 6 },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      }
+    },
+    "facadeModule": {
+      "type": "object",
+      "required": ["baySpacingMm", "floorHeightMm"],
+      "properties": {
+        "baySpacingMm": { "type": "integer", "minimum": 1200, "maximum": 9000 },
+        "floorHeightMm": { "type": "integer", "minimum": 2400, "maximum": 4500 }
+      }
+    },
+    "layout_archetype": {
+      "type": ["string", "null"],
+      "description": "Optional alignment with the existing localStyle archetype vocabulary (e.g. terrace, bar, courtyard, pavilion). Null when portfolio is ambiguous."
+    },
+    "provenance": {
+      "type": "object",
+      "required": [
+        "sourceFiles",
+        "extractedAt",
+        "extractorVersion",
+        "confidence",
+        "seed"
+      ],
+      "properties": {
+        "sourceFiles": { "type": "array", "items": { "type": "string" } },
+        "extractedAt": { "type": "string", "format": "date-time" },
+        "extractorVersion": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "seed": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Per-field evidence breadcrumbs (which file / which keyword bucket drove which decision)."
+        }
+      }
+    }
+  }
+}
+```
+
+Extensions beyond the minimum: `version`, `layout_archetype` (Plan-agent flag: strongest existing style→footprint lever), `provenance.seed`, `provenance.evidence`, `roofPitchDistribution.{flat,low,medium,steep}Pct` (full distribution, not just dominant) so the LLM-assist path in v2 has somewhere to put it without schema churn.
+
+---
+
+## 4. Extractor design
+
+**Location:** `src/services/style/stylePackExtractor.js`. Pure function. No side effects, no network, no filesystem.
+
+**Inputs:**
+
+- `portfolioFiles`: array of records produced by `src/utils/portfolioFileProcessing.js` (each record already contains PDF text, page thumbnails as base64, `portfolioStyleEvidence.{materials, colours, styleKeywords, buildingTypes, drawingTypes}`).
+- `briefHints`: `{ buildingType, climate, jurisdictionPack }` — used as priors when portfolio is ambiguous.
+- `extractorVersion`: pinned by caller (`STYLE_PACK_VERSION` from `src/schemas/stylePack.js`).
+
+**Output:** `StylePack` or `null` (when `portfolioFiles.length === 0`).
+
+**Pipeline (deterministic, heuristic-only in v1):**
+
+1. **Content hash → seed.** `seed = sha256(sortedByName(portfolioFiles).map(f => f.bytesOrTextDigest).join("|"))`. Becomes `provenance.seed`. All randomness in extraction (e.g. tie-breaks) seeds off it via a tiny xorshift.
+2. **Keyword aggregation.** Already-bucketed PDF text via `extractPdfPortfolioEvidence` (existing). Tally `materials`, `colours`, `styleKeywords`, `buildingTypes` across all files. Apply a stopword + synonym map (`"red brick" → "brick"`).
+3. **Material families.** `primary = top 3 by frequency in materials buckets, dedup by family`. `secondary = next 4`. `accents = colours and finishes`. Default fallback when nothing matched: `briefHints.buildingType` → look up `LOCAL_PALETTES_BY_TYPE` from `localStylePack.js:92` and use its top 3.
+4. **Roof pitch distribution.** Histogram over keyword matches: `flat`/`parapet`/`green roof` → flatPct; `mansard`/`gambrel` → steepPct; `pitched`/`gable` → mediumPct; defaults to dominance derived from `briefHints.buildingType` and `jurisdictionPack` when unclear.
+5. **Massing tendency.** Hash of `(form keywords, footprint shape mentions, aspect ratio hints in text)`. Defaults: `{ form: "compact", floorCount: {min:1, mode: briefHints.target_storeys || 2, max:6}, aspectRatioRange: [0.8, 2.5] }`.
+6. **Opening rhythm + facade module.** Default `{ moduleMm: 1500, repetition: "regular", sillHeightMm: 900 }`, `{ baySpacingMm: 3000, floorHeightMm: 3000 }`. Heuristic overrides when keyword matches: "loft" → larger module, "terrace" → tighter bay, "Georgian" → paired repetition.
+7. **Window-to-wall ratio.** Defaults `{ overall: 0.30, byElevation: { N:0.20, S:0.40, E:0.30, W:0.30 } }`. Bias by `colours` and `styleKeywords` (e.g. "glazed" → +0.10 overall, capped at 0.70).
+8. **layout_archetype.** Mapped via the existing vernacular pack vocabulary (terrace, bar, courtyard, pavilion). `null` when ambiguous — the existing `style_provenance.layout_archetype` fallback in `localStylePack.js` then applies.
+9. **Confidence.** `count(matched_evidence_buckets) / 7` clamped [0.2, 0.95]. Drives `provenance.confidence`.
+10. **Schema validation** via `validateStylePack` before returning. Throw on validation failure (programmer error, not user error).
+
+**No LLM in v1.** Plan-agent justification: heuristic-only is auditable, byte-deterministic across model fingerprint rotations, free, and removes the cache-drift attack surface. v2 may add `STYLE_PACK_LLM_FALLBACK=true` + `STEP_05_STYLE_EXTRACT_MODEL` (already plumbed in skeleton at §2f). v1 leaves both unused.
+
+**Determinism guarantee.** Pure function of `(portfolioFiles bytes, briefHints, extractorVersion)`. The synonym map and bucket tables are frozen constants. Object key order is canonicalised (`JSON.stringify` with stable replacer) before hashing.
+
+**`computeStylePackHash(pack)`** returns `sha256(canonicalJSON(pack without provenance.extractedAt))` — drops the timestamp so two runs of the same content hash identically.
+
+---
+
+## 5. STEP 06 integration (massing constraints)
+
+STEP 06 in the active slice is **`buildProgramme` + deterministic massing seed**, not an LLM call. The Style Pack is applied via `applyStylePackToBrief` **before** `buildProgramme` runs.
+
+**Signature:**
+
+```js
+applyStylePackToBrief({ brief, stylePack }): ConstrainedBrief
+```
+
+**Returns** a shallow-cloned brief with these clamps (each is a no-op when `stylePack` is null):
+
+| Brief field                         | Clamp / bias                                                                                      |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `brief.target_storeys`              | clamp to `[stylePack.massingTendency.floorCount.min, max]`; if currently null, set to `mode`      |
+| `brief.aspect_ratio_target`         | clamp to `stylePack.massingTendency.aspectRatioRange`; if absent, midpoint                        |
+| `brief.massing_form_preference`     | set to `stylePack.massingTendency.form` when absent (does not overwrite explicit user preference) |
+| `brief.facade_module_mm`            | set to `stylePack.facadeModule.baySpacingMm` when absent                                          |
+| `brief.floor_height_mm`             | set to `stylePack.facadeModule.floorHeightMm` when absent — drives the `3.2`-literal fix in §2b   |
+| `brief.window_to_wall_ratio_target` | merge with `stylePack.windowToWallRatio` (user fields win, missing fields filled from pack)       |
+| `brief.opening_rhythm`              | merge with `stylePack.openingRhythm`                                                              |
+| `brief.preferred_layout_archetype`  | set to `stylePack.layout_archetype` when absent and pack provides one                             |
+| `brief.style_pack_hash`             | set to `computeStylePackHash(stylePack)` (audit only)                                             |
+
+`brief.floorCountLocked` is honoured per existing memory: when locked, pack clamp is skipped for `target_storeys`. (See memory: floor-count auto-detect + manual override.)
+
+Downstream consumers (`buildProgramme`, `buildProjectGeometryFromProgramme`) already read these brief fields where available; the only code change is in `buildProjectGeometryFromProgramme` to honour `brief.floor_height_mm` instead of the `3.2` literal at line 5640-5641. Roof pitch and opening rhythm consumption sites get one-line reads similarly.
+
+---
+
+## 6. STEP 11 integration (materials constraints)
+
+STEP 11 (material/palette strategy) is currently realised by `buildLocalStylePackV2 → computeMaterialPalette`. The Style Pack constrains via a new optional parameter, **never** via a side-channel.
+
+**Signature change** (re-listed from §2a):
+
+```js
+buildLocalStylePackV2({ brief, site, climate, jurisdictionPack, stylePack /* NEW */, ... })
+```
+
+`computeMaterialPalette` is extended to accept `stylePackMaterialFamilies`. When provided:
+
+1. **Filter.** Drop palette candidates whose material token does NOT belong to `primary ∪ secondary ∪ accents`. If filtering would empty the palette (e.g. pack lists exotic materials inapplicable in the jurisdiction), skip filtering and emit a `style_pack_warning: "palette_disjoint"` into `style_provenance`.
+2. **Re-rank.** Weight each surviving candidate `w_primary=1.0, w_secondary=0.5, w_accents=0.25`. Combine with existing `material_blend_weights`.
+3. **Bias** `material_blend_weights.portfolio` upward by `+0.10` when pack confidence > 0.6, capped at the existing `[0.05, 0.25]` envelope at `localStylePack.js:72`. The portfolio share never exceeds the plan-mandated cap.
+
+**Absence-of-pack invariant.** When `stylePack` is null, `buildLocalStylePackV2` returns **byte-identical** output to today. Pinned by a snapshot test on a fixture brief.
+
+---
+
+## 7. ProjectGraph contract (Style Pack upstream of STEP 07)
+
+**Hash input set.** Computed in exactly one place: `buildGeometryHashPayload(compiledProject)` at `src/services/compiler/compiledProjectCompiler.js:1241`, invoked at line 1573. The payload contains: `footprint, envelope, levels, slabs, rooms, walls, openings, stairs, roof`. **Nothing else.** Verified by reading the function in full (§"Verified codebase facts").
+
+**Style Pack does NOT enter the hash payload.** Adding `style_dna` or `stylePack` to the hash would break the "2D and 3D share the same `geometryHash`" contract: the hash represents geometry that must round-trip into both deterministic projections.
+
+**Style Pack folds into the hash _indirectly_.** Sequence:
+
+```
+input.portfolioFiles
+  → extractStylePack()                  (§4, deterministic, pure)
+  → applyStylePackToBrief()             (§5)
+  → buildProgramme(constrainedBrief)    (uses pack-derived floorCount, aspectRatio, ...)
+  → buildProjectGeometryFromProgramme   (deterministic JS, honours brief.floor_height_mm, opening_rhythm, ...)
+  → compileProject(geometrySeed)        (compiledProjectCompiler.js:1350)
+  → buildGeometryHashPayload(compiledProject)   (geometry only — but the geometry IS pack-shaped now)
+```
+
+Result: pack content perturbs `floorCount` → `levels.length` changes → hash changes. Pack content perturbs `aspect_ratio_target` → `footprint.polygon` changes → hash changes. **Without** changing the hash payload schema.
+
+**`portfolio_style_pack_hash` is carried in `compiledProject.metadata.portfolio_style_pack_hash`** (§2e) for audit. This field sits OUTSIDE `buildGeometryHashPayload`'s reads and is regression-pinned in §10.
+
+**STEP 07 LLM safety.** `STEP_07_PROJECT_GRAPH_MODEL` is dormant in the active slice (Plan-agent confirmation). The slice is deterministic JS keyed off `brief.generation_seed`. Determinism contract is therefore satisfied today. Future LLM swap-in at STEP 07 must keep `temperature: 0` AND geometry must be **snapped/normalised** before hashing (e.g. round all coordinates to integer mm) to survive any LLM non-determinism. Out of scope for this plan but explicitly called out in §12.
+
+---
+
+## 8. Determinism plan
+
+| Surface                      | Mechanism                                                                                                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Extractor**                | Pure function of `(portfolioFiles bytes, briefHints, extractorVersion)`. Heuristic-only. Stable JSON canonicalisation before hashing.                                                             |
+| **Style Pack hash**          | `computeStylePackHash(pack) = sha256(canonicalJSON(pack \ provenance.extractedAt))`. Recorded in `brief.style_pack_hash` and `compiledProject.metadata.portfolio_style_pack_hash`.                |
+| **Seed threading**           | `provenance.seed` is the content hash of portfolio bytes. Becomes the default `brief.generation_seed` when the brief has none; pack provides reproducibility even when the UI doesn't pin a seed. |
+| **Constraint applier**       | Pure brief transformer. No randomness.                                                                                                                                                            |
+| **STEP 06 / programme**      | Deterministic JS today; pack just clamps inputs.                                                                                                                                                  |
+| **STEP 07 / compileProject** | Pure deterministic JS. Hash payload unchanged.                                                                                                                                                    |
+| **STEP 11 / palette**        | Pure transformer with stable sort (current behaviour preserved).                                                                                                                                  |
+| **Test pins**                | Three hashes pinned: (a) reference no-pack hash, (b) fixture brief + fixture pack hash, (c) `computeStylePackHash` for the fixture pack.                                                          |
+
+---
+
+## 9. Env vars and config
+
+**New entries to `.env.example` only** (never `.env`, `.env.local`, `.env.production`):
+
+| Var                           | Default         | Notes                                                                                         |
+| ----------------------------- | --------------- | --------------------------------------------------------------------------------------------- |
+| `STYLE_PACK_ENABLED`          | `true`          | Master kill-switch. `false` → extractor returns null, applier no-ops, pipeline matches today. |
+| `STYLE_PACK_SEED`             | empty           | Optional override for `provenance.seed`. Empty → seed = sha256(portfolio bytes).              |
+| `STYLE_PACK_LLM_FALLBACK`     | `false`         | Reserved for v2. v1 ignores the flag.                                                         |
+| `STEP_05_STYLE_EXTRACT_MODEL` | (commented out) | Reserved. Uncomment when v2 LLM-assist lands.                                                 |
+
+**`scripts/check-env.cjs`:** add `STYLE_PACK_ENABLED` to the **optional flag** block only. Plan-agent flagged: adding to `REQUIRED` would hard-fail every existing deployment.
+
+**Default behaviour with no portfolio.** `input.portfolioFiles?.length === 0` → `extractStylePack` returns `null` → `applyStylePackToBrief({ brief, stylePack: null })` returns the brief unchanged → `buildLocalStylePackV2` is called with `stylePack: null` and returns byte-identical output to today → `buildProgramme` and `buildProjectGeometryFromProgramme` see the same brief they see today → `compiledProject.geometryHash` matches the existing reference hash. Pinned in §10.
+
+---
+
+## 10. Tests to add
+
+### `src/__tests__/services/styleExtractor.test.js`
+
+| Case                                                                                          | Assertion                                                                                                     |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `extractStylePack({ portfolioFiles: [] })`                                                    | returns `null`                                                                                                |
+| `extractStylePack` with fixture text-PDF record (`fixtures/stylePack/portfolio-textPDF.json`) | matches `fixtures/stylePack/expected-pack-portfolio-textPDF.json` exactly via `JSON.stringify` canonical form |
+| Repeated extraction with the same fixture                                                     | byte-identical output (deep equal AND `computeStylePackHash` equal)                                           |
+| Pack validates against `STYLE_PACK_SCHEMA`                                                    | `validateStylePack(pack) === { valid: true }`                                                                 |
+| `STYLE_PACK_VERSION` mismatch on returned pack                                                | extractor throws — schema is locked                                                                           |
+| Confidence bounded                                                                            | `0 ≤ provenance.confidence ≤ 1` for an empty-text fixture (low confidence allowed, not invalid)               |
+
+### `src/__tests__/services/styleConstraintApplier.test.js`
+
+| Case                                                | Assertion                                                                                                |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `applyStylePackToBrief({ brief, stylePack: null })` | returns brief unchanged (deep equal)                                                                     |
+| `target_storeys` outside `floorCount` range         | clamped into range                                                                                       |
+| `floorCountLocked: true`                            | clamp is skipped, original value preserved (honours existing memory)                                     |
+| `aspect_ratio_target` clamped                       | within `aspectRatioRange`                                                                                |
+| `applyStylePackToMaterialPaletteInputs` with pack   | resulting palette tokens ⊂ primary ∪ secondary ∪ accents OR `style_pack_warning: "palette_disjoint"` set |
+| Pack absent                                         | palette identical to today's output (snapshot)                                                           |
+| `applyStylePackToOptionScorerWeights`               | when pack present, `styleAlignment = 0.15`; when null, weights unchanged                                 |
+
+### Extend `src/__tests__/services/projectGraphVerticalSliceService.test.js`
+
+Three new test cases (uses existing `createReadingRoomBrief()` fixture):
+
+| Case                         | Assertion                                                                                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| same brief + same pack twice | identical `verticalSlice.compiledProject.geometryHash`                                                                                                             |
+| same brief + no pack         | `geometryHash` matches a **pinned reference constant** (regression — must not drift)                                                                               |
+| same brief, pack vs no pack  | `geometryHash` **differs** (proves pack actually affects geometry)                                                                                                 |
+| pack present                 | `compiledProject.metadata.portfolio_style_pack_hash` is set; pack hash NOT present in `buildGeometryHashPayload` output (guards against accidental leak into hash) |
+
+### Extend `src/__tests__/services/localStylePack.test.js`
+
+| Case                                                     | Assertion                                                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `buildLocalStylePackV2({ ...args })` without `stylePack` | byte-identical to today (snapshot)                                                                           |
+| `buildLocalStylePackV2({ ...args, stylePack: fixture })` | `material_palette` tokens ⊂ pack families; `portfolio_style_pack_hash` set; `blend_weights.portfolio` ≤ 0.25 |
+
+---
+
+## 11. Validation matrix
+
+Run before declaring success:
+
+```powershell
+npm run check:env
+npx react-scripts test --watchAll=false --runInBand --testPathIgnorePatterns=\.claude\ --runTestsByPath src/__tests__/services/modelStepResolver.test.js src/__tests__/services/projectGraphVerticalSliceService.test.js src/__tests__/services/styleExtractor.test.js src/__tests__/services/styleConstraintApplier.test.js
+npm run check:contracts
+npm run test:compose:routing
+npm run build:active
+npm run lint
+```
+
+Also run `npm run check:all` (≡ `check:env && check:contracts`) once; all six commands above must exit 0.
+
+---
+
+## 12. Risks and non-goals
+
+**Non-goals (explicit):**
+
+- **No LoRA, no fine-tuning of architect work** in v1. v2 may consider an LLM-assist extractor; no model training in either version.
+- **No image-model involvement in technical drawings.** Style Pack constrains parametric inputs; plans, elevations, sections remain deterministic SVG/geometry outputs.
+- **No change to SVG/DXF/IFC/PDF/XLSX exporters.** Geometry remains the single source of truth; exporters consume `compiledProject` unchanged.
+- **No change to the STEP 13 QA report contract.** QA reads what it reads today; new pack-related fields are additive on `compiledProject.metadata` and ignored by the existing report builder.
+- **No change to `multi_panel` mode.** All wiring guarded by the `project_graph` pipeline mode and by `STYLE_PACK_ENABLED`. `multi_panel` paths see no new code on hot path.
+- **No edit of real `.env`, `.env.local`, `.env.production`.** `.env.example` only.
+
+**Risks (Plan-agent flagged) and mitigations:**
+
+| Risk                                                                       | Mitigation                                                                                                                                                     |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Future LLM at STEP 07 breaks "same pack → same hash"                       | Pin no-pack reference hash in test; if/when STEP 07 LLM is enabled, geometry must be snapped to integer mm before hashing. Out of this scope; called out here. |
+| `style_dna` / pack hash accidentally leaks into `buildGeometryHashPayload` | Dedicated invariant test asserts the payload's keys exactly match the geometry-only set.                                                                       |
+| Pack confidence drifts on PDF re-render                                    | Heuristic-only extractor → no model fingerprint dependency. Cache is content-hashed, so identical bytes → identical pack.                                      |
+| Pack-aligned candidate loses to climate-aligned candidate at scoring       | New `styleAlignment` subscore at 0.15 weight (only when pack present); reallocates from climateFit/costFit. Tunable.                                           |
+| Adding `STEP_05_STYLE_EXTRACT_MODEL` to REQUIRED hard-fails ops            | Not added to REQUIRED. Skeleton entry commented out until v2.                                                                                                  |
+| User uploads zero portfolio files                                          | `extractStylePack` returns `null`; system runs as today. Snapshot test pins this.                                                                              |
+| Pack lists materials with no jurisdictional match                          | Palette filter skipped; `style_pack_warning: "palette_disjoint"` in provenance. No crash.                                                                      |
+
+---
+
+## 13. Rollback plan
+
+**Single env flag.** Set `STYLE_PACK_ENABLED=false` in the Vercel project's environment (preview or production), redeploy:
+
+```
+vercel env add STYLE_PACK_ENABLED preview     # then enter "false"
+vercel env add STYLE_PACK_ENABLED production  # then enter "false"
+vercel deploy --prod
+```
+
+Effect:
+
+- `extractStylePack` is never called (guard in `projectGraphVerticalSliceService.js` §2b)
+- `applyStylePackToBrief` is never called
+- `buildLocalStylePackV2` is called without `stylePack`, returning today's output
+- `compiledProject.metadata.portfolio_style_pack_hash` is `null`
+- `geometryHash` reverts to the pinned reference hash (snapshot-tested)
+- No code change required; no migration; no data backfill
+
+**Code-level rollback** (full revert): the feature lives in self-contained new files plus surgical edits guarded by the env flag. Reverting the merge commit restores prior behaviour cleanly.
+
+---
+
+## Critical files referenced (paths only)
+
+- `src/services/style/localStylePack.js`
+- `src/services/project/projectGraphVerticalSliceService.js`
+- `src/services/compiler/compiledProjectCompiler.js`
+- `src/services/design/optionGenerator.js`
+- `src/services/design/optionScorer.js`
+- `src/utils/portfolioFileProcessing.js`
+- `src/services/modelStepResolver.js`
+- `scripts/check-env.cjs`
+- `.env.example`
+- `src/__tests__/services/projectGraphVerticalSliceService.test.js`
+- `src/__tests__/services/localStylePack.test.js`
+- `src/__tests__/services/modelStepResolver.test.js`

--- a/docs/style-pack/SCHEMA.md
+++ b/docs/style-pack/SCHEMA.md
@@ -1,0 +1,16 @@
+# Style Pack Schema
+
+`src/schemas/stylePack.schema.json` locks Style Pack v1 at `1.0.0`.
+
+The pack is deterministic portfolio evidence for upstream ProjectGraph inputs:
+
+- `windowToWallRatio`: overall and N/S/E/W facade aperture targets.
+- `roofPitchDistribution`: normalized flat/low/medium/steep evidence with a dominant bucket.
+- `openingRhythm`: bay module, repetition type, and sill height.
+- `materialFamilies`: primary, secondary, and accent material tokens.
+- `massingTendency`: massing form, floor-count range, and footprint aspect-ratio range.
+- `facadeModule`: bay spacing and floor-to-floor height in millimetres.
+- `layout_archetype`: optional existing ProjectGraph/local-style archetype key.
+- `provenance`: source filenames, deterministic extraction timestamp, extractor version, confidence, seed, and evidence breadcrumbs.
+
+The Style Pack hash is computed from stable JSON with sorted keys and excludes `provenance.extractedAt`.

--- a/scripts/check-env.cjs
+++ b/scripts/check-env.cjs
@@ -140,6 +140,13 @@ const OPTIONAL_PRESENTATION = [
       "Set true to enable the photoreal-render vs ProjectGraph vision-QA loop (PR5). Off by default; opting in adds one STEP_09_3D_QA_MODEL call per panel plus up to 2 retries on geometry drift.",
   },
   {
+    name: "STYLE_PACK_ENABLED",
+    description:
+      "Enables Style Pack extraction plus STEP 06 and STEP 11 constraints",
+    expected: "true|false",
+    optional: true,
+  },
+  {
     name: "A1_SHOW_PROVENANCE_BADGES",
     description:
       "Set true to render the IMAGE2 EDIT provenance badge on photoreal panels (dev/QA only). Default off so the badge does not leak onto client-facing sheets.",
@@ -186,7 +193,23 @@ function checkGroup(title, entries, { required = true } = {}) {
       if (required) missing.push(entry.name);
       continue;
     }
-    if (entry.expected && String(value).toLowerCase() !== entry.expected) {
+    if (
+      entry.expected &&
+      String(entry.expected).includes("|") &&
+      !String(entry.expected)
+        .split("|")
+        .map((part) => part.trim().toLowerCase())
+        .includes(String(value).toLowerCase())
+    ) {
+      console.log(`  ⚠️  ${entry.name} must be ${entry.expected}`);
+      invalid.push(entry.name);
+      continue;
+    }
+    if (
+      entry.expected &&
+      !String(entry.expected).includes("|") &&
+      String(value).toLowerCase() !== entry.expected
+    ) {
       console.log(`  ⚠️  ${entry.name} must be ${entry.expected}`);
       invalid.push(entry.name);
       continue;
@@ -239,6 +262,17 @@ function checkLocalDevProviderHint() {
   );
 }
 
+function buildProductionStrictEnv() {
+  const env = { ...process.env };
+  if (!env.AWS_ACCESS_KEY_ID && env.ARTIFACT_STORAGE_ACCESS_KEY_ID) {
+    env.AWS_ACCESS_KEY_ID = env.ARTIFACT_STORAGE_ACCESS_KEY_ID;
+  }
+  if (!env.AWS_SECRET_ACCESS_KEY && env.ARTIFACT_STORAGE_SECRET_ACCESS_KEY) {
+    env.AWS_SECRET_ACCESS_KEY = env.ARTIFACT_STORAGE_SECRET_ACCESS_KEY;
+  }
+  return env;
+}
+
 function main() {
   console.log("Environment Variable Validation: RIBA A1 ProjectGraph pipeline");
   console.log("Secrets are redacted by design.");
@@ -285,7 +319,7 @@ function main() {
   // and non-integer retention/concurrency env values. Non-production runs
   // surface the same checks but only the warnings section.
   const { errors: prodErrors, warnings: prodWarnings } =
-    runProductionStrictChecks(process.env);
+    runProductionStrictChecks(buildProductionStrictEnv());
   if (prodErrors.length > 0) {
     console.log("\nProduction-strict errors");
     console.log("────────────────────────");

--- a/scripts/smoke/build-portfolio-fixture.mjs
+++ b/scripts/smoke/build-portfolio-fixture.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Build a portfolioFiles fixture from real PDFs in D:\Training data AIARCHI\portfolio.
+// Usage: node scripts/smoke/build-portfolio-fixture.mjs --count 3 --out outputs/style-pack-smoke/portfolioFiles.json [--seed <int>]
+
+import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import { dirname, join, basename } from "path";
+import { mkdir, writeFile, readdir, readFile, stat } from "fs/promises";
+import crypto from "crypto";
+import {
+  extractPortfolioEvidenceFromPdfText,
+} from "../../src/utils/pdfToImages.js";
+
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const ARGS = process.argv.slice(2);
+function arg(name, fallback) {
+  const idx = ARGS.indexOf(name);
+  if (idx === -1) return fallback;
+  return ARGS[idx + 1];
+}
+
+const PORTFOLIO_DIR = "D:\\Training data AIARCHI\\portfolio";
+const COUNT = Number(arg("--count", "3"));
+const OUT = arg("--out", "outputs/style-pack-smoke/portfolioFiles.json");
+const SEED = arg("--seed", "20260518");
+
+// pdfjs-dist via legacy build for Node
+const pdfjsLib = require("pdfjs-dist/legacy/build/pdf.mjs");
+
+function pickN(arr, n, seedStr) {
+  // Deterministic sort by sha256(seed||name) then take first n.
+  return [...arr]
+    .map((name) => ({
+      name,
+      key: crypto.createHash("sha256").update(`${seedStr}|${name}`).digest("hex"),
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key))
+    .slice(0, n)
+    .map((entry) => entry.name);
+}
+
+async function extractTextFromPdf(buf) {
+  const loadingTask = pdfjsLib.getDocument({
+    data: new Uint8Array(buf),
+    isEvalSupported: false,
+    useWorkerFetch: false,
+    disableFontFace: true,
+    standardFontDataUrl: null,
+  });
+  const pdf = await loadingTask.promise;
+  const pageCount = Number(pdf.numPages || 0);
+  const pageTexts = [];
+  for (let pageNumber = 1; pageNumber <= pageCount; pageNumber += 1) {
+    const page = await pdf.getPage(pageNumber);
+    const content = await page.getTextContent();
+    const text = (content?.items || [])
+      .map((item) => item.str || "")
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+    pageTexts.push({ pageNumber, text, charCount: text.length });
+  }
+  return {
+    pageCount,
+    pageTexts,
+    fullText: pageTexts.map((p) => p.text).join(" ").replace(/\s+/g, " ").trim(),
+  };
+}
+
+function buildRecord(name, sizeBytes, extracted) {
+  const evidence = extractPortfolioEvidenceFromPdfText(extracted.fullText);
+  const textExtracted = extracted.fullText.length > 0;
+  return {
+    name,
+    size: `${(sizeBytes / 1024 / 1024).toFixed(2)} MB`,
+    type: "application/pdf",
+    file: null,
+    dataUrl: null,
+    preview: null,
+    isPdf: true,
+    convertedFromPdf: false,
+    thumbnails: [],
+    pdf: {
+      pageCount: extracted.pageCount,
+      textExtracted,
+      textCharCount: extracted.fullText.length,
+      textSample: extracted.fullText.slice(0, 700),
+      pageCharCounts: extracted.pageTexts.map((p) => p.charCount),
+      sourceGaps: textExtracted
+        ? []
+        : [
+            {
+              code: "PDF_TEXT_NOT_SELECTABLE",
+              severity: "warning",
+              message:
+                "PDF contains no selectable text; OCR is disabled so portfolio evidence is image-only.",
+            },
+          ],
+    },
+    sourceGaps: textExtracted
+      ? []
+      : [
+          {
+            code: "PDF_TEXT_NOT_SELECTABLE",
+            severity: "warning",
+            message:
+              "PDF contains no selectable text; OCR is disabled so portfolio evidence is image-only.",
+          },
+        ],
+    portfolioStyleEvidence: textExtracted ? evidence : null,
+    text: extracted.fullText.slice(0, 5000),
+    bytesOrTextDigest: crypto
+      .createHash("sha256")
+      .update(extracted.fullText || name)
+      .digest("hex"),
+  };
+}
+
+async function main() {
+  const entries = (await readdir(PORTFOLIO_DIR)).filter((f) =>
+    f.toLowerCase().endsWith(".pdf"),
+  );
+  const picks = pickN(entries, COUNT, SEED);
+  console.log(`[fixture] seed=${SEED} picked ${picks.length}/${entries.length}:`);
+  picks.forEach((p) => console.log(`  - ${p}`));
+
+  const records = [];
+  for (const name of picks) {
+    const path = join(PORTFOLIO_DIR, name);
+    const stats = await stat(path);
+    const buf = await readFile(path);
+    try {
+      const extracted = await extractTextFromPdf(buf);
+      const record = buildRecord(name, stats.size, extracted);
+      records.push(record);
+      console.log(
+        `[fixture] ${name} pages=${extracted.pageCount} chars=${extracted.fullText.length} extracted=${record.pdf.textExtracted}`,
+      );
+    } catch (err) {
+      console.error(`[fixture] FAILED ${name}: ${err?.message || err}`);
+    }
+  }
+
+  const outDir = dirname(OUT);
+  await mkdir(outDir, { recursive: true });
+  await writeFile(OUT, JSON.stringify(records, null, 2), "utf8");
+  console.log(`[fixture] wrote ${records.length} records to ${OUT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/smoke/deterministic-style-pack-smoke.mjs
+++ b/scripts/smoke/deterministic-style-pack-smoke.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+// Deterministic Style Pack smoke against the real-portfolio fixture.
+// Asserts: schema valid, all required fields populated, stable hash, fallback
+// material families for image-only PDFs, geometryHash differs from the
+// pinned no-pack value (5cfd1cb6242bdf27), and geometryHash is stable across
+// two identical runs.
+
+import { fileURLToPath } from "url";
+import { dirname, join, resolve } from "path";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import {
+  extractStylePack,
+  computeStylePackHash,
+} from "../../src/services/style/stylePackExtractor.js";
+import { validateStylePack } from "../../src/schemas/stylePack.js";
+import {
+  applyStylePackToBrief,
+} from "../../src/services/style/stylePackConstraintApplier.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..", "..");
+
+// Hash pin for THIS smoke's brief shape; the canonical unit-test brief is
+// pinned separately in projectGraphVerticalSliceService.test.js (5cfd1cb6242bdf27).
+const NO_PACK_PIN = "8147e50fcf3f4734";
+
+function arg(name, fallback) {
+  const idx = process.argv.indexOf(name);
+  if (idx === -1) return fallback;
+  return process.argv[idx + 1];
+}
+
+const FIXTURE_PATH = resolve(
+  ROOT,
+  arg("--fixture", "outputs/style-pack-smoke/portfolioFiles.json"),
+);
+const OUT_DIR = resolve(ROOT, "outputs/style-pack-smoke");
+
+const COLOURS = {
+  reset: "\x1b[0m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  bold: "\x1b[1m",
+};
+
+const assertions = [];
+function assert(label, passed, detail = "") {
+  assertions.push({ label, passed, detail });
+  const tag = passed
+    ? `${COLOURS.green}PASS${COLOURS.reset}`
+    : `${COLOURS.red}FAIL${COLOURS.reset}`;
+  console.log(`  [${tag}] ${label}${detail ? `  ${COLOURS.cyan}${detail}${COLOURS.reset}` : ""}`);
+}
+
+async function main() {
+  console.log(`${COLOURS.bold}Style Pack deterministic smoke${COLOURS.reset}`);
+  console.log(`  fixture: ${FIXTURE_PATH}`);
+  const portfolioFiles = JSON.parse(await readFile(FIXTURE_PATH, "utf8"));
+  console.log(`  portfolioFiles: ${portfolioFiles.length}`);
+  portfolioFiles.forEach((record) => {
+    console.log(
+      `    - ${record.name} pages=${record.pdf?.pageCount} extracted=${record.pdf?.textExtracted}`,
+    );
+  });
+
+  console.log("\n[1] extractor — schema validity");
+  const briefHints = {
+    buildingType: "dwelling",
+    target_storeys: 2,
+  };
+  const packA = extractStylePack({ portfolioFiles, briefHints });
+  const validation = validateStylePack(packA);
+  assert("pack is non-null", packA !== null);
+  assert(
+    "pack validates against STYLE_PACK_SCHEMA",
+    validation.valid,
+    validation.errors?.length ? JSON.stringify(validation.errors) : "",
+  );
+  assert(
+    "version is 1.0.0",
+    packA?.version === "1.0.0",
+    `got ${packA?.version}`,
+  );
+  assert(
+    "provenance.sourceFiles names every input",
+    Array.isArray(packA?.provenance?.sourceFiles) &&
+      packA.provenance.sourceFiles.length === portfolioFiles.length,
+    `got ${packA?.provenance?.sourceFiles?.length}/${portfolioFiles.length}`,
+  );
+  assert(
+    "provenance.seed is 64-char hex sha256",
+    typeof packA?.provenance?.seed === "string" &&
+      /^[a-f0-9]{64}$/.test(packA.provenance.seed),
+  );
+  assert(
+    "provenance.extractedAt is the stable epoch",
+    packA?.provenance?.extractedAt === "1970-01-01T00:00:00.000Z",
+  );
+  assert(
+    "materialFamilies.primary has 1..4 tokens",
+    Array.isArray(packA?.materialFamilies?.primary) &&
+      packA.materialFamilies.primary.length >= 1 &&
+      packA.materialFamilies.primary.length <= 4,
+    `got ${JSON.stringify(packA?.materialFamilies?.primary)}`,
+  );
+  assert(
+    "massingTendency.floorCount has min<=mode<=max",
+    packA?.massingTendency?.floorCount &&
+      packA.massingTendency.floorCount.min <=
+        packA.massingTendency.floorCount.mode &&
+      packA.massingTendency.floorCount.mode <=
+        packA.massingTendency.floorCount.max,
+  );
+  assert(
+    "facadeModule.floorHeightMm in [2400,4500]",
+    Number.isInteger(packA?.facadeModule?.floorHeightMm) &&
+      packA.facadeModule.floorHeightMm >= 2400 &&
+      packA.facadeModule.floorHeightMm <= 4500,
+  );
+
+  console.log("\n[2] extractor — deterministic across runs");
+  const packB = extractStylePack({ portfolioFiles, briefHints });
+  const hashA = computeStylePackHash(packA);
+  const hashB = computeStylePackHash(packB);
+  assert("packA === packB by deep equal", JSON.stringify(packA) === JSON.stringify(packB));
+  assert("hashA === hashB", hashA === hashB, hashA);
+
+  console.log("\n[3] constraint applier — brief mutations from pack");
+  const briefBase = {
+    project_name: "Real Portfolio Smoke",
+    building_type: "dwelling",
+    target_storeys: 2,
+    user_intent: { style_keywords: [] },
+  };
+  const constrained = applyStylePackToBrief({
+    brief: briefBase,
+    stylePack: packA,
+  });
+  assert(
+    "constrained.style_pack_hash === computeStylePackHash(pack)",
+    constrained.style_pack_hash === hashA,
+  );
+  assert(
+    "constrained.floor_height_mm is from pack",
+    constrained.floor_height_mm === packA.facadeModule.floorHeightMm,
+    `got ${constrained.floor_height_mm}`,
+  );
+  assert(
+    "constrained.facade_module_mm is from pack",
+    constrained.facade_module_mm === packA.facadeModule.baySpacingMm,
+    `got ${constrained.facade_module_mm}`,
+  );
+  assert(
+    "constrained.opening_rhythm.moduleMm is from pack",
+    constrained.opening_rhythm?.moduleMm === packA.openingRhythm.moduleMm,
+    `got ${constrained.opening_rhythm?.moduleMm}`,
+  );
+
+  console.log("\n[4] geometryHash divergence (vertical-slice internals)");
+  const sliceModule = await import(
+    "../../src/services/project/projectGraphVerticalSliceService.js"
+  );
+  const compiler = await import("../../src/services/compiler/index.js");
+  const internals = sliceModule.__projectGraphVerticalSliceInternals;
+
+  function buildReadingRoomBrief() {
+    return {
+      project_name: "Style Pack Smoke",
+      project_type_support: { selectedSubType: "detached-house" },
+      site_input: {
+        address: "12 Test Street, London, UK",
+        site_input_mode: "manual",
+      },
+      target_floor_area_m2: 180,
+      target_storeys: 2,
+      manualFloors: 2,
+      floorCountLocked: true,
+      generation_seed: 24680,
+      enforce_ndss: false,
+      user_intent: { style_keywords: [] },
+      sitePolygon: [
+        { x: 0, y: 0 },
+        { x: 25, y: 0 },
+        { x: 25, y: 18 },
+        { x: 0, y: 18 },
+      ],
+      siteMetrics: { areaM2: 450 },
+      seed: 24680,
+    };
+  }
+
+  function compileWithPack(stylePack) {
+    const input = buildReadingRoomBrief();
+    let brief = internals.normalizeBrief(input);
+    brief = applyStylePackToBrief({ brief, stylePack });
+    const site = internals.buildSiteContext({
+      brief,
+      sitePolygon: input.sitePolygon,
+      siteMetrics: input.siteMetrics,
+    });
+    const climate = internals.buildClimatePack(brief, site);
+    const localStyle = internals.buildLocalStylePack(
+      brief,
+      site,
+      climate,
+      null,
+      { stylePack },
+    );
+    const programme = internals.buildProgramme({
+      brief,
+      programSpaces: [],
+    });
+    const projectGeometry = internals.buildProjectGeometryFromProgramme({
+      brief,
+      site,
+      programme,
+      localStyle,
+      climate,
+    });
+    const compiled = internals.compileProject({
+      projectGeometry,
+      masterDNA: {
+        projectName: brief.project_name,
+        projectID: projectGeometry.project_id,
+        styleDNA: projectGeometry.metadata.style_dna,
+        rooms: programme.spaces,
+      },
+      locationData: {
+        address: brief.site_input.address,
+        coordinates: { lat: site.lat, lng: site.lon },
+        climate: { type: climate.weather_source },
+        localMaterials: localStyle.material_palette,
+      },
+    });
+    return { brief, localStyle, programme, projectGeometry, compiled };
+  }
+
+  const noPack = compileWithPack(null);
+  const withPack1 = compileWithPack(packA);
+  const withPack2 = compileWithPack(packA);
+
+  assert(
+    `noPack geometryHash matches pinned ${NO_PACK_PIN}`,
+    noPack.compiled.geometryHash === NO_PACK_PIN,
+    `got ${noPack.compiled.geometryHash}`,
+  );
+  assert(
+    "withPack geometryHash is stable across two runs (same seed + pack)",
+    withPack1.compiled.geometryHash === withPack2.compiled.geometryHash,
+    `${withPack1.compiled.geometryHash} === ${withPack2.compiled.geometryHash}`,
+  );
+  assert(
+    "withPack geometryHash differs from noPack",
+    withPack1.compiled.geometryHash !== noPack.compiled.geometryHash,
+    `withPack=${withPack1.compiled.geometryHash} noPack=${noPack.compiled.geometryHash}`,
+  );
+  assert(
+    "compiledProject.metadata.portfolio_style_pack_hash is set",
+    withPack1.compiled.metadata?.portfolio_style_pack_hash === hashA,
+  );
+
+  const hashPayloadNoPack = compiler.buildGeometryHashPayload(noPack.compiled);
+  const hashPayloadWithPack = compiler.buildGeometryHashPayload(
+    withPack1.compiled,
+  );
+  assert(
+    "buildGeometryHashPayload(noPack) has no portfolio_style_pack_hash",
+    !Object.prototype.hasOwnProperty.call(
+      hashPayloadNoPack,
+      "portfolio_style_pack_hash",
+    ),
+  );
+  assert(
+    "buildGeometryHashPayload(withPack).portfolio_style_pack_hash === pack hash",
+    hashPayloadWithPack.portfolio_style_pack_hash === hashA,
+  );
+
+  console.log("\n[5] localStyle material palette reflects pack");
+  const noPackPalette = noPack.localStyle.material_palette;
+  const withPackPalette = withPack1.localStyle.material_palette;
+  const packFamilies = [
+    ...packA.materialFamilies.primary,
+    ...packA.materialFamilies.secondary,
+    ...packA.materialFamilies.accents,
+  ].map((entry) => String(entry).toLowerCase());
+  const matched = withPackPalette.filter((material) =>
+    packFamilies.some(
+      (token) =>
+        String(material).toLowerCase().includes(token) ||
+        token.includes(String(material).toLowerCase()),
+    ),
+  );
+  const warning =
+    withPack1.localStyle.style_provenance?.style_pack_warning || null;
+  assert(
+    "palette intersects pack families OR palette_disjoint warning fired",
+    matched.length > 0 || warning === "palette_disjoint",
+    `matched=${matched.length} warning=${warning} pack.primary=${JSON.stringify(packA.materialFamilies.primary)} palette=${JSON.stringify(withPackPalette)}`,
+  );
+  assert(
+    "withPack.portfolio_style_pack_hash is set on localStyle",
+    withPack1.localStyle.portfolio_style_pack_hash === hashA,
+  );
+
+  await mkdir(OUT_DIR, { recursive: true });
+  await writeFile(
+    join(OUT_DIR, "pack.json"),
+    JSON.stringify(packA, null, 2),
+    "utf8",
+  );
+  await writeFile(
+    join(OUT_DIR, "hashes.json"),
+    JSON.stringify(
+      {
+        stylePackHash: hashA,
+        noPackGeometryHash: noPack.compiled.geometryHash,
+        withPackGeometryHash: withPack1.compiled.geometryHash,
+        noPackPinExpected: NO_PACK_PIN,
+        noPackPaletteSample: noPackPalette.slice(0, 6),
+        withPackPaletteSample: withPackPalette.slice(0, 6),
+        constrainedBrief: {
+          style_pack_hash: constrained.style_pack_hash,
+          floor_height_mm: constrained.floor_height_mm,
+          facade_module_mm: constrained.facade_module_mm,
+          opening_rhythm: constrained.opening_rhythm,
+          window_to_wall_ratio_target: constrained.window_to_wall_ratio_target,
+          roof_pitch_dominant: constrained.roof_pitch_dominant,
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  console.log(`\nWrote pack.json + hashes.json to ${OUT_DIR}`);
+
+  const failed = assertions.filter((a) => !a.passed);
+  console.log(`\n${COLOURS.bold}Summary${COLOURS.reset}: ${assertions.length - failed.length}/${assertions.length} pass, ${failed.length} fail`);
+  if (failed.length > 0) {
+    console.log(`\n${COLOURS.red}FAILED${COLOURS.reset}:`);
+    failed.forEach((entry) => console.log(`  - ${entry.label} ${entry.detail}`));
+    process.exit(1);
+  }
+  console.log(`${COLOURS.green}ALL PASS${COLOURS.reset}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/scripts/smoke/export-dxf-ifc.mjs
+++ b/scripts/smoke/export-dxf-ifc.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Exercise DXF + IFC export endpoints against the compiledProject from the
+// server smoke run. Saves outputs alongside response-200.json.
+
+import { fileURLToPath } from "url";
+import { dirname, resolve, join } from "path";
+import { readFile, writeFile } from "fs/promises";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..", "..");
+const SERVER = process.env.SMOKE_SERVER || "http://localhost:3001";
+const OUT_DIR = resolve(ROOT, "outputs/style-pack-smoke/server-run");
+
+async function main() {
+  const body = JSON.parse(
+    await readFile(join(OUT_DIR, "response-200.json"), "utf8"),
+  );
+  const compiledProject =
+    body?.artifacts?.compiledProject ||
+    body?.compiledProject ||
+    body?.bundle?.compiledProject ||
+    null;
+  if (!compiledProject) {
+    console.error("[export-smoke] no compiledProject on response");
+    process.exit(2);
+  }
+  console.log(
+    `[export-smoke] compiledProject.geometryHash=${compiledProject.geometryHash} levels=${compiledProject.levels?.length}`,
+  );
+
+  const projectName = "StylePackPortfolioE2E";
+
+  console.log("\n[1] DXF export");
+  const t0 = Date.now();
+  const dxfResp = await fetch(`${SERVER}/api/project/export/dxf`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ compiledProject, projectName }),
+  });
+  const dxfBuf = Buffer.from(await dxfResp.arrayBuffer());
+  console.log(
+    `  status=${dxfResp.status} elapsedMs=${Date.now() - t0} bytes=${dxfBuf.length}`,
+  );
+  await writeFile(join(OUT_DIR, "export.dxf"), dxfBuf);
+  // Sanity: a DXF file should start with the section marker "0\nSECTION" or similar.
+  const dxfHead = dxfBuf.subarray(0, 80).toString("utf8");
+  console.log(`  head: ${dxfHead.replace(/\r?\n/g, " | ").slice(0, 200)}`);
+  const dxfOk =
+    dxfResp.status === 200 &&
+    dxfBuf.length > 200 &&
+    /\bSECTION\b/.test(dxfHead);
+  console.log(`  ${dxfOk ? "OK" : "FAIL"}`);
+
+  console.log("\n[2] IFC export");
+  const t1 = Date.now();
+  const ifcResp = await fetch(`${SERVER}/api/project/export/ifc`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ compiledProject, projectName }),
+  });
+  const ifcText = await ifcResp.text();
+  console.log(
+    `  status=${ifcResp.status} elapsedMs=${Date.now() - t1} bytes=${ifcText.length}`,
+  );
+  await writeFile(join(OUT_DIR, "export.ifc"), ifcText, "utf8");
+  const ifcHead = ifcText.slice(0, 80);
+  console.log(`  head: ${ifcHead.replace(/\r?\n/g, " | ").slice(0, 200)}`);
+  const ifcOk =
+    ifcResp.status === 200 &&
+    ifcText.length > 200 &&
+    ifcText.startsWith("ISO-10303-21");
+  console.log(`  ${ifcOk ? "OK" : "FAIL"}`);
+
+  console.log("\nSummary:");
+  console.log(`  DXF: ${dxfOk ? "PASS" : "FAIL"} (${dxfBuf.length} bytes)`);
+  console.log(`  IFC: ${ifcOk ? "PASS" : "FAIL"} (${ifcText.length} bytes)`);
+  if (!dxfOk || !ifcOk) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(3);
+});

--- a/scripts/smoke/server-portfolio-e2e.mjs
+++ b/scripts/smoke/server-portfolio-e2e.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Full-server E2E: POST to /api/project/generate-vertical-slice with a real
+// portfolio attached, capture the result (or failure mode), and check the
+// Style Pack flows into the slice output.
+
+import { fileURLToPath } from "url";
+import { dirname, join, resolve } from "path";
+import { mkdir, readFile, writeFile } from "fs/promises";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..", "..");
+const SERVER = process.env.SMOKE_SERVER || "http://localhost:3001";
+const OUT_DIR = resolve(ROOT, "outputs/style-pack-smoke/server-run");
+
+function nowStamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  console.log(`[server-smoke] target ${SERVER}`);
+
+  const health = await fetch(`${SERVER}/api/health`).then((r) => r.json());
+  await writeFile(
+    join(OUT_DIR, `health.json`),
+    JSON.stringify(health, null, 2),
+    "utf8",
+  );
+  console.log(
+    `[server-smoke] health: openaiReasoning=${health?.openaiReasoning} openaiImages=${health?.openaiImages}`,
+  );
+
+  const portfolioFiles = JSON.parse(
+    await readFile(
+      resolve(ROOT, "outputs/style-pack-smoke/portfolioFiles.json"),
+      "utf8",
+    ),
+  );
+
+  const briefPayload = {
+    projectId: `style-pack-smoke-${nowStamp()}`,
+    seed: 24680,
+    generation_seed: 24680,
+    project_name: "Style Pack Real Portfolio E2E",
+    building_type: "dwelling",
+    project_type_support: {
+      selectedSubType: "detached-house",
+    },
+    site_input: {
+      address: "Burn Road, Immingham DN40, UK",
+      site_input_mode: "address",
+    },
+    target_floor_area_m2: 180,
+    target_storeys: 2,
+    manualFloors: 2,
+    floorCountLocked: true,
+    user_intent: { style_keywords: [] },
+    enforce_ndss: false,
+    sitePolygon: [
+      { x: 0, y: 0 },
+      { x: 25, y: 0 },
+      { x: 25, y: 18 },
+      { x: 0, y: 18 },
+    ],
+    siteMetrics: { areaM2: 450 },
+    portfolioFiles,
+  };
+
+  await writeFile(
+    join(OUT_DIR, "request.json"),
+    JSON.stringify(briefPayload, null, 2),
+    "utf8",
+  );
+
+  console.log(`[server-smoke] POST /api/project/generate-vertical-slice (portfolioFiles=${portfolioFiles.length})`);
+  const t0 = Date.now();
+  let response;
+  try {
+    response = await fetch(`${SERVER}/api/project/generate-vertical-slice`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(briefPayload),
+    });
+  } catch (err) {
+    console.error(`[server-smoke] network error: ${err?.message || err}`);
+    await writeFile(
+      join(OUT_DIR, "error.txt"),
+      `network error: ${err?.message || err}`,
+      "utf8",
+    );
+    process.exit(2);
+  }
+  const elapsedMs = Date.now() - t0;
+  const status = response.status;
+  let body;
+  const text = await response.text();
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = { raw: text };
+  }
+  await writeFile(
+    join(OUT_DIR, `response-${status}.json`),
+    JSON.stringify(body, null, 2),
+    "utf8",
+  );
+  console.log(`[server-smoke] status=${status} elapsedMs=${elapsedMs}`);
+
+  if (status !== 200) {
+    console.error(
+      `[server-smoke] non-200 — body snippet: ${(text || "").slice(0, 600)}`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `[server-smoke] success — stylePackHash=${body?.stylePackHash || body?.style_pack?.provenance?.seed || "absent"} geometryHash=${body?.geometryHash || body?.metadata?.geometryHash}`,
+  );
+
+  const summary = {
+    elapsedMs,
+    status,
+    geometryHash: body?.geometryHash || body?.metadata?.geometryHash || null,
+    stylePackHash:
+      body?.stylePackHash || body?.metadata?.portfolio_style_pack_hash || null,
+    stylePackPresent: Boolean(body?.style_pack || body?.stylePack),
+    stylePackVersion: body?.style_pack?.version || body?.stylePack?.version,
+    stylePackMaterialFamilies:
+      body?.style_pack?.materialFamilies ||
+      body?.stylePack?.materialFamilies ||
+      null,
+    artifactSurfaceKeys: Object.keys(body?.artifacts || {}),
+    panelKeys: Object.keys(body?.panelMap || body?.artifacts?.panelMap || {}),
+  };
+  await writeFile(
+    join(OUT_DIR, "summary.json"),
+    JSON.stringify(summary, null, 2),
+    "utf8",
+  );
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(3);
+});

--- a/scripts/verify-style-pack.ps1
+++ b/scripts/verify-style-pack.ps1
@@ -1,0 +1,39 @@
+$expected = @(
+  "src/services/style/stylePackExtractor.js",
+  "src/services/style/stylePackConstraintApplier.js",
+  "src/schemas/stylePack.schema.json",
+  "src/schemas/stylePack.js",
+  "api/style-pack/extract.js",
+  "src/__tests__/services/styleExtractor.test.js",
+  "src/__tests__/services/styleConstraintApplier.test.js",
+  "src/__tests__/fixtures/stylePack/portfolio-textPDF.json",
+  "src/__tests__/fixtures/stylePack/expected-pack-portfolio-textPDF.json",
+  "docs/style-pack/PLAN.md",
+  "docs/style-pack/SCHEMA.md",
+  "docs/style-pack/IMPLEMENTATION_NOTES.md",
+  "src/services/style/localStylePack.js",
+  "src/services/project/projectGraphVerticalSliceService.js",
+  "src/services/design/optionGenerator.js",
+  "src/services/design/optionScorer.js",
+  "src/services/compiler/compiledProjectCompiler.js",
+  "src/hooks/useArchitectAIWorkflow.js",
+  ".env.example",
+  "scripts/check-env.cjs",
+  "src/__tests__/services/projectGraphVerticalSliceService.test.js",
+  "src/__tests__/services/localStylePack.test.js"
+)
+$missing = @()
+foreach ($p in $expected) {
+  if (-not (Test-Path $p)) { $missing += $p }
+}
+if ($missing.Count -gt 0) {
+  Write-Host "MISSING FILES:" -ForegroundColor Red
+  $missing | ForEach-Object { Write-Host "  $_" }
+  exit 1
+}
+$flagHits = (Select-String -Path ".env.example","scripts/check-env.cjs" -Pattern "STYLE_PACK_ENABLED" -SimpleMatch).Count
+if ($flagHits -lt 2) {
+  Write-Host "FAIL: STYLE_PACK_ENABLED not wired into env.example + check-env.cjs (hits=$flagHits)" -ForegroundColor Red
+  exit 1
+}
+Write-Host "OK: all expected files present, flag wired." -ForegroundColor Green

--- a/src/__tests__/fixtures/stylePack/expected-pack-portfolio-textPDF.json
+++ b/src/__tests__/fixtures/stylePack/expected-pack-portfolio-textPDF.json
@@ -1,0 +1,70 @@
+{
+  "version": "1.0.0",
+  "windowToWallRatio": {
+    "overall": 0.42,
+    "byElevation": {
+      "N": 0.32,
+      "S": 0.52,
+      "E": 0.42,
+      "W": 0.42
+    }
+  },
+  "roofPitchDistribution": {
+    "flatPct": 0,
+    "lowPct": 0,
+    "mediumPct": 1,
+    "steepPct": 0,
+    "dominant": "medium"
+  },
+  "openingRhythm": {
+    "moduleMm": 1200,
+    "repetition": "paired",
+    "sillHeightMm": 450
+  },
+  "materialFamilies": {
+    "primary": ["timber", "brick", "slate"],
+    "secondary": ["stone", "stone sill", "glass"],
+    "accents": ["red", "dark green", "dark", "green"]
+  },
+  "massingTendency": {
+    "form": "compact",
+    "floorCount": {
+      "min": 3,
+      "mode": 3,
+      "max": 3
+    },
+    "aspectRatioRange": [0.35, 0.75]
+  },
+  "facadeModule": {
+    "baySpacingMm": 2400,
+    "floorHeightMm": 3400
+  },
+  "layout_archetype": "linear_side_hall",
+  "provenance": {
+    "sourceFiles": ["victorian-terrace-shopfront.pdf"],
+    "extractedAt": "1970-01-01T00:00:00.000Z",
+    "extractorVersion": "1.0.0",
+    "confidence": 0.95,
+    "seed": "21ff23208373c8ebe963f27f31f2a1e8419675a02140f549c6f63c07c60b647d",
+    "evidence": {
+      "materials": ["timber", "brick", "slate", "stone", "stone sill", "glass"],
+      "colours": ["red", "dark green", "dark", "green"],
+      "styleKeywords": [
+        "shopfront",
+        "terrace",
+        "gable",
+        "paired",
+        "paired bays",
+        "pitched",
+        "pitched gable roof",
+        "regular",
+        "regular sash windows",
+        "sash",
+        "shopfront base",
+        "three storey"
+      ],
+      "buildingTypes": ["mixed use terrace"],
+      "drawingTypes": ["elevation", "section"]
+    }
+  }
+}

--- a/src/__tests__/fixtures/stylePack/portfolio-textPDF.json
+++ b/src/__tests__/fixtures/stylePack/portfolio-textPDF.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "victorian-terrace-shopfront.pdf",
+    "type": "application/pdf",
+    "bytesOrTextDigest": "portfolio-textPDF-fixture-v1",
+    "text": "Victorian terrace with a three storey narrow frontage and deep plot. Red brick facade, timber shopfront base, dark green painted timber, regular sash windows in paired bays, slate pitched gable roof and detailed stone sill courses. Elevation and section drawings show repeated bay rhythm and shopfront glazing.",
+    "portfolioStyleEvidence": {
+      "materials": [
+        "red brick",
+        "timber shopfront",
+        "slate roof",
+        "stone sill"
+      ],
+      "colours": ["red", "dark green"],
+      "styleKeywords": [
+        "victorian terrace",
+        "shopfront base",
+        "regular sash windows",
+        "paired bays",
+        "pitched gable roof",
+        "three storey"
+      ],
+      "buildingTypes": ["mixed use terrace"],
+      "drawingTypes": ["elevation", "section"]
+    }
+  }
+]

--- a/src/__tests__/services/localStylePack.test.js
+++ b/src/__tests__/services/localStylePack.test.js
@@ -3,6 +3,17 @@ import {
   computeBlendWeights,
   computeMaterialPalette,
 } from "../../services/style/localStylePack.js";
+import expectedPack from "../fixtures/stylePack/expected-pack-portfolio-textPDF.json" with { type: "json" };
+
+function materialAllowedByPack(material, pack) {
+  const tokens = [
+    ...pack.materialFamilies.primary,
+    ...pack.materialFamilies.secondary,
+    ...pack.materialFamilies.accents,
+  ].map((entry) => String(entry).toLowerCase());
+  const text = String(material || "").toLowerCase();
+  return tokens.some((token) => text.includes(token) || token.includes(text));
+}
 
 describe("localStylePack ProjectGraph blend controls", () => {
   test("honours explicit portfolio style weight", () => {
@@ -54,5 +65,52 @@ describe("localStylePack ProjectGraph blend controls", () => {
     expect(pack.blend_weights.portfolio).toBe(0.5);
     expect(pack.material_blend_weights.local).toBe(1);
     expect(pack.material_blend_weights.portfolio).toBe(0);
+  });
+
+  test("stylePack null preserves no-pack output byte-for-byte at object level", () => {
+    const args = {
+      brief: {
+        building_type: "community",
+        project_name: "No Pack Reading Room",
+        user_intent: {
+          style_keywords: ["warm brick", "timber"],
+        },
+      },
+      site: {},
+      climate: { overheating: { risk_level: "medium" } },
+      createStableId: (...parts) => parts.join("-"),
+    };
+
+    expect(buildLocalStylePackV2({ ...args, stylePack: null })).toEqual(
+      buildLocalStylePackV2(args),
+    );
+  });
+
+  test("stylePack constrains palette and records bounded portfolio evidence", () => {
+    const pack = buildLocalStylePackV2({
+      brief: {
+        building_type: "community",
+        project_name: "Packed Reading Room",
+        user_intent: {
+          style_keywords: ["warm brick", "timber"],
+        },
+      },
+      site: {},
+      climate: { overheating: { risk_level: "low" } },
+      stylePack: expectedPack,
+      createStableId: (...parts) => parts.join("-"),
+    });
+
+    expect(pack.portfolio_style_pack_hash).toEqual(expect.any(String));
+    expect(pack.material_blend_weights.portfolio).toBeLessThanOrEqual(0.25);
+    if (pack.style_provenance.style_pack_warning) {
+      expect(pack.style_provenance.style_pack_warning).toBe("palette_disjoint");
+    } else {
+      expect(
+        pack.material_palette.every((material) =>
+          materialAllowedByPack(material, expectedPack),
+        ),
+      ).toBe(true);
+    }
   });
 });

--- a/src/__tests__/services/projectGraphVerticalSliceService.test.js
+++ b/src/__tests__/services/projectGraphVerticalSliceService.test.js
@@ -11,6 +11,10 @@ import {
   A1_TEST_RASTER_MODE_ENV,
   A1_TEST_RASTER_STUB_VALUE,
 } from "../../services/render/svgRasteriser.js";
+import expectedStylePack from "../fixtures/stylePack/expected-pack-portfolio-textPDF.json" with { type: "json" };
+import { computeStylePackHash } from "../../services/style/stylePackExtractor.js";
+import { applyStylePackToBrief } from "../../services/style/stylePackConstraintApplier.js";
+import { buildGeometryHashPayload } from "../../services/compiler/compiledProjectCompiler.js";
 
 jest.setTimeout(420000);
 
@@ -64,6 +68,56 @@ function createReadingRoomBrief() {
       ],
     },
   };
+}
+
+function compileReadingRoomStylePackFixture(stylePack = null) {
+  const input = { ...createReadingRoomBrief(), seed: 13579 };
+  let brief = __projectGraphVerticalSliceInternals.normalizeBrief(input);
+  brief = applyStylePackToBrief({ brief, stylePack });
+  const site = __projectGraphVerticalSliceInternals.buildSiteContext({
+    brief,
+    sitePolygon: input.sitePolygon,
+    siteMetrics: input.siteMetrics,
+  });
+  const climate = __projectGraphVerticalSliceInternals.buildClimatePack(
+    brief,
+    site,
+  );
+  const localStyle = __projectGraphVerticalSliceInternals.buildLocalStylePack(
+    brief,
+    site,
+    climate,
+    null,
+    { stylePack },
+  );
+  const programme = __projectGraphVerticalSliceInternals.buildProgramme({
+    brief,
+    programSpaces: [],
+  });
+  const projectGeometry =
+    __projectGraphVerticalSliceInternals.buildProjectGeometryFromProgramme({
+      brief,
+      site,
+      programme,
+      localStyle,
+      climate,
+    });
+  const compiledProject = __projectGraphVerticalSliceInternals.compileProject({
+    projectGeometry,
+    masterDNA: {
+      projectName: brief.project_name,
+      projectID: projectGeometry.project_id,
+      styleDNA: projectGeometry.metadata.style_dna,
+      rooms: programme.spaces,
+    },
+    locationData: {
+      address: brief.site_input.address,
+      coordinates: { lat: site.lat, lng: site.lon },
+      climate: { type: climate.weather_source },
+      localMaterials: localStyle.material_palette,
+    },
+  });
+  return { brief, localStyle, programme, projectGeometry, compiledProject };
 }
 
 function createKensingtonReferenceMatchBrief() {
@@ -527,6 +581,7 @@ describe("projectGraphVerticalSliceService", () => {
     process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED;
   const originalOpenAIStrictImageGen = process.env.OPENAI_STRICT_IMAGE_GEN;
   const originalA1TestRasterMode = process.env[A1_TEST_RASTER_MODE_ENV];
+  const originalStylePackEnabled = process.env.STYLE_PACK_ENABLED;
   const originalFetch = global.fetch;
 
   beforeEach(() => {
@@ -538,6 +593,7 @@ describe("projectGraphVerticalSliceService", () => {
     delete process.env.OPENAI_REASONING_API_KEY;
     process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "false";
     process.env.OPENAI_STRICT_IMAGE_GEN = "false";
+    delete process.env.STYLE_PACK_ENABLED;
     delete process.env.GOOGLE_MAPS_API_KEY;
     delete process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
     // PR-D follow-up: opt the whole suite into the lightweight raster /
@@ -605,6 +661,11 @@ describe("projectGraphVerticalSliceService", () => {
       delete process.env[A1_TEST_RASTER_MODE_ENV];
     } else {
       process.env[A1_TEST_RASTER_MODE_ENV] = originalA1TestRasterMode;
+    }
+    if (originalStylePackEnabled === undefined) {
+      delete process.env.STYLE_PACK_ENABLED;
+    } else {
+      process.env.STYLE_PACK_ENABLED = originalStylePackEnabled;
     }
     global.fetch = originalFetch;
   });
@@ -2853,6 +2914,31 @@ describe("projectGraphVerticalSliceService", () => {
     expect(qa.status).toBe("fail");
     expect(qa.issues.map((issue) => issue.code)).toContain(
       "TECHNICAL_DRAWING_PANEL_ID_MISMATCH",
+    );
+  });
+
+  test("Style Pack is deterministic, upstream of geometry, and hash-addressed", async () => {
+    const noPack = compileReadingRoomStylePackFixture(null);
+    const first = compileReadingRoomStylePackFixture(expectedStylePack);
+    const second = compileReadingRoomStylePackFixture(expectedStylePack);
+    const expectedStylePackHash = computeStylePackHash(expectedStylePack);
+
+    expect(noPack.compiledProject.geometryHash).toBe("5cfd1cb6242bdf27");
+    expect(second.compiledProject.geometryHash).toBe(
+      first.compiledProject.geometryHash,
+    );
+    expect(first.compiledProject.geometryHash).not.toBe(
+      noPack.compiledProject.geometryHash,
+    );
+    expect(first.compiledProject.metadata.portfolio_style_pack_hash).toBe(
+      expectedStylePackHash,
+    );
+    expect(buildGeometryHashPayload(noPack.compiledProject)).not.toHaveProperty(
+      "portfolio_style_pack_hash",
+    );
+    expect(buildGeometryHashPayload(first.compiledProject)).toHaveProperty(
+      "portfolio_style_pack_hash",
+      expectedStylePackHash,
     );
   });
 

--- a/src/__tests__/services/styleConstraintApplier.test.js
+++ b/src/__tests__/services/styleConstraintApplier.test.js
@@ -1,0 +1,129 @@
+import expectedPack from "../fixtures/stylePack/expected-pack-portfolio-textPDF.json" with { type: "json" };
+import {
+  applyStylePackToBrief,
+  applyStylePackToMaterialPaletteInputs,
+  applyStylePackToOptionScorerWeights,
+} from "../../services/style/stylePackConstraintApplier.js";
+import { computeMaterialPalette } from "../../services/style/localStylePack.js";
+
+function materialAllowedByPack(material, pack) {
+  const tokens = [
+    ...pack.materialFamilies.primary,
+    ...pack.materialFamilies.secondary,
+    ...pack.materialFamilies.accents,
+  ].map((entry) => String(entry).toLowerCase());
+  const text = String(material || "").toLowerCase();
+  return tokens.some((token) => text.includes(token) || token.includes(text));
+}
+
+describe("stylePackConstraintApplier", () => {
+  test("applyStylePackToBrief returns an unchanged brief when pack is absent", () => {
+    const brief = { project_name: "No Pack", target_storeys: 2 };
+    expect(applyStylePackToBrief({ brief, stylePack: null })).toEqual(brief);
+  });
+
+  test("clamps target_storeys into the pack floor-count range", () => {
+    const constrained = applyStylePackToBrief({
+      brief: { project_name: "Clamp", target_storeys: 1 },
+      stylePack: expectedPack,
+    });
+    expect(constrained.target_storeys).toBe(3);
+  });
+
+  test("honours floorCountLocked by skipping the floor-count clamp", () => {
+    const constrained = applyStylePackToBrief({
+      brief: {
+        project_name: "Locked",
+        target_storeys: 1,
+        floorCountLocked: true,
+      },
+      stylePack: expectedPack,
+    });
+    expect(constrained.target_storeys).toBe(1);
+  });
+
+  test("clamps aspect ratio and fills facade/opening defaults", () => {
+    const constrained = applyStylePackToBrief({
+      brief: {
+        project_name: "Aspect",
+        target_storeys: 3,
+        aspect_ratio_target: 2,
+      },
+      stylePack: expectedPack,
+    });
+    expect(constrained.aspect_ratio_target).toBeLessThanOrEqual(0.75);
+    expect(constrained.facade_module_mm).toBe(2400);
+    expect(constrained.floor_height_mm).toBe(3400);
+    expect(constrained.opening_rhythm).toEqual(expectedPack.openingRhythm);
+    expect(constrained.window_to_wall_ratio_target).toEqual(
+      expectedPack.windowToWallRatio,
+    );
+  });
+
+  test("material palette inputs constrain palette tokens or mark disjoint", () => {
+    const inputs = {
+      brief: {
+        building_type: "community",
+        project_name: "Palette",
+        user_intent: { style_keywords: ["warm brick", "timber"] },
+      },
+      site: {},
+      climate: { overheating: { risk_level: "low" } },
+      paletteSize: 6,
+    };
+    const constrainedInputs = applyStylePackToMaterialPaletteInputs({
+      inputs,
+      stylePack: expectedPack,
+    });
+    const palette = computeMaterialPalette(constrainedInputs);
+
+    if (palette.style_pack_warning) {
+      expect(palette.style_pack_warning).toBe("palette_disjoint");
+    } else {
+      expect(
+        palette.palette.every((material) =>
+          materialAllowedByPack(material, expectedPack),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("absent pack leaves material palette inputs and output identical", () => {
+    const inputs = {
+      brief: {
+        building_type: "dwelling",
+        project_name: "No Pack Palette",
+        user_intent: { style_keywords: ["brick", "slate"] },
+      },
+      site: {},
+      climate: { overheating: { risk_level: "medium" } },
+    };
+
+    expect(
+      computeMaterialPalette(
+        applyStylePackToMaterialPaletteInputs({ inputs, stylePack: null }),
+      ),
+    ).toEqual(computeMaterialPalette(inputs));
+  });
+
+  test("reallocates option scorer weights only when a pack is present", () => {
+    const weights = {
+      programmeFit: 0.25,
+      climateFit: 0.2,
+      costFit: 0.15,
+      styleAlignment: 0,
+    };
+
+    expect(
+      applyStylePackToOptionScorerWeights({ weights, stylePack: null }),
+    ).toBe(weights);
+    expect(
+      applyStylePackToOptionScorerWeights({ weights, stylePack: expectedPack }),
+    ).toEqual({
+      programmeFit: 0.25,
+      climateFit: 0.1,
+      costFit: 0.1,
+      styleAlignment: 0.15,
+    });
+  });
+});

--- a/src/__tests__/services/styleExtractor.test.js
+++ b/src/__tests__/services/styleExtractor.test.js
@@ -1,0 +1,82 @@
+import portfolioFixture from "../fixtures/stylePack/portfolio-textPDF.json" with { type: "json" };
+import expectedPack from "../fixtures/stylePack/expected-pack-portfolio-textPDF.json" with { type: "json" };
+import {
+  computeStylePackHash,
+  extractStylePack,
+  stableStylePackStringify,
+} from "../../services/style/stylePackExtractor.js";
+import {
+  STYLE_PACK_SCHEMA,
+  STYLE_PACK_VERSION,
+  validateStylePack,
+} from "../../schemas/stylePack.js";
+
+const EXPECTED_PACK_HASH =
+  "b7c5c5651366430255098e48eff4b43ebf7092dbb84773832456b07e13477f8c";
+
+describe("stylePackExtractor", () => {
+  test("returns null when no portfolio files are present", () => {
+    expect(extractStylePack({ portfolioFiles: [] })).toBeNull();
+  });
+
+  test("extracts the locked expected pack from the text-PDF fixture", () => {
+    const pack = extractStylePack({
+      portfolioFiles: portfolioFixture,
+      briefHints: { buildingType: "community", target_storeys: 2 },
+    });
+
+    expect(pack).toEqual(expectedPack);
+    expect(stableStylePackStringify(pack)).toBe(
+      stableStylePackStringify(expectedPack),
+    );
+    expect(computeStylePackHash(pack)).toBe(EXPECTED_PACK_HASH);
+  });
+
+  test("repeated extraction is byte-identical and hash-identical", () => {
+    const first = extractStylePack({
+      portfolioFiles: portfolioFixture,
+      briefHints: { buildingType: "community", target_storeys: 2 },
+    });
+    const second = extractStylePack({
+      portfolioFiles: portfolioFixture,
+      briefHints: { buildingType: "community", target_storeys: 2 },
+    });
+
+    expect(first).toEqual(second);
+    expect(stableStylePackStringify(first)).toBe(
+      stableStylePackStringify(second),
+    );
+    expect(computeStylePackHash(first)).toBe(computeStylePackHash(second));
+  });
+
+  test("validates against the locked schema", () => {
+    expect(STYLE_PACK_SCHEMA.title).toBe("StylePack");
+    expect(validateStylePack(expectedPack)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  test("throws when extractor version does not match the locked schema", () => {
+    expect(() =>
+      extractStylePack({
+        portfolioFiles: portfolioFixture,
+        extractorVersion: "2.0.0",
+      }),
+    ).toThrow(/Style Pack validation failed/);
+    expect(STYLE_PACK_VERSION).toBe("1.0.0");
+  });
+
+  test("low-evidence portfolio records still produce bounded confidence", () => {
+    const pack = extractStylePack({
+      portfolioFiles: [
+        { name: "empty.pdf", text: "", portfolioStyleEvidence: {} },
+      ],
+      briefHints: { buildingType: "dwelling", target_storeys: 2 },
+    });
+
+    expect(pack.provenance.confidence).toBeGreaterThanOrEqual(0);
+    expect(pack.provenance.confidence).toBeLessThanOrEqual(1);
+    expect(validateStylePack(pack).valid).toBe(true);
+  });
+});

--- a/src/hooks/useArchitectAIWorkflow.js
+++ b/src/hooks/useArchitectAIWorkflow.js
@@ -1453,6 +1453,7 @@ async function runProjectGraphVerticalSliceWorkflow({
     sheetSeries: verticalSlice.artifacts?.sheetSeries || [],
     sheetSplitDecision: verticalSlice.artifacts?.sheetSplitDecision || null,
     projectGraph: verticalSlice.projectGraph,
+    style_pack: verticalSlice.style_pack || verticalSlice.stylePack || null,
     projectGraphId:
       verticalSlice.projectGraph?.project_graph_id ||
       verticalSlice.projectGraph?.project_id ||
@@ -1547,6 +1548,10 @@ async function runProjectGraphVerticalSliceWorkflow({
         verticalSlice.projectGraph?.project_id ||
         null,
       geometryHash: verticalSlice.geometryHash,
+      stylePackHash:
+        verticalSlice.stylePackHash ||
+        verticalSlice.metadata?.portfolio_style_pack_hash ||
+        null,
       panelCount: Object.keys(panelMap).length,
       sourceOfTruth: "ProjectGraph",
       sheetSizeMm: verticalSlice.artifacts?.a1Sheet?.sheet_size_mm || {

--- a/src/schemas/stylePack.js
+++ b/src/schemas/stylePack.js
@@ -1,0 +1,336 @@
+import stylePackSchemaJson from "./stylePack.schema.json" with { type: "json" };
+
+export const STYLE_PACK_SCHEMA = Object.freeze(stylePackSchemaJson);
+export const STYLE_PACK_VERSION = "1.0.0";
+export const EMPTY_STYLE_PACK = null;
+
+const TOP_LEVEL_KEYS = new Set([
+  "version",
+  "windowToWallRatio",
+  "roofPitchDistribution",
+  "openingRhythm",
+  "materialFamilies",
+  "massingTendency",
+  "facadeModule",
+  "layout_archetype",
+  "provenance",
+]);
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function addError(errors, path, message) {
+  errors.push({ path, message });
+}
+
+function validateNumber(errors, path, value, min, max, integer = false) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    addError(errors, path, "must be a finite number");
+    return;
+  }
+  if (integer && !Number.isInteger(value)) {
+    addError(errors, path, "must be an integer");
+  }
+  if (value < min || value > max) {
+    addError(errors, path, `must be between ${min} and ${max}`);
+  }
+}
+
+function validateStringArray(errors, path, value, { min = 0, max = Infinity }) {
+  if (!Array.isArray(value)) {
+    addError(errors, path, "must be an array");
+    return;
+  }
+  if (value.length < min || value.length > max) {
+    addError(errors, path, `must contain between ${min} and ${max} items`);
+  }
+  value.forEach((entry, index) => {
+    if (typeof entry !== "string") {
+      addError(errors, `${path}/${index}`, "must be a string");
+    }
+  });
+}
+
+function validateEnum(errors, path, value, allowed) {
+  if (!allowed.includes(value)) {
+    addError(errors, path, `must be one of ${allowed.join(", ")}`);
+  }
+}
+
+export function validateStylePack(pack) {
+  const errors = [];
+  if (!isObject(pack)) {
+    return {
+      valid: false,
+      errors: [{ path: "", message: "Style Pack must be an object" }],
+    };
+  }
+
+  for (const key of Object.keys(pack)) {
+    if (!TOP_LEVEL_KEYS.has(key)) {
+      addError(errors, `/${key}`, "is not allowed");
+    }
+  }
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in pack)) {
+      addError(errors, `/${key}`, "is required");
+    }
+  }
+
+  if (pack.version !== STYLE_PACK_VERSION) {
+    addError(errors, "/version", `must be ${STYLE_PACK_VERSION}`);
+  }
+
+  const wwr = pack.windowToWallRatio;
+  if (!isObject(wwr)) {
+    addError(errors, "/windowToWallRatio", "must be an object");
+  } else {
+    validateNumber(errors, "/windowToWallRatio/overall", wwr.overall, 0, 0.95);
+    const byElevation = wwr.byElevation;
+    if (!isObject(byElevation)) {
+      addError(errors, "/windowToWallRatio/byElevation", "must be an object");
+    } else {
+      ["N", "S", "E", "W"].forEach((key) =>
+        validateNumber(
+          errors,
+          `/windowToWallRatio/byElevation/${key}`,
+          byElevation[key],
+          0,
+          0.95,
+        ),
+      );
+    }
+  }
+
+  const roof = pack.roofPitchDistribution;
+  if (!isObject(roof)) {
+    addError(errors, "/roofPitchDistribution", "must be an object");
+  } else {
+    ["flatPct", "lowPct", "mediumPct", "steepPct"].forEach((key) =>
+      validateNumber(errors, `/roofPitchDistribution/${key}`, roof[key], 0, 1),
+    );
+    validateEnum(errors, "/roofPitchDistribution/dominant", roof.dominant, [
+      "flat",
+      "low",
+      "medium",
+      "steep",
+    ]);
+  }
+
+  const rhythm = pack.openingRhythm;
+  if (!isObject(rhythm)) {
+    addError(errors, "/openingRhythm", "must be an object");
+  } else {
+    validateNumber(
+      errors,
+      "/openingRhythm/moduleMm",
+      rhythm.moduleMm,
+      600,
+      6000,
+      true,
+    );
+    validateEnum(errors, "/openingRhythm/repetition", rhythm.repetition, [
+      "regular",
+      "asymmetric",
+      "paired",
+    ]);
+    validateNumber(
+      errors,
+      "/openingRhythm/sillHeightMm",
+      rhythm.sillHeightMm,
+      0,
+      2200,
+      true,
+    );
+  }
+
+  const materials = pack.materialFamilies;
+  if (!isObject(materials)) {
+    addError(errors, "/materialFamilies", "must be an object");
+  } else {
+    validateStringArray(
+      errors,
+      "/materialFamilies/primary",
+      materials.primary,
+      {
+        min: 1,
+        max: 4,
+      },
+    );
+    validateStringArray(
+      errors,
+      "/materialFamilies/secondary",
+      materials.secondary,
+      { max: 6 },
+    );
+    validateStringArray(
+      errors,
+      "/materialFamilies/accents",
+      materials.accents,
+      {
+        max: 6,
+      },
+    );
+  }
+
+  const massing = pack.massingTendency;
+  if (!isObject(massing)) {
+    addError(errors, "/massingTendency", "must be an object");
+  } else {
+    validateEnum(errors, "/massingTendency/form", massing.form, [
+      "compact",
+      "L",
+      "U",
+      "courtyard",
+      "articulated",
+    ]);
+    const floorCount = massing.floorCount;
+    if (!isObject(floorCount)) {
+      addError(errors, "/massingTendency/floorCount", "must be an object");
+    } else {
+      ["min", "mode", "max"].forEach((key) =>
+        validateNumber(
+          errors,
+          `/massingTendency/floorCount/${key}`,
+          floorCount[key],
+          1,
+          12,
+          true,
+        ),
+      );
+      if (
+        Number.isInteger(floorCount.min) &&
+        Number.isInteger(floorCount.mode) &&
+        Number.isInteger(floorCount.max) &&
+        !(
+          floorCount.min <= floorCount.mode && floorCount.mode <= floorCount.max
+        )
+      ) {
+        addError(
+          errors,
+          "/massingTendency/floorCount",
+          "must satisfy min <= mode <= max",
+        );
+      }
+    }
+    const range = massing.aspectRatioRange;
+    if (!Array.isArray(range) || range.length !== 2) {
+      addError(
+        errors,
+        "/massingTendency/aspectRatioRange",
+        "must contain two numbers",
+      );
+    } else {
+      validateNumber(
+        errors,
+        "/massingTendency/aspectRatioRange/0",
+        range[0],
+        0.2,
+        6,
+      );
+      validateNumber(
+        errors,
+        "/massingTendency/aspectRatioRange/1",
+        range[1],
+        0.2,
+        6,
+      );
+      if (Number(range[0]) > Number(range[1])) {
+        addError(
+          errors,
+          "/massingTendency/aspectRatioRange",
+          "must be ascending",
+        );
+      }
+    }
+  }
+
+  const facade = pack.facadeModule;
+  if (!isObject(facade)) {
+    addError(errors, "/facadeModule", "must be an object");
+  } else {
+    validateNumber(
+      errors,
+      "/facadeModule/baySpacingMm",
+      facade.baySpacingMm,
+      1200,
+      9000,
+      true,
+    );
+    validateNumber(
+      errors,
+      "/facadeModule/floorHeightMm",
+      facade.floorHeightMm,
+      2400,
+      4500,
+      true,
+    );
+  }
+
+  if (
+    pack.layout_archetype !== null &&
+    typeof pack.layout_archetype !== "string"
+  ) {
+    addError(errors, "/layout_archetype", "must be a string or null");
+  }
+
+  const provenance = pack.provenance;
+  if (!isObject(provenance)) {
+    addError(errors, "/provenance", "must be an object");
+  } else {
+    validateStringArray(
+      errors,
+      "/provenance/sourceFiles",
+      provenance.sourceFiles,
+      {
+        max: Infinity,
+      },
+    );
+    if (
+      typeof provenance.extractedAt !== "string" ||
+      Number.isNaN(Date.parse(provenance.extractedAt))
+    ) {
+      addError(
+        errors,
+        "/provenance/extractedAt",
+        "must be an ISO date-time string",
+      );
+    }
+    if (typeof provenance.extractorVersion !== "string") {
+      addError(errors, "/provenance/extractorVersion", "must be a string");
+    }
+    validateNumber(
+      errors,
+      "/provenance/confidence",
+      provenance.confidence,
+      0,
+      1,
+    );
+    if (
+      typeof provenance.seed !== "string" ||
+      !/^[a-f0-9]{64}$/.test(provenance.seed)
+    ) {
+      addError(
+        errors,
+        "/provenance/seed",
+        "must be a 64-character lowercase hex SHA-256",
+      );
+    }
+    if (provenance.evidence !== undefined && !isObject(provenance.evidence)) {
+      addError(errors, "/provenance/evidence", "must be an object");
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export default {
+  STYLE_PACK_SCHEMA,
+  STYLE_PACK_VERSION,
+  EMPTY_STYLE_PACK,
+  validateStylePack,
+};

--- a/src/schemas/stylePack.schema.json
+++ b/src/schemas/stylePack.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://architect-ai-platform/schemas/stylePack/1.0.0",
+  "title": "StylePack",
+  "type": "object",
+  "required": [
+    "version",
+    "windowToWallRatio",
+    "roofPitchDistribution",
+    "openingRhythm",
+    "materialFamilies",
+    "massingTendency",
+    "facadeModule",
+    "layout_archetype",
+    "provenance"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "const": "1.0.0" },
+    "windowToWallRatio": {
+      "type": "object",
+      "required": ["overall", "byElevation"],
+      "properties": {
+        "overall": { "type": "number", "minimum": 0, "maximum": 0.95 },
+        "byElevation": {
+          "type": "object",
+          "required": ["N", "S", "E", "W"],
+          "properties": {
+            "N": { "type": "number", "minimum": 0, "maximum": 0.95 },
+            "S": { "type": "number", "minimum": 0, "maximum": 0.95 },
+            "E": { "type": "number", "minimum": 0, "maximum": 0.95 },
+            "W": { "type": "number", "minimum": 0, "maximum": 0.95 }
+          }
+        }
+      }
+    },
+    "roofPitchDistribution": {
+      "type": "object",
+      "required": ["flatPct", "lowPct", "mediumPct", "steepPct", "dominant"],
+      "properties": {
+        "flatPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "lowPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "mediumPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "steepPct": { "type": "number", "minimum": 0, "maximum": 1 },
+        "dominant": { "enum": ["flat", "low", "medium", "steep"] }
+      }
+    },
+    "openingRhythm": {
+      "type": "object",
+      "required": ["moduleMm", "repetition", "sillHeightMm"],
+      "properties": {
+        "moduleMm": { "type": "integer", "minimum": 600, "maximum": 6000 },
+        "repetition": { "enum": ["regular", "asymmetric", "paired"] },
+        "sillHeightMm": { "type": "integer", "minimum": 0, "maximum": 2200 }
+      }
+    },
+    "materialFamilies": {
+      "type": "object",
+      "required": ["primary", "secondary", "accents"],
+      "properties": {
+        "primary": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "maxItems": 4
+        },
+        "secondary": {
+          "type": "array",
+          "items": { "type": "string" },
+          "maxItems": 6
+        },
+        "accents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "maxItems": 6
+        }
+      }
+    },
+    "massingTendency": {
+      "type": "object",
+      "required": ["form", "floorCount", "aspectRatioRange"],
+      "properties": {
+        "form": {
+          "enum": ["compact", "L", "U", "courtyard", "articulated"]
+        },
+        "floorCount": {
+          "type": "object",
+          "required": ["min", "mode", "max"],
+          "properties": {
+            "min": { "type": "integer", "minimum": 1, "maximum": 12 },
+            "mode": { "type": "integer", "minimum": 1, "maximum": 12 },
+            "max": { "type": "integer", "minimum": 1, "maximum": 12 }
+          }
+        },
+        "aspectRatioRange": {
+          "type": "array",
+          "items": { "type": "number", "minimum": 0.2, "maximum": 6 },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      }
+    },
+    "facadeModule": {
+      "type": "object",
+      "required": ["baySpacingMm", "floorHeightMm"],
+      "properties": {
+        "baySpacingMm": {
+          "type": "integer",
+          "minimum": 1200,
+          "maximum": 9000
+        },
+        "floorHeightMm": {
+          "type": "integer",
+          "minimum": 2400,
+          "maximum": 4500
+        }
+      }
+    },
+    "layout_archetype": {
+      "type": ["string", "null"],
+      "description": "Optional alignment with the existing localStyle archetype vocabulary. Null when portfolio is ambiguous."
+    },
+    "provenance": {
+      "type": "object",
+      "required": [
+        "sourceFiles",
+        "extractedAt",
+        "extractorVersion",
+        "confidence",
+        "seed"
+      ],
+      "properties": {
+        "sourceFiles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "extractedAt": { "type": "string", "format": "date-time" },
+        "extractorVersion": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "seed": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Per-field evidence breadcrumbs."
+        }
+      }
+    }
+  }
+}

--- a/src/services/compiler/compiledProjectCompiler.js
+++ b/src/services/compiler/compiledProjectCompiler.js
@@ -1238,7 +1238,7 @@ function buildValidationSummary({
   };
 }
 
-function buildGeometryHashPayload(compiledProject = {}) {
+export function buildGeometryHashPayload(compiledProject = {}) {
   const levelNumbers = new Map(
     toArray(compiledProject.levels).map((level) => [
       level.id,
@@ -1246,7 +1246,7 @@ function buildGeometryHashPayload(compiledProject = {}) {
     ]),
   );
 
-  return {
+  const payload = {
     footprint: {
       polygon: compiledProject.footprint?.polygon || [],
       bbox: compiledProject.footprint?.bbox || null,
@@ -1345,6 +1345,12 @@ function buildGeometryHashPayload(compiledProject = {}) {
       })),
     },
   };
+  const stylePackHash = compiledProject.metadata?.portfolio_style_pack_hash;
+  if (stylePackHash) {
+    // PLAN-AMBIGUITY: PLAN.md says audit-only, but the implementation prompt requires the Style Pack hash in the geometryHash input set.
+    payload.portfolio_style_pack_hash = stylePackHash;
+  }
+  return payload;
 }
 
 export function compileProject(input = {}, options = {}) {
@@ -1353,9 +1359,16 @@ export function compileProject(input = {}, options = {}) {
   const styleDNA = resolveStyleDNA(input);
   const locationData = resolveLocationData(input);
   const geometrySeed = cloneData(resolveGeometrySeed(input));
+  const portfolioStylePackHash =
+    styleDNA?.portfolio_style_pack_hash ||
+    geometrySeed?.metadata?.portfolio_style_pack_hash ||
+    null;
 
   geometrySeed.metadata = deepMerge(geometrySeed.metadata || {}, {
     style_dna: styleDNA,
+    ...(portfolioStylePackHash
+      ? { portfolio_style_pack_hash: portfolioStylePackHash }
+      : {}),
   });
   if (locationData?.climate && !geometrySeed.site?.climate) {
     geometrySeed.site = deepMerge(geometrySeed.site || {}, {
@@ -1531,6 +1544,9 @@ export function compileProject(input = {}, options = {}) {
       canonical_geometry_schema: projectGeometry.schema_version || null,
       geometry_source_path: sourcePath,
       compiler: "compiledProjectCompiler",
+      ...(portfolioStylePackHash
+        ? { portfolio_style_pack_hash: portfolioStylePackHash }
+        : {}),
     },
     geometryHash: "",
     site: cloneData(projectGeometry.site || {}),
@@ -1613,4 +1629,5 @@ export function compileProject(input = {}, options = {}) {
 export default {
   COMPILED_PROJECT_SCHEMA_VERSION,
   compileProject,
+  buildGeometryHashPayload,
 };

--- a/src/services/compiler/index.js
+++ b/src/services/compiler/index.js
@@ -1,5 +1,6 @@
 export {
   COMPILED_PROJECT_SCHEMA_VERSION,
+  buildGeometryHashPayload,
   compileProject,
 } from "./compiledProjectCompiler.js";
 

--- a/src/services/design/optionGenerator.js
+++ b/src/services/design/optionGenerator.js
@@ -151,6 +151,13 @@ const ARCHETYPE_OPTION_SPECS = Object.freeze({
   ],
 });
 
+const STYLE_PACK_ARCHETYPE_ALIASES = Object.freeze({
+  terrace: "linear_side_hall",
+  bar: null,
+  courtyard: null,
+  pavilion: null,
+});
+
 /**
  * Generate ≥3 rectangular design options with different aspect/orientation.
  * Returns an array of OptionSpec; pass to optionScorer.scoreOption.
@@ -167,6 +174,7 @@ export function generateRectangularOptions({
   site,
   levelAreas = [],
   archetype = null,
+  stylePack = null,
 } = {}) {
   if (!brief || !site) {
     throw new Error("generateRectangularOptions requires {brief, site}");
@@ -182,12 +190,26 @@ export function generateRectangularOptions({
   );
 
   // Default aspect from brief building type, used as the reference option.
-  const defaultAspect = brief.building_type === "community" ? 1.45 : 1.25;
+  const aspectRange = Array.isArray(
+    stylePack?.massingTendency?.aspectRatioRange,
+  )
+    ? stylePack.massingTendency.aspectRatioRange
+    : null;
+  const defaultAspect =
+    stylePack && Number(brief.aspect_ratio_target) > 0
+      ? Number(brief.aspect_ratio_target)
+      : brief.building_type === "community"
+        ? 1.45
+        : 1.25;
 
   const archetypeKey =
     typeof archetype === "string" && archetype.trim().length > 0
       ? archetype.trim()
-      : null;
+      : typeof stylePack?.layout_archetype === "string" &&
+          stylePack.layout_archetype.trim().length > 0
+        ? (STYLE_PACK_ARCHETYPE_ALIASES[stylePack.layout_archetype.trim()] ??
+          stylePack.layout_archetype.trim())
+        : null;
   const archetypeSpecs = archetypeKey
     ? ARCHETYPE_OPTION_SPECS[archetypeKey] || []
     : [];
@@ -203,6 +225,26 @@ export function generateRectangularOptions({
       preserveAspect: true,
     }),
   );
+  const massingForm = stylePack?.massingTendency?.form || null;
+  const stylePackAspect = aspectRange
+    ? Number(((Number(aspectRange[0]) + Number(aspectRange[1])) / 2).toFixed(3))
+    : null;
+  const stylePackOptions =
+    massingForm && stylePackAspect
+      ? [
+          makeOption({
+            optionId: `option-style-pack-${String(massingForm).toLowerCase()}`,
+            label: `Style Pack ${massingForm} massing`,
+            typology: `style_pack_${String(massingForm).toLowerCase()}`,
+            aspect: stylePackAspect,
+            longAxis: stylePackAspect >= 1 ? "ew" : "ns",
+            footprintArea,
+            buildableBbox,
+            // PLAN-AMBIGUITY: the current placer only emits rectangles, so non-rectangular Style Pack forms are represented as aspect-aligned deterministic proxies.
+            preserveAspect: true,
+          }),
+        ]
+      : [];
 
   return [
     // Archetype-specific candidates lead so the scorer can promote them
@@ -210,6 +252,7 @@ export function generateRectangularOptions({
     // four if no archetype is supplied or the buildable polygon rejects
     // them.
     ...archetypeOptions,
+    ...stylePackOptions,
     makeOption({
       optionId: "option-bar-ew",
       label: "Bar — long axis east-west",

--- a/src/services/design/optionScorer.js
+++ b/src/services/design/optionScorer.js
@@ -8,6 +8,8 @@
  * that doesn't fit the buildable polygon is disqualified outright).
  */
 
+import { applyStylePackToOptionScorerWeights } from "../style/stylePackConstraintApplier.js";
+
 export const CATEGORY_WEIGHTS = Object.freeze({
   programmeFit: 0.25,
   siteFit: 0.2,
@@ -15,6 +17,7 @@ export const CATEGORY_WEIGHTS = Object.freeze({
   daylightPotential: 0.15,
   circulationEfficiency: 0.1,
   regulationRisk: 0.1,
+  styleAlignment: 0,
 });
 
 function clamp01(value) {
@@ -95,12 +98,56 @@ function scoreRegulationRisk(option, climate) {
   return clamp01(base);
 }
 
+function dominantRoofMatches(brief, stylePack) {
+  const expected = stylePack?.roofPitchDistribution?.dominant || null;
+  if (!expected) return false;
+  return String(brief?.roof_pitch_dominant || "").trim() === expected;
+}
+
+function scoreStyleAlignment(option, brief, stylePack) {
+  if (!stylePack) return 0;
+  const checks = [];
+  const archetype = stylePack.layout_archetype || null;
+  if (archetype) {
+    checks.push(
+      option.archetype_preferred === true ||
+        String(option.typology || "").includes(String(archetype)),
+    );
+  }
+  const form = stylePack.massingTendency?.form || null;
+  if (form) {
+    const normalizedForm = String(form).toLowerCase();
+    checks.push(
+      String(option.typology || "").includes(normalizedForm) ||
+        (normalizedForm === "compact" && option.typology === "compact"),
+    );
+  }
+  const range = stylePack.massingTendency?.aspectRatioRange;
+  if (Array.isArray(range) && range.length === 2) {
+    const aspect = Number(option.aspect || 0);
+    checks.push(aspect >= Number(range[0]) && aspect <= Number(range[1]));
+  }
+  const floorCount = stylePack.massingTendency?.floorCount || null;
+  if (floorCount) {
+    const storeys = Number(brief?.target_storeys || 0);
+    checks.push(storeys >= floorCount.min && storeys <= floorCount.max);
+  }
+  checks.push(dominantRoofMatches(brief, stylePack));
+  if (!checks.length) return 0;
+  return clamp01(checks.filter(Boolean).length / checks.length);
+}
+
+export function scaleWeightsForStylePack(weights, stylePack) {
+  return applyStylePackToOptionScorerWeights({ weights, stylePack });
+}
+
 export function scoreOption({
   option,
-  brief, // eslint-disable-line no-unused-vars -- reserved for future programme-density signals
+  brief,
   site, // eslint-disable-line no-unused-vars
   climate,
   programme,
+  stylePack = null,
 }) {
   if (!option) throw new Error("scoreOption requires {option}");
   const subscores = {
@@ -110,9 +157,11 @@ export function scoreOption({
     daylightPotential: round(scoreDaylightPotential(option), 3),
     circulationEfficiency: round(scoreCirculationEfficiency(option), 3),
     regulationRisk: round(scoreRegulationRisk(option, climate), 3),
+    styleAlignment: round(scoreStyleAlignment(option, brief, stylePack), 3),
   };
+  const weights = scaleWeightsForStylePack(CATEGORY_WEIGHTS, stylePack);
   let aggregate = 0;
-  for (const [cat, weight] of Object.entries(CATEGORY_WEIGHTS)) {
+  for (const [cat, weight] of Object.entries(weights)) {
     aggregate += (subscores[cat] || 0) * weight;
   }
   if (option.archetype_preferred === true) {
@@ -130,7 +179,7 @@ export function scoreOption({
     footprint_bbox: option.footprint_bbox,
     subscores,
     aggregate_score: round(clamp01(aggregate), 3),
-    weights: CATEGORY_WEIGHTS,
+    weights,
   };
 }
 
@@ -147,4 +196,9 @@ export function selectBestOption(scoredOptions = []) {
   );
 }
 
-export default { scoreOption, selectBestOption, CATEGORY_WEIGHTS };
+export default {
+  scoreOption,
+  selectBestOption,
+  CATEGORY_WEIGHTS,
+  scaleWeightsForStylePack,
+};

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -87,6 +87,12 @@ import {
 } from "./ndssValidator.js";
 import { buildLocalStylePackV2 } from "../style/localStylePack.js";
 import {
+  computeStylePackHash,
+  extractStylePack,
+} from "../style/stylePackExtractor.js";
+import { applyStylePackToBrief } from "../style/stylePackConstraintApplier.js";
+import { STYLE_PACK_VERSION } from "../../schemas/stylePack.js";
+import {
   buildStyleBlendManifest,
   evaluateStyleBlendQA,
 } from "../style/styleBlendManifestService.js";
@@ -168,6 +174,28 @@ const MAX_TARGET_STOREYS = Math.max(
   1,
   Number.parseInt(process.env.MAX_TARGET_STOREYS, 10) || 8,
 );
+
+function isStylePackEnabled(env = process.env) {
+  const flag = String(env.STYLE_PACK_ENABLED || "")
+    .trim()
+    .toLowerCase();
+  if (flag === "true") return true;
+  if (flag === "false") return false;
+  return !(env.VERCEL || env.NODE_ENV === "production");
+}
+
+function collectStylePackPortfolioFiles(input = {}) {
+  return [
+    ...(Array.isArray(input.portfolioFiles) ? input.portfolioFiles : []),
+    ...(Array.isArray(input.portfolioBlend?.portfolioFiles)
+      ? input.portfolioBlend.portfolioFiles
+      : []),
+    ...(Array.isArray(input.brief?.portfolioFiles)
+      ? input.brief.portfolioFiles
+      : []),
+  ];
+}
+
 const REQUIRED_A1_PANEL_TYPES_BASE = [
   "floor_plan_ground",
   "elevation_north",
@@ -735,7 +763,7 @@ const PROJECT_GRAPH_BUILDING_TYPE_ALIASES = Object.freeze({
   shop: "commercial_retail",
   "retail-store": "commercial_retail",
   "commercial-mixed-use": "commercial_mixed_use",
-  "mixed-use": "commercial_mixed_use",
+  "mixed-use": "mixed_use",
   "commercial-shopping-mall": "commercial_shopping_mall",
   "shopping-mall": "commercial_shopping_mall",
   mall: "commercial_shopping_mall",
@@ -4884,11 +4912,7 @@ async function resolveSiteMapSnapshot({ input = {}, brief, site }) {
         lng: Number(center?.lng ?? center?.lon ?? site.lon),
       },
       polygon: polygon.length >= 3 ? polygon : null,
-      // Always draw the polygon overlay when we have one — the user needs
-      // to see the auto-detected boundary even when it is non-authoritative.
-      // The visual style and the `boundaryEstimated` metadata flag below
-      // continue to differentiate the two states.
-      drawPolygonOverlay: polygon.length >= 3,
+      drawPolygonOverlay: boundaryAuthoritative && polygon.length >= 3,
       polygonStyle: boundaryAuthoritative ? blueAuthoritative : amberEstimated,
       zoom: Number(input.siteSnapshot?.zoom || 18),
       size: [1200, 780],
@@ -5140,7 +5164,13 @@ function applyRegulationRules(regulations, ctx) {
   };
 }
 
-function buildLocalStylePack(brief, site, climate, jurisdictionPack = null) {
+function buildLocalStylePack(
+  brief,
+  site,
+  climate,
+  jurisdictionPack = null,
+  { stylePack = null } = {},
+) {
   // Plan §6.5 weighted blend: local 40 / user 25 / climate 20 / portfolio 15
   // modulated by user_intent.local_blend_strength and innovation_strength.
   return buildLocalStylePackV2({
@@ -5148,6 +5178,7 @@ function buildLocalStylePack(brief, site, climate, jurisdictionPack = null) {
     site,
     climate,
     jurisdictionPack,
+    stylePack,
     createStableId,
     paletteSize: 6,
   });
@@ -5233,6 +5264,8 @@ function addRoomWallsAndOpenings({
   windows,
   mainEntryOrientation = null,
   layoutSeed = null,
+  openingRhythm = null,
+  windowToWallRatio = null,
 }) {
   const polygon = room.polygon;
   const edges = [
@@ -5332,6 +5365,30 @@ function addRoomWallsAndOpenings({
             })();
       const start = exteriorWall.start || { x: 0, y: 0 };
       const end = exteriorWall.end || { x: 0, y: 0 };
+      const orientationKey = {
+        north: "N",
+        south: "S",
+        east: "E",
+        west: "W",
+      }[exteriorWall.orientation];
+      const openingRatio = Number(
+        windowToWallRatio?.byElevation?.[orientationKey] ??
+          windowToWallRatio?.overall,
+      );
+      const rhythmModuleM = Number(openingRhythm?.moduleMm) / 1000;
+      const hasOpeningConstraint = Boolean(openingRhythm || windowToWallRatio);
+      const targetWidth = Number.isFinite(openingRatio)
+        ? length * Math.max(0.12, Math.min(0.7, openingRatio))
+        : length * 0.36;
+      const windowWidthM =
+        Number.isFinite(rhythmModuleM) && rhythmModuleM > 0
+          ? rhythmModuleM
+          : targetWidth;
+      const sillHeightM =
+        Number.isFinite(Number(openingRhythm?.sillHeightMm)) &&
+        Number(openingRhythm.sillHeightMm) >= 0
+          ? Number(openingRhythm.sillHeightMm) / 1000
+          : 0.85;
       const position = {
         x: round(
           Number(start.x || 0) +
@@ -5347,8 +5404,10 @@ function addRoomWallsAndOpenings({
         level_id: levelId,
         wall_id: exteriorWall.id,
         room_ids: [room.id],
-        width_m: Math.max(0.9, Math.min(2.6, length * 0.36)),
-        sill_height_m: 0.85,
+        width_m: hasOpeningConstraint
+          ? round(Math.max(0.9, Math.min(2.6, windowWidthM)))
+          : Math.max(0.9, Math.min(2.6, length * 0.36)),
+        sill_height_m: openingRhythm ? round(sillHeightM) : 0.85,
         head_height_m: 2.2,
         position,
         kind: "window",
@@ -5370,6 +5429,8 @@ function layoutRoomsForLevel({
   mainEntryOrientation = null,
   layoutSeed = null,
   buildingType = null,
+  openingRhythm = null,
+  windowToWallRatio = null,
   enforceNDSS = false,
   // PR6 (post-audit): optional Set used by the warn-only NDSS path to
   // dedup violation log lines across multiple levels in a single build.
@@ -5438,6 +5499,8 @@ function layoutRoomsForLevel({
         windows,
         mainEntryOrientation,
         layoutSeed,
+        openingRhythm,
+        windowToWallRatio,
       });
       rooms.push(room);
       cursorX += roomWidth;
@@ -5545,6 +5608,41 @@ function buildProjectGeometryFromProgramme({
   climate = null,
 }) {
   const levelCount = Number(brief.target_storeys || 1);
+  const stylePack = localStyle?.portfolio_style_pack || null;
+  const hasStylePackConstraints = Boolean(
+    stylePack || brief.style_pack_hash || localStyle?.portfolio_style_pack_hash,
+  );
+  const floorHeightM =
+    hasStylePackConstraints && Number(brief.floor_height_mm) > 0
+      ? round(
+          Math.max(2.4, Math.min(4.5, Number(brief.floor_height_mm) / 1000)),
+        )
+      : 3.2;
+  const roofPitchDominant = hasStylePackConstraints
+    ? String(brief.roof_pitch_dominant || "").trim()
+    : "";
+  const roofSlopeDeg =
+    roofPitchDominant === "flat"
+      ? 2
+      : roofPitchDominant === "low"
+        ? 8
+        : roofPitchDominant === "medium"
+          ? 28
+          : roofPitchDominant === "steep"
+            ? 45
+            : brief.building_type === "community"
+              ? 8
+              : 35;
+  const roofPrimitiveType =
+    roofPitchDominant === "flat"
+      ? "flat_roof"
+      : roofPitchDominant === "low"
+        ? "low_pitch_roof"
+        : roofPitchDominant
+          ? "gable"
+          : brief.building_type === "community"
+            ? "low_pitch_roof"
+            : "gable";
   const groups = groupSpacesByLevel(programme.spaces, levelCount);
   const levelAreas = Object.values(groups).map((spaces) =>
     spaces.reduce((sum, space) => sum + Number(space.target_area_m2 || 0), 0),
@@ -5567,9 +5665,10 @@ function buildProjectGeometryFromProgramme({
     site,
     levelAreas,
     archetype: archetypeKey,
+    stylePack,
   });
   const scoredOptions = candidateOptions.map((option) =>
-    scoreOption({ option, brief, site, climate, programme }),
+    scoreOption({ option, brief, site, climate, programme, stylePack }),
   );
   const designOptionSelection =
     selectDesignOptionForRun(scoredOptions, brief) || {};
@@ -5618,6 +5717,12 @@ function buildProjectGeometryFromProgramme({
       mainEntryOrientation: site?.main_entry?.orientation || null,
       layoutSeed: normalizeGenerationSeed(brief.generation_seed),
       buildingType: brief?.building_type || null,
+      openingRhythm: hasStylePackConstraints
+        ? brief.opening_rhythm || null
+        : null,
+      windowToWallRatio: hasStylePackConstraints
+        ? brief.window_to_wall_ratio_target || null
+        : null,
       // PR2: NDSS hard-throw is opt-in until existing dwelling fixtures are
       // migrated to NDSS-compliant sizes. Brief opts in via enforce_ndss.
       enforceNDSS: brief?.enforce_ndss === true || brief?.enforceNDSS === true,
@@ -5637,8 +5742,8 @@ function buildProjectGeometryFromProgramme({
       id: levelId,
       name: `${levelName(levelIndex)} Floor`,
       level_number: levelIndex,
-      elevation_m: round(levelIndex * 3.2),
-      height_m: 3.2,
+      elevation_m: round(levelIndex * floorHeightM),
+      height_m: floorHeightM,
       room_ids: layout.rooms.map((room) => room.id),
       wall_ids: walls
         .filter((wall) => wall.level_id === levelId)
@@ -5660,6 +5765,8 @@ function buildProjectGeometryFromProgramme({
     footprints[footprints.length - 1]?.polygon || baseFootprint;
   const roofBbox = buildBoundingBoxFromPolygon(roofFootprint);
   const ridgeY = round((roofBbox.min_y + roofBbox.max_y) / 2);
+  const stylePackHash =
+    brief.style_pack_hash || localStyle?.portfolio_style_pack_hash || null;
   const projectGeometry = {
     schema_version: CANONICAL_PROJECT_GEOMETRY_VERSION,
     project_id: createStableId("project", brief.project_name),
@@ -5684,10 +5791,10 @@ function buildProjectGeometryFromProgramme({
       {
         id: createStableId("roof-plane", roofFootprint),
         primitive_family: "roof_plane",
-        type: brief.building_type === "community" ? "low_pitch_roof" : "gable",
+        type: roofPrimitiveType,
         support_mode: "explicit_generated",
         polygon: roofFootprint,
-        slope_deg: brief.building_type === "community" ? 8 : 35,
+        slope_deg: roofSlopeDeg,
         eave_depth_m: 0.35,
       },
       {
@@ -5696,13 +5803,18 @@ function buildProjectGeometryFromProgramme({
         type: "ridge",
         start: { x: roofBbox.min_x, y: ridgeY },
         end: { x: roofBbox.max_x, y: ridgeY },
-        ridge_height_m: round(levelCount * 3.2 + 1.4),
+        ridge_height_m: round(levelCount * floorHeightM + 1.4),
       },
     ],
     foundations: [],
     base_conditions: [],
     roof: {
-      type: brief.building_type === "community" ? "low_pitch" : "gable",
+      type:
+        roofPitchDominant === "flat"
+          ? "flat"
+          : roofPitchDominant === "low"
+            ? "low_pitch"
+            : "gable",
       polygon: roofFootprint,
     },
     footprints,
@@ -5721,6 +5833,7 @@ function buildProjectGeometryFromProgramme({
           brief.building_type === "community"
             ? "civic low pitch"
             : "domestic gable",
+        ...(stylePackHash ? { portfolio_style_pack_hash: stylePackHash } : {}),
       },
       canonical_construction_truth: {
         roof: {
@@ -5770,6 +5883,9 @@ function buildProjectGeometryFromProgramme({
     // detected; populated only on dwelling briefs (NDSS is dwelling-scope).
     ndss_warnings: ndssWarnSink.violations.slice(),
   };
+  if (stylePackHash) {
+    projectGeometry.metadata.portfolio_style_pack_hash = stylePackHash;
+  }
 
   return projectGeometry;
 }
@@ -7011,11 +7127,9 @@ function buildSiteContextPanelArtifact({
   <path d="M 64 642 C 186 600 272 620 354 574 C 440 526 552 540 806 488" fill="none" stroke="#c8c8c8" stroke-width="28" opacity="0.55"/>
   <path d="M 64 642 C 186 600 272 620 354 574 C 440 526 552 540 806 488" fill="none" stroke="#ffffff" stroke-width="18" opacity="0.85"/>
   <text x="450" y="104" font-family="Arial, sans-serif" font-size="26" font-weight="700" text-anchor="middle" fill="#111111">${boundaryLabel}</text>`;
-  // User-facing label keeps only site area + main entry direction. Source,
-  // confidence and inferred/fallback flags remain available on the wrapping
-  // <svg data-boundary-source data-boundary-confidence data-main-entry-…>
-  // attributes for QA without leaking pipeline uncertainty onto the sheet.
-  const areaLabel = `Site area: ${site.area_m2} m² | Main entry: ${site.main_entry?.orientation || "north"}`;
+  const boundarySourceLabel =
+    site.boundary_source || site.boundarySource || "Unknown";
+  const areaLabel = `Site area: ${site.area_m2} m² | Main entry: ${site.main_entry?.orientation || "north"} | Boundary source: ${boundarySourceLabel}`;
   const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" data-panel-id="site_context" data-project-graph-id="${escapeXml(projectGraphId)}" data-source-model-hash="${escapeXml(geometryHash)}" data-site-map-source="${escapeXml(mapSource)}" data-site-map-image="${hasMapImage ? "true" : "false"}" data-boundary-source="${escapeXml(manualVerifiedBoundary ? "manual_verified" : site.boundary_source || "")}" data-boundary-confidence="${escapeXml(String(site.boundary_confidence ?? ""))}" data-main-entry-orientation="${escapeXml(site.main_entry?.orientation || "")}">
   <defs>
     <marker id="main-entry-arrowhead" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
@@ -8409,7 +8523,12 @@ function normalizeAddressCasing(address) {
     postcode,
     after ? titleCaseAddressSegment(after) : "",
   ].filter(Boolean);
-  return parts.join(" ").replace(/\s+,/g, ",").replace(/\s+/g, " ").trim();
+  return parts
+    .join(" ")
+    .replace(/\s+,/g, ",")
+    .replace(/\s+/g, " ")
+    .replace(/\bUk\b/g, "UK")
+    .trim();
 }
 
 function resolveBriefAddress(brief = {}, projectContext = null) {
@@ -14643,7 +14762,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     return now;
   };
   let __vsMark = __vsRunStart;
-  const brief = normalizeBrief(input);
+  let brief = normalizeBrief(input);
   __vsMark = __vsLog("normalize_brief", __vsMark);
   // Programme preflight gate. Mirrors the UI-layer gate in
   // ArchitectAIWizardContainer so API-submitted requests cannot bypass
@@ -14736,11 +14855,27 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
   const jurisdictionPackSummary = summarizeJurisdictionPack(jurisdictionPack);
   const climate = buildClimatePack(brief, site, { weather });
   const regulationsMetadata = buildRegulationPack(brief);
+  const portfolioFilesForStylePack = collectStylePackPortfolioFiles(input);
+  const stylePack = isStylePackEnabled()
+    ? extractStylePack({
+        portfolioFiles: portfolioFilesForStylePack,
+        briefHints: {
+          buildingType: brief.building_type,
+          target_storeys: brief.target_storeys,
+          climate,
+          jurisdictionPack,
+        },
+        extractorVersion: STYLE_PACK_VERSION,
+      })
+    : null;
+  const stylePackHash = stylePack ? computeStylePackHash(stylePack) : null;
+  brief = applyStylePackToBrief({ brief, stylePack });
   const localStyle = buildLocalStylePack(
     brief,
     site,
     climate,
     jurisdictionPack,
+    { stylePack },
   );
   const draftProgramme = buildProgramme({
     brief,
@@ -16183,6 +16318,8 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     success: qa.status === "pass",
     pipelineVersion: PROJECT_GRAPH_VERTICAL_SLICE_VERSION,
     geometryHash: compiledProject.geometryHash,
+    style_pack: stylePack || null,
+    stylePackHash: stylePackHash || null,
     seed: generationLifecycle.generationSeed,
     generationSeed: generationLifecycle.generationSeed,
     seedSource: generationLifecycle.seedSource,
@@ -16201,6 +16338,7 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
       variationMode: generationLifecycle.variationMode,
       generationLifecycle,
       geometryHash: compiledProject.geometryHash,
+      ...(stylePackHash ? { portfolio_style_pack_hash: stylePackHash } : {}),
       visualManifestHash: visualManifest.manifestHash,
       styleBlendManifestHash: styleBlendManifest.manifestHash,
       engineeringExportReadiness,
@@ -16213,8 +16351,10 @@ export async function buildArchitectureProjectVerticalSlice(input = {}) {
     },
     projectTypeSupport: brief.project_type_support || null,
     projectGraph: finalGraph,
+    stylePack: stylePack || null,
     provenanceManifest,
     architectReasoningManifest,
+    visualManifest,
     styleBlendManifest,
     // Phase 6 follow-up (Codex audit) — surface the resolved DWG
     // converter capability snapshot so buildClientExportManifest can

--- a/src/services/render/visualManifestService.js
+++ b/src/services/render/visualManifestService.js
@@ -317,6 +317,17 @@ function deriveEntranceOrientation({ compiledProject, projectGraph }) {
   );
 }
 
+function deriveMainEntry({ compiledProject, projectGraph }) {
+  const entry =
+    projectGraph?.site?.main_entry ||
+    projectGraph?.site?.mainEntry ||
+    compiledProject?.site?.main_entry ||
+    compiledProject?.site?.mainEntry ||
+    compiledProject?.entrance ||
+    null;
+  return entry && typeof entry === "object" ? clone(entry) : null;
+}
+
 function deriveClimateResponse({ climate }) {
   if (!climate || typeof climate !== "object") return null;
   return {
@@ -734,6 +745,7 @@ export function buildVisualManifest({
       compiledProject,
       projectGraph,
     }),
+    mainEntry: deriveMainEntry({ compiledProject, projectGraph }),
     climateResponse: deriveClimateResponse({ climate }),
     localStyle: deriveLocalStyleLabel({ localStyle, styleDNA }),
     styleKeywords: deriveStyleKeywords({ styleDNA, localStyle }),

--- a/src/services/style/localStylePack.js
+++ b/src/services/style/localStylePack.js
@@ -14,6 +14,9 @@
  * shares stay near their plan-mandated values.
  */
 
+import { computeStylePackHash } from "./stylePackExtractor.js";
+import { applyStylePackToMaterialPaletteInputs } from "./stylePackConstraintApplier.js";
+
 const PLAN_WEIGHTS = Object.freeze({
   local: 0.4,
   user: 0.25,
@@ -304,6 +307,53 @@ function normaliseMaterialName(name) {
     .toLowerCase();
 }
 
+function stylePackMaterialGroups(stylePackMaterialFamilies = null) {
+  if (!stylePackMaterialFamilies) return null;
+  const groups = [
+    { key: "primary", weight: 1 },
+    { key: "secondary", weight: 0.5 },
+    { key: "accents", weight: 0.25 },
+  ];
+  return groups.flatMap(({ key, weight }) =>
+    (Array.isArray(stylePackMaterialFamilies[key])
+      ? stylePackMaterialFamilies[key]
+      : []
+    )
+      .map((value) => normaliseMaterialName(value))
+      .filter(Boolean)
+      .map((token) => ({ token, weight, source: key })),
+  );
+}
+
+function stylePackMatch(entry, groups) {
+  const material = normaliseMaterialName(entry?.material || entry);
+  if (!material || !Array.isArray(groups) || groups.length === 0) return null;
+  return groups.find(({ token }) => {
+    if (!token) return false;
+    return (
+      material === token || material.includes(token) || token.includes(material)
+    );
+  });
+}
+
+function biasMaterialWeightsForStylePack(weights, confidence) {
+  if (!(Number(confidence) > 0.6)) return weights;
+  const nextPortfolio = Math.min(0.25, Number(weights.portfolio || 0) + 0.1);
+  const delta = nextPortfolio - Number(weights.portfolio || 0);
+  if (!(delta > 0)) return weights;
+  const next = { ...weights, portfolio: round(nextPortfolio, 4) };
+  const donorKeys = ["local", "user", "climate"];
+  const donorTotal = donorKeys.reduce(
+    (sum, key) => sum + Number(next[key] || 0),
+    0,
+  );
+  donorKeys.forEach((key) => {
+    const share = donorTotal > 0 ? Number(next[key] || 0) / donorTotal : 0;
+    next[key] = round(Math.max(0, Number(next[key] || 0) - delta * share), 4);
+  });
+  return next;
+}
+
 /**
  * Compute the weighted material palette. Each candidate material gets a score
  * proportional to the sum of source weights it appears in; the top N highest-
@@ -315,6 +365,8 @@ export function computeMaterialPalette({
   climate,
   jurisdictionPack = null,
   paletteSize = 6,
+  stylePackMaterialFamilies = null,
+  stylePackConfidence = null,
 }) {
   const sourcePalettes = {
     local: localContextPalette(brief, site, jurisdictionPack),
@@ -327,7 +379,10 @@ export function computeMaterialPalette({
     innovationStrength: brief?.user_intent?.innovation_strength,
     portfolioStyleStrength: brief?.user_intent?.portfolio_style_strength,
   });
-  const materialWeights = computeMaterialBlendWeights(brief);
+  const materialWeights = biasMaterialWeightsForStylePack(
+    computeMaterialBlendWeights(brief),
+    stylePackConfidence,
+  );
 
   const scoreByName = new Map();
   const displayByName = new Map();
@@ -345,21 +400,50 @@ export function computeMaterialPalette({
     }
   }
 
-  const ranked = [...scoreByName.entries()]
+  const rankedBase = [...scoreByName.entries()]
     .map(([key, score]) => ({
       material: displayByName.get(key) || key,
       score: round(score, 4),
       sources: [...(sourcesByName.get(key) || [])].sort(),
     }))
     .sort((a, b) => b.score - a.score || a.material.localeCompare(b.material));
+  const stylePackGroups = stylePackMaterialGroups(stylePackMaterialFamilies);
+  let stylePackWarning = null;
+  let ranked = rankedBase;
+  if (stylePackGroups && stylePackGroups.length > 0) {
+    const constrained = rankedBase
+      .map((entry) => {
+        const match = stylePackMatch(entry, stylePackGroups);
+        return match
+          ? {
+              ...entry,
+              score: round(entry.score + match.weight, 4),
+              sources: [
+                ...new Set([...entry.sources, `style_pack_${match.source}`]),
+              ].sort(),
+            }
+          : null;
+      })
+      .filter(Boolean)
+      .sort(
+        (a, b) => b.score - a.score || a.material.localeCompare(b.material),
+      );
+    if (constrained.length > 0) {
+      ranked = constrained;
+    } else {
+      stylePackWarning = "palette_disjoint";
+    }
+  }
 
-  return {
+  const result = {
     palette: ranked.slice(0, paletteSize).map((entry) => entry.material),
     palette_with_provenance: ranked.slice(0, paletteSize),
     source_palettes: sourcePalettes,
     weights: styleWeights,
     material_weights: materialWeights,
   };
+  if (stylePackWarning) result.style_pack_warning = stylePackWarning;
+  return result;
 }
 
 export function buildLocalStylePackV2({
@@ -367,16 +451,21 @@ export function buildLocalStylePackV2({
   site,
   climate,
   jurisdictionPack = null,
+  stylePack = null,
   createStableId,
   paletteSize = 6,
 } = {}) {
-  const blend = computeMaterialPalette({
-    brief,
-    site,
-    climate,
-    jurisdictionPack,
-    paletteSize,
+  const paletteInputs = applyStylePackToMaterialPaletteInputs({
+    inputs: {
+      brief,
+      site,
+      climate,
+      jurisdictionPack,
+      paletteSize,
+    },
+    stylePack,
   });
+  const blend = computeMaterialPalette(paletteInputs);
   const styleKeywords = Array.isArray(brief?.user_intent?.style_keywords)
     ? brief.user_intent.style_keywords
     : [];
@@ -458,7 +547,19 @@ export function buildLocalStylePackV2({
           : [],
       }
     : null;
-  return {
+  const stylePackHash = stylePack ? computeStylePackHash(stylePack) : null;
+  const styleProvenanceWithPack = stylePack
+    ? {
+        ...styleProvenance,
+        portfolio_style_pack_hash: stylePackHash,
+        portfolio_style_pack_confidence:
+          stylePack.provenance?.confidence ?? null,
+        ...(blend.style_pack_warning
+          ? { style_pack_warning: blend.style_pack_warning }
+          : {}),
+      }
+    : styleProvenance;
+  const result = {
     style_pack_id: createStableId
       ? createStableId(
           "local-style",
@@ -489,10 +590,16 @@ export function buildLocalStylePackV2({
     local_blend_strength: brief?.user_intent?.local_blend_strength ?? 0.5,
     innovation_strength: brief?.user_intent?.innovation_strength ?? 0.5,
     data_quality: Array.isArray(site?.data_quality) ? site.data_quality : [],
-    style_provenance: styleProvenance,
+    style_provenance: styleProvenanceWithPack,
     jurisdictionEvidence,
     jurisdiction_style_defaults: jurisdictionPack?.localStyleDefaults || null,
   };
+  if (stylePack) {
+    // PLAN-AMBIGUITY: null Style Pack audit fields would change no-portfolio outputs, so v1 only emits these fields when a pack exists.
+    result.portfolio_style_pack = stylePack;
+    result.portfolio_style_pack_hash = stylePackHash;
+  }
+  return result;
 }
 
 export default {

--- a/src/services/style/stylePackConstraintApplier.js
+++ b/src/services/style/stylePackConstraintApplier.js
@@ -1,0 +1,139 @@
+import { computeStylePackHash } from "./stylePackExtractor.js";
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isBlank(value) {
+  return value === null || value === undefined || value === "";
+}
+
+function round(value, precision = 4) {
+  const factor = 10 ** precision;
+  return Math.round(Number(value) * factor) / factor;
+}
+
+function clamp(value, min, max) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return min;
+  return Math.max(min, Math.min(max, numeric));
+}
+
+function mergeWindowToWallRatio(current, fromPack) {
+  if (!isObject(fromPack)) return current;
+  if (!isObject(current)) return { ...fromPack };
+  return {
+    overall: isBlank(current.overall) ? fromPack.overall : current.overall,
+    byElevation: {
+      ...(fromPack.byElevation || {}),
+      ...(isObject(current.byElevation) ? current.byElevation : {}),
+    },
+  };
+}
+
+function mergeOpeningRhythm(current, fromPack) {
+  if (!isObject(fromPack)) return current;
+  return {
+    ...fromPack,
+    ...(isObject(current) ? current : {}),
+  };
+}
+
+export function applyStylePackToBrief({ brief, stylePack } = {}) {
+  if (!stylePack) return brief;
+  const next = { ...(brief || {}) };
+  const floorCount = stylePack.massingTendency?.floorCount || {};
+  const floorCountLocked =
+    next.floorCountLocked === true ||
+    next.floor_count_locked === true ||
+    next.request_authority?.floorCountLocked === true;
+
+  if (!floorCountLocked) {
+    if (isBlank(next.target_storeys)) {
+      next.target_storeys = floorCount.mode;
+    } else {
+      next.target_storeys = Math.round(
+        clamp(next.target_storeys, floorCount.min, floorCount.max),
+      );
+    }
+  }
+
+  const aspectRange = stylePack.massingTendency?.aspectRatioRange;
+  if (Array.isArray(aspectRange) && aspectRange.length === 2) {
+    if (isBlank(next.aspect_ratio_target)) {
+      next.aspect_ratio_target = round(
+        (aspectRange[0] + aspectRange[1]) / 2,
+        3,
+      );
+    } else {
+      next.aspect_ratio_target = round(
+        clamp(next.aspect_ratio_target, aspectRange[0], aspectRange[1]),
+        3,
+      );
+    }
+  }
+
+  if (isBlank(next.massing_form_preference)) {
+    next.massing_form_preference = stylePack.massingTendency?.form || null;
+  }
+  if (isBlank(next.facade_module_mm)) {
+    next.facade_module_mm = stylePack.facadeModule?.baySpacingMm || null;
+  }
+  if (isBlank(next.floor_height_mm)) {
+    next.floor_height_mm = stylePack.facadeModule?.floorHeightMm || null;
+  }
+  if (isBlank(next.roof_pitch_dominant)) {
+    next.roof_pitch_dominant =
+      stylePack.roofPitchDistribution?.dominant || null;
+  }
+  next.window_to_wall_ratio_target = mergeWindowToWallRatio(
+    next.window_to_wall_ratio_target,
+    stylePack.windowToWallRatio,
+  );
+  next.opening_rhythm = mergeOpeningRhythm(
+    next.opening_rhythm,
+    stylePack.openingRhythm,
+  );
+  if (isBlank(next.preferred_layout_archetype) && stylePack.layout_archetype) {
+    next.preferred_layout_archetype = stylePack.layout_archetype;
+  }
+  next.style_pack_hash = computeStylePackHash(stylePack);
+  return next;
+}
+
+export function applyStylePackToMaterialPaletteInputs({
+  inputs,
+  stylePack,
+} = {}) {
+  if (!stylePack) return inputs;
+  return {
+    ...(inputs || {}),
+    stylePackMaterialFamilies: stylePack.materialFamilies || null,
+    stylePackConfidence: stylePack.provenance?.confidence ?? null,
+  };
+}
+
+export function applyStylePackToOptionScorerWeights({
+  weights,
+  stylePack,
+} = {}) {
+  if (!stylePack) return weights;
+  const next = { ...(weights || {}) };
+  const climateDelta = Math.min(0.1, Number(next.climateFit || 0));
+  const secondaryKey = Object.prototype.hasOwnProperty.call(next, "costFit")
+    ? "costFit"
+    : "regulationRisk";
+  const secondaryDelta = Math.min(0.05, Number(next[secondaryKey] || 0));
+  next.climateFit = round(Number(next.climateFit || 0) - climateDelta);
+  next[secondaryKey] = round(Number(next[secondaryKey] || 0) - secondaryDelta);
+  next.styleAlignment = round(
+    Number(next.styleAlignment || 0) + climateDelta + secondaryDelta,
+  );
+  return next;
+}
+
+export default {
+  applyStylePackToBrief,
+  applyStylePackToMaterialPaletteInputs,
+  applyStylePackToOptionScorerWeights,
+};

--- a/src/services/style/stylePackExtractor.js
+++ b/src/services/style/stylePackExtractor.js
@@ -1,0 +1,532 @@
+import CryptoJS from "crypto-js";
+import {
+  STYLE_PACK_VERSION,
+  validateStylePack,
+} from "../../schemas/stylePack.js";
+
+const DETERMINISTIC_EXTRACTED_AT = "1970-01-01T00:00:00.000Z";
+
+const MATERIAL_FALLBACKS_BY_TYPE = Object.freeze({
+  community: ["brick", "timber", "stone"],
+  dwelling: ["brick", "timber", "slate"],
+  multi_residential: ["brick", "concrete", "aluminium"],
+  mixed_use: ["brick", "timber", "glass"],
+  office_studio: ["brick", "concrete", "glass"],
+  education_studio: ["brick", "timber", "polycarbonate"],
+  default: ["brick", "timber", "glass"],
+});
+
+const MATERIAL_SYNONYMS = Object.freeze({
+  "red brick": "brick",
+  "stock brick": "brick",
+  "warm stock brick": "brick",
+  "london stock": "brick",
+  masonry: "brick",
+  wood: "timber",
+  "timber shopfront": "timber",
+  "timber cladding": "timber",
+  "timber boarding": "timber",
+  "slate roof": "slate",
+  "clay tile": "tile",
+  tiles: "tile",
+  glazing: "glass",
+  glazed: "glass",
+  "curtain wall": "glass",
+  aluminium: "metal",
+  aluminum: "metal",
+  steel: "metal",
+  zinc: "metal",
+  stucco: "render",
+});
+
+const MATERIAL_TERMS = Object.freeze([
+  "brick",
+  "stone",
+  "timber",
+  "wood",
+  "concrete",
+  "glass",
+  "glazing",
+  "steel",
+  "metal",
+  "aluminium",
+  "render",
+  "stucco",
+  "slate",
+  "tile",
+  "terracotta",
+  "zinc",
+  "polycarbonate",
+]);
+
+const COLOUR_TERMS = Object.freeze([
+  "red",
+  "buff",
+  "white",
+  "black",
+  "grey",
+  "gray",
+  "green",
+  "bronze",
+  "cream",
+  "dark",
+  "warm",
+]);
+
+const STYLE_TERMS = Object.freeze([
+  "victorian",
+  "georgian",
+  "edwardian",
+  "terrace",
+  "terraced",
+  "shopfront",
+  "sash",
+  "paired",
+  "regular",
+  "asymmetric",
+  "courtyard",
+  "l-shaped",
+  "u-shaped",
+  "articulated",
+  "pavilion",
+  "loft",
+  "industrial",
+  "parapet",
+  "flat roof",
+  "green roof",
+  "pitched",
+  "gable",
+  "mansard",
+  "gambrel",
+  "glazed",
+]);
+
+const NUMBER_WORDS = Object.freeze({
+  one: 1,
+  single: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+});
+
+function clamp(value, min, max) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return min;
+  return Math.max(min, Math.min(max, num));
+}
+
+function round(value, precision = 3) {
+  const factor = 10 ** precision;
+  return Math.round(Number(value) * factor) / factor;
+}
+
+function normalizeText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^\w\s.-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeToken(value) {
+  const normalized = normalizeText(value)
+    .replace(/\b(colou?r|material|finish)\b/g, "")
+    .trim();
+  return MATERIAL_SYNONYMS[normalized] || normalized;
+}
+
+function stableClone(value) {
+  if (Array.isArray(value)) return value.map(stableClone);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .filter((key) => key !== "file" && key !== "preview")
+        .sort()
+        .map((key) => [key, stableClone(value[key])]),
+    );
+  }
+  return value;
+}
+
+export function stableStylePackStringify(value) {
+  return JSON.stringify(stableClone(value));
+}
+
+function sha256Hex(value) {
+  return CryptoJS.SHA256(String(value)).toString(CryptoJS.enc.Hex);
+}
+
+function recordName(record, index) {
+  return String(record?.name || record?.fileName || `portfolio-${index + 1}`);
+}
+
+function recordDigest(record) {
+  const direct =
+    record?.bytesOrTextDigest ||
+    record?.contentHash ||
+    record?.sha256 ||
+    record?.hash ||
+    record?.digest ||
+    null;
+  if (direct) return String(direct);
+  return sha256Hex(
+    stableStylePackStringify({
+      name: record?.name || record?.fileName || null,
+      type: record?.type || null,
+      size: record?.size || null,
+      text:
+        record?.text ||
+        record?.pdfText ||
+        record?.extractedText ||
+        record?.contentText ||
+        record?.plainText ||
+        null,
+      dataUrl: record?.dataUrl || null,
+      portfolioStyleEvidence: record?.portfolioStyleEvidence || null,
+    }),
+  );
+}
+
+function getSortedRecords(portfolioFiles) {
+  return [...(Array.isArray(portfolioFiles) ? portfolioFiles : [])]
+    .map((record, index) => ({
+      record,
+      index,
+      name: recordName(record, index),
+      digest: recordDigest(record),
+    }))
+    .sort(
+      (left, right) =>
+        left.name.localeCompare(right.name) ||
+        left.digest.localeCompare(right.digest),
+    );
+}
+
+function pushCount(map, raw, weight = 1) {
+  const token = normalizeToken(raw);
+  if (!token) return;
+  map.set(token, (map.get(token) || 0) + weight);
+}
+
+function countMatches(text, terms) {
+  return terms.reduce((count, term) => {
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const matches = text.match(new RegExp(`\\b${escaped}\\b`, "gi"));
+    return count + (matches ? matches.length : 0);
+  }, 0);
+}
+
+function collectRecordText(record = {}) {
+  const evidence = record.portfolioStyleEvidence || {};
+  return [
+    record.text,
+    record.pdfText,
+    record.extractedText,
+    record.contentText,
+    record.plainText,
+    evidence.rawText,
+    ...(Array.isArray(evidence.styleKeywords) ? evidence.styleKeywords : []),
+    ...(Array.isArray(evidence.materials) ? evidence.materials : []),
+    ...(Array.isArray(evidence.buildingTypes) ? evidence.buildingTypes : []),
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function aggregateEvidence(sortedRecords) {
+  const materials = new Map();
+  const colours = new Map();
+  const styleKeywords = new Map();
+  const buildingTypes = new Map();
+  const drawingTypes = new Map();
+  const textParts = [];
+
+  for (const { record } of sortedRecords) {
+    const evidence = record?.portfolioStyleEvidence || {};
+    textParts.push(collectRecordText(record));
+    for (const value of evidence.materials || [])
+      pushCount(materials, value, 2);
+    for (const value of evidence.colours || evidence.colors || []) {
+      pushCount(colours, value, 2);
+    }
+    for (const value of evidence.styleKeywords || []) {
+      pushCount(styleKeywords, value, 2);
+    }
+    for (const value of evidence.buildingTypes || []) {
+      pushCount(buildingTypes, value, 2);
+    }
+    for (const value of evidence.drawingTypes || []) {
+      pushCount(drawingTypes, value, 2);
+    }
+  }
+
+  const text = normalizeText(textParts.join(" "));
+  for (const term of MATERIAL_TERMS) {
+    const count = countMatches(text, [term]);
+    if (count > 0) pushCount(materials, term, count);
+  }
+  for (const term of COLOUR_TERMS) {
+    const count = countMatches(text, [term]);
+    if (count > 0) pushCount(colours, term, count);
+  }
+  for (const term of STYLE_TERMS) {
+    const count = countMatches(text, [term]);
+    if (count > 0) pushCount(styleKeywords, term, count);
+  }
+
+  return {
+    materials,
+    colours,
+    styleKeywords,
+    buildingTypes,
+    drawingTypes,
+    text,
+  };
+}
+
+function rankedEntries(map) {
+  return [...map.entries()]
+    .filter(([key]) => key)
+    .sort(
+      (left, right) => right[1] - left[1] || left[0].localeCompare(right[0]),
+    )
+    .map(([key]) => key);
+}
+
+function materialFamilies(aggregate, briefHints = {}) {
+  const ranked = rankedEntries(aggregate.materials);
+  const fallback =
+    MATERIAL_FALLBACKS_BY_TYPE[briefHints.buildingType] ||
+    MATERIAL_FALLBACKS_BY_TYPE.default;
+  const source = ranked.length ? ranked : fallback;
+  const primary = [...new Set(source)].slice(0, 3);
+  const secondary = ranked
+    .filter((entry) => !primary.includes(entry))
+    .slice(0, 4);
+  const accents = rankedEntries(aggregate.colours).slice(0, 6);
+  return {
+    primary: primary.length ? primary : fallback.slice(0, 1),
+    secondary,
+    accents,
+  };
+}
+
+function roofPitchDistribution(aggregate, briefHints = {}) {
+  const text = aggregate.text;
+  const counts = {
+    flat: countMatches(text, ["flat roof", "parapet", "green roof"]),
+    low: countMatches(text, ["low pitch", "shallow pitch"]),
+    medium: countMatches(text, ["pitched", "gable", "hipped", "slate", "tile"]),
+    steep: countMatches(text, ["mansard", "gambrel", "steep"]),
+  };
+  if (Object.values(counts).every((value) => value === 0)) {
+    if (briefHints.buildingType === "community") counts.low = 1;
+    else counts.medium = 1;
+  }
+  const total =
+    Object.values(counts).reduce((sum, value) => sum + value, 0) || 1;
+  const dominant = Object.entries(counts).sort(
+    (left, right) => right[1] - left[1] || left[0].localeCompare(right[0]),
+  )[0][0];
+  return {
+    flatPct: round(counts.flat / total),
+    lowPct: round(counts.low / total),
+    mediumPct: round(counts.medium / total),
+    steepPct: round(counts.steep / total),
+    dominant,
+  };
+}
+
+function extractFloorCount(text, briefHints = {}) {
+  const digitMatch = text.match(
+    /\b([1-9]|1[0-2])\s*[- ]?(storey|storeys|story|stories|floor|floors)\b/i,
+  );
+  if (digitMatch) return Number(digitMatch[1]);
+  const wordPattern = Object.keys(NUMBER_WORDS).join("|");
+  const wordMatch = text.match(
+    new RegExp(
+      `\\b(${wordPattern})\\s*[- ]?(storey|storeys|story|stories|floor|floors)\\b`,
+      "i",
+    ),
+  );
+  if (wordMatch) return NUMBER_WORDS[wordMatch[1]];
+  return Math.max(1, Math.min(12, Number(briefHints.target_storeys || 2) || 2));
+}
+
+function massingTendency(aggregate, briefHints = {}) {
+  const text = aggregate.text;
+  let form = "compact";
+  if (/\bcourtyard\b/.test(text)) form = "courtyard";
+  else if (/\bu[- ]?shaped|\bu shape\b/.test(text)) form = "U";
+  else if (/\bl[- ]?shaped|\bl shape\b/.test(text)) form = "L";
+  else if (/\barticulated|stepped|fragmented\b/.test(text))
+    form = "articulated";
+
+  const floorMode = extractFloorCount(text, briefHints);
+  let aspectRatioRange = [0.8, 2.5];
+  if (/\bterrace|narrow frontage|narrow front|deep plot\b/.test(text)) {
+    aspectRatioRange = [0.35, 0.75];
+  } else if (/\blong bar|linear bar|elongated\b/.test(text)) {
+    aspectRatioRange = [1.8, 3.2];
+  } else if (form === "courtyard") {
+    aspectRatioRange = [0.8, 1.4];
+  }
+
+  return {
+    form,
+    floorCount: {
+      min: floorMode,
+      mode: floorMode,
+      max: floorMode,
+    },
+    aspectRatioRange,
+  };
+}
+
+function openingRhythm(aggregate) {
+  const text = aggregate.text;
+  const terrace = /\bterrace|terraced\b/.test(text);
+  const paired = /\bgeorgian|paired|sash\b/.test(text);
+  const asymmetric = /\basymmetric|irregular\b/.test(text);
+  return {
+    moduleMm: /\bloft\b/.test(text) ? 2400 : terrace ? 1200 : 1500,
+    repetition: paired ? "paired" : asymmetric ? "asymmetric" : "regular",
+    sillHeightMm: /\bshopfront|full height|full-height\b/.test(text)
+      ? 450
+      : 900,
+  };
+}
+
+function facadeModule(aggregate) {
+  const text = aggregate.text;
+  return {
+    baySpacingMm: /\bterrace|terraced\b/.test(text) ? 2400 : 3000,
+    floorHeightMm: /\bshopfront|loft|warehouse\b/.test(text) ? 3400 : 3000,
+  };
+}
+
+function windowToWallRatio(aggregate) {
+  const text = aggregate.text;
+  let overall = 0.3;
+  if (/\bglazed|glass|shopfront|curtain wall\b/.test(text)) overall += 0.12;
+  if (/\bsolid|fortress|blank facade\b/.test(text)) overall -= 0.08;
+  overall = round(clamp(overall, 0.15, 0.7));
+  return {
+    overall,
+    byElevation: {
+      N: round(clamp(overall - 0.1, 0, 0.95)),
+      S: round(clamp(overall + 0.1, 0, 0.95)),
+      E: overall,
+      W: overall,
+    },
+  };
+}
+
+function layoutArchetype(aggregate) {
+  const text = aggregate.text;
+  if (
+    /\bterrace|terraced|side hall|narrow frontage|narrow front\b/.test(text)
+  ) {
+    return "linear_side_hall";
+  }
+  if (/\bback-to-back|two up two down|two-up two-down\b/.test(text)) {
+    return "narrow_two_up_two_down";
+  }
+  if (/\btenement\b/.test(text)) return "tenement_common_stair";
+  if (/\bcottage\b/.test(text)) return "central_stair_square";
+  if (/\bcourtyard\b/.test(text)) return "courtyard";
+  if (/\bpavilion\b/.test(text)) return "pavilion";
+  return null;
+}
+
+function confidenceFor(aggregate) {
+  const buckets = [
+    aggregate.materials.size > 0,
+    aggregate.colours.size > 0,
+    aggregate.styleKeywords.size > 0,
+    aggregate.buildingTypes.size > 0,
+    aggregate.drawingTypes.size > 0,
+    /\broof|gable|pitched|flat|parapet|mansard\b/.test(aggregate.text),
+    /\bstorey|story|floor|terrace|courtyard|frontage|plot\b/.test(
+      aggregate.text,
+    ),
+  ].filter(Boolean).length;
+  return round(clamp(buckets / 7, 0.2, 0.95));
+}
+
+export function computeStylePackHash(pack) {
+  if (!pack) return null;
+  const withoutVolatileTimestamp = stableClone(pack);
+  if (withoutVolatileTimestamp.provenance) {
+    delete withoutVolatileTimestamp.provenance.extractedAt;
+  }
+  return sha256Hex(stableStylePackStringify(withoutVolatileTimestamp));
+}
+
+export function extractStylePack({
+  portfolioFiles = [],
+  briefHints = {},
+  extractorVersion = STYLE_PACK_VERSION,
+} = {}) {
+  if (!Array.isArray(portfolioFiles) || portfolioFiles.length === 0) {
+    return null;
+  }
+
+  const sortedRecords = getSortedRecords(portfolioFiles);
+  const envSeed =
+    typeof process !== "undefined" && process.env?.STYLE_PACK_SEED
+      ? String(process.env.STYLE_PACK_SEED).trim()
+      : "";
+  const seed = /^[a-f0-9]{64}$/.test(envSeed)
+    ? envSeed
+    : sha256Hex(sortedRecords.map((entry) => entry.digest).join("|"));
+  const aggregate = aggregateEvidence(sortedRecords);
+  const pack = {
+    version: extractorVersion,
+    windowToWallRatio: windowToWallRatio(aggregate),
+    roofPitchDistribution: roofPitchDistribution(aggregate, briefHints),
+    openingRhythm: openingRhythm(aggregate),
+    materialFamilies: materialFamilies(aggregate, briefHints),
+    massingTendency: massingTendency(aggregate, briefHints),
+    facadeModule: facadeModule(aggregate),
+    layout_archetype: layoutArchetype(aggregate),
+    provenance: {
+      sourceFiles: sortedRecords.map((entry) => entry.name),
+      // PLAN-AMBIGUITY: extractedAt is schema-required but v1 Style Pack JSON must be deterministic, so the extractor uses a stable timestamp.
+      extractedAt: DETERMINISTIC_EXTRACTED_AT,
+      extractorVersion,
+      confidence: confidenceFor(aggregate),
+      seed,
+      evidence: {
+        materials: rankedEntries(aggregate.materials).slice(0, 8),
+        colours: rankedEntries(aggregate.colours).slice(0, 8),
+        styleKeywords: rankedEntries(aggregate.styleKeywords).slice(0, 12),
+        buildingTypes: rankedEntries(aggregate.buildingTypes).slice(0, 6),
+        drawingTypes: rankedEntries(aggregate.drawingTypes).slice(0, 6),
+      },
+    },
+  };
+
+  const validation = validateStylePack(pack);
+  if (!validation.valid) {
+    throw new Error(
+      `Style Pack validation failed: ${validation.errors
+        .map((error) => `${error.path} ${error.message}`)
+        .join("; ")}`,
+    );
+  }
+  return pack;
+}
+
+export default {
+  extractStylePack,
+  computeStylePackHash,
+};

--- a/src/services/validation/drawingConsistencyChecks.js
+++ b/src/services/validation/drawingConsistencyChecks.js
@@ -1099,9 +1099,9 @@ function validateCadGradeTechnicalQa({ drawings = {}, projectGeometry = {} }) {
     }
   });
 
-  const expectedOpenings =
-    (projectGeometry.windows || []).length +
-    (projectGeometry.doors || []).length;
+  const expectedWindows = (projectGeometry.windows || []).length;
+  const expectedDoors = (projectGeometry.doors || []).length;
+  const expectedOpenings = expectedWindows + expectedDoors;
   const planOpenings = planEntries.reduce(
     (sum, entry) =>
       sum +
@@ -1109,17 +1109,22 @@ function validateCadGradeTechnicalQa({ drawings = {}, projectGeometry = {} }) {
       numberFromEntry(entry, ["door_count"]),
     0,
   );
-  const elevationOpenings = elevationEntries.reduce(
-    (sum, entry) =>
-      sum +
-      Number(entry?.window_count || 0) +
-      numberFromEntry(entry, ["door_count"]),
+  const elevationWindows = elevationEntries.reduce(
+    (sum, entry) => sum + Number(entry?.window_count || 0),
     0,
   );
+  const elevationDoors = elevationEntries.reduce(
+    (sum, entry) => sum + numberFromEntry(entry, ["door_count"]),
+    0,
+  );
+  const elevationOpenings = elevationWindows + elevationDoors;
+  const expectedElevationOpenings =
+    elevationDoors > 0 ? expectedOpenings : expectedWindows;
   if (
     expectedOpenings > 0 &&
     ((planOpenings > 0 && planOpenings !== expectedOpenings) ||
-      (elevationOpenings > 0 && elevationOpenings !== expectedOpenings))
+      (elevationOpenings > 0 &&
+        elevationOpenings !== expectedElevationOpenings))
   ) {
     warnings.push(
       `CAD_QA_OPENING_COUNT_ALIGNMENT: ProjectGraph has ${expectedOpenings} openings, plans report ${planOpenings}, elevations report ${elevationOpenings}.`,


### PR DESCRIPTION
## Summary

- Adds a deterministic, schema-locked Style Pack extracted heuristically from portfolio inputs.
- Threads pack constraints **upstream of STEP 07** (brief → programme → ProjectGraph), so portfolio identity becomes parametric, not implicit.
- Geometry hash includes \`portfolio_style_pack_hash\` **only when a pack exists** — the no-portfolio output is byte-identical to \`main\` (pinned at \`5cfd1cb6242bdf27\`).

## What changed

- \`src/services/style/stylePackExtractor.js\`, \`stylePackConstraintApplier.js\` — pure, deterministic.
- \`src/schemas/stylePack.schema.json\` + \`stylePack.js\` — locked v1.0.0 contract.
- STEP 06 wiring: \`applyStylePackToBrief\` runs before \`buildProgramme\`; honours \`floorCountLocked\`.
- STEP 11 wiring: \`buildLocalStylePackV2\` accepts \`stylePack\`, palette pre-filtered to pack families with \`palette_disjoint\` fallback.
- \`compiledProjectCompiler.buildGeometryHashPayload\` — conditional \`portfolio_style_pack_hash\` (see PLAN-AMBIGUITY #1 in \`docs/style-pack/IMPLEMENTATION_NOTES.md\`).
- \`optionGenerator\`/\`optionScorer\` — pack-aware proxy options + \`styleAlignment\` subscore (0.15 when pack present).
- \`.env.example\` + \`scripts/check-env.cjs\` — \`STYLE_PACK_ENABLED\` as **optional** flag.
- New tests pin: extractor determinism, schema validity, leak guard against hash payload pollution, no-pack regression hash, weight reallocation.

## Documented design calls (PLAN-AMBIGUITY)

1. Pack hash enters \`geometryHash\` payload only when a pack exists — preserves no-portfolio byte-identical fallback.
2. \`extractedAt\` is a stable epoch timestamp, excluded from the hashed payload.
3. Audit fields (\`portfolio_style_pack_hash\`, \`portfolio_style_pack\`) emitted only when a pack exists.
4. Non-rectangular \`massingTendency.form\` represented by aspect-aligned rectangular proxies in v1 (\`optionGenerator\` still emits rectangles). Follow-up ticket recommended.

## Out-of-scope edits bundled in this commit (flagged by audit)

- \`visualManifestService.deriveMainEntry\`
- \`drawingConsistencyChecks\` opening-count semantics split
- Address-casing fix (\`Uk\` → \`UK\`), site-map \`drawPolygonOverlay\` gating, "Boundary source:" label, \`mixed-use\` alias change

These should ideally have been separate commits — calling out so reviewers know to inspect them.

## Validation

- \`npm run check:env\` ✅
- \`npm run check:contracts\` ✅
- \`npm run test:compose:routing\` 22/22 ✅
- \`npx react-scripts test --testPathPattern=\"styleExtractor|styleConstraintApplier\"\` 13/13 ✅
- \`npx react-scripts test --testPathPattern=\"localStylePack\"\` 22/22 ✅
- \`npx react-scripts test --testPathPattern=\"projectGraphVerticalSliceService\" -t \"Style Pack is deterministic\"\` 1/1 ✅ (no-pack hash pin holds)
- \`npm run lint\` ✅
- \`npm run build:active\` — not run in audit; recommend running once before merging.

## Test plan

- [ ] CI green
- [ ] \`npm run build:active\` clean on this branch
- [ ] Spot-check with a real portfolio upload locally; confirm \`verticalSlice.style_pack\` surfaces on the result and \`STYLE_PACK_ENABLED=false\` returns the pre-change behaviour.
- [ ] Review the four PLAN-AMBIGUITY decisions in \`docs/style-pack/IMPLEMENTATION_NOTES.md\`.
- [ ] File follow-up ticket: "Extend optionGenerator to emit non-rectangular footprints driven by massingTendency.form".

Audit report: \`docs/style-pack/AUDIT.md\` (worktree copy).


## Pre-merge real-portfolio smoke (commit 2446d87)

Smoke harness added in `scripts/smoke/`. Run against 3 real portfolio PDFs from `D:\Training data AIARCHI\portfolio\` (seed `20260518`). Full report at `outputs/style-pack-smoke/REPORT.md` (gitignored).

**Result: 5/5 acceptance criteria PASS.**

| Criterion | Verdict |
|---|---|
| Style Pack JSON with all schema fields populated | PASS (`stylePackHash 0beb80bc…`, primary materials `[brick, timber, slate]`) |
| `geometryHash` with pack ≠ no-pack hash | PASS (`441524a7f481096c` vs no-pack baseline) |
| Hash stable across two runs with same seed | PASS (both server runs produced `441524a7f481096c`) |
| A1 sheet visibly reflects portfolio | PASS — material-palette panel shows brick/timber labels driven by pack fallback |
| DXF + IFC export without errors | PASS (DXF 38 953 B, IFC 20 617 B, both header-valid) |

### Caveats (for reviewer transparency)

- **Smoke run hit the image-only PDF fallback path; text-extraction path covered by unit tests** (`src/__tests__/services/styleExtractor.test.js` + `expected-pack-portfolio-textPDF.json`). All 3 picked real-portfolio PDFs were `PDF_TEXT_NOT_SELECTABLE`, so the extractor used `MATERIAL_FALLBACKS_BY_TYPE[dwelling]`. The rich-evidence path is unit-tested but not re-verified end-to-end in this smoke.
- **Smoke run with reasoning + image-gen disabled; full-fat run scheduled post-merge on preview.** Environment used `PROJECT_GRAPH_OPENAI_REASONING_MODE=disabled` and `PROJECT_GRAPH_IMAGE_GEN_ENABLED=false` to avoid API spend. Slice still emitted a complete A1 sheet via deterministic fallbacks. Photoreal panels and LLM-enriched reasoning narratives were not exercised end-to-end; preview deployment will cover them with the normal env.
