### PR TITLE
CL-1: render-provider abstraction for ProjectGraph rendered panels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,22 @@ PROJECT_GRAPH_OPENAI_REASONING_MODE=required
 # panels and OpenAI image usage is exactly zero. The deterministic SVG path
 # is the only path that runs in CI.
 PROJECT_GRAPH_IMAGE_GEN_ENABLED=false
+# CL-1 of the ControlNet/Redux render-stack plan introduces an explicit
+# provider selector for the rendered-panel layer (mock | openai | replicate).
+# Leaving this unset preserves byte-identical legacy behaviour:
+#   - PROJECT_GRAPH_IMAGE_GEN_ENABLED=true → implicit "openai".
+#   - PROJECT_GRAPH_IMAGE_GEN_ENABLED=false → deterministic fallback.
+# Setting `mock` selects the deterministic-fallback path explicitly: the
+# renderer does NOT produce a rasterised PNG and does NOT call any paid
+# API. The compiled control SVG remains the panel asset; artifacts stamp
+# providerUsed=deterministic / imageProviderUsed=deterministic /
+# imageRenderFallback=true / imageRenderFallbackReason=mock_provider with
+# sourceGaps including MOCK_PROVIDER_NO_RENDER. Use this in local dev or
+# tests when you want to force deterministic visuals while keeping OpenAI
+# keys intact in the environment.
+# Setting `replicate` is currently a stub (real adapter lands in CL-4
+# behind PROJECT_GRAPH_CONTROLNET_RENDER_ENABLED).
+# PROJECT_GRAPH_RENDER_PROVIDER=
 # If true, visual panels fail instead of silently falling back when OpenAI image generation fails.
 OPENAI_STRICT_IMAGE_GEN=false
 # Optional: enable AI texture thumbnails over the procedural material cards.

--- a/scripts/check-env.cjs
+++ b/scripts/check-env.cjs
@@ -125,6 +125,11 @@ const OPTIONAL_PRESENTATION = [
       "Set true to call OpenAI image generation for ProjectGraph visual panels",
   },
   {
+    name: "PROJECT_GRAPH_RENDER_PROVIDER",
+    description:
+      "CL-1 explicit render-provider selector (mock | openai | replicate). When unset the renderer falls back to the legacy behaviour: implicit openai if PROJECT_GRAPH_IMAGE_GEN_ENABLED=true, else deterministic. `replicate` is a stub until CL-4.",
+  },
+  {
     name: "OPENAI_STRICT_IMAGE_GEN",
     description:
       "Set true to fail visual panels instead of falling back after OpenAI image errors",

--- a/src/__tests__/services/projectGraphMockProviderVerticalSlice.test.js
+++ b/src/__tests__/services/projectGraphMockProviderVerticalSlice.test.js
@@ -1,0 +1,175 @@
+/**
+ * CL-1 (audit fix): vertical-slice contract for PROJECT_GRAPH_RENDER_PROVIDER=mock.
+ *
+ * The audit blocker was: an earlier mock implementation returned a pngBuffer +
+ * provenance, and `projectGraphVerticalSliceService.js` treats any truthy
+ * `renderProvenance` as a successful OpenAI photoreal render
+ * (lines 9757-9760, 9804). That would have leaked mock output through as
+ * `providerUsed=openai`, `imageProviderUsed=openai`,
+ * `asset_type=geometry_locked_presentation_svg`.
+ *
+ * This test exercises the REAL `renderProjectGraphPanelImage` through
+ * `buildVisual3DPanelArtifacts` with the mock provider selected and asserts
+ * the artifact metadata is unambiguously deterministic — no photoreal stamps
+ * anywhere. Any future regression that re-introduces a pngBuffer from the
+ * mock path will trip these assertions.
+ */
+
+import {
+  buildVisual3DPanelArtifacts,
+  buildResultPanelMap,
+} from "../../services/project/projectGraphVerticalSliceService.js";
+import { ensureCompiledProjectRenderInputs } from "../../services/compiler/compiledProjectRenderInputs.js";
+import { MOCK_PROVIDER_SOURCE_GAP } from "../../services/render/providers/mockProjectGraphRenderProvider.js";
+
+jest.mock("../../services/compiler/compiledProjectRenderInputs.js", () => ({
+  ensureCompiledProjectRenderInputs: jest.fn(),
+}));
+
+const PANEL_TYPES = [
+  "hero_3d",
+  "exterior_render",
+  "axonometric",
+  "interior_3d",
+];
+const GEOMETRY_HASH = "geom-mock-provider-contract";
+
+function makeRenderInputs() {
+  return Object.fromEntries(
+    PANEL_TYPES.map((panelType) => [
+      panelType,
+      {
+        svgString: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 80"><rect width="100" height="80"/><text>${panelType}</text></svg>`,
+        svgHash: `control-svg-hash-${panelType}`,
+        controlViewType: `${panelType}_control`,
+        width: 100,
+        height: 80,
+        metadata: {
+          width: 100,
+          height: 80,
+          normalizedViewBox: "0 0 100 80",
+          camera: { view: panelType },
+          controlViewType: `${panelType}_control`,
+        },
+      },
+    ]),
+  );
+}
+
+function makeBaseArgs() {
+  return {
+    compiledProject: {
+      geometryHash: GEOMETRY_HASH,
+      levels: [{ id: "ground", height_m: 3 }],
+    },
+    geometryHash: GEOMETRY_HASH,
+    brief: { project_name: "Mock Provider Contract", building_type: "house" },
+    visualManifest: { manifestId: "vm-mock", manifestHash: "vm-hash-mock" },
+    programmeSummary: { totalAreaM2: 100 },
+    region: "London",
+  };
+}
+
+describe("buildVisual3DPanelArtifacts — PROJECT_GRAPH_RENDER_PROVIDER=mock contract", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    // Even with the legacy gate ON, the explicit mock provider must take
+    // precedence and produce deterministic-fallback metadata.
+    process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED = "true";
+    process.env.PROJECT_GRAPH_RENDER_PROVIDER = "mock";
+    process.env.OPENAI_STRICT_IMAGE_GEN = "false";
+    // Set a key so the openai validateAvailable would pass — proves mock
+    // wins over a fully-configured OpenAI environment.
+    process.env.OPENAI_IMAGES_API_KEY = "sk-test-mock-contract";
+    jest.clearAllMocks();
+    ensureCompiledProjectRenderInputs.mockReturnValue(makeRenderInputs());
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test("each visual artifact carries deterministic stamps, never openai/photoreal", async () => {
+    const artifacts = await buildVisual3DPanelArtifacts(makeBaseArgs());
+
+    const artifactList = Object.values(artifacts);
+    expect(artifactList.length).toBe(PANEL_TYPES.length);
+
+    const observedPanelTypes = artifactList
+      .map((a) => a.panel_type || a.panelType)
+      .sort();
+    expect(observedPanelTypes).toEqual([...PANEL_TYPES].sort());
+
+    for (const artifact of artifactList) {
+      const panelType = artifact.panel_type || artifact.panelType;
+
+      // Asset type must remain the compiled control SVG — never the
+      // geometry-locked photoreal wrapper.
+      expect(artifact.asset_type).toBe("compiled_3d_control_svg");
+      expect(artifact.asset_type).not.toBe("geometry_locked_presentation_svg");
+
+      // Per-panel metadata stamps required by the audit.
+      expect(artifact.metadata.imageRenderFallback).toBe(true);
+      expect(artifact.metadata.imageRenderFallbackReason).toBe("mock_provider");
+      expect(artifact.metadata.providerUsed).toBe("deterministic");
+      expect(artifact.metadata.imageProviderUsed).toBe("deterministic");
+
+      // Negative assertions: none of the photoreal markers may appear.
+      expect(artifact.metadata.providerUsed).not.toBe("openai");
+      expect(artifact.metadata.imageProviderUsed).not.toBe("openai");
+      expect(artifact.metadata.visualRenderMode).not.toBe(
+        "photoreal_image_gen",
+      );
+      expect(artifact.metadata.openaiImageUsed).not.toBe(true);
+
+      // CL-1 (re-audit fix): sourceGaps must propagate through the artifact
+      // top-level AND artifact.metadata so downstream UI/QA can explain WHY
+      // the panel landed on deterministic fallback.
+      expect(Array.isArray(artifact.sourceGaps)).toBe(true);
+      expect(artifact.sourceGaps).toContain(MOCK_PROVIDER_SOURCE_GAP);
+      expect(Array.isArray(artifact.metadata.sourceGaps)).toBe(true);
+      expect(artifact.metadata.sourceGaps).toContain(MOCK_PROVIDER_SOURCE_GAP);
+      // Literal pin so a refactor cannot rename the gap unnoticed.
+      expect(MOCK_PROVIDER_SOURCE_GAP).toBe("MOCK_PROVIDER_NO_RENDER");
+
+      // Sanity: panel_type is one of the four 3D types and geometry hash
+      // chain is preserved.
+      expect(panelType).toMatch(
+        /^(hero_3d|exterior_render|axonometric|interior_3d)$/,
+      );
+      expect(
+        artifact.metadata.sourceGeometryHash ||
+          artifact.metadata.geometryHash ||
+          artifact.geometryHash ||
+          GEOMETRY_HASH,
+      ).toBe(GEOMETRY_HASH);
+    }
+  });
+
+  test("buildResultPanelMap propagates sourceGaps into the result panel projection", async () => {
+    // CL-1 (re-audit fix): the panelMap projection consumed by the UI/result
+    // builders must carry sourceGaps both at the top level and inside the
+    // cloned metadata. Otherwise downstream consumers cannot tell mock
+    // fallback from a real deterministic-fallback.
+    const artifacts = await buildVisual3DPanelArtifacts(makeBaseArgs());
+    const panelMap = buildResultPanelMap(artifacts);
+
+    expect(Object.keys(panelMap).sort()).toEqual([...PANEL_TYPES].sort());
+
+    for (const panelType of PANEL_TYPES) {
+      const panel = panelMap[panelType];
+      expect(panel).toBeDefined();
+      expect(Array.isArray(panel.sourceGaps)).toBe(true);
+      expect(panel.sourceGaps).toContain(MOCK_PROVIDER_SOURCE_GAP);
+      expect(Array.isArray(panel.metadata.sourceGaps)).toBe(true);
+      expect(panel.metadata.sourceGaps).toContain(MOCK_PROVIDER_SOURCE_GAP);
+
+      // Negative: panelMap must not advertise photoreal markers either.
+      expect(panel.metadata.providerUsed).not.toBe("openai");
+      expect(panel.metadata.imageProviderUsed).not.toBe("openai");
+      expect(panel.sourceType).toBe("compiled_3d_control_svg");
+    }
+  });
+});

--- a/src/__tests__/services/render/projectGraphImageRenderer.providerAbstraction.test.js
+++ b/src/__tests__/services/render/projectGraphImageRenderer.providerAbstraction.test.js
@@ -1,0 +1,296 @@
+/**
+ * CL-1: provider-abstraction tests for projectGraphImageRenderer.
+ *
+ * These tests cover the NEW behaviour introduced by the registry seam —
+ * mock provider, replicate stub, unknown provider, and the structured
+ * `sourceGaps` field. Pre-existing OpenAI behaviour is covered in
+ * `../projectGraphImageRenderer.test.js`; both suites must stay green.
+ */
+
+import { renderProjectGraphPanelImage } from "../../../services/render/projectGraphImageRenderer.js";
+import {
+  selectProvider,
+  describeProviderRegistry,
+  KNOWN_PROVIDER_NAMES,
+  RENDER_PROVIDER_ENV_VAR,
+} from "../../../services/render/providers/renderProviderRegistry.js";
+import { rasteriseSvgToPng } from "../../../services/render/svgRasteriser.js";
+import { validateTechnicalPanelAuthority } from "../../../services/validation/drawingConsistencyChecks.js";
+
+jest.mock("../../../services/render/svgRasteriser.js", () => ({
+  rasteriseSvgToPng: jest.fn(),
+}));
+
+const REFERENCE_PNG = Buffer.from("rasterised-control-svg-bytes");
+const VALID_ARGS = {
+  panelType: "hero_3d",
+  deterministicSvg: "<svg><rect width='10' height='10'/></svg>",
+  prompt: "Render a 1.5-storey UK vernacular brick farmhouse",
+  geometryHash: "geo-hash-abc",
+};
+
+describe("renderProjectGraphPanelImage provider abstraction (CL-1)", () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.OPENAI_IMAGES_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_REASONING_API_KEY;
+    delete process.env.REACT_APP_OPENAI_API_KEY;
+    delete process.env.PROJECT_GRAPH_IMAGE_GEN_ENABLED;
+    delete process.env.OPENAI_STRICT_IMAGE_GEN;
+    delete process.env.PROJECT_GRAPH_RENDER_PROVIDER;
+    global.fetch = jest.fn(() => {
+      throw new Error("fetch should not be invoked when provider != openai");
+    });
+    rasteriseSvgToPng.mockResolvedValue({ pngBuffer: REFERENCE_PNG });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  describe("registry", () => {
+    test("known providers", () => {
+      expect(KNOWN_PROVIDER_NAMES).toEqual(
+        expect.arrayContaining(["openai", "mock", "replicate"]),
+      );
+    });
+
+    test("no env → gate_disabled (no provider selected)", () => {
+      const selection = selectProvider({ env: {} });
+      expect(selection.provider).toBeNull();
+      expect(selection.reason).toBe("gate_disabled");
+    });
+
+    test("PROJECT_GRAPH_IMAGE_GEN_ENABLED=true (no explicit) → legacy_implicit openai", () => {
+      const selection = selectProvider({
+        env: { PROJECT_GRAPH_IMAGE_GEN_ENABLED: "true" },
+      });
+      expect(selection.resolvedName).toBe("openai");
+      expect(selection.reason).toBe("legacy_implicit");
+    });
+
+    test("PROJECT_GRAPH_RENDER_PROVIDER=mock → explicit mock", () => {
+      const selection = selectProvider({
+        env: { [RENDER_PROVIDER_ENV_VAR]: "mock" },
+      });
+      expect(selection.resolvedName).toBe("mock");
+      expect(selection.reason).toBe("explicit");
+    });
+
+    test("PROJECT_GRAPH_RENDER_PROVIDER=foo → unknown_provider", () => {
+      const selection = selectProvider({
+        env: { [RENDER_PROVIDER_ENV_VAR]: "foo" },
+      });
+      expect(selection.provider).toBeNull();
+      expect(selection.reason).toBe("unknown_provider");
+      expect(selection.explicitRequest).toBe("foo");
+    });
+
+    test("describeProviderRegistry returns diagnostics", () => {
+      const description = describeProviderRegistry({
+        PROJECT_GRAPH_RENDER_PROVIDER: "mock",
+      });
+      expect(description.selectedProvider).toBe("mock");
+      expect(description.selectionReason).toBe("explicit");
+      expect(description.providers.mock.configured).toBe(true);
+      expect(description.providers.replicate.configured).toBe(false);
+    });
+  });
+
+  describe("renderer dispatch", () => {
+    test("PROJECT_GRAPH_RENDER_PROVIDER=mock returns null PNG + deterministic markers (no synthetic render)", async () => {
+      // Audit fix: mock must NEVER masquerade as a successful render. It
+      // returns the deterministic-fallback shape so the slice service keeps
+      // the compiled control SVG as the panel asset.
+      process.env.PROJECT_GRAPH_RENDER_PROVIDER = "mock";
+
+      const result = await renderProjectGraphPanelImage(VALID_ARGS);
+
+      expect(result.pngBuffer).toBeNull();
+      expect(result.provider).toBe("mock");
+      expect(result.providerUsed).toBe("deterministic");
+      expect(result.imageProviderUsed).toBe("deterministic");
+      expect(result.imageRenderFallback).toBe(true);
+      expect(result.imageRenderFallbackReason).toBe("mock_provider");
+      expect(result.fallbackReason).toBe("mock_provider");
+      expect(result.sourceGaps).toEqual(["MOCK_PROVIDER_NO_RENDER"]);
+      expect(result.provenance.sourceGeometryHash).toBe("geo-hash-abc");
+      expect(global.fetch).not.toHaveBeenCalled();
+      // No rasterisation either — mock unavailable short-circuits before the
+      // orchestrator's rasteriseSvgToPng call.
+      expect(rasteriseSvgToPng).not.toHaveBeenCalled();
+    });
+
+    test("mock provenance mirrors deterministic stamps so the slice service stamps providerUsed=deterministic", async () => {
+      // The slice service uses
+      //   const provider = renderProvenance ? "openai" : "deterministic";
+      // at projectGraphVerticalSliceService.js:9757 to decide artifact
+      // metadata. renderProvenance is set only when renderResult.pngBuffer
+      // is truthy AND the IoU gate passes. With pngBuffer=null the slice
+      // service breaks the render loop early (line 9641) and renderProvenance
+      // stays null → "deterministic" everywhere.
+      process.env.PROJECT_GRAPH_RENDER_PROVIDER = "mock";
+
+      const result = await renderProjectGraphPanelImage(VALID_ARGS);
+
+      // Reproduce the slice service's gating condition verbatim.
+      const sliceRenderProvenance = result.pngBuffer ? result.provenance : null;
+      expect(sliceRenderProvenance).toBeNull();
+
+      // What the slice would stamp under that condition.
+      const sliceArtifactProvider = sliceRenderProvenance
+        ? "openai"
+        : "deterministic";
+      const sliceArtifactAssetType = sliceRenderProvenance
+        ? "geometry_locked_presentation_svg"
+        : "compiled_3d_control_svg";
+
+      expect(sliceArtifactProvider).toBe("deterministic");
+      expect(sliceArtifactAssetType).toBe("compiled_3d_control_svg");
+      // And the renderer's own metadata must not advertise openai/photoreal.
+      expect(result.providerUsed).not.toBe("openai");
+      expect(result.imageProviderUsed).not.toBe("openai");
+      expect(result.provenance.providerUsed).toBe("deterministic");
+      expect(result.provenance.imageProviderUsed).toBe("deterministic");
+    });
+
+    test("PROJECT_GRAPH_RENDER_PROVIDER=replicate stub falls back with PROVIDER_NOT_IMPLEMENTED gap", async () => {
+      process.env.PROJECT_GRAPH_RENDER_PROVIDER = "replicate";
+
+      const result = await renderProjectGraphPanelImage(VALID_ARGS);
+
+      expect(result.pngBuffer).toBeNull();
+      expect(result.provider).toBe("replicate");
+      expect(result.imageProviderUsed).toBe("deterministic");
+      expect(result.imageRenderFallbackReason).toBe("PROVIDER_NOT_IMPLEMENTED");
+      expect(result.sourceGaps).toEqual(["PROVIDER_NOT_IMPLEMENTED"]);
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(rasteriseSvgToPng).not.toHaveBeenCalled();
+    });
+
+    test("PROJECT_GRAPH_RENDER_PROVIDER=foo (unknown) returns UNKNOWN_PROVIDER gap", async () => {
+      process.env.PROJECT_GRAPH_RENDER_PROVIDER = "foo";
+
+      const result = await renderProjectGraphPanelImage(VALID_ARGS);
+
+      expect(result.pngBuffer).toBeNull();
+      expect(result.imageRenderFallbackReason).toBe("unknown_provider");
+      expect(result.sourceGaps).toEqual(["UNKNOWN_PROVIDER:foo"]);
+      expect(rasteriseSvgToPng).not.toHaveBeenCalled();
+    });
+
+    test("no env at all → gate_disabled with IMAGE_GEN_DISABLED gap", async () => {
+      const result = await renderProjectGraphPanelImage(VALID_ARGS);
+
+      expect(result.pngBuffer).toBeNull();
+      expect(result.imageProviderUsed).toBe("deterministic");
+      expect(result.imageRenderFallbackReason).toBe("gate_disabled");
+      expect(result.sourceGaps).toEqual(["IMAGE_GEN_DISABLED"]);
+      expect(rasteriseSvgToPng).not.toHaveBeenCalled();
+    });
+
+    test("explicit mock with missing deterministicSvg falls back without rasterising", async () => {
+      process.env.PROJECT_GRAPH_RENDER_PROVIDER = "mock";
+
+      const result = await renderProjectGraphPanelImage({
+        ...VALID_ARGS,
+        deterministicSvg: "",
+      });
+
+      expect(result.pngBuffer).toBeNull();
+      expect(result.imageRenderFallbackReason).toBe("missing_control_svg");
+      expect(result.provider).toBe("mock");
+      expect(rasteriseSvgToPng).not.toHaveBeenCalled();
+    });
+
+    test("strict mode does NOT throw for explicit mock provider failures", async () => {
+      // Strict mode is OpenAI-specific; selecting mock explicitly should
+      // never escalate to a strict throw even when the gate flag is set.
+      process.env.PROJECT_GRAPH_RENDER_PROVIDER = "mock";
+      process.env.OPENAI_STRICT_IMAGE_GEN = "true";
+
+      const result = await renderProjectGraphPanelImage({
+        ...VALID_ARGS,
+        prompt: "",
+      });
+
+      expect(result.imageRenderFallbackReason).toBe("missing_prompt");
+      expect(result.provider).toBe("mock");
+    });
+
+    test("rendered result always carries geometryHash + deterministic provenance for mock", async () => {
+      process.env.PROJECT_GRAPH_RENDER_PROVIDER = "mock";
+
+      const result = await renderProjectGraphPanelImage(VALID_ARGS);
+
+      expect(result.provenance).toMatchObject({
+        sourceGeometryHash: "geo-hash-abc",
+        provider: "mock",
+        providerUsed: "deterministic",
+        imageProviderUsed: "deterministic",
+        imageRenderFallback: true,
+        imageRenderFallbackReason: "mock_provider",
+        referenceSource: "compiled_3d_control_svg",
+      });
+    });
+  });
+
+  describe("technical-panel non-contamination (regression)", () => {
+    // CL-1 refactor must not change the drawing-consistency contract: any
+    // technical panel stamped with an image-model provider stays a blocker,
+    // and a clean deterministic-SVG technical panel passes.
+    const TECHNICAL_GEOMETRY_HASH = "tech-geo-hash-1";
+    const TECHNICAL_SVG =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+
+    function cleanTechnicalPanels(overrides = {}) {
+      const make = (type) => ({
+        type,
+        svg: TECHNICAL_SVG,
+        geometryHash: TECHNICAL_GEOMETRY_HASH,
+        sourceGeometryHash: TECHNICAL_GEOMETRY_HASH,
+        source_model_hash: TECHNICAL_GEOMETRY_HASH,
+        technicalDrawing: true,
+        renderer: "deterministic_svg",
+        providerUsed: "deterministic_svg",
+        imageProviderUsed: "none",
+        source: "compiled_project_technical_panel",
+        ...(overrides[type] || {}),
+      });
+      return [
+        make("floor_plan_ground"),
+        make("elevation_north"),
+        make("section_AA"),
+      ];
+    }
+
+    test("clean deterministic-SVG technical panels pass after CL-1", () => {
+      const result = validateTechnicalPanelAuthority({
+        technicalPanels: cleanTechnicalPanels(),
+        expectedGeometryHash: TECHNICAL_GEOMETRY_HASH,
+      });
+      expect(result.errors).toEqual([]);
+    });
+
+    test("technical panel stamped imageProviderUsed=openai still trips TECHNICAL_PANEL_IMAGE_MODEL_USED", () => {
+      const result = validateTechnicalPanelAuthority({
+        technicalPanels: cleanTechnicalPanels({
+          floor_plan_ground: {
+            providerUsed: "openai",
+            imageProviderUsed: "openai",
+          },
+        }),
+        expectedGeometryHash: TECHNICAL_GEOMETRY_HASH,
+      });
+      expect(result.errors.map((error) => error.code)).toContain(
+        "TECHNICAL_PANEL_IMAGE_MODEL_USED",
+      );
+    });
+  });
+});

--- a/src/__tests__/services/render/providers/mockProjectGraphRenderProvider.test.js
+++ b/src/__tests__/services/render/providers/mockProjectGraphRenderProvider.test.js
@@ -1,0 +1,65 @@
+/**
+ * CL-1 (audit fix): unit tests for the mock ProjectGraph render provider.
+ *
+ * The mock provider is unavailable for rendering by design — selecting it
+ * flows through the renderer's deterministic-fallback path so no PNG buffer
+ * or provenance is ever produced. These tests pin that contract so a future
+ * refactor cannot re-introduce the "mock returns a synthetic PNG" regression
+ * that the CL-1 audit blocked.
+ */
+
+import mockProvider, {
+  getConfig,
+  validateAvailable,
+  render,
+  MOCK_PROVIDER_VERSION,
+  MOCK_PROVIDER_FALLBACK_REASON,
+  MOCK_PROVIDER_SOURCE_GAP,
+} from "../../../../services/render/providers/mockProjectGraphRenderProvider.js";
+
+describe("mockProjectGraphRenderProvider", () => {
+  test("exports a frozen provider object with name=mock", () => {
+    expect(mockProvider.name).toBe("mock");
+    expect(mockProvider.version).toBe(MOCK_PROVIDER_VERSION);
+    expect(Object.isFrozen(mockProvider)).toBe(true);
+  });
+
+  test("getConfig advertises rendersImages=false", () => {
+    const config = getConfig();
+    expect(config).toMatchObject({
+      provider: "mock",
+      configured: true,
+      rendersImages: false,
+    });
+  });
+
+  test("validateAvailable returns available=false with mock_provider fallback", () => {
+    expect(validateAvailable()).toEqual({
+      available: false,
+      fallbackReason: MOCK_PROVIDER_FALLBACK_REASON,
+      sourceGaps: [MOCK_PROVIDER_SOURCE_GAP],
+    });
+  });
+
+  test("MOCK_PROVIDER_FALLBACK_REASON is the literal 'mock_provider'", () => {
+    // Pin the literal so the slice service's
+    // `imageRenderFallbackReason === "mock_provider"` contract holds.
+    expect(MOCK_PROVIDER_FALLBACK_REASON).toBe("mock_provider");
+  });
+
+  test("render is a defensive throw — it must never be called in production", async () => {
+    // If a future refactor accidentally bypasses validateAvailable, render
+    // throws rather than silently producing a buffer.
+    await expect(render()).rejects.toMatchObject({
+      code: "MOCK_PROVIDER_RENDER_INVOKED",
+      fallbackReason: "mock_provider",
+    });
+  });
+
+  test("render never returns a buffer (no synthetic PNG path exists)", async () => {
+    // Defensive: capture the contract verbally.
+    await expect(
+      render({ panelType: "hero_3d", referencePng: Buffer.from("x") }),
+    ).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/src/services/project/projectGraphVerticalSliceService.js
+++ b/src/services/project/projectGraphVerticalSliceService.js
@@ -9758,6 +9758,20 @@ export async function buildVisual3DPanelArtifacts({
       const providerUsed = renderProvenance ? "openai" : "deterministic";
       const imageProviderUsed = renderProvenance ? "openai" : "deterministic";
       const imageRenderFallback = renderProvenance === null;
+      // CL-1 (audit re-fix): structured source gaps from the render provider
+      // must surface on the visual artifact so downstream consumers (UI,
+      // QA, manifest validators) can explain WHY a panel landed on
+      // deterministic fallback — e.g. ["MOCK_PROVIDER_NO_RENDER"],
+      // ["IMAGE_GEN_DISABLED"], ["PROVIDER_NOT_IMPLEMENTED"], or
+      // ["UNKNOWN_PROVIDER:foo"]. Empty array when the renderer succeeded or
+      // when image gen is skipped via renderQualityTier.
+      const sourceGaps =
+        Array.isArray(renderResult?.sourceGaps) &&
+        renderResult.sourceGaps.length > 0
+          ? [...renderResult.sourceGaps]
+          : Array.isArray(renderResult?.provenance?.sourceGaps)
+            ? [...renderResult.provenance.sourceGaps]
+            : [];
       const renderModel =
         renderProvenance?.model || renderResult?.model || null;
       const requestId =
@@ -9828,6 +9842,7 @@ export async function buildVisual3DPanelArtifacts({
           imageProviderUsed,
           imageRenderFallback,
           imageRenderFallbackReason,
+          sourceGaps,
           model: renderModel,
           requestId,
           usage,
@@ -9866,6 +9881,7 @@ export async function buildVisual3DPanelArtifacts({
             providerUsed,
             imageRenderFallback,
             imageRenderFallbackReason,
+            sourceGaps: [...sourceGaps],
             imageRenderModel: renderModel,
             model: renderModel,
             imageRenderSize: renderProvenance?.size || null,
@@ -12193,7 +12209,7 @@ function svgToDataUrl(svgString = "") {
   return svgToSanitizedDataUrl(String(svgString || ""));
 }
 
-function buildResultPanelMap(panelArtifacts = {}) {
+export function buildResultPanelMap(panelArtifacts = {}) {
   return Object.fromEntries(
     artifactArray(panelArtifacts)
       .filter((artifact) => artifact?.panel_type || artifact?.panelType)
@@ -12229,6 +12245,13 @@ function buildResultPanelMap(panelArtifacts = {}) {
             variationMode: artifact.variationMode || null,
             source_model_hash: artifact.source_model_hash || null,
             svgHash: artifact.svgHash || null,
+            // CL-1 (audit re-fix): expose render-provider source gaps on the
+            // result panel projection so UI/QA consumers can see WHY a panel
+            // is on deterministic fallback (e.g. ["MOCK_PROVIDER_NO_RENDER"],
+            // ["IMAGE_GEN_DISABLED"], ["PROVIDER_NOT_IMPLEMENTED"]).
+            sourceGaps: Array.isArray(artifact.sourceGaps)
+              ? [...artifact.sourceGaps]
+              : [],
             metadata: cloneData(artifact.metadata || {}),
           },
         ];

--- a/src/services/render/projectGraphImageRenderer.js
+++ b/src/services/render/projectGraphImageRenderer.js
@@ -8,9 +8,9 @@
  *   1. Rasterising the deterministic SVG to a PNG silhouette / massing
  *      reference (preserves geometry: footprint, opening positions, roof
  *      shape, storey count).
- *   2. Calling OpenAI's `/v1/images/edits` endpoint with the PNG as the
- *      reference image plus a climate + style + programme aware prompt
- *      (built by `panelPromptBuilders.js`).
+ *   2. Dispatching the rasterised reference + prompt to a selected render
+ *      provider (openai / mock / replicate-stub) via the provider registry
+ *      in `./providers/renderProviderRegistry.js`.
  *   3. Returning the rendered PNG bytes plus provenance.
  *
  * The reference-image approach is critical: text-only prompts cannot
@@ -19,163 +19,47 @@
  * compiled-geometry silhouette, the generated render shares the SAME
  * geometry hash as every other panel.
  *
- * Pipeline mode gating: only runs when `PIPELINE_MODE=project_graph` (or
- * unset → default project_graph) AND `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true`.
- * Falls back to the deterministic SVG cleanly when disabled or on failure.
+ * Provider selection — CL-1:
+ *   - `PROJECT_GRAPH_RENDER_PROVIDER` explicit values: `openai|mock|replicate`.
+ *   - When unset and `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true`, legacy implicit
+ *     `openai` (byte-identical to pre-CL-1 production behaviour).
+ *   - When unset and `PROJECT_GRAPH_IMAGE_GEN_ENABLED=false`, deterministic
+ *     fallback with `imageRenderFallbackReason: "gate_disabled"`.
+ *   - `replicate` is a stub returning `PROVIDER_NOT_IMPLEMENTED` until CL-4.
+ *
+ * Hard invariants (per the approved plan):
+ *   - ProjectGraph / compiledProject is the only geometry authority.
+ *     Image-model output never feeds back into deterministic SVG / DXF /
+ *     IFC / JSON / XLSX. Enforced by `drawingConsistencyChecks.js`.
+ *   - `geometryHash` is the cross-artifact identity key; CL-2 will add
+ *     `controlSvgHash`, `footprintMaskHash`, `depthHash`, `lineartHash`
+ *     and CL-3 `reduxReferenceSetHash`, all carried through the request /
+ *     result shape defined in `renderProviderRegistry.js`. None of those
+ *     enter `geometryHash`.
  *
  * @module services/render/projectGraphImageRenderer
  */
 
 import logger from "../../utils/logger.js";
-import openaiEnv from "../openaiProviderEnv.cjs";
 import { rasteriseSvgToPng } from "./svgRasteriser.js";
+import openaiImageEditProvider, {
+  getConfig as getOpenAIProviderConfig,
+  resolveImageGenEnabled,
+  resolveStrictImageGen,
+  resolveSize,
+  resolveImageModel,
+  PANEL_TYPE_TO_SIZE,
+} from "./providers/openaiImageEditProvider.js";
+import { selectProvider } from "./providers/renderProviderRegistry.js";
 
-const RENDERER_VERSION = "project-graph-image-renderer-v1";
+const RENDERER_VERSION = "project-graph-image-renderer-v2";
 
-const PANEL_TYPE_TO_SIZE = Object.freeze({
-  hero_3d: "1536x1024",
-  exterior_render: "1536x1024",
-  axonometric: "1024x1024",
-  interior_3d: "1280x1024",
-});
-
-const ALLOWED_OPENAI_SIZES = new Set([
-  "256x256",
-  "512x512",
-  "1024x1024",
-  "1024x1536",
-  "1536x1024",
-  "1024x1792",
-  "1792x1024",
-]);
-
-function parsePositiveInt(value, fallback, { min = 1 } = {}) {
-  const parsed = Number.parseInt(value || "", 10);
-  if (!Number.isFinite(parsed) || parsed < min) {
-    return fallback;
-  }
-  return parsed;
-}
-
-function createOpenAIRequestTimeoutSignal(timeoutMs, externalSignal) {
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return {
-      signal: externalSignal,
-      dispose: () => {},
-    };
-  }
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => {
-    controller.abort(
-      Object.assign(
-        new Error(`OpenAI request timed out after ${timeoutMs}ms`),
-        {
-          name: "AbortError",
-          code: "OPENAI_REQUEST_TIMEOUT",
-        },
-      ),
-    );
-  }, timeoutMs);
-
-  if (externalSignal) {
-    if (externalSignal.aborted) {
-      clearTimeout(timeoutId);
-      controller.abort(externalSignal.reason);
-    } else {
-      externalSignal.addEventListener(
-        "abort",
-        () => {
-          clearTimeout(timeoutId);
-          controller.abort(externalSignal.reason);
-        },
-        { once: true },
-      );
-    }
-  }
-
-  return {
-    signal: controller.signal,
-    dispose: () => clearTimeout(timeoutId),
-  };
-}
-
-async function fetchWithTimeout(
-  url,
-  options = {},
-  timeoutMs = 120_000,
-  { fetchImpl = global.fetch } = {},
-) {
-  const { signal: externalSignal, ...restOptions } = options;
-  const requestTimeout = createOpenAIRequestTimeoutSignal(
-    timeoutMs,
-    externalSignal,
-  );
-  try {
-    return await fetchImpl(url, {
-      ...restOptions,
-      signal: requestTimeout.signal,
-    });
-  } finally {
-    requestTimeout.dispose();
-  }
-}
-
-function resolveImageGenEnabled(env = process.env) {
-  return openaiEnv.isTruthy(
-    openaiEnv.readEnv(env, "PROJECT_GRAPH_IMAGE_GEN_ENABLED"),
-  );
-}
-
-function resolveStrictImageGen(env = process.env) {
-  return openaiEnv.isTruthy(openaiEnv.readEnv(env, "OPENAI_STRICT_IMAGE_GEN"));
-}
-
-function resolveImageModel(env = process.env) {
-  return (
-    openaiEnv.readEnv(env, "STEP_10_IMAGE_MODEL") ||
-    openaiEnv.readEnv(env, "OPENAI_IMAGE_MODEL") ||
-    "gpt-image-2"
-  ).trim();
-}
-
-function resolveSize(panelType) {
-  const target = PANEL_TYPE_TO_SIZE[panelType] || "1024x1024";
-  return ALLOWED_OPENAI_SIZES.has(target) ? target : "1024x1024";
-}
-
-function resolveOpenAIImageTimeoutMs(env = process.env) {
-  return parsePositiveInt(
-    openaiEnv.readEnv(env, "OPENAI_IMAGE_FETCH_TIMEOUT_MS"),
-    parsePositiveInt(
-      openaiEnv.readEnv(env, "OPENAI_REASONING_FETCH_TIMEOUT_MS"),
-      120_000,
-    ),
-    { min: 1000 },
-  );
-}
-
-function resolveOpenAIImageDownloadTimeoutMs(env = process.env) {
-  return parsePositiveInt(
-    openaiEnv.readEnv(env, "OPENAI_IMAGE_DOWNLOAD_TIMEOUT_MS"),
-    resolveOpenAIImageTimeoutMs(env),
-    { min: 1000 },
-  );
-}
-
+/**
+ * Legacy diagnostics export — returns the OpenAI provider snapshot so
+ * pre-CL-1 callers (tests, status endpoints) see the same shape.
+ */
 export function getProjectGraphImageProviderConfig(env = process.env) {
-  const keyInfo = openaiEnv.resolveOpenAIImageApiKeyInfo(env);
-  const orgProject = openaiEnv.getOpenAIOrgProjectDiagnostics(env);
-  return {
-    imageGenEnabled: resolveImageGenEnabled(env),
-    strictImageGen: resolveStrictImageGen(env),
-    openaiConfigured: keyInfo.hasKey,
-    keySource: keyInfo.keySource,
-    keyLast4: keyInfo.keyLast4,
-    warning: keyInfo.warning,
-    model: resolveImageModel(env),
-    ...orgProject,
-  };
+  return getOpenAIProviderConfig(env);
 }
 
 function createStrictImageError({ panelType, reason, error }) {
@@ -197,10 +81,12 @@ function createFallbackResult({
   reason,
   config,
   error,
+  providerName = "openai",
+  sourceGaps = [],
 }) {
   return {
     pngBuffer: null,
-    provider: "openai",
+    provider: providerName,
     providerUsed: "deterministic",
     imageProviderUsed: "deterministic",
     imageRenderFallback: true,
@@ -216,10 +102,11 @@ function createFallbackResult({
     usage: error?.usage || null,
     status: error?.status || null,
     error: error?.message || null,
+    sourceGaps,
     provenance: {
       renderer: RENDERER_VERSION,
       panelType,
-      provider: "openai",
+      provider: providerName,
       providerUsed: "deterministic",
       imageProviderUsed: "deterministic",
       imageRenderFallback: true,
@@ -235,22 +122,42 @@ function createFallbackResult({
       requestId: error?.requestId || null,
       usage: error?.usage || null,
       error: error?.message || null,
+      sourceGaps,
     },
   };
 }
 
-function handleFallback({ panelType, geometryHash, reason, config, error }) {
-  logger.warn(`[OpenAI] SKIP image edit panel=${panelType} reason=${reason}`, {
-    panelType,
-    reason,
-    strictImageGen: config.strictImageGen,
-    openaiConfigured: config.openaiConfigured,
-    keySource: config.keySource,
-    orgConfigured: config.orgConfigured,
-    projectConfigured: config.projectConfigured,
-    error: error?.message || null,
-  });
-  if (config.strictImageGen) {
+/**
+ * Strict-mode promotion applies ONLY when the intended provider was OpenAI
+ * (explicit `PROJECT_GRAPH_RENDER_PROVIDER=openai` or the legacy implicit
+ * gate). Selecting `mock` or `replicate` explicitly never escalates a
+ * fallback into a thrown error.
+ */
+function handleFallback({
+  panelType,
+  geometryHash,
+  reason,
+  config,
+  error,
+  providerName = "openai",
+  sourceGaps = [],
+}) {
+  logger.warn(
+    `[${providerName}] SKIP render panel=${panelType} reason=${reason}`,
+    {
+      panelType,
+      reason,
+      providerName,
+      strictImageGen: config.strictImageGen,
+      openaiConfigured: config.openaiConfigured,
+      keySource: config.keySource,
+      orgConfigured: config.orgConfigured,
+      projectConfigured: config.projectConfigured,
+      error: error?.message || null,
+      sourceGaps,
+    },
+  );
+  if (config.strictImageGen && providerName === "openai") {
     throw createStrictImageError({ panelType, reason, error });
   }
   return createFallbackResult({
@@ -259,154 +166,73 @@ function handleFallback({ panelType, geometryHash, reason, config, error }) {
     reason,
     config,
     error,
+    providerName,
+    sourceGaps,
   });
 }
 
-/**
- * Build a multipart/form-data body for the OpenAI images edit endpoint.
- * Uses the global FormData / Blob (Node 18+ supports both natively).
- */
-function buildImageEditFormData({ imageBuffer, prompt, model, size }) {
-  if (typeof FormData === "undefined" || typeof Blob === "undefined") {
-    throw new Error(
-      "FormData/Blob unavailable in this runtime; OpenAI images.edit requires Node 18+ or fetch polyfill.",
-    );
-  }
-  const form = new FormData();
-  form.set("model", model);
-  form.set("prompt", prompt);
-  form.set("size", size);
-  form.set("n", "1");
-  form.set(
-    "image",
-    new Blob([imageBuffer], { type: "image/png" }),
-    "reference.png",
-  );
-  return form;
-}
-
-/**
- * Call OpenAI `/v1/images/edits` with the reference image + prompt and
- * return the rendered PNG bytes. Throws on non-200 or empty response so the
- * caller can fall back to the deterministic SVG.
- */
-async function callOpenAIImageEdit({ imageBuffer, prompt, panelType, env }) {
-  const keyInfo = openaiEnv.resolveOpenAIImageApiKeyInfo(env);
-  if (!keyInfo.hasKey) {
-    const error = new Error(
-      "OPENAI_IMAGES_API_KEY, OPENAI_API_KEY, or OPENAI_REASONING_API_KEY is not set.",
-    );
-    error.fallbackReason = "missing_api_key";
-    throw error;
-  }
-  const model = resolveImageModel(env);
-  const size = resolveSize(panelType);
-  const form = buildImageEditFormData({ imageBuffer, prompt, model, size });
-
-  logger.info(`[OpenAI] START image edit panel=${panelType} model=${model}`, {
-    panelType,
-    model,
-    size,
-    keySource: keyInfo.keySource,
-    keyLast4: keyInfo.keyLast4,
-    ...openaiEnv.getOpenAIOrgProjectDiagnostics(env),
-  });
-
-  const response = await fetchWithTimeout(
-    "https://api.openai.com/v1/images/edits",
-    {
-      method: "POST",
-      headers: openaiEnv.buildOpenAIRequestHeaders(keyInfo, env),
-      body: form,
-    },
-    resolveOpenAIImageTimeoutMs(env),
-    { fetchImpl: global.fetch },
-  );
-
-  const requestId =
-    response.headers?.get?.("x-request-id") ||
-    response.headers?.get?.("openai-request-id") ||
-    null;
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(
-      `OpenAI images.edit failed (${response.status}): ${data?.error?.message || "unknown"}`,
-    );
-    error.status = response.status;
-    error.requestId = requestId;
-    error.usage = data?.usage || null;
-    error.fallbackReason = "openai_error";
-    logger.warn(`[OpenAI] FAIL image edit panel=${panelType}`, {
-      panelType,
-      model,
-      status: response.status,
-      requestId,
-      reason: data?.error?.message || "unknown",
-    });
-    throw error;
-  }
-
-  const entry = (data.data || [])[0];
-  if (!entry?.b64_json && !entry?.url) {
-    const error = new Error("OpenAI images.edit returned no image payload.");
-    error.requestId = requestId;
-    error.usage = data?.usage || null;
-    error.fallbackReason = "empty_response";
-    throw error;
-  }
-
-  let pngBuffer;
-  if (entry.b64_json) {
-    pngBuffer = Buffer.from(entry.b64_json, "base64");
-  } else {
-    const fetchResp = await fetchWithTimeout(
-      entry.url,
-      { method: "GET" },
-      resolveOpenAIImageDownloadTimeoutMs(env),
-      { fetchImpl: global.fetch },
-    );
-    if (!fetchResp.ok) {
-      throw new Error(
-        `Failed to download generated image: ${fetchResp.status}`,
-      );
-    }
-    const arrayBuffer = await fetchResp.arrayBuffer();
-    pngBuffer = Buffer.from(arrayBuffer);
-  }
-
-  logger.info(`[OpenAI] OK image edit panel=${panelType}`, {
-    panelType,
-    model,
-    requestId,
-    bytes: pngBuffer.length,
-    usage: data?.usage || null,
-  });
-
+function assembleSuccessResult({
+  panelType,
+  geometryHash,
+  providerResult,
+  qaAttemptLog,
+}) {
+  const meta = providerResult.providerMetadata || {};
+  const providerName = meta.provider || "openai";
   return {
-    pngBuffer,
-    model,
-    size,
-    revisedPrompt: entry.revised_prompt || null,
-    requestId,
-    usage: data?.usage || null,
-    keySource: keyInfo.keySource,
-    keyLast4: keyInfo.keyLast4,
-    ...openaiEnv.getOpenAIOrgProjectDiagnostics(env),
+    pngBuffer: providerResult.pngBuffer,
+    provider: providerName,
+    providerUsed: meta.providerUsed || providerName,
+    imageProviderUsed: meta.imageProviderUsed || providerName,
+    imageRenderFallback: Boolean(meta.imageRenderFallback),
+    imageRenderFallbackReason: meta.imageRenderFallbackReason || null,
+    fallbackReason: meta.imageRenderFallbackReason || null,
+    openaiConfigured: providerName === "openai" ? true : null,
+    requestId: providerResult.requestId || null,
+    usage: providerResult.usage || null,
+    sourceGaps: providerResult.sourceGaps || [],
+    provenance: {
+      renderer: RENDERER_VERSION,
+      panelType,
+      provider: providerName,
+      providerUsed: meta.providerUsed || providerName,
+      imageProviderUsed: meta.imageProviderUsed || providerName,
+      imageRenderFallback: Boolean(meta.imageRenderFallback),
+      imageRenderFallbackReason: meta.imageRenderFallbackReason || null,
+      model: providerResult.model || null,
+      size: providerResult.size || null,
+      revisedPrompt: providerResult.revisedPrompt || null,
+      requestId: providerResult.requestId || null,
+      usage: providerResult.usage || null,
+      keySource: meta.keySource || null,
+      keyLast4: meta.keyLast4 || null,
+      orgConfigured: meta.orgConfigured ?? null,
+      projectConfigured: meta.projectConfigured ?? null,
+      sourceGeometryHash: geometryHash,
+      referenceSource: meta.referenceSource || "compiled_3d_control_svg",
+      sourceGaps: providerResult.sourceGaps || [],
+      qaAttempts: qaAttemptLog.length > 0 ? qaAttemptLog : null,
+    },
   };
 }
 
 /**
  * Render a single 3D panel (hero_3d / exterior_render / axonometric /
- * interior_3d) by anchoring an OpenAI image-edit call on the deterministic
+ * interior_3d) by anchoring the active provider on the deterministic
  * ProjectGraph SVG silhouette.
+ *
+ * Public API is unchanged from pre-CL-1.
  *
  * @param {object} args
  * @param {string} args.panelType                  - One of the 3D panel types.
  * @param {string} args.deterministicSvg           - Compiled-geometry control SVG.
  * @param {string} args.prompt                     - Climate+style+programme aware prompt.
  * @param {string} args.geometryHash               - For provenance.
- * @returns {Promise<{ pngBuffer: Buffer, provenance: object } | null>}
- *   Rendered PNG plus provenance, or null when image-gen is disabled / fails.
+ * @param {object} [args.env]                      - Defaults to process.env.
+ * @param {object} [args.projectGeometry]          - PR5 vision-QA input.
+ * @param {number} [args.maxQARetries]             - PR5 opt-in retry count.
+ * @param {Function} [args.qaVerifier]             - PR5 verifier injection.
+ * @returns {Promise<object|null>}                 - Render result + provenance.
  */
 export async function renderProjectGraphPanelImage({
   panelType,
@@ -414,24 +240,18 @@ export async function renderProjectGraphPanelImage({
   prompt,
   geometryHash,
   env = process.env,
-  // PR5 (A1 defect remediation): optional ProjectGraph geometry used by
-  // the vision-QA verifier to score the rendered image against canonical
-  // properties. When omitted, QA is skipped silently (same behaviour as
-  // pre-PR5).
+  // PR5 inputs preserved unchanged.
   projectGeometry = null,
-  // PR5: opt-in retry-on-drift count. Default 0 keeps pre-PR5 behaviour;
-  // production opts in via the renderer caller passing `maxQARetries: 2`
-  // when A1_RENDER_GEOMETRY_QA_ENABLED=true. Capped at 2 to bound cost.
   maxQARetries = 0,
-  // PR5: testable verifier injection. When supplied, used in place of
-  // the default OpenAI vision call. Tests pass mocks; production leaves
-  // this null and the verifier resolves STEP_09_3D_QA_MODEL itself.
   qaVerifier = null,
 } = {}) {
-  const config = getProjectGraphImageProviderConfig(env);
-  if (!config.imageGenEnabled) {
+  const config = getOpenAIProviderConfig(env);
+  const selection = selectProvider({ env });
+
+  // ─── Selection outcomes that short-circuit before rasterisation ──────
+  if (selection.reason === "gate_disabled") {
     logger.info(
-      `[OpenAI] SKIP image edit panel=${panelType || "unknown"} reason=gate_disabled PROJECT_GRAPH_IMAGE_GEN_ENABLED=false`,
+      `[render] SKIP panel=${panelType || "unknown"} reason=gate_disabled PROJECT_GRAPH_IMAGE_GEN_ENABLED=false`,
       {
         panelType,
         model: config.model,
@@ -444,8 +264,26 @@ export async function renderProjectGraphPanelImage({
       geometryHash,
       reason: "gate_disabled",
       config,
+      providerName: "openai",
+      sourceGaps: ["IMAGE_GEN_DISABLED"],
     });
   }
+
+  if (selection.reason === "unknown_provider") {
+    return handleFallback({
+      panelType,
+      geometryHash,
+      reason: "unknown_provider",
+      config,
+      providerName: selection.explicitRequest || "openai",
+      sourceGaps: [`UNKNOWN_PROVIDER:${selection.explicitRequest}`],
+    });
+  }
+
+  const provider = selection.provider;
+  const providerName = provider.name;
+
+  // ─── Input validation (same ordering as pre-CL-1) ────────────────────
   if (
     !panelType ||
     typeof deterministicSvg !== "string" ||
@@ -456,6 +294,7 @@ export async function renderProjectGraphPanelImage({
       geometryHash,
       reason: "missing_control_svg",
       config,
+      providerName,
     });
   }
   if (!prompt || typeof prompt !== "string" || !prompt.trim()) {
@@ -464,14 +303,20 @@ export async function renderProjectGraphPanelImage({
       geometryHash,
       reason: "missing_prompt",
       config,
+      providerName,
     });
   }
-  if (!config.openaiConfigured) {
+
+  // ─── Provider availability gate ──────────────────────────────────────
+  const availability = provider.validateAvailable(env);
+  if (!availability.available) {
     return handleFallback({
       panelType,
       geometryHash,
-      reason: "missing_api_key",
+      reason: availability.fallbackReason || "provider_unavailable",
       config,
+      providerName,
+      sourceGaps: availability.sourceGaps || [],
     });
   }
 
@@ -487,13 +332,7 @@ export async function renderProjectGraphPanelImage({
       },
     });
 
-    // PR5: render-then-verify-then-retry loop. Default maxQARetries=0
-    // preserves the pre-PR5 single-shot behaviour. When the caller opts
-    // in (maxQARetries>=1) AND the env gate A1_RENDER_GEOMETRY_QA_ENABLED
-    // is set, each render is scored against the canonical ProjectGraph
-    // properties; on a sub-threshold score we amend the prompt with the
-    // mismatch list and re-render up to `maxQARetries` times before
-    // falling back to the deterministic SVG.
+    // ─── Render-then-verify-then-retry loop (provider-agnostic) ──────
     const clampedRetries = Math.max(0, Math.min(2, Number(maxQARetries) || 0));
     let activePrompt = prompt;
     let lastResult = null;
@@ -503,20 +342,18 @@ export async function renderProjectGraphPanelImage({
 
     while (attempts <= clampedRetries) {
       attempts += 1;
-      lastResult = await callOpenAIImageEdit({
-        imageBuffer: referencePng,
-        prompt: activePrompt,
+      lastResult = await provider.render({
         panelType,
+        referencePng,
+        prompt: activePrompt,
+        geometryHash,
         env,
       });
 
       if (clampedRetries === 0) {
-        // QA loop opted out — keep pre-PR5 single-call behaviour.
         break;
       }
 
-      // Lazy-import to keep the verifier optional. When the env gate is
-      // disabled the module returns ok:true / skipped:true immediately.
       const { verifyRenderAgainstGeometry, amendPromptForRetry } =
         await import("./renderGeometryQA.js");
       lastQa = await verifyRenderAgainstGeometry({
@@ -536,17 +373,13 @@ export async function renderProjectGraphPanelImage({
       });
       if (lastQa.ok || lastQa.skipped) break;
       if (attempts > clampedRetries) break;
-      // Amend the prompt with the mismatch list and try again.
       const expected = lastQa.expected || null;
       activePrompt = amendPromptForRetry(prompt, lastQa.mismatches, expected);
     }
 
     if (lastQa && !lastQa.ok && !lastQa.skipped) {
-      // Exhausted retries with sub-threshold scores — fall back to the
-      // deterministic SVG axonometric. The badge flips to
-      // "DETERMINISTIC FALLBACK" via the artifact metadata flag.
       logger.warn(
-        `[OpenAI] FALLBACK panel=${panelType} reason=geometry_drift score=${lastQa.score}`,
+        `[${providerName}] FALLBACK panel=${panelType} reason=geometry_drift score=${lastQa.score}`,
         {
           panelType,
           attempts,
@@ -559,54 +392,27 @@ export async function renderProjectGraphPanelImage({
         geometryHash,
         reason: "geometry_drift",
         config,
+        providerName,
         error: new Error(
           `Render QA failed after ${attempts} attempts; mismatches: ${(lastQa.mismatches || []).join("; ") || "(none)"}`,
         ),
       });
     }
 
-    return {
-      pngBuffer: lastResult.pngBuffer,
-      provider: "openai",
-      providerUsed: "openai",
-      imageProviderUsed: "openai",
-      imageRenderFallback: false,
-      imageRenderFallbackReason: null,
-      fallbackReason: null,
-      openaiConfigured: true,
-      requestId: lastResult.requestId,
-      usage: lastResult.usage,
-      provenance: {
-        renderer: RENDERER_VERSION,
-        panelType,
-        provider: "openai",
-        providerUsed: "openai",
-        imageProviderUsed: "openai",
-        imageRenderFallback: false,
-        imageRenderFallbackReason: null,
-        model: lastResult.model,
-        size: lastResult.size,
-        revisedPrompt: lastResult.revisedPrompt,
-        requestId: lastResult.requestId,
-        usage: lastResult.usage,
-        keySource: lastResult.keySource,
-        keyLast4: lastResult.keyLast4,
-        orgConfigured: lastResult.orgConfigured,
-        projectConfigured: lastResult.projectConfigured,
-        sourceGeometryHash: geometryHash,
-        referenceSource: "compiled_3d_control_svg",
-        // PR5 provenance: QA loop attempt history. Absent when
-        // maxQARetries === 0 (pre-PR5 default).
-        qaAttempts: qaAttemptLog.length > 0 ? qaAttemptLog : null,
-      },
-    };
+    return assembleSuccessResult({
+      panelType,
+      geometryHash,
+      providerResult: lastResult,
+      qaAttemptLog,
+    });
   } catch (error) {
     return handleFallback({
       panelType,
       geometryHash,
-      reason: error?.fallbackReason || "openai_error",
+      reason: error?.fallbackReason || `${providerName}_error`,
       config,
       error,
+      providerName,
     });
   }
 }
@@ -618,4 +424,5 @@ export const __test = {
   resolveImageModel,
   getProjectGraphImageProviderConfig,
   PANEL_TYPE_TO_SIZE,
+  RENDERER_VERSION,
 };

--- a/src/services/render/providers/mockProjectGraphRenderProvider.js
+++ b/src/services/render/providers/mockProjectGraphRenderProvider.js
@@ -1,0 +1,79 @@
+/**
+ * Mock ProjectGraph render provider — CL-1.
+ *
+ * The mock provider is deliberately **unavailable for rendering**. Selecting
+ * it via `PROJECT_GRAPH_RENDER_PROVIDER=mock` flows through the renderer's
+ * existing deterministic-fallback path, so:
+ *
+ *   - `pngBuffer` is null (no synthetic photoreal output, ever).
+ *   - The downstream vertical slice keeps the compiled control SVG as the
+ *     panel asset (`asset_type: compiled_3d_control_svg`).
+ *   - Artifact metadata stamps `providerUsed: deterministic`,
+ *     `imageProviderUsed: deterministic`, `imageRenderFallback: true`,
+ *     `imageRenderFallbackReason: mock_provider`.
+ *
+ * Tightened in response to a CL-1 audit blocker: an earlier version returned
+ * a rasterised PNG and provenance, which the slice service's
+ * `renderProvenance ? "openai" : "deterministic"` stamping rule
+ * (`projectGraphVerticalSliceService.js:9757-9760, :9804`) treated as a
+ * successful OpenAI photoreal render. That leaked mock output through as
+ * `providerUsed=openai` / `imageProviderUsed=openai` /
+ * `asset_type=geometry_locked_presentation_svg`. Forbidden.
+ *
+ * @module services/render/providers/mockProjectGraphRenderProvider
+ */
+
+export const MOCK_PROVIDER_VERSION = "mock-projectgraph-render-provider-v2";
+
+export const MOCK_PROVIDER_FALLBACK_REASON = "mock_provider";
+export const MOCK_PROVIDER_SOURCE_GAP = "MOCK_PROVIDER_NO_RENDER";
+
+export function getConfig(/* env */) {
+  return {
+    provider: "mock",
+    configured: true,
+    rendersImages: false,
+    description:
+      "Mock provider — never renders a photoreal image; the renderer falls through to deterministic-fallback metadata so the compiled control SVG remains the panel asset.",
+  };
+}
+
+/**
+ * Always returns `available: false` with the structured fallback metadata
+ * the renderer's `handleFallback` consumes. This is the single source of
+ * truth for the mock behaviour — `render` below is defensive and never
+ * reached in production code paths.
+ */
+export function validateAvailable(/* env */) {
+  return {
+    available: false,
+    fallbackReason: MOCK_PROVIDER_FALLBACK_REASON,
+    sourceGaps: [MOCK_PROVIDER_SOURCE_GAP],
+  };
+}
+
+/**
+ * Defensive guard: if a future refactor accidentally bypasses
+ * `validateAvailable` and invokes `render`, throw a structured error rather
+ * than silently producing a buffer. The thrown error carries
+ * `fallbackReason: "mock_provider"` so the renderer's outer catch maps it
+ * to the correct deterministic-fallback path.
+ */
+export async function render() {
+  const error = new Error(
+    "mockProjectGraphRenderProvider.render must not be invoked — validateAvailable returns unavailable so the renderer falls through to deterministic fallback. Calling render() directly indicates a regression in the provider abstraction.",
+  );
+  error.fallbackReason = MOCK_PROVIDER_FALLBACK_REASON;
+  error.code = "MOCK_PROVIDER_RENDER_INVOKED";
+  throw error;
+}
+
+const mockProjectGraphRenderProvider = Object.freeze({
+  name: "mock",
+  version: MOCK_PROVIDER_VERSION,
+  getConfig,
+  validateAvailable,
+  render,
+});
+
+export default mockProjectGraphRenderProvider;

--- a/src/services/render/providers/openaiImageEditProvider.js
+++ b/src/services/render/providers/openaiImageEditProvider.js
@@ -1,0 +1,382 @@
+/**
+ * OpenAI image-edit provider — CL-1 of the ControlNet/Redux render-stack plan.
+ *
+ * Extracted verbatim from `projectGraphImageRenderer.js` so the existing
+ * production behaviour (gated by `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true`)
+ * remains byte-identical when this provider is selected — either explicitly
+ * via `PROJECT_GRAPH_RENDER_PROVIDER=openai` or implicitly via the legacy
+ * gate when no explicit provider is set.
+ *
+ * @module services/render/providers/openaiImageEditProvider
+ */
+
+import logger from "../../../utils/logger.js";
+import openaiEnv from "../../openaiProviderEnv.cjs";
+
+export const OPENAI_IMAGE_EDIT_PROVIDER_VERSION =
+  "openai-image-edit-provider-v1";
+
+export const PANEL_TYPE_TO_SIZE = Object.freeze({
+  hero_3d: "1536x1024",
+  exterior_render: "1536x1024",
+  axonometric: "1024x1024",
+  interior_3d: "1280x1024",
+});
+
+export const ALLOWED_OPENAI_SIZES = new Set([
+  "256x256",
+  "512x512",
+  "1024x1024",
+  "1024x1536",
+  "1536x1024",
+  "1024x1792",
+  "1792x1024",
+]);
+
+function parsePositiveInt(value, fallback, { min = 1 } = {}) {
+  const parsed = Number.parseInt(value || "", 10);
+  if (!Number.isFinite(parsed) || parsed < min) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function createOpenAIRequestTimeoutSignal(timeoutMs, externalSignal) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return {
+      signal: externalSignal,
+      dispose: () => {},
+    };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(
+      Object.assign(
+        new Error(`OpenAI request timed out after ${timeoutMs}ms`),
+        {
+          name: "AbortError",
+          code: "OPENAI_REQUEST_TIMEOUT",
+        },
+      ),
+    );
+  }, timeoutMs);
+
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      clearTimeout(timeoutId);
+      controller.abort(externalSignal.reason);
+    } else {
+      externalSignal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timeoutId);
+          controller.abort(externalSignal.reason);
+        },
+        { once: true },
+      );
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    dispose: () => clearTimeout(timeoutId),
+  };
+}
+
+async function fetchWithTimeout(
+  url,
+  options = {},
+  timeoutMs = 120_000,
+  { fetchImpl = global.fetch } = {},
+) {
+  const { signal: externalSignal, ...restOptions } = options;
+  const requestTimeout = createOpenAIRequestTimeoutSignal(
+    timeoutMs,
+    externalSignal,
+  );
+  try {
+    return await fetchImpl(url, {
+      ...restOptions,
+      signal: requestTimeout.signal,
+    });
+  } finally {
+    requestTimeout.dispose();
+  }
+}
+
+export function resolveImageGenEnabled(env = process.env) {
+  return openaiEnv.isTruthy(
+    openaiEnv.readEnv(env, "PROJECT_GRAPH_IMAGE_GEN_ENABLED"),
+  );
+}
+
+export function resolveStrictImageGen(env = process.env) {
+  return openaiEnv.isTruthy(openaiEnv.readEnv(env, "OPENAI_STRICT_IMAGE_GEN"));
+}
+
+export function resolveImageModel(env = process.env) {
+  return (
+    openaiEnv.readEnv(env, "STEP_10_IMAGE_MODEL") ||
+    openaiEnv.readEnv(env, "OPENAI_IMAGE_MODEL") ||
+    "gpt-image-2"
+  ).trim();
+}
+
+export function resolveSize(panelType) {
+  const target = PANEL_TYPE_TO_SIZE[panelType] || "1024x1024";
+  return ALLOWED_OPENAI_SIZES.has(target) ? target : "1024x1024";
+}
+
+export function resolveOpenAIImageTimeoutMs(env = process.env) {
+  return parsePositiveInt(
+    openaiEnv.readEnv(env, "OPENAI_IMAGE_FETCH_TIMEOUT_MS"),
+    parsePositiveInt(
+      openaiEnv.readEnv(env, "OPENAI_REASONING_FETCH_TIMEOUT_MS"),
+      120_000,
+    ),
+    { min: 1000 },
+  );
+}
+
+export function resolveOpenAIImageDownloadTimeoutMs(env = process.env) {
+  return parsePositiveInt(
+    openaiEnv.readEnv(env, "OPENAI_IMAGE_DOWNLOAD_TIMEOUT_MS"),
+    resolveOpenAIImageTimeoutMs(env),
+    { min: 1000 },
+  );
+}
+
+/**
+ * Diagnostics snapshot for the OpenAI provider. Drives the legacy
+ * `getProjectGraphImageProviderConfig` export so existing tests/callers do
+ * not see a behaviour change.
+ */
+export function getConfig(env = process.env) {
+  const keyInfo = openaiEnv.resolveOpenAIImageApiKeyInfo(env);
+  const orgProject = openaiEnv.getOpenAIOrgProjectDiagnostics(env);
+  return {
+    imageGenEnabled: resolveImageGenEnabled(env),
+    strictImageGen: resolveStrictImageGen(env),
+    openaiConfigured: keyInfo.hasKey,
+    keySource: keyInfo.keySource,
+    keyLast4: keyInfo.keyLast4,
+    warning: keyInfo.warning,
+    model: resolveImageModel(env),
+    ...orgProject,
+  };
+}
+
+/**
+ * Provider availability gate consulted before the renderer rasterises the
+ * reference SVG. Returns structured source gaps when the provider cannot
+ * run, so the renderer can fall back deterministically.
+ */
+export function validateAvailable(env = process.env) {
+  if (!resolveImageGenEnabled(env)) {
+    return {
+      available: false,
+      fallbackReason: "gate_disabled",
+      sourceGaps: ["PROJECT_GRAPH_IMAGE_GEN_ENABLED_FALSE"],
+    };
+  }
+  const keyInfo = openaiEnv.resolveOpenAIImageApiKeyInfo(env);
+  if (!keyInfo.hasKey) {
+    return {
+      available: false,
+      fallbackReason: "missing_api_key",
+      sourceGaps: ["MISSING_OPENAI_IMAGES_API_KEY"],
+    };
+  }
+  return { available: true };
+}
+
+/**
+ * Build a multipart/form-data body for the OpenAI images edit endpoint.
+ * Uses the global FormData / Blob (Node 18+ supports both natively).
+ */
+function buildImageEditFormData({ imageBuffer, prompt, model, size }) {
+  if (typeof FormData === "undefined" || typeof Blob === "undefined") {
+    throw new Error(
+      "FormData/Blob unavailable in this runtime; OpenAI images.edit requires Node 18+ or fetch polyfill.",
+    );
+  }
+  const form = new FormData();
+  form.set("model", model);
+  form.set("prompt", prompt);
+  form.set("size", size);
+  form.set("n", "1");
+  form.set(
+    "image",
+    new Blob([imageBuffer], { type: "image/png" }),
+    "reference.png",
+  );
+  return form;
+}
+
+/**
+ * Call OpenAI `/v1/images/edits` with the reference image + prompt and
+ * return the rendered PNG bytes. Throws on non-200 or empty response so the
+ * caller can fall back to the deterministic SVG.
+ */
+async function callOpenAIImageEdit({ imageBuffer, prompt, panelType, env }) {
+  const keyInfo = openaiEnv.resolveOpenAIImageApiKeyInfo(env);
+  if (!keyInfo.hasKey) {
+    const error = new Error(
+      "OPENAI_IMAGES_API_KEY, OPENAI_API_KEY, or OPENAI_REASONING_API_KEY is not set.",
+    );
+    error.fallbackReason = "missing_api_key";
+    throw error;
+  }
+  const model = resolveImageModel(env);
+  const size = resolveSize(panelType);
+  const form = buildImageEditFormData({ imageBuffer, prompt, model, size });
+
+  logger.info(`[OpenAI] START image edit panel=${panelType} model=${model}`, {
+    panelType,
+    model,
+    size,
+    keySource: keyInfo.keySource,
+    keyLast4: keyInfo.keyLast4,
+    ...openaiEnv.getOpenAIOrgProjectDiagnostics(env),
+  });
+
+  const response = await fetchWithTimeout(
+    "https://api.openai.com/v1/images/edits",
+    {
+      method: "POST",
+      headers: openaiEnv.buildOpenAIRequestHeaders(keyInfo, env),
+      body: form,
+    },
+    resolveOpenAIImageTimeoutMs(env),
+    { fetchImpl: global.fetch },
+  );
+
+  const requestId =
+    response.headers?.get?.("x-request-id") ||
+    response.headers?.get?.("openai-request-id") ||
+    null;
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(
+      `OpenAI images.edit failed (${response.status}): ${data?.error?.message || "unknown"}`,
+    );
+    error.status = response.status;
+    error.requestId = requestId;
+    error.usage = data?.usage || null;
+    error.fallbackReason = "openai_error";
+    logger.warn(`[OpenAI] FAIL image edit panel=${panelType}`, {
+      panelType,
+      model,
+      status: response.status,
+      requestId,
+      reason: data?.error?.message || "unknown",
+    });
+    throw error;
+  }
+
+  const entry = (data.data || [])[0];
+  if (!entry?.b64_json && !entry?.url) {
+    const error = new Error("OpenAI images.edit returned no image payload.");
+    error.requestId = requestId;
+    error.usage = data?.usage || null;
+    error.fallbackReason = "empty_response";
+    throw error;
+  }
+
+  let pngBuffer;
+  if (entry.b64_json) {
+    pngBuffer = Buffer.from(entry.b64_json, "base64");
+  } else {
+    const fetchResp = await fetchWithTimeout(
+      entry.url,
+      { method: "GET" },
+      resolveOpenAIImageDownloadTimeoutMs(env),
+      { fetchImpl: global.fetch },
+    );
+    if (!fetchResp.ok) {
+      throw new Error(
+        `Failed to download generated image: ${fetchResp.status}`,
+      );
+    }
+    const arrayBuffer = await fetchResp.arrayBuffer();
+    pngBuffer = Buffer.from(arrayBuffer);
+  }
+
+  logger.info(`[OpenAI] OK image edit panel=${panelType}`, {
+    panelType,
+    model,
+    requestId,
+    bytes: pngBuffer.length,
+    usage: data?.usage || null,
+  });
+
+  return {
+    pngBuffer,
+    model,
+    size,
+    revisedPrompt: entry.revised_prompt || null,
+    requestId,
+    usage: data?.usage || null,
+    keySource: keyInfo.keySource,
+    keyLast4: keyInfo.keyLast4,
+    ...openaiEnv.getOpenAIOrgProjectDiagnostics(env),
+  };
+}
+
+/**
+ * Provider-contract `render` entrypoint. Returns the OpenAI-rendered PNG
+ * plus a normalised provenance block. Caller is responsible for assembling
+ * the final `ProjectGraphRenderResult`.
+ */
+export async function render({
+  panelType,
+  referencePng,
+  prompt,
+  env = process.env,
+}) {
+  const result = await callOpenAIImageEdit({
+    imageBuffer: referencePng,
+    prompt,
+    panelType,
+    env,
+  });
+  return {
+    pngBuffer: result.pngBuffer,
+    model: result.model,
+    size: result.size,
+    revisedPrompt: result.revisedPrompt,
+    requestId: result.requestId,
+    usage: result.usage,
+    providerMetadata: {
+      provider: "openai",
+      providerUsed: "openai",
+      imageProviderUsed: "openai",
+      imageRenderFallback: false,
+      imageRenderFallbackReason: null,
+      keySource: result.keySource,
+      keyLast4: result.keyLast4,
+      orgConfigured: result.orgConfigured,
+      projectConfigured: result.projectConfigured,
+      referenceSource: "compiled_3d_control_svg",
+    },
+    sourceGaps: [],
+  };
+}
+
+const openaiImageEditProvider = Object.freeze({
+  name: "openai",
+  version: OPENAI_IMAGE_EDIT_PROVIDER_VERSION,
+  getConfig,
+  validateAvailable,
+  render,
+});
+
+export default openaiImageEditProvider;
+
+export const __test = {
+  callOpenAIImageEdit,
+  buildImageEditFormData,
+  fetchWithTimeout,
+  parsePositiveInt,
+};

--- a/src/services/render/providers/renderProviderRegistry.js
+++ b/src/services/render/providers/renderProviderRegistry.js
@@ -1,0 +1,182 @@
+/**
+ * Render Provider Registry — CL-1 of the ControlNet/Redux render-stack plan.
+ *
+ * Provider-neutral seam for the ProjectGraph rendered-panel pipeline. The
+ * registry exposes a small contract so the renderer can dispatch to mock /
+ * openai / replicate adapters without leaking provider-specific code into
+ * `projectGraphImageRenderer.js`.
+ *
+ * Invariants (hard):
+ *   - ProjectGraph / compiledProject remains the only geometry authority.
+ *     Providers receive a rasterised deterministic-geometry reference image;
+ *     they never invent geometry.
+ *   - Deterministic technical drawings (plans / elevations / sections) and
+ *     engineering exports (DXF, IFC, JSON, XLSX) MUST NOT call into any
+ *     provider here. Enforced by `drawingConsistencyChecks.js` blockers.
+ *   - `geometryHash` is the cross-artifact identity key. Future
+ *     `controlSvgHash`, `footprintMaskHash`, `depthHash`, `lineartHash` (CL-2)
+ *     and `reduxReferenceSetHash` (CL-3) flow through the contract below but
+ *     never enter `geometryHash`.
+ *
+ * Resolution rules (`selectProvider`):
+ *   1. If `PROJECT_GRAPH_RENDER_PROVIDER` is set to a known name, use it.
+ *   2. Else if `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true` (legacy implicit), use
+ *      `openai`. This preserves byte-identical production behaviour for runs
+ *      that were already opted-in before CL-1.
+ *   3. Otherwise return `{ provider: null, reason: "gate_disabled" }` so the
+ *      renderer takes the existing deterministic-fallback path.
+ *
+ * Provider contract (each provider exports a frozen object):
+ *   - `name: "openai" | "mock" | "replicate"`
+ *   - `getConfig(env): object`                      — diagnostics snapshot
+ *   - `validateAvailable(env): { available, fallbackReason?, sourceGaps? }`
+ *   - `render(request): Promise<ProviderRenderResult>` — throws on call
+ *     failure with `.fallbackReason` set; never returns synthetic success.
+ *
+ * @module services/render/providers/renderProviderRegistry
+ */
+
+import openaiEnv from "../../openaiProviderEnv.cjs";
+import openaiImageEditProvider from "./openaiImageEditProvider.js";
+import mockProjectGraphRenderProvider from "./mockProjectGraphRenderProvider.js";
+import replicateFluxRenderProvider from "./replicateFluxRenderProvider.js";
+
+export const RENDER_PROVIDER_ENV_VAR = "PROJECT_GRAPH_RENDER_PROVIDER";
+export const RENDER_PROVIDER_REGISTRY_VERSION = "render-provider-registry-v1";
+
+const PROVIDERS = Object.freeze({
+  openai: openaiImageEditProvider,
+  mock: mockProjectGraphRenderProvider,
+  replicate: replicateFluxRenderProvider,
+});
+
+export const KNOWN_PROVIDER_NAMES = Object.freeze(Object.keys(PROVIDERS));
+
+/**
+ * @typedef {object} ProjectGraphRenderRequest
+ * @property {"hero_3d"|"exterior_render"|"axonometric"|"interior_3d"} panelType
+ * @property {Buffer} referencePng                Rasterised deterministic SVG (geometry-locked).
+ * @property {string} prompt                      Climate + style + programme aware prompt.
+ * @property {string} deterministicSvg            Source SVG, for providers that need it raw.
+ * @property {string} geometryHash                Cross-artifact identity (never derived from images).
+ * @property {string} [controlSvgHash]            CL-2 — sha of compiled control SVG.
+ * @property {string} [footprintMaskHash]         CL-2 — sha of binary footprint mask PNG.
+ * @property {string} [depthHash]                 CL-2 — sha of ProjectGraph-derived depth PNG.
+ * @property {string} [lineartHash]               CL-2 — sha of compiled lineart/canny PNG.
+ * @property {string} [reduxReferenceSetHash]     CL-3 — sha of portfolio reference bundle.
+ * @property {object} [providerOptions]           Provider-specific opaque options.
+ * @property {object} env                         Resolved env snapshot (defaults to process.env).
+ */
+
+/**
+ * @typedef {object} ProviderRenderResult
+ * @property {Buffer} pngBuffer
+ * @property {string} model
+ * @property {string} [size]
+ * @property {string} [revisedPrompt]
+ * @property {string} [requestId]
+ * @property {object} [usage]
+ * @property {object} providerMetadata          Provider-specific provenance fields.
+ * @property {string[]} [sourceGaps]            Structured reasons for partial fulfilment.
+ */
+
+function normaliseName(name) {
+  return typeof name === "string" ? name.trim().toLowerCase() : "";
+}
+
+/**
+ * Resolve the active render provider per the rules above.
+ *
+ * @param {{ env?: object, overrideName?: string }} [options]
+ * @returns {{
+ *   provider: object|null,
+ *   resolvedName: string|null,
+ *   reason: "explicit"|"legacy_implicit"|"gate_disabled"|"unknown_provider",
+ *   explicitRequest: string|null,
+ * }}
+ */
+export function selectProvider({
+  env = process.env,
+  overrideName = null,
+} = {}) {
+  const explicitRaw =
+    overrideName ?? openaiEnv.readEnv(env, RENDER_PROVIDER_ENV_VAR);
+  const explicit = normaliseName(explicitRaw);
+
+  if (explicit) {
+    const provider = PROVIDERS[explicit];
+    if (!provider) {
+      return {
+        provider: null,
+        resolvedName: explicit,
+        reason: "unknown_provider",
+        explicitRequest: explicit,
+      };
+    }
+    return {
+      provider,
+      resolvedName: provider.name,
+      reason: "explicit",
+      explicitRequest: explicit,
+    };
+  }
+
+  if (
+    openaiEnv.isTruthy(
+      openaiEnv.readEnv(env, "PROJECT_GRAPH_IMAGE_GEN_ENABLED"),
+    )
+  ) {
+    return {
+      provider: PROVIDERS.openai,
+      resolvedName: "openai",
+      reason: "legacy_implicit",
+      explicitRequest: null,
+    };
+  }
+
+  return {
+    provider: null,
+    resolvedName: null,
+    reason: "gate_disabled",
+    explicitRequest: null,
+  };
+}
+
+/**
+ * Lookup a provider by name. Returns null when unknown.
+ * @param {string} name
+ */
+export function getProviderByName(name) {
+  return PROVIDERS[normaliseName(name)] || null;
+}
+
+/**
+ * Provider availability snapshot for diagnostics endpoints (not used in CL-1
+ * production code, but useful for CL-6 UI / status routes).
+ * @param {object} [env]
+ */
+export function describeProviderRegistry(env = process.env) {
+  const selection = selectProvider({ env });
+  return {
+    registryVersion: RENDER_PROVIDER_REGISTRY_VERSION,
+    known: KNOWN_PROVIDER_NAMES,
+    explicit: openaiEnv.readEnv(env, RENDER_PROVIDER_ENV_VAR) || null,
+    selectedProvider: selection.resolvedName,
+    selectionReason: selection.reason,
+    providers: KNOWN_PROVIDER_NAMES.reduce((acc, name) => {
+      acc[name] = PROVIDERS[name].getConfig
+        ? PROVIDERS[name].getConfig(env)
+        : { configured: false };
+      return acc;
+    }, {}),
+  };
+}
+
+export default {
+  selectProvider,
+  getProviderByName,
+  describeProviderRegistry,
+  RENDER_PROVIDER_ENV_VAR,
+  RENDER_PROVIDER_REGISTRY_VERSION,
+  KNOWN_PROVIDER_NAMES,
+};

--- a/src/services/render/providers/replicateFluxRenderProvider.js
+++ b/src/services/render/providers/replicateFluxRenderProvider.js
@@ -1,0 +1,54 @@
+/**
+ * Replicate FLUX render provider — CL-1 STUB.
+ *
+ * Returns `available: false` unconditionally. The real adapter lands in CL-4
+ * behind `PROJECT_GRAPH_CONTROLNET_RENDER_ENABLED=true`. Until then,
+ * selecting this provider via `PROJECT_GRAPH_RENDER_PROVIDER=replicate`
+ * falls through to the deterministic-fallback path and records the
+ * structured source gap `PROVIDER_NOT_IMPLEMENTED` on the result.
+ *
+ * @module services/render/providers/replicateFluxRenderProvider
+ */
+
+export const REPLICATE_PROVIDER_VERSION =
+  "replicate-flux-render-provider-stub-v1";
+
+export function getConfig(env = process.env) {
+  return {
+    provider: "replicate",
+    configured: false,
+    enabled: false,
+    note: "Replicate FLUX provider stub — real adapter ships in CL-4 of the ControlNet/Redux render-stack plan.",
+    flagControlNetRenderEnabled: Boolean(
+      env?.PROJECT_GRAPH_CONTROLNET_RENDER_ENABLED,
+    ),
+    tokenPresent: Boolean(env?.REPLICATE_API_TOKEN),
+  };
+}
+
+export function validateAvailable(/* env */) {
+  return {
+    available: false,
+    fallbackReason: "PROVIDER_NOT_IMPLEMENTED",
+    sourceGaps: ["PROVIDER_NOT_IMPLEMENTED"],
+  };
+}
+
+export async function render() {
+  const error = new Error(
+    "Replicate FLUX provider is a CL-1 stub; real adapter lands in CL-4.",
+  );
+  error.fallbackReason = "PROVIDER_NOT_IMPLEMENTED";
+  error.code = "REPLICATE_PROVIDER_NOT_IMPLEMENTED";
+  throw error;
+}
+
+const replicateFluxRenderProvider = Object.freeze({
+  name: "replicate",
+  version: REPLICATE_PROVIDER_VERSION,
+  getConfig,
+  validateAvailable,
+  render,
+});
+
+export default replicateFluxRenderProvider;


### PR DESCRIPTION
## Summary

First PR of the ControlNet/Redux render-stack plan. Introduces a provider-neutral seam around [src/services/render/projectGraphImageRenderer.js](src/services/render/projectGraphImageRenderer.js) so the rendered-panel layer can dispatch to `mock` / `openai` / `replicate` without leaking provider-specific code into the vertical slice service. `ProjectGraph` / `compiledProject` remains the sole geometry authority; deterministic technical drawings (plans, elevations, sections) and DXF/IFC/JSON/XLSX exports are untouched.

**Why now**: CL-2 (ProjectGraph conditioning images) and CL-4 (real Replicate adapter) need a stable contract to plug into. CL-1 establishes that contract and keeps default production behaviour byte-identical — runs with `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true` (no `PROJECT_GRAPH_RENDER_PROVIDER` set) continue to call OpenAI exactly as before.

## What it does

- **`providers/renderProviderRegistry.js`** — `selectProvider()` with explicit env override + legacy-implicit `openai` when the gate flag is set; `gate_disabled` / `unknown_provider` paths surface structured `sourceGaps`.
- **`providers/openaiImageEditProvider.js`** — extracted from the existing inline OpenAI logic. Same `/v1/images/edits` path, same retry / strict-mode behaviour, same provenance shape — locked by the existing six OpenAI tests.
- **`providers/mockProjectGraphRenderProvider.js`** — deliberately unavailable for rendering. `validateAvailable` returns `{ available: false, fallbackReason: "mock_provider", sourceGaps: ["MOCK_PROVIDER_NO_RENDER"] }` so the renderer's existing `handleFallback` emits a deterministic-fallback shape: `pngBuffer: null`, `providerUsed: "deterministic"`, `imageProviderUsed: "deterministic"`, `imageRenderFallback: true`, `imageRenderFallbackReason: "mock_provider"`. The defensive `render()` throws if invoked, guarding against future regressions.
- **`providers/replicateFluxRenderProvider.js`** — stub returning unavailable with `sourceGaps=["PROVIDER_NOT_IMPLEMENTED"]`. Real adapter lands in CL-4.
- **`buildVisual3DPanelArtifacts`** (slice service) — structured `sourceGaps` from the render result now propagate onto the visual artifact top-level, `artifact.metadata`, and the `buildResultPanelMap` projection (now exported) so downstream UI / QA / manifest validators can explain WHY a panel landed on deterministic fallback (mock, replicate stub, missing key, gate disabled, etc.).
- **`PROJECT_GRAPH_RENDER_PROVIDER`** added to [.env.example](.env.example) (commented default, with full provider semantics) and [scripts/check-env.cjs](scripts/check-env.cjs) `OPTIONAL_PRESENTATION`.

## Hard invariants preserved

- `ProjectGraph` / `compiledProject` remains the only geometry authority.
- Deterministic SVG plans, elevations, sections, DXF, IFC, JSON, XLSX are not routed through any image model. Enforced by [drawingConsistencyChecks.js](src/services/validation/drawingConsistencyChecks.js) blockers (regression test included).
- `geometryHash` is the cross-artifact identity key; portfolio references (CL-3) and conditioning hashes (CL-2) flow through the new request/result shape but never enter `geometryHash`.

## What is NOT in this PR

- No ProjectGraph conditioning images (CL-2; gated on PR #109 boundary-CAD input).
- No portfolio / Redux reference handling (CL-3).
- No real Replicate adapter, no paid API calls (CL-4).
- No render-mask compliance gate (CL-5; extends `silhouetteIoUGate.js`).
- No UI controls (CL-6).
- No LoRA fine-tuning (explicitly out of scope).

## Test plan

- [x] `npx react-scripts test ... projectGraphImageRenderer.providerAbstraction.test.js` — 17/17 provider-abstraction tests (registry selection, dispatch, source gaps, technical-panel non-contamination, slice-stamping conditional)
- [x] `npx react-scripts test ... mockProjectGraphRenderProvider.test.js` — 6/6 unit tests pinning the unavailable-only contract and the `mock_provider` literal
- [x] `npx react-scripts test ... projectGraphImageRenderer.test.js` — 6/6 existing OpenAI tests unchanged and green (byte-identical behaviour)
- [x] `npx react-scripts test ... projectGraphMockProviderVerticalSlice.test.js` — 2/2 vertical-slice contract tests proving `PROJECT_GRAPH_RENDER_PROVIDER=mock` produces deterministic stamps + `MOCK_PROVIDER_NO_RENDER` source gap on the artifact, `artifact.metadata`, AND the `buildResultPanelMap` projection — even with `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true` and `OPENAI_IMAGES_API_KEY` set
- [x] Regression suite: `projectGraphRenderQualityTier`, `projectGraphVisualImage2Phase2`, `drawingConsistencyChecks`, `silhouetteIoUGate`, `visualManifestValidator` — all green
- [x] `npm run lint` — clean
- [x] `npm run check:contracts` — PASSED
- [x] `npm run test:compose:routing` — 22/22

100 passed, 0 failures in the focused + regression suite.

## Manual smoke (deferred)

No manual smoke required for CL-1 — there are no paid API paths or new external integrations. Default production behaviour is byte-identical when env is unchanged.

## Provider resolution table

| Env | Selected | Reason | pngBuffer | imageProviderUsed |
|---|---|---|---|---|
| nothing set | none | `gate_disabled` | null | `deterministic` |
| `PROJECT_GRAPH_IMAGE_GEN_ENABLED=true` (no explicit) | `openai` | `legacy_implicit` | from API | `openai` |
| `PROJECT_GRAPH_RENDER_PROVIDER=openai` (+ key + gen_enabled) | `openai` | `explicit` | from API | `openai` |
| `PROJECT_GRAPH_RENDER_PROVIDER=mock` | mock | `explicit` → fallback | null | `deterministic` |
| `PROJECT_GRAPH_RENDER_PROVIDER=replicate` | replicate stub | `explicit` → fallback | null | `deterministic` |
| `PROJECT_GRAPH_RENDER_PROVIDER=foo` | none | `unknown_provider` | null | `deterministic` |

Per the approved plan in `plans/controlnet-lora-luminous-phoenix.md`: stop after CL-1. Next gate before opening any further CL PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)